### PR TITLE
fix(dolt): preserve transaction outcome boundaries

### DIFF
--- a/backend/conformance/conformance.go
+++ b/backend/conformance/conformance.go
@@ -26,6 +26,7 @@ package conformance
 
 import (
 	"context"
+	"database/sql/driver"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -208,6 +209,7 @@ func RunAll(t *testing.T, factory Factory) {
 
 	// Transaction
 	t.Run("Transaction", func(t *testing.T) { testTransaction(t, factory) })
+	t.Run("TransactionCallbackAtMostOnce", func(t *testing.T) { testTransactionCallbackAtMostOnce(t, factory) })
 	t.Run("TransactionSnapshotReads", func(t *testing.T) { testTransactionSnapshotReads(t, factory) })
 	t.Run("TransactionReadYourWrites", func(t *testing.T) { testTransactionReadYourWrites(t, factory) })
 }
@@ -945,6 +947,22 @@ func testTransaction(t *testing.T, f Factory) {
 	}
 	if !found {
 		t.Errorf("label 'from-tx' not found, got %v", labels)
+	}
+}
+
+func testTransactionCallbackAtMostOnce(t *testing.T, f Factory) {
+	s := f(t)
+	calls := 0
+
+	err := s.RunInTransaction(ctx(), "test: transient callback", func(storage.Transaction) error {
+		calls++
+		return driver.ErrBadConn
+	})
+	if !errors.Is(err, driver.ErrBadConn) {
+		t.Errorf("RunInTransaction error = %v, want original callback error %v", err, driver.ErrBadConn)
+	}
+	if calls != 1 {
+		t.Errorf("transaction callback calls = %d, want 1", calls)
 	}
 }
 

--- a/backend/errors.go
+++ b/backend/errors.go
@@ -18,19 +18,20 @@ type ErrUnsupported = storage.ErrUnsupported
 // identities: a backend must return (or wrap) these values, not
 // equivalently-worded errors of its own.
 var (
-	ErrAlreadyClaimed    = storage.ErrAlreadyClaimed
-	ErrAlreadyExists     = storage.ErrAlreadyExists
-	ErrAssigneeMismatch  = storage.ErrAssigneeMismatch
-	ErrCloseBlocked      = storage.ErrCloseBlocked
-	ErrCloseOpenChildren = storage.ErrCloseOpenChildren
-	ErrNotClaimable      = storage.ErrNotClaimable
-	ErrNotFound          = storage.ErrNotFound
-	ErrNotInitialized    = storage.ErrNotInitialized
-	ErrNotOwner          = storage.ErrNotOwner
-	ErrPrefixMismatch    = storage.ErrPrefixMismatch
-	ErrStatusMismatch    = storage.ErrStatusMismatch
-	ErrValidation        = storage.ErrValidation
-	ErrVersionMismatch   = storage.ErrVersionMismatch
+	ErrAlreadyClaimed      = storage.ErrAlreadyClaimed
+	ErrAlreadyExists       = storage.ErrAlreadyExists
+	ErrAssigneeMismatch    = storage.ErrAssigneeMismatch
+	ErrCloseBlocked        = storage.ErrCloseBlocked
+	ErrCloseOpenChildren   = storage.ErrCloseOpenChildren
+	ErrCommitIndeterminate = storage.ErrCommitIndeterminate
+	ErrNotClaimable        = storage.ErrNotClaimable
+	ErrNotFound            = storage.ErrNotFound
+	ErrNotInitialized      = storage.ErrNotInitialized
+	ErrNotOwner            = storage.ErrNotOwner
+	ErrPrefixMismatch      = storage.ErrPrefixMismatch
+	ErrStatusMismatch      = storage.ErrStatusMismatch
+	ErrValidation          = storage.ErrValidation
+	ErrVersionMismatch     = storage.ErrVersionMismatch
 
 	// ErrFieldTooLong pairs with MaxFieldLen.
 	ErrFieldTooLong = types.ErrFieldTooLong

--- a/backend/errors_test.go
+++ b/backend/errors_test.go
@@ -1,0 +1,21 @@
+package backend_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/steveyegge/beads/backend"
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+func TestErrCommitIndeterminateAliasesStorageSentinel(t *testing.T) {
+	if backend.ErrCommitIndeterminate != storage.ErrCommitIndeterminate {
+		t.Fatal("backend ErrCommitIndeterminate must preserve storage sentinel identity")
+	}
+
+	err := fmt.Errorf("commit: %w", backend.ErrCommitIndeterminate)
+	if !errors.Is(err, storage.ErrCommitIndeterminate) {
+		t.Fatalf("errors.Is(err, storage.ErrCommitIndeterminate) = false; err = %v", err)
+	}
+}

--- a/beads.go
+++ b/beads.go
@@ -30,7 +30,10 @@ import (
 	"github.com/steveyegge/beads/internal/workspacegate"
 )
 
-// Storage is the interface for beads storage operations
+// Storage is the interface for beads storage operations. Its
+// RunInTransaction callback is invoked at most once per public call; callers
+// retry it explicitly after a callback has started when their operation is
+// safe to repeat.
 type Storage = beads.Storage
 
 func configuredBackendUnavailable(backend string) error {
@@ -193,7 +196,8 @@ func AsDependentQuerier(s Storage) (DependentQuerier, bool) {
 // and ErrNotClaimable — the ones ParseClaimConflict recovers assignee/status
 // detail from — are re-exported with the other error sentinels below.
 var (
-	ErrCircuitOpen = dolt.ErrCircuitOpen
+	ErrCircuitOpen         = dolt.ErrCircuitOpen
+	ErrCommitIndeterminate = storage.ErrCommitIndeterminate
 )
 
 // IssueClaimer is the atomic-claim surface of a Storage. ClaimIssue and

--- a/errors_test.go
+++ b/errors_test.go
@@ -8,9 +8,25 @@ import (
 
 	"github.com/steveyegge/beads"
 	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/dolt"
 	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/types"
 )
+
+func TestReExportCommitIndeterminate(t *testing.T) {
+	t.Parallel()
+
+	if beads.ErrCommitIndeterminate != storage.ErrCommitIndeterminate {
+		t.Error("beads.ErrCommitIndeterminate is not the shared storage sentinel value (identity broken)")
+	}
+	if dolt.ErrCommitIndeterminate != storage.ErrCommitIndeterminate {
+		t.Error("dolt.ErrCommitIndeterminate is not the shared storage sentinel value (identity broken)")
+	}
+	wrapped := fmt.Errorf("update issue: %w", storage.ErrCommitIndeterminate)
+	if !errors.Is(wrapped, beads.ErrCommitIndeterminate) {
+		t.Errorf("errors.Is(wrapped, beads.ErrCommitIndeterminate) = false; err = %v", wrapped)
+	}
+}
 
 // TestReExportCloseBlocked proves the public beads.ErrCloseBlocked alias is the
 // same value as the internal sentinel and composes through errors.Is when

--- a/internal/storage/dolt/circuit_test.go
+++ b/internal/storage/dolt/circuit_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -638,6 +639,41 @@ func TestRunInTransactionPermanentCallbackErrorsDoNotTripCircuit(t *testing.T) {
 	}
 	if unrelatedCalls != 1 {
 		t.Fatalf("unrelated operation calls = %d, want 1", unrelatedCalls)
+	}
+}
+
+func TestRunInTransactionPostCallbackIndeterminateFailureTripsCircuitWithoutReplay(t *testing.T) {
+	t.Setenv("BEADS_TEST_MODE", "")
+	breaker := newTestCircuitBreaker(t)
+	store := &DoltStore{breaker: breaker}
+	infraErr := fmt.Errorf("commit response lost: %w: %w", testConnectionLoss, ErrCommitIndeterminate)
+	callbackCalls := 0
+	runnerCalls := 0
+
+	for i := 0; i < circuitFailureThreshold; i++ {
+		err := store.runInTransaction(context.Background(), "test: infrastructure commit", func(storage.Transaction) error {
+			callbackCalls++
+			return nil
+		}, func(_ context.Context, _ string, fn func(storage.Transaction) error) error {
+			runnerCalls++
+			if err := fn(nil); err != nil {
+				return err
+			}
+			return infraErr
+		})
+		if !errors.Is(err, ErrCommitIndeterminate) {
+			t.Fatalf("RunInTransaction attempt %d error = %v, want ErrCommitIndeterminate", i+1, err)
+		}
+		if callbackCalls != i+1 {
+			t.Fatalf("callback calls after attempt %d = %d, want %d (no replay)", i+1, callbackCalls, i+1)
+		}
+		if runnerCalls != i+1 {
+			t.Fatalf("transaction runner calls after attempt %d = %d, want %d (no replay)", i+1, runnerCalls, i+1)
+		}
+	}
+
+	if state := breaker.State(); state != circuitOpen {
+		t.Fatalf("circuit state after infrastructure commit failures = %q, want %q", state, circuitOpen)
 	}
 }
 

--- a/internal/storage/dolt/circuit_test.go
+++ b/internal/storage/dolt/circuit_test.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	mysql "github.com/go-sql-driver/mysql"
+
+	"github.com/steveyegge/beads/internal/storage"
 )
 
 func TestCircuitBreaker_InitiallyAllows(t *testing.T) {
@@ -593,6 +595,49 @@ func TestWithRetryTyped1105DoesNotRetryOrTripCircuit(t *testing.T) {
 	}
 	if state := breaker.State(); state != circuitClosed {
 		t.Fatalf("circuit state = %q, want %q", state, circuitClosed)
+	}
+}
+
+func TestRunInTransactionPermanentCallbackErrorsDoNotTripCircuit(t *testing.T) {
+	t.Setenv("BEADS_TEST_MODE", "")
+	breaker := newTestCircuitBreaker(t)
+	store := &DoltStore{breaker: breaker}
+	callbackErr := errors.New("invalid connection")
+	callbackCalls := 0
+	runnerCalls := 0
+
+	for i := 0; i < circuitFailureThreshold; i++ {
+		err := store.runInTransaction(context.Background(), "test: external callback", func(storage.Transaction) error {
+			callbackCalls++
+			return callbackErr
+		}, func(_ context.Context, _ string, fn func(storage.Transaction) error) error {
+			runnerCalls++
+			return fn(nil)
+		})
+		if !errors.Is(err, callbackErr) {
+			t.Fatalf("RunInTransaction attempt %d error = %v, want %v", i+1, err, callbackErr)
+		}
+	}
+
+	if callbackCalls != circuitFailureThreshold {
+		t.Fatalf("callback calls = %d, want %d", callbackCalls, circuitFailureThreshold)
+	}
+	if runnerCalls != circuitFailureThreshold {
+		t.Fatalf("transaction runner calls = %d, want %d", runnerCalls, circuitFailureThreshold)
+	}
+	if state := breaker.State(); state != circuitClosed {
+		t.Fatalf("circuit state after external callback errors = %q, want %q", state, circuitClosed)
+	}
+
+	unrelatedCalls := 0
+	if err := store.withRetry(context.Background(), func() error {
+		unrelatedCalls++
+		return nil
+	}); err != nil {
+		t.Fatalf("unrelated operation after callback errors: %v", err)
+	}
+	if unrelatedCalls != 1 {
+		t.Fatalf("unrelated operation calls = %d, want 1", unrelatedCalls)
 	}
 }
 

--- a/internal/storage/dolt/claim_commit_boundary_test.go
+++ b/internal/storage/dolt/claim_commit_boundary_test.go
@@ -28,6 +28,7 @@ type claimCommitBoundaryDriver struct {
 	checkedUpdate   bool
 	verifyAssignee  string
 	verifyStatus    types.Status
+	activeWisp      bool
 
 	claimMutations  int
 	claimedIDs      []string
@@ -84,6 +85,9 @@ func (c *claimCommitBoundaryConn) QueryContext(_ context.Context, query string, 
 
 	switch {
 	case strings.Contains(query, "SELECT 1 FROM wisps WHERE id = ? LIMIT 1"):
+		if c.driver.activeWisp {
+			return &claimCommitBoundaryRows{columns: []string{"exists"}, values: [][]driver.Value{{int64(1)}}}, nil
+		}
 		return &claimCommitBoundaryRows{columns: []string{"exists"}}, nil
 	case strings.Contains(query, "SELECT assignee, status FROM issues WHERE id = ?"):
 		c.driver.claimStateReads++

--- a/internal/storage/dolt/claim_commit_boundary_test.go
+++ b/internal/storage/dolt/claim_commit_boundary_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -23,16 +24,22 @@ type claimCommitBoundaryDriver struct {
 	stageErr        error
 	commitErr       error
 	nothingToCommit bool
+	checkedUpdate   bool
+	verifyAssignee  string
+	verifyStatus    types.Status
 
-	claimMutations int
-	claimedIDs     []string
-	stageCalls     int
-	doltCommits    int
-	txCommits      int
-	txRollbacks    int
-	txAttempts     int
-	activeID       string
-	readyIDs       []string
+	claimMutations  int
+	claimedIDs      []string
+	updateMutations int
+	eventInserts    int
+	claimStateReads int
+	stageCalls      int
+	doltCommits     int
+	txCommits       int
+	txRollbacks     int
+	txAttempts      int
+	activeID        string
+	readyIDs        []string
 }
 
 func (d *claimCommitBoundaryDriver) Open(string) (driver.Conn, error) {
@@ -77,6 +84,18 @@ func (c *claimCommitBoundaryConn) QueryContext(_ context.Context, query string, 
 	switch {
 	case strings.Contains(query, "SELECT 1 FROM wisps WHERE id = ? LIMIT 1"):
 		return &claimCommitBoundaryRows{columns: []string{"exists"}}, nil
+	case strings.Contains(query, "SELECT assignee, status FROM issues WHERE id = ?"):
+		c.driver.claimStateReads++
+		assignee := ""
+		status := types.StatusOpen
+		if c.driver.checkedUpdate && c.driver.claimStateReads > 1 {
+			assignee = c.driver.verifyAssignee
+			status = c.driver.verifyStatus
+		}
+		return &claimCommitBoundaryRows{
+			columns: []string{"assignee", "status"},
+			values:  [][]driver.Value{{assignee, string(status)}},
+		}, nil
 	case strings.Contains(query, "SELECT id FROM issues"):
 		return &claimCommitBoundaryRows{
 			columns: []string{"id"},
@@ -126,6 +145,12 @@ func (c *claimCommitBoundaryConn) ExecContext(_ context.Context, query string, _
 	if strings.Contains(query, "UPDATE issues") && strings.Contains(query, "SET assignee") {
 		c.driver.claimMutations++
 		c.driver.claimedIDs = append(c.driver.claimedIDs, c.driver.activeID)
+	}
+	if strings.Contains(query, "UPDATE issues") && strings.Contains(query, "`title`") {
+		c.driver.updateMutations++
+	}
+	if strings.Contains(query, "INSERT INTO events") {
+		c.driver.eventInserts++
 	}
 	return driver.RowsAffected(1), nil
 }
@@ -278,6 +303,44 @@ func TestClaimReadyIssueDoltCommitResponseLossDoesNotDoubleClaim(t *testing.T) {
 	}
 	if driver.doltCommits != 1 {
 		t.Fatalf("DOLT_COMMIT calls = %d, want 1", driver.doltCommits)
+	}
+}
+
+func TestUpdateIssueCheckedMixedCoordinationCommitLossIsNotMasked(t *testing.T) {
+	driver := &claimCommitBoundaryDriver{
+		commitErr:      testConnectionLoss,
+		checkedUpdate:  true,
+		verifyAssignee: "alice",
+		verifyStatus:   types.StatusInProgress,
+	}
+	store := newClaimCommitBoundaryStore(driver)
+	store.serverMode = true
+	t.Cleanup(func() { _ = store.db.Close() })
+
+	expectedAssignee := ""
+	expectedStatus := string(types.StatusOpen)
+	err := store.UpdateIssueChecked(context.Background(), "claim-boundary", map[string]interface{}{
+		"assignee": "alice",
+		"status":   string(types.StatusInProgress),
+		"title":    "ordinary field must not be masked",
+	}, "alice", storage.UpdateIssueOptions{
+		ExpectedAssignee: &expectedAssignee,
+		ExpectedStatus:   &expectedStatus,
+	})
+	if !errors.Is(err, ErrCommitIndeterminate) {
+		t.Fatalf("UpdateIssueChecked() error = %v, want ErrCommitIndeterminate", err)
+	}
+	if !errors.Is(err, testConnectionLoss) {
+		t.Fatalf("UpdateIssueChecked() error = %v, want cause %v", err, testConnectionLoss)
+	}
+
+	driver.mu.Lock()
+	defer driver.mu.Unlock()
+	if driver.updateMutations != 1 || driver.eventInserts != 1 {
+		t.Fatalf("mixed update attempts = updates:%d events:%d, want updates:1 events:1", driver.updateMutations, driver.eventInserts)
+	}
+	if driver.txAttempts != 1 || driver.doltCommits != 1 || driver.txRollbacks != 1 {
+		t.Fatalf("transaction outcomes = attempts:%d Dolt commits:%d rollbacks:%d, want 1, 1, 1", driver.txAttempts, driver.doltCommits, driver.txRollbacks)
 	}
 }
 

--- a/internal/storage/dolt/claim_commit_boundary_test.go
+++ b/internal/storage/dolt/claim_commit_boundary_test.go
@@ -23,6 +23,7 @@ type claimCommitBoundaryDriver struct {
 
 	stageErr        error
 	commitErr       error
+	sqlCommitErr    error
 	nothingToCommit bool
 	checkedUpdate   bool
 	verifyAssignee  string
@@ -163,7 +164,7 @@ func (t *claimCommitBoundaryTx) Commit() error {
 	t.driver.mu.Lock()
 	defer t.driver.mu.Unlock()
 	t.driver.txCommits++
-	return nil
+	return t.driver.sqlCommitErr
 }
 
 func (t *claimCommitBoundaryTx) Rollback() error {

--- a/internal/storage/dolt/claim_commit_boundary_test.go
+++ b/internal/storage/dolt/claim_commit_boundary_test.go
@@ -311,6 +311,62 @@ func TestClaimReadyIssueDoltCommitResponseLossDoesNotDoubleClaim(t *testing.T) {
 	}
 }
 
+// TestClaimReadyIssueVerifyFailureDoesNotRecordCircuitSuccess pins the fix for
+// the verify-gated circuit-accounting major: when the SQL write commits but the
+// post-write verify-by-re-read contradicts the reported success, the breaker
+// must NOT be reset. withCircuitWrite records terminal success only after
+// verifiedReadyClaim returns nil, and the nested withRetryTx / verify reads
+// defer their own success reset to that boundary. Before the fix, withRetryTx
+// reset the breaker the instant the SQL commit returned — laundering a phantom
+// claim (reported success, failed verification) into breaker-health optimism.
+func TestClaimReadyIssueVerifyFailureDoesNotRecordCircuitSuccess(t *testing.T) {
+	t.Setenv("BEADS_TEST_MODE", "")
+	// The commit succeeds (no commitErr/sqlCommitErr), but the verify re-read
+	// returns ("", open) — checkedUpdate stays false — which cannot match
+	// claimedBy("alice"), so the claim reports success then fails verification.
+	driver := &claimCommitBoundaryDriver{readyIDs: []string{"ready-first"}}
+	store := newClaimCommitBoundaryStore(driver)
+	store.serverMode = true
+	breaker := newTestCircuitBreaker(t)
+	store.breaker = breaker
+	t.Cleanup(func() { _ = store.db.Close() })
+
+	// Prime the breaker to one failure short of tripping. If the operation
+	// preserves the counter, one further failure trips it; if the write reset it
+	// (the bug), the counter is back to zero and one failure leaves it closed.
+	for i := 0; i < circuitFailureThreshold-1; i++ {
+		breaker.RecordFailure()
+	}
+	if state := breaker.State(); state != circuitClosed {
+		t.Fatalf("circuit state after priming = %q, want %q", state, circuitClosed)
+	}
+
+	claimed, err := store.ClaimReadyIssue(context.Background(), types.WorkFilter{}, "alice")
+	if err == nil {
+		t.Fatal("ClaimReadyIssue() error = nil, want a verification failure")
+	}
+	if claimed != nil {
+		t.Fatalf("ClaimReadyIssue() claimed = %+v, want nil when verify contradicts the reported success", claimed)
+	}
+
+	// The write must have reported success (the SQL tx committed) so the buggy
+	// path's premature RecordSuccess would have fired here.
+	driver.mu.Lock()
+	if driver.claimMutations != 1 || driver.doltCommits != 1 || driver.txCommits != 1 {
+		t.Fatalf("write outcome = mutations:%d Dolt commits:%d SQL commits:%d, want 1,1,1 (write must report success)",
+			driver.claimMutations, driver.doltCommits, driver.txCommits)
+	}
+	driver.mu.Unlock()
+
+	// The verify failure must have left the breaker's failure counter intact:
+	// one more failure trips it. Had the write recorded success before verify,
+	// the counter would be zero and this single failure would leave it closed.
+	breaker.RecordFailure()
+	if state := breaker.State(); state != circuitOpen {
+		t.Fatalf("circuit state after verify-failed claim + one failure = %q, want %q (RecordSuccess must not fire before verify)", state, circuitOpen)
+	}
+}
+
 func TestUpdateIssueCheckedMixedCoordinationCommitLossIsNotMasked(t *testing.T) {
 	driver := &claimCommitBoundaryDriver{
 		commitErr:      testConnectionLoss,

--- a/internal/storage/dolt/claim_commit_boundary_test.go
+++ b/internal/storage/dolt/claim_commit_boundary_test.go
@@ -1,0 +1,286 @@
+package dolt
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// claimCommitBoundaryDriver models a permanent claim through its SQL mutation,
+// DOLT_ADD, and DOLT_COMMIT phases. It deliberately keeps the issue open after
+// rollback so an unsafe retry is visible as a second claim mutation.
+type claimCommitBoundaryDriver struct {
+	mu sync.Mutex
+
+	stageErr        error
+	commitErr       error
+	nothingToCommit bool
+
+	claimMutations int
+	claimedIDs     []string
+	stageCalls     int
+	doltCommits    int
+	txCommits      int
+	txRollbacks    int
+	txAttempts     int
+	activeID       string
+	readyIDs       []string
+}
+
+func (d *claimCommitBoundaryDriver) Open(string) (driver.Conn, error) {
+	return &claimCommitBoundaryConn{driver: d}, nil
+}
+
+func (d *claimCommitBoundaryDriver) Connect(context.Context) (driver.Conn, error) {
+	return &claimCommitBoundaryConn{driver: d}, nil
+}
+
+func (d *claimCommitBoundaryDriver) Driver() driver.Driver { return d }
+
+type claimCommitBoundaryConn struct {
+	driver *claimCommitBoundaryDriver
+}
+
+func (c *claimCommitBoundaryConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("claim commit boundary driver does not prepare statements")
+}
+
+func (c *claimCommitBoundaryConn) Close() error { return nil }
+
+func (c *claimCommitBoundaryConn) Begin() (driver.Tx, error) {
+	c.driver.mu.Lock()
+	c.driver.txAttempts++
+	c.driver.activeID = "claim-boundary"
+	if len(c.driver.readyIDs) > 0 {
+		index := c.driver.txAttempts - 1
+		if index >= len(c.driver.readyIDs) {
+			index = len(c.driver.readyIDs) - 1
+		}
+		c.driver.activeID = c.driver.readyIDs[index]
+	}
+	c.driver.mu.Unlock()
+	return &claimCommitBoundaryTx{driver: c.driver}, nil
+}
+
+func (c *claimCommitBoundaryConn) QueryContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Rows, error) {
+	c.driver.mu.Lock()
+	defer c.driver.mu.Unlock()
+
+	switch {
+	case strings.Contains(query, "SELECT 1 FROM wisps WHERE id = ? LIMIT 1"):
+		return &claimCommitBoundaryRows{columns: []string{"exists"}}, nil
+	case strings.Contains(query, "SELECT id FROM issues"):
+		return &claimCommitBoundaryRows{
+			columns: []string{"id"},
+			values:  [][]driver.Value{{c.driver.activeID}},
+		}, nil
+	case strings.Contains(query, "FROM issues") && strings.Contains(query, "LEFT JOIN leases") && strings.Contains(query, "WHERE id IN ("):
+		return &claimCommitBoundaryRows{
+			columns: claimBoundaryIssueColumns(),
+			values:  [][]driver.Value{claimBoundaryIssueValues(c.driver.activeID)},
+		}, nil
+	case strings.Contains(query, "FROM issues") && strings.Contains(query, "LEFT JOIN leases") && strings.Contains(query, "WHERE id = ?"):
+		return &claimCommitBoundaryRows{
+			columns: claimBoundaryIssueColumns(),
+			values:  [][]driver.Value{claimBoundaryIssueValues(c.driver.activeID)},
+		}, nil
+	case strings.Contains(query, "SELECT label FROM labels"):
+		return &claimCommitBoundaryRows{columns: []string{"label"}}, nil
+	case strings.Contains(query, "SELECT issue_id, label FROM labels"):
+		return &claimCommitBoundaryRows{columns: []string{"issue_id", "label"}}, nil
+	case strings.Contains(query, "SELECT name, category FROM custom_statuses"):
+		return &claimCommitBoundaryRows{columns: []string{"name", "category"}}, nil
+	case strings.Contains(query, "SELECT value FROM config"):
+		return &claimCommitBoundaryRows{columns: []string{"value"}}, nil
+	case strings.Contains(query, "CALL DOLT_ADD"):
+		c.driver.stageCalls++
+		if c.driver.stageErr != nil {
+			return nil, c.driver.stageErr
+		}
+		return &claimCommitBoundaryRows{columns: []string{"status"}}, nil
+	case strings.Contains(query, "CALL DOLT_COMMIT"):
+		c.driver.doltCommits++
+		if c.driver.commitErr != nil && c.driver.doltCommits == 1 {
+			return nil, c.driver.commitErr
+		}
+		if c.driver.nothingToCommit {
+			return nil, errors.New("nothing to commit")
+		}
+		return &claimCommitBoundaryRows{columns: []string{"hash"}}, nil
+	default:
+		return &claimCommitBoundaryRows{columns: []string{"value"}}, nil
+	}
+}
+
+func (c *claimCommitBoundaryConn) ExecContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Result, error) {
+	c.driver.mu.Lock()
+	defer c.driver.mu.Unlock()
+	if strings.Contains(query, "UPDATE issues") && strings.Contains(query, "SET assignee") {
+		c.driver.claimMutations++
+		c.driver.claimedIDs = append(c.driver.claimedIDs, c.driver.activeID)
+	}
+	return driver.RowsAffected(1), nil
+}
+
+type claimCommitBoundaryTx struct {
+	driver *claimCommitBoundaryDriver
+}
+
+func (t *claimCommitBoundaryTx) Commit() error {
+	t.driver.mu.Lock()
+	defer t.driver.mu.Unlock()
+	t.driver.txCommits++
+	return nil
+}
+
+func (t *claimCommitBoundaryTx) Rollback() error {
+	t.driver.mu.Lock()
+	defer t.driver.mu.Unlock()
+	t.driver.txRollbacks++
+	return nil
+}
+
+type claimCommitBoundaryRows struct {
+	columns []string
+	values  [][]driver.Value
+	index   int
+}
+
+func (r *claimCommitBoundaryRows) Columns() []string { return r.columns }
+func (r *claimCommitBoundaryRows) Close() error      { return nil }
+func (r *claimCommitBoundaryRows) Next(dest []driver.Value) error {
+	if r.index >= len(r.values) {
+		return io.EOF
+	}
+	copy(dest, r.values[r.index])
+	r.index++
+	return nil
+}
+
+func claimBoundaryIssueColumns() []string {
+	parts := strings.Split(strings.ReplaceAll(issueops.IssueSelectColumns, "\n", " "), ",")
+	for i := range parts {
+		parts[i] = strings.TrimSpace(parts[i])
+	}
+	return parts
+}
+
+func claimBoundaryIssueValues(id string) []driver.Value {
+	values := make([]driver.Value, 0, len(claimBoundaryIssueColumns()))
+	for _, column := range claimBoundaryIssueColumns() {
+		switch column {
+		case "id":
+			values = append(values, id)
+		case "title":
+			values = append(values, "claim boundary")
+		case "description", "design", "acceptance_criteria", "notes":
+			values = append(values, "")
+		case "status":
+			values = append(values, string(types.StatusOpen))
+		case "priority":
+			values = append(values, int64(2))
+		case "issue_type":
+			values = append(values, string(types.TypeTask))
+		case "compaction_level":
+			values = append(values, int64(0))
+		default:
+			values = append(values, nil)
+		}
+	}
+	return values
+}
+
+func newClaimCommitBoundaryStore(d *claimCommitBoundaryDriver) *DoltStore {
+	return &DoltStore{db: sql.OpenDB(d)}
+}
+
+func TestClaimIssueDoltCommitResponseLossIsIndeterminateAndNotReplayed(t *testing.T) {
+	driver := &claimCommitBoundaryDriver{commitErr: testConnectionLoss}
+	store := newClaimCommitBoundaryStore(driver)
+	t.Cleanup(func() { _ = store.db.Close() })
+
+	err := store.ClaimIssue(context.Background(), "claim-boundary", "alice")
+	if !errors.Is(err, ErrCommitIndeterminate) {
+		t.Fatalf("ClaimIssue() error = %v, want ErrCommitIndeterminate", err)
+	}
+	if !errors.Is(err, testConnectionLoss) {
+		t.Fatalf("ClaimIssue() error = %v, want cause %v", err, testConnectionLoss)
+	}
+
+	driver.mu.Lock()
+	defer driver.mu.Unlock()
+	if driver.claimMutations != 1 {
+		t.Fatalf("claim mutations = %d, want 1", driver.claimMutations)
+	}
+	if driver.doltCommits != 1 {
+		t.Fatalf("DOLT_COMMIT calls = %d, want 1", driver.doltCommits)
+	}
+	if driver.txCommits != 0 || driver.txRollbacks != 1 {
+		t.Fatalf("SQL transaction outcomes = commits:%d rollbacks:%d, want commits:0 rollbacks:1", driver.txCommits, driver.txRollbacks)
+	}
+}
+
+func TestClaimIssueDoltAddFailureCannotReportSuccess(t *testing.T) {
+	stageErr := errors.New("stage failed")
+	driver := &claimCommitBoundaryDriver{stageErr: stageErr, nothingToCommit: true}
+	store := newClaimCommitBoundaryStore(driver)
+	t.Cleanup(func() { _ = store.db.Close() })
+
+	err := store.ClaimIssue(context.Background(), "claim-boundary", "alice")
+	if !errors.Is(err, stageErr) {
+		t.Fatalf("ClaimIssue() error = %v, want stage failure %v", err, stageErr)
+	}
+
+	driver.mu.Lock()
+	defer driver.mu.Unlock()
+	if driver.stageCalls != 1 {
+		t.Fatalf("DOLT_ADD calls = %d, want 1", driver.stageCalls)
+	}
+	if driver.doltCommits != 0 {
+		t.Fatalf("DOLT_COMMIT calls = %d, want 0 after staging failure", driver.doltCommits)
+	}
+	if driver.txCommits != 0 || driver.txRollbacks != 1 {
+		t.Fatalf("SQL transaction outcomes = commits:%d rollbacks:%d, want commits:0 rollbacks:1", driver.txCommits, driver.txRollbacks)
+	}
+}
+
+func TestClaimReadyIssueDoltCommitResponseLossDoesNotDoubleClaim(t *testing.T) {
+	driver := &claimCommitBoundaryDriver{
+		commitErr: testConnectionLoss,
+		readyIDs:  []string{"ready-first", "ready-second"},
+	}
+	store := newClaimCommitBoundaryStore(driver)
+	t.Cleanup(func() { _ = store.db.Close() })
+
+	claimed, err := store.ClaimReadyIssue(context.Background(), types.WorkFilter{}, "alice")
+	if !errors.Is(err, ErrCommitIndeterminate) {
+		t.Fatalf("ClaimReadyIssue() error = %v, want ErrCommitIndeterminate", err)
+	}
+	if claimed != nil {
+		t.Fatalf("ClaimReadyIssue() claimed = %+v, want nil while commit outcome is indeterminate", claimed)
+	}
+
+	driver.mu.Lock()
+	defer driver.mu.Unlock()
+	if got, want := strings.Join(driver.claimedIDs, ","), "ready-first"; got != want {
+		t.Fatalf("claimed IDs = %q, want %q (no replay onto another ready issue)", got, want)
+	}
+	if driver.txAttempts != 1 {
+		t.Fatalf("transaction attempts = %d, want 1", driver.txAttempts)
+	}
+	if driver.doltCommits != 1 {
+		t.Fatalf("DOLT_COMMIT calls = %d, want 1", driver.doltCommits)
+	}
+}
+
+var _ driver.Connector = (*claimCommitBoundaryDriver)(nil)
+var _ driver.ExecerContext = (*claimCommitBoundaryConn)(nil)
+var _ driver.QueryerContext = (*claimCommitBoundaryConn)(nil)

--- a/internal/storage/dolt/claim_commit_boundary_test.go
+++ b/internal/storage/dolt/claim_commit_boundary_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/types"
+	publicops "github.com/steveyegge/beads/issueops"
 )
 
 // claimCommitBoundaryDriver models a permanent claim through its SQL mutation,
@@ -364,6 +365,134 @@ func TestClaimReadyIssueVerifyFailureDoesNotRecordCircuitSuccess(t *testing.T) {
 	breaker.RecordFailure()
 	if state := breaker.State(); state != circuitOpen {
 		t.Fatalf("circuit state after verify-failed claim + one failure = %q, want %q (RecordSuccess must not fire before verify)", state, circuitOpen)
+	}
+}
+
+// TestIssueOperationsUpdateClaimVerifyFailureDoesNotRecordCircuitSuccess pins the
+// fix for the verify-gated circuit-accounting major on the IssueLifecycle.Update
+// facade (the twin of the ClaimReadyIssue regression above). A facade claim whose
+// SQL/Dolt write commits but whose post-write verify-by-re-read contradicts the
+// reported success must NOT reset the breaker. verifiedUpdate now runs the write
+// and its verify under withCircuitWrite, so the nested runIssueOperationTx
+// inherits the managed context and defers its success reset to the boundary,
+// which records success only after verifiedClaimWrite returns nil. Before the fix,
+// withRetryTx reset the breaker the instant the SQL commit returned — laundering a
+// phantom facade claim (reported success, failed verification) into breaker-health
+// optimism.
+func TestIssueOperationsUpdateClaimVerifyFailureDoesNotRecordCircuitSuccess(t *testing.T) {
+	t.Setenv("BEADS_TEST_MODE", "")
+	// The commit succeeds (no commitErr/sqlCommitErr), but every verify re-read
+	// returns ("", open) — checkedUpdate stays false — which cannot match
+	// claimedAs("alice", in_progress), so the facade claim reports success then
+	// fails verification.
+	driver := &claimCommitBoundaryDriver{}
+	store := newClaimCommitBoundaryStore(driver)
+	store.serverMode = true
+	breaker := newTestCircuitBreaker(t)
+	store.breaker = breaker
+	t.Cleanup(func() { _ = store.db.Close() })
+
+	// Prime the breaker to one failure short of tripping. If the operation
+	// preserves the counter, one further failure trips it; if the write reset it
+	// (the bug), the counter is back to zero and one failure leaves it closed.
+	for i := 0; i < circuitFailureThreshold-1; i++ {
+		breaker.RecordFailure()
+	}
+	if state := breaker.State(); state != circuitClosed {
+		t.Fatalf("circuit state after priming = %q, want %q", state, circuitClosed)
+	}
+
+	operations := &issueOperations{store: store}
+	_, err := operations.Update(context.Background(), publicops.UpdateRequest{
+		Actor:   "alice",
+		IssueID: "claim-boundary",
+		Claim:   true,
+	})
+	if err == nil {
+		t.Fatal("facade claim Update error = nil, want a verification failure")
+	}
+	if !strings.Contains(err.Error(), "did not land") {
+		t.Fatalf("facade claim Update error = %v, want a verify 'did not land' failure", err)
+	}
+
+	// The write must have reported success (the SQL tx committed and DOLT_COMMIT
+	// landed) so the buggy path's premature RecordSuccess would have fired here.
+	driver.mu.Lock()
+	if driver.claimMutations != 1 || driver.doltCommits != 1 || driver.txCommits != 1 {
+		t.Fatalf("write outcome = mutations:%d Dolt commits:%d SQL commits:%d, want 1,1,1 (write must report success)",
+			driver.claimMutations, driver.doltCommits, driver.txCommits)
+	}
+	driver.mu.Unlock()
+
+	// The verify failure must have left the breaker's failure counter intact: one
+	// more failure trips it. Had the write recorded success before verify, the
+	// counter would be zero and this single failure would leave it closed.
+	breaker.RecordFailure()
+	if state := breaker.State(); state != circuitOpen {
+		t.Fatalf("circuit state after verify-failed facade claim + one failure = %q, want %q (RecordSuccess must not fire before verify)", state, circuitOpen)
+	}
+}
+
+// TestIssueOperationsUpdateGuardedVerifyFailureDoesNotRecordCircuitSuccess is the
+// coordination-only guarded twin of the facade-claim regression above. A guarded
+// status write whose compare-and-set precondition passes and whose write commits,
+// but whose post-write verify shows the coordination state did not land, must not
+// reset the breaker either. The guarded branch is verifiable for the same reason a
+// claim is — its postcondition is provable from an assignee/status re-read — so it
+// travels the same withCircuitWrite boundary and must defer success accounting the
+// same way.
+func TestIssueOperationsUpdateGuardedVerifyFailureDoesNotRecordCircuitSuccess(t *testing.T) {
+	t.Setenv("BEADS_TEST_MODE", "")
+	// checkedUpdate stays false, so every SELECT assignee,status returns
+	// ("", open). The CAS read sees open and matches ExpectedStatus open, so the
+	// guard passes and the write runs; the post-write verify sees open again,
+	// which cannot match the wanted status in_progress, so the update reports
+	// success then fails verification.
+	driver := &claimCommitBoundaryDriver{}
+	store := newClaimCommitBoundaryStore(driver)
+	store.serverMode = true
+	breaker := newTestCircuitBreaker(t)
+	store.breaker = breaker
+	t.Cleanup(func() { _ = store.db.Close() })
+
+	for i := 0; i < circuitFailureThreshold-1; i++ {
+		breaker.RecordFailure()
+	}
+	if state := breaker.State(); state != circuitClosed {
+		t.Fatalf("circuit state after priming = %q, want %q", state, circuitClosed)
+	}
+
+	operations := &issueOperations{store: store}
+	expectedStatus := types.StatusOpen
+	_, err := operations.Update(context.Background(), publicops.UpdateRequest{
+		Actor:          "alice",
+		IssueID:        "claim-boundary",
+		ExpectedStatus: &expectedStatus,
+		Patch: publicops.IssuePatch{
+			Status: publicops.Field[publicops.Status]{Set: true, Value: types.StatusInProgress},
+		},
+	})
+	if err == nil {
+		t.Fatal("guarded coordination Update error = nil, want a verification failure")
+	}
+	if !strings.Contains(err.Error(), "did not land") {
+		t.Fatalf("guarded coordination Update error = %v, want a verify 'did not land' failure", err)
+	}
+
+	// A coordination-only status write trips neither driver mutation counter (its
+	// UPDATE leads with updated_at and back-tick-quotes the status column), so the
+	// write-reported-success signal is the committed SQL tx plus the landed
+	// DOLT_COMMIT — exactly what would have fired the buggy premature RecordSuccess.
+	driver.mu.Lock()
+	if driver.doltCommits != 1 || driver.txCommits != 1 {
+		t.Fatalf("write outcome = Dolt commits:%d SQL commits:%d, want 1,1 (write must report success)",
+			driver.doltCommits, driver.txCommits)
+	}
+	driver.mu.Unlock()
+
+	breaker.RecordFailure()
+	if state := breaker.State(); state != circuitOpen {
+		t.Fatalf("circuit state after verify-failed guarded update + one failure = %q, want %q (RecordSuccess must not fire before verify)", state, circuitOpen)
 	}
 }
 

--- a/internal/storage/dolt/claim_verify.go
+++ b/internal/storage/dolt/claim_verify.go
@@ -30,9 +30,9 @@ import (
 //
 //   - reported success        -> verify; a mismatch fails LOUDLY (the caller
 //     must know it does not hold the claim)
-//   - ambiguous commit loss   -> (errCommitPhase, surfaced by withRetryTx as
-//     indeterminate) verify; applied -> success, verified rolled back -> replay
-//     the write once (safe: nothing landed)
+//   - ambiguous commit loss   -> (ErrCommitIndeterminate, surfaced by
+//     withRetryTx) verify; applied -> success, every other outcome returns the
+//     original indeterminate error without replaying a mutation
 //   - any other error         -> honest failure (CAS lost, not-claimable, or
 //     pre-commit errors withRetryTx already retried); no verify needed
 //
@@ -176,9 +176,7 @@ func (s *DoltStore) readClaimStateIn(ctx context.Context, table, id string) (str
 }
 
 // verifiedClaimWrite runs write and resolves its outcome against the database
-// state per the protocol above. write must be safe to run twice when its first
-// run verifiably did not land (all claim-family writes are: they are CAS
-// updates, idempotent for the winning actor).
+// state per the protocol above.
 //
 // A verify that contradicts a reported success can in principle also be a
 // legitimate concurrent mutation (a forced unclaim landing within the
@@ -188,40 +186,30 @@ func (s *DoltStore) verifiedClaimWrite(ctx context.Context, id string, post clai
 	if !s.serverMode || s.isActiveWisp(ctx, id) {
 		return write()
 	}
-	const maxReplays = 1
-	for attempt := 0; ; attempt++ {
-		err := write()
-		if err != nil && !errors.Is(err, errCommitPhase) {
+	err := write()
+	if err != nil && !errors.Is(err, ErrCommitIndeterminate) {
+		return err
+	}
+	assignee, status, verr := s.readClaimState(ctx, id)
+	if verr != nil {
+		if err != nil {
 			return err
 		}
-		assignee, status, verr := s.readClaimState(ctx, id)
-		if verr != nil {
-			if err != nil {
-				return err // the honest indeterminate error from withRetryTx
-			}
-			return fmt.Errorf("%s of %s reported success but could not be verified (server degraded?): %w — re-read the issue before trusting the %s",
-				post.op, id, verr, post.op)
-		}
-		if post.want(assignee, status) {
-			if err != nil {
-				doltMetrics.claimVerifyRecovered.Add(ctx, 1, metric.WithAttributes(
-					attribute.String("op", post.op), attribute.String("outcome", "applied")))
-			}
-			return nil
-		}
-		if err != nil {
-			if attempt < maxReplays {
-				// Verified rolled back: nothing landed, so one replay is safe.
-				doltMetrics.claimVerifyRecovered.Add(ctx, 1, metric.WithAttributes(
-					attribute.String("op", post.op), attribute.String("outcome", "replayed")))
-				continue
-			}
-			return fmt.Errorf("%s of %s did not land (connection lost during commit; rollback verified by re-read): %w",
-				post.op, id, err)
-		}
-		doltMetrics.claimVerifyLost.Add(ctx, 1, metric.WithAttributes(
-			attribute.String("op", post.op)))
-		return fmt.Errorf("%s of %s reported success but did not land (found assignee=%q status=%q, want %s) — server likely degraded; treat the %s as NOT applied",
-			post.op, id, assignee, status, post.desc, post.op)
+		return fmt.Errorf("%s of %s reported success but could not be verified (server degraded?): %w — re-read the issue before trusting the %s",
+			post.op, id, verr, post.op)
 	}
+	if post.want(assignee, status) {
+		if err != nil {
+			doltMetrics.claimVerifyRecovered.Add(ctx, 1, metric.WithAttributes(
+				attribute.String("op", post.op), attribute.String("outcome", "applied")))
+		}
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	doltMetrics.claimVerifyLost.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("op", post.op)))
+	return fmt.Errorf("%s of %s reported success but did not land (found assignee=%q status=%q, want %s) — server likely degraded; treat the %s as NOT applied",
+		post.op, id, assignee, status, post.desc, post.op)
 }

--- a/internal/storage/dolt/claim_verify.go
+++ b/internal/storage/dolt/claim_verify.go
@@ -187,9 +187,6 @@ func (s *DoltStore) verifiedClaimWrite(ctx context.Context, id string, post clai
 	}
 	assignee, status, verr := s.readClaimState(ctx, id)
 	if verr != nil {
-		if err != nil {
-			return err
-		}
 		return fmt.Errorf("%s of %s reported success but could not be verified (server degraded?): %w — re-read the issue before trusting the %s",
 			post.op, id, verr, post.op)
 	}

--- a/internal/storage/dolt/claim_verify.go
+++ b/internal/storage/dolt/claim_verify.go
@@ -81,24 +81,21 @@ func unclaimed() claimPostcondition {
 // guardedUpdatePostcondition derives the postcondition for a guarded update
 // (bd-wsqvw: UpdateIssueOptions.ExpectedAssignee/ExpectedStatus) that writes
 // the coordination fields. ok is false — no verification — when the update
-// carries no guard, or when it guards but writes neither assignee nor status
-// (a guarded edit of ordinary fields is not claim-family: a lost notes edit is
-// an annoyance, not a phantom claim). The postcondition checks only the
-// coordination fields the update actually sets, since the others may be
-// legitimately touched by concurrent writers.
-//
-// Attribution narrowness (lion review, PR #5008): because only the SET
-// coordination fields are checked, a commit-phase loss whose transaction
-// verifiably rolled back can still verify as "applied" when a racing actor
-// landed the SAME target values inside the verify window. The coordination
-// state is then correct but it is the racer's write, not ours: any ordinary
-// fields riding the same update (title, notes, …) and our event row are
-// silently gone despite the reported success. Mitigation is usage-side, not
-// machinery: keep guarded coordination writes single-purpose (assignee/status
-// only), which is how the wheelhouse park/restore consumers use them.
+// carries no guard, when it guards but writes neither assignee nor status, or
+// when ordinary fields ride alongside the coordination write. Verification
+// reads only assignee/status, so it cannot prove that a mixed update (or its
+// event) landed; such a write must retain ErrCommitIndeterminate instead of
+// turning a matching coordination state into false success. For a
+// coordination-only update, the postcondition checks every field requested by
+// the caller while allowing other coordination fields to change concurrently.
 func guardedUpdatePostcondition(opts storage.UpdateIssueOptions, updates map[string]interface{}) (claimPostcondition, bool) {
 	if opts.ExpectedAssignee == nil && opts.ExpectedStatus == nil {
 		return claimPostcondition{}, false
+	}
+	for field := range updates {
+		if field != "assignee" && field != "status" {
+			return claimPostcondition{}, false
+		}
 	}
 	newAssignee, setsAssignee := updates["assignee"].(string)
 	newStatus, setsStatus := updates["status"].(string)

--- a/internal/storage/dolt/claim_verify.go
+++ b/internal/storage/dolt/claim_verify.go
@@ -3,7 +3,6 @@ package dolt
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -30,9 +29,8 @@ import (
 //
 //   - reported success        -> verify; a mismatch fails LOUDLY (the caller
 //     must know it does not hold the claim)
-//   - ambiguous commit loss   -> (ErrCommitIndeterminate, surfaced by
-//     withRetryTx) verify; applied -> success, every other outcome returns the
-//     original indeterminate error without replaying a mutation
+//   - ambiguous commit loss   -> retain ErrCommitIndeterminate. Assignee and
+//     status alone cannot prove the lease and actor-attributed event landed.
 //   - any other error         -> honest failure (CAS lost, not-claimable, or
 //     pre-commit errors withRetryTx already retried); no verify needed
 //
@@ -184,7 +182,7 @@ func (s *DoltStore) verifiedClaimWrite(ctx context.Context, id string, post clai
 		return write()
 	}
 	err := write()
-	if err != nil && !errors.Is(err, ErrCommitIndeterminate) {
+	if err != nil {
 		return err
 	}
 	assignee, status, verr := s.readClaimState(ctx, id)
@@ -196,14 +194,7 @@ func (s *DoltStore) verifiedClaimWrite(ctx context.Context, id string, post clai
 			post.op, id, verr, post.op)
 	}
 	if post.want(assignee, status) {
-		if err != nil {
-			doltMetrics.claimVerifyRecovered.Add(ctx, 1, metric.WithAttributes(
-				attribute.String("op", post.op), attribute.String("outcome", "applied")))
-		}
 		return nil
-	}
-	if err != nil {
-		return err
 	}
 	doltMetrics.claimVerifyLost.Add(ctx, 1, metric.WithAttributes(
 		attribute.String("op", post.op)))

--- a/internal/storage/dolt/claim_verify_test.go
+++ b/internal/storage/dolt/claim_verify_test.go
@@ -98,14 +98,14 @@ func TestVerifiedReadyClaimDoesNotReplayDefiniteMySQLError(t *testing.T) {
 	}
 }
 
-// TestVerifiedClaimWriteConvertsAppliedIndeterminate: the wy-x543k direction —
-// the write actually landed but the connection died during commit and bd
-// printed an error. Verify-by-re-read must convert it into an accurate success.
-func TestVerifiedClaimWriteConvertsAppliedIndeterminate(t *testing.T) {
+// TestVerifiedClaimWriteRetainsAppliedIndeterminate proves matching issue
+// fields alone do not prove the lease and actor-attributed event also landed.
+func TestVerifiedClaimWriteRetainsAppliedIndeterminate(t *testing.T) {
 	s, cleanup := setupTestStore(t)
 	defer cleanup()
 	ctx, cancel := testContext(t)
 	defer cancel()
+	s.serverMode = true
 
 	id := claimVerifyTestIssue(t, s)
 	if err := rawClaim(t, s, id, "alice"); err != nil {
@@ -117,8 +117,8 @@ func TestVerifiedClaimWriteConvertsAppliedIndeterminate(t *testing.T) {
 		calls++
 		return fmt.Errorf("write commit result indeterminate after connection loss: i/o timeout (%w)", ErrCommitIndeterminate)
 	})
-	if err != nil {
-		t.Fatalf("expected applied-indeterminate to resolve to success, got: %v", err)
+	if !errors.Is(err, ErrCommitIndeterminate) {
+		t.Fatalf("applied-indeterminate error = %v, want ErrCommitIndeterminate", err)
 	}
 	if calls != 1 {
 		t.Fatalf("write must not be replayed when the re-read shows it applied; ran %d times", calls)

--- a/internal/storage/dolt/claim_verify_test.go
+++ b/internal/storage/dolt/claim_verify_test.go
@@ -115,7 +115,7 @@ func TestVerifiedClaimWriteConvertsAppliedIndeterminate(t *testing.T) {
 	calls := 0
 	err := s.verifiedClaimWrite(ctx, id, claimedBy("alice"), func() error {
 		calls++
-		return fmt.Errorf("write commit result indeterminate after connection loss: i/o timeout (%w)", errCommitPhase)
+		return fmt.Errorf("write commit result indeterminate after connection loss: i/o timeout (%w)", ErrCommitIndeterminate)
 	})
 	if err != nil {
 		t.Fatalf("expected applied-indeterminate to resolve to success, got: %v", err)
@@ -125,10 +125,9 @@ func TestVerifiedClaimWriteConvertsAppliedIndeterminate(t *testing.T) {
 	}
 }
 
-// TestVerifiedClaimWriteReplaysVerifiedRollback: the wy-ejph3 direction — the
-// connection died during commit AND the transaction rolled back. The re-read
-// proves nothing landed, so one replay is safe and must proceed.
-func TestVerifiedClaimWriteReplaysVerifiedRollback(t *testing.T) {
+// TestVerifiedClaimWriteDoesNotReplayIndeterminate pins the public no-replay
+// contract when the verified postcondition does not match.
+func TestVerifiedClaimWriteDoesNotReplayIndeterminate(t *testing.T) {
 	s, cleanup := setupTestStore(t)
 	defer cleanup()
 	ctx, cancel := testContext(t)
@@ -137,27 +136,24 @@ func TestVerifiedClaimWriteReplaysVerifiedRollback(t *testing.T) {
 	id := claimVerifyTestIssue(t, s)
 
 	calls := 0
+	indeterminate := fmt.Errorf("write commit result indeterminate after connection loss: i/o timeout (%w)", ErrCommitIndeterminate)
 	err := s.verifiedClaimWrite(ctx, id, claimedBy("alice"), func() error {
 		calls++
-		if calls == 1 {
-			// First attempt: commit-phase connection loss, nothing landed.
-			return fmt.Errorf("write commit result indeterminate after connection loss: i/o timeout (%w)", errCommitPhase)
-		}
-		return rawClaim(t, s, id, "alice")
+		return indeterminate
 	})
-	if err != nil {
-		t.Fatalf("expected verified-rollback replay to succeed, got: %v", err)
+	if err != indeterminate {
+		t.Fatalf("error = %v, want original indeterminate error %v", err, indeterminate)
 	}
-	if calls != 2 {
-		t.Fatalf("expected exactly one replay (2 write runs), got %d", calls)
+	if calls != 1 {
+		t.Fatalf("write runs = %d, want exactly one after indeterminate commit", calls)
 	}
 
 	assignee, status, err := s.readClaimState(ctx, id)
 	if err != nil {
 		t.Fatalf("read claim state: %v", err)
 	}
-	if assignee != "alice" || status != types.StatusInProgress {
-		t.Fatalf("replayed claim not in effect: assignee=%q status=%q", assignee, status)
+	if assignee != "" || status != types.StatusOpen {
+		t.Fatalf("claim was replayed: assignee=%q status=%q", assignee, status)
 	}
 }
 
@@ -183,10 +179,10 @@ func TestVerifiedClaimWriteFailsLoudlyOnLostWrite(t *testing.T) {
 	}
 }
 
-// TestVerifiedClaimWriteIndeterminateStaysIndeterminateTwice: a replay that
-// itself dies at commit phase with nothing landed must not loop forever — the
-// one-replay budget exhausts and the caller gets the verified-rollback error.
-func TestVerifiedClaimWriteIndeterminateStaysIndeterminateTwice(t *testing.T) {
+// TestVerifiedReadyClaimDoesNotReplayIndeterminate proves ready-claim does not
+// re-scan the ready front and possibly claim a different issue after an
+// indeterminate commit response.
+func TestVerifiedReadyClaimDoesNotReplayIndeterminate(t *testing.T) {
 	s, cleanup := setupTestStore(t)
 	defer cleanup()
 	ctx, cancel := testContext(t)
@@ -195,66 +191,30 @@ func TestVerifiedClaimWriteIndeterminateStaysIndeterminateTwice(t *testing.T) {
 	id := claimVerifyTestIssue(t, s)
 
 	calls := 0
-	err := s.verifiedClaimWrite(ctx, id, claimedBy("alice"), func() error {
-		calls++
-		return fmt.Errorf("write commit result indeterminate after connection loss: i/o timeout (%w)", errCommitPhase)
-	})
-	if err == nil {
-		t.Fatal("expected failure after replay budget exhausted, got nil")
-	}
-	if calls != 2 {
-		t.Fatalf("expected exactly 2 write runs (original + one replay), got %d", calls)
-	}
-	if !strings.Contains(err.Error(), "did not land") {
-		t.Fatalf("error should report the verified rollback, got: %v", err)
-	}
-}
-
-// TestVerifiedReadyClaimReplayConvertsAppliedIndeterminate: the replay leg of
-// the bespoke ready-claim path must keep the wrapper's verify semantics (lion
-// review on PR #5006). First attempt: commit-phase loss, verified rolled back
-// (nothing landed) -> replay. The replay actually lands the claim but ALSO
-// reports commit-phase loss (the wy-x543k direction, now on attempt two). The
-// verify pass must convert that into an accurate success instead of returning
-// the raw indeterminate error — which would leave an applied claim orphaned
-// on an issue the caller was told it failed to claim.
-func TestVerifiedReadyClaimReplayConvertsAppliedIndeterminate(t *testing.T) {
-	s, cleanup := setupTestStore(t)
-	defer cleanup()
-	ctx, cancel := testContext(t)
-	defer cancel()
-
-	id := claimVerifyTestIssue(t, s)
-
-	calls := 0
+	indeterminate := fmt.Errorf("write commit result indeterminate after connection loss: i/o timeout (%w)", ErrCommitIndeterminate)
 	got, err := s.verifiedReadyClaim(ctx, "alice", func() (*types.Issue, error) {
 		calls++
-		if calls == 1 {
-			// Commit-phase loss, transaction rolled back: nothing landed.
-			return &types.Issue{ID: id}, fmt.Errorf("write commit result indeterminate after connection loss: i/o timeout (%w)", errCommitPhase)
-		}
-		// Replay: the claim lands, but the connection dies during commit again.
-		if err := rawClaim(t, s, id, "alice"); err != nil {
-			return nil, err
-		}
-		return &types.Issue{ID: id}, fmt.Errorf("write commit result indeterminate after connection loss: i/o timeout (%w)", errCommitPhase)
+		return &types.Issue{ID: id}, indeterminate
 	})
-	if err != nil {
-		t.Fatalf("expected applied-indeterminate replay to resolve to success, got: %v", err)
+	if err != indeterminate {
+		t.Fatalf("error = %v, want original indeterminate error %v", err, indeterminate)
 	}
-	if got == nil || got.ID != id {
-		t.Fatalf("recovered success must return the claimed issue %s, got %+v", id, got)
+	if got != nil {
+		t.Fatalf("claimed issue = %+v, want nil", got)
 	}
-	if calls != 2 {
-		t.Fatalf("expected exactly one replay (2 write runs), got %d", calls)
+	if calls != 1 {
+		t.Fatalf("write runs = %d, want exactly one after indeterminate commit", calls)
 	}
 
 	assignee, status, verr := s.readClaimState(ctx, id)
 	if verr != nil {
 		t.Fatalf("read claim state: %v", verr)
 	}
-	if assignee != "alice" || status != types.StatusInProgress {
-		t.Fatalf("claim not in effect after recovered replay: assignee=%q status=%q", assignee, status)
+	if assignee != "" || status != types.StatusOpen {
+		t.Fatalf("ready claim was replayed: assignee=%q status=%q", assignee, status)
+	}
+	if !errors.Is(err, ErrCommitIndeterminate) {
+		t.Fatalf("error = %v, want ErrCommitIndeterminate", err)
 	}
 }
 

--- a/internal/storage/dolt/commit_dirty_wisp_test.go
+++ b/internal/storage/dolt/commit_dirty_wisp_test.go
@@ -1,0 +1,107 @@
+package dolt
+
+import (
+	"context"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestCommitToleratesDirtyIgnoredWisp locks in that a dirty dolt_ignore'd table
+// (a wisp) is invisible to the commit path: HasCommittablePending reports
+// nothing to commit and Commit succeeds without staging or destroying it.
+//
+// A dirty wisp is the normal steady state — creating an ephemeral issue writes
+// the wisps table and deliberately does not DOLT_COMMIT it (issues.go). Both
+// commitWorkingSet and HasCommittablePending exclude such tables with a
+// dolt_ignore anti-join; before that filter, commitWorkingSet fed every
+// dolt_status row into a fail-hard DOLT_ADD loop, so an ordinary Commit could
+// fail (or its behavior silently depended on Dolt's version-specific handling
+// of DOLT_ADD on an ignored table — a no-op on 2.2.0). This test dirties a wisp
+// and asserts Commit() succeeds, so a future Dolt that changes ignored-table
+// staging cannot regress that silently.
+//
+// The assertion bites on this harness: setupTestStore's shared branch-per-test
+// database materializes ignored tables at HEAD, so a dirty wisp really does
+// surface in dolt_status (the same reason TestCreateIssueCommitsInitialRelational
+// Data must exclude the dolt_ignore'd events table from its clean check). Without
+// the anti-join, HasCommittablePending would therefore see the wisp and wrongly
+// report committable work.
+func TestCommitToleratesDirtyIgnoredWisp(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	// A durable create auto-commits, leaving a clean committed baseline and
+	// proving the store commits real work — so a later "nothing to commit" is
+	// the anti-join at work, not a dead store.
+	durable := &types.Issue{
+		ID:        "dirty-wisp-durable",
+		Title:     "Durable baseline",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, durable, "tester"); err != nil {
+		t.Fatalf("CreateIssue durable: %v", err)
+	}
+	requireCleanTables(ctx, t, store, "issues")
+
+	// An ephemeral create writes the wisps table without committing it.
+	wisp := &types.Issue{
+		ID:        "dirty-wisp-ephemeral",
+		Title:     "Ephemeral wisp",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+	}
+	if err := store.CreateIssue(ctx, wisp, "tester"); err != nil {
+		t.Fatalf("CreateIssue wisp: %v", err)
+	}
+
+	// Precondition: the ignored wisps table is genuinely dirty, so the
+	// anti-join is actually exercised rather than passing vacuously. If a future
+	// Dolt stops surfacing ignored tables here, this fails loudly — the premise
+	// changed and the anti-join's coverage must be re-examined.
+	if !tableDirty(ctx, t, store, "wisps") {
+		t.Fatal("wisps not dirty after ephemeral create; anti-join would pass vacuously")
+	}
+
+	// The wisp is the only dirty table, and it is ignored, so the commit path
+	// must see nothing committable.
+	pending, err := store.HasCommittablePending(ctx)
+	if err != nil {
+		t.Fatalf("HasCommittablePending: %v", err)
+	}
+	if pending {
+		t.Fatal("HasCommittablePending = true with only a dirty ignored wisp; anti-join not applied")
+	}
+
+	// The reviewer's core ask: Commit tolerates the dirty ignored table.
+	if err := store.Commit(ctx, "commit over a dirty wisp"); err != nil {
+		t.Fatalf("Commit over a dirty ignored wisp: %v", err)
+	}
+
+	// Commit left the ignored table exactly as it was — neither staged into a
+	// commit nor discarded. The wisp is still dirty and still readable.
+	if !tableDirty(ctx, t, store, "wisps") {
+		t.Fatal("wisps no longer dirty after Commit; the ignored table was touched")
+	}
+	if _, err := store.GetIssue(ctx, wisp.ID); err != nil {
+		t.Fatalf("GetIssue wisp after Commit: %v", err)
+	}
+}
+
+// tableDirty reports whether a table shows uncommitted changes in dolt_status.
+func tableDirty(ctx context.Context, t *testing.T, store *DoltStore, table string) bool {
+	t.Helper()
+	var n int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM dolt_status WHERE table_name = ?", table).Scan(&n); err != nil {
+		t.Fatalf("query dolt_status for %s: %v", table, err)
+	}
+	return n > 0
+}

--- a/internal/storage/dolt/credentials.go
+++ b/internal/storage/dolt/credentials.go
@@ -264,6 +264,12 @@ func (s *DoltStore) decryptPassword(encrypted []byte) (string, error) {
 // AddFederationPeer adds or updates a federation peer with credentials.
 // This stores credentials in the database and also adds the Dolt remote.
 func (s *DoltStore) AddFederationPeer(ctx context.Context, peer *storage.FederationPeer) error {
+	return s.withCircuitWrite(ctx, func(ctx context.Context) error {
+		return s.addFederationPeer(ctx, peer)
+	})
+}
+
+func (s *DoltStore) addFederationPeer(ctx context.Context, peer *storage.FederationPeer) error {
 	// Validate peer name
 	if err := validatePeerName(peer.Name); err != nil {
 		return fmt.Errorf("invalid peer name: %w", err)

--- a/internal/storage/dolt/dependencies.go
+++ b/internal/storage/dolt/dependencies.go
@@ -29,6 +29,12 @@ func (s *DoltStore) AddDependency(ctx context.Context, dep *types.Dependency, ac
 // Delegates SQL work to issueops.AddDependencyInTx; handles Dolt versioning
 // and cache invalidation. EmitEvent records a dependency_added history event.
 func (s *DoltStore) AddDependencyWithOptions(ctx context.Context, dep *types.Dependency, actor string, addOpts storage.DependencyAddOptions) error {
+	return s.withCircuitWrite(ctx, func(ctx context.Context) error {
+		return s.addDependencyWithOptions(ctx, dep, actor, addOpts)
+	})
+}
+
+func (s *DoltStore) addDependencyWithOptions(ctx context.Context, dep *types.Dependency, actor string, addOpts storage.DependencyAddOptions) error {
 	isCrossPrefix := isCrossPrefixDep(dep.IssueID, dep.DependsOnID)
 
 	// Route to wisp_dependencies if the source is an active wisp.
@@ -88,49 +94,48 @@ func (s *DoltStore) RemoveDependency(ctx context.Context, issueID, dependsOnID s
 // Delegates SQL work to issueops.RemoveDependencyInTx which handles wisp routing.
 // EmitEvent records a dependency_removed history event for the explicit dep verb.
 func (s *DoltStore) RemoveDependencyWithOptions(ctx context.Context, issueID, dependsOnID string, actor string, rmOpts storage.DependencyRemoveOptions) error {
-	// Wisps live in dolt_ignored tables — skip Dolt versioning entirely.
-	if s.isActiveWisp(ctx, issueID) {
+	return s.withCircuitWrite(ctx, func(ctx context.Context) error {
+		// Wisps live in dolt_ignored tables — skip Dolt versioning entirely.
+		if s.isActiveWisp(ctx, issueID) {
+			tx, err := s.db.BeginTx(ctx, nil)
+			if err != nil {
+				return fmt.Errorf("failed to begin transaction: %w", err)
+			}
+			defer func() { _ = tx.Rollback() }()
+			if _, err := issueops.RemoveDependencyInTx(ctx, tx, issueID, dependsOnID, actor, rmOpts.EmitEvent); err != nil {
+				return err
+			}
+			if err := s.commitSQLTx(ctx, "commit remove wisp dependency", tx); err != nil {
+				return err
+			}
+			return nil
+		}
+
 		tx, err := s.db.BeginTx(ctx, nil)
 		if err != nil {
 			return fmt.Errorf("failed to begin transaction: %w", err)
 		}
 		defer func() { _ = tx.Rollback() }()
-		if _, err := issueops.RemoveDependencyInTx(ctx, tx, issueID, dependsOnID, actor, rmOpts.EmitEvent); err != nil {
+
+		eventWritten, err := issueops.RemoveDependencyInTx(ctx, tx, issueID, dependsOnID, actor, rmOpts.EmitEvent)
+		if err != nil {
 			return err
 		}
-		if err := s.commitSQLTx(ctx, "commit remove wisp dependency", tx); err != nil {
+
+		if err := s.commitSQLTx(ctx, "sql commit", tx); err != nil {
 			return err
 		}
-		return nil
-	}
-
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	eventWritten, err := issueops.RemoveDependencyInTx(ctx, tx, issueID, dependsOnID, actor, rmOpts.EmitEvent)
-	if err != nil {
-		return err
-	}
-
-	if err := s.commitSQLTx(ctx, "sql commit", tx); err != nil {
-		return err
-	}
-	// GH#2455: Use explicit DOLT_ADD to avoid sweeping up stale config changes.
-	// Stage events only when RemoveDependencyInTx actually recorded a
-	// dependency_removed event (explicit verb + genuine edge removal). A
-	// structural or missing-edge remove writes no event, so staging events would
-	// sweep unrelated pending event rows into this dependency commit.
-	tables := []string{"dependencies"}
-	if eventWritten {
-		tables = append(tables, "events")
-	}
-	if err := s.doltAddAndCommit(ctx, tables, "dependency: remove "+issueID+" -> "+dependsOnID); err != nil {
-		return err
-	}
-	return nil
+		// GH#2455: Use explicit DOLT_ADD to avoid sweeping up stale config changes.
+		// Stage events only when RemoveDependencyInTx actually recorded a
+		// dependency_removed event (explicit verb + genuine edge removal). A
+		// structural or missing-edge remove writes no event, so staging events would
+		// sweep unrelated pending event rows into this dependency commit.
+		tables := []string{"dependencies"}
+		if eventWritten {
+			tables = append(tables, "events")
+		}
+		return s.doltAddAndCommit(ctx, tables, "dependency: remove "+issueID+" -> "+dependsOnID)
+	})
 }
 
 // GetDependencies retrieves issues that this issue depends on

--- a/internal/storage/dolt/dependencies.go
+++ b/internal/storage/dolt/dependencies.go
@@ -98,8 +98,8 @@ func (s *DoltStore) RemoveDependencyWithOptions(ctx context.Context, issueID, de
 		if _, err := issueops.RemoveDependencyInTx(ctx, tx, issueID, dependsOnID, actor, rmOpts.EmitEvent); err != nil {
 			return err
 		}
-		if err := tx.Commit(); err != nil {
-			return wrapSQLCommitError("commit remove wisp dependency", err)
+		if err := s.commitSQLTx(ctx, "commit remove wisp dependency", tx); err != nil {
+			return err
 		}
 		return nil
 	}
@@ -115,8 +115,8 @@ func (s *DoltStore) RemoveDependencyWithOptions(ctx context.Context, issueID, de
 		return err
 	}
 
-	if err := tx.Commit(); err != nil {
-		return wrapSQLCommitError("sql commit", err)
+	if err := s.commitSQLTx(ctx, "sql commit", tx); err != nil {
+		return err
 	}
 	// GH#2455: Use explicit DOLT_ADD to avoid sweeping up stale config changes.
 	// Stage events only when RemoveDependencyInTx actually recorded a

--- a/internal/storage/dolt/dependencies.go
+++ b/internal/storage/dolt/dependencies.go
@@ -98,7 +98,10 @@ func (s *DoltStore) RemoveDependencyWithOptions(ctx context.Context, issueID, de
 		if _, err := issueops.RemoveDependencyInTx(ctx, tx, issueID, dependsOnID, actor, rmOpts.EmitEvent); err != nil {
 			return err
 		}
-		return wrapTransactionError("commit remove wisp dependency", tx.Commit())
+		if err := tx.Commit(); err != nil {
+			return wrapSQLCommitError("commit remove wisp dependency", err)
+		}
+		return nil
 	}
 
 	tx, err := s.db.BeginTx(ctx, nil)
@@ -113,7 +116,7 @@ func (s *DoltStore) RemoveDependencyWithOptions(ctx context.Context, issueID, de
 	}
 
 	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("sql commit: %w", err)
+		return wrapSQLCommitError("sql commit", err)
 	}
 	// GH#2455: Use explicit DOLT_ADD to avoid sweeping up stale config changes.
 	// Stage events only when RemoveDependencyInTx actually recorded a

--- a/internal/storage/dolt/dependency_commit_boundary_test.go
+++ b/internal/storage/dolt/dependency_commit_boundary_test.go
@@ -1,0 +1,150 @@
+package dolt
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// dependencyCommitBoundaryDriver models dependency removal through its SQL
+// mutation and transaction commit. A lost commit response is returned after
+// the delete so an unsafe replay is visible as a second mutation attempt.
+type dependencyCommitBoundaryDriver struct {
+	mu sync.Mutex
+
+	activeWisp bool
+	commitErr  error
+
+	deletes     int
+	txAttempts  int
+	commitCalls int
+}
+
+func (d *dependencyCommitBoundaryDriver) Open(string) (driver.Conn, error) {
+	return &dependencyCommitBoundaryConn{driver: d}, nil
+}
+
+func (d *dependencyCommitBoundaryDriver) Connect(context.Context) (driver.Conn, error) {
+	return &dependencyCommitBoundaryConn{driver: d}, nil
+}
+
+func (d *dependencyCommitBoundaryDriver) Driver() driver.Driver { return d }
+
+type dependencyCommitBoundaryConn struct {
+	driver *dependencyCommitBoundaryDriver
+}
+
+func (c *dependencyCommitBoundaryConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("dependency commit boundary driver does not prepare statements")
+}
+
+func (c *dependencyCommitBoundaryConn) Close() error { return nil }
+
+func (c *dependencyCommitBoundaryConn) Begin() (driver.Tx, error) {
+	c.driver.mu.Lock()
+	c.driver.txAttempts++
+	c.driver.mu.Unlock()
+	return &dependencyCommitBoundaryTx{driver: c.driver}, nil
+}
+
+func (c *dependencyCommitBoundaryConn) QueryContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Rows, error) {
+	c.driver.mu.Lock()
+	defer c.driver.mu.Unlock()
+
+	switch {
+	case strings.Contains(query, "SELECT 1 FROM wisps WHERE id = ? LIMIT 1"):
+		if c.driver.activeWisp {
+			return &dependencyCommitBoundaryRows{columns: []string{"exists"}, values: [][]driver.Value{{int64(1)}}}, nil
+		}
+		return &dependencyCommitBoundaryRows{columns: []string{"exists"}}, nil
+	case strings.Contains(query, "SELECT type FROM dependencies"),
+		strings.Contains(query, "SELECT type FROM wisp_dependencies"):
+		return &dependencyCommitBoundaryRows{columns: []string{"type"}, values: [][]driver.Value{{"related"}}}, nil
+	default:
+		return &dependencyCommitBoundaryRows{columns: []string{"value"}}, nil
+	}
+}
+
+func (c *dependencyCommitBoundaryConn) ExecContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Result, error) {
+	c.driver.mu.Lock()
+	defer c.driver.mu.Unlock()
+	if strings.Contains(query, "DELETE FROM dependencies") || strings.Contains(query, "DELETE FROM wisp_dependencies") {
+		c.driver.deletes++
+	}
+	return driver.RowsAffected(1), nil
+}
+
+type dependencyCommitBoundaryTx struct {
+	driver *dependencyCommitBoundaryDriver
+}
+
+func (t *dependencyCommitBoundaryTx) Commit() error {
+	t.driver.mu.Lock()
+	defer t.driver.mu.Unlock()
+	t.driver.commitCalls++
+	return t.driver.commitErr
+}
+
+func (t *dependencyCommitBoundaryTx) Rollback() error { return nil }
+
+type dependencyCommitBoundaryRows struct {
+	columns []string
+	values  [][]driver.Value
+	index   int
+}
+
+func (r *dependencyCommitBoundaryRows) Columns() []string { return r.columns }
+func (r *dependencyCommitBoundaryRows) Close() error      { return nil }
+func (r *dependencyCommitBoundaryRows) Next(dest []driver.Value) error {
+	if r.index >= len(r.values) {
+		return io.EOF
+	}
+	copy(dest, r.values[r.index])
+	r.index++
+	return nil
+}
+
+func TestRemoveDependencySQLCommitResponseLossIsIndeterminateAndNotReplayed(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		activeWisp bool
+	}{
+		{name: "regular"},
+		{name: "wisp", activeWisp: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			driver := &dependencyCommitBoundaryDriver{
+				activeWisp: tc.activeWisp,
+				commitErr:  testConnectionLoss,
+			}
+			store := &DoltStore{db: sql.OpenDB(driver)}
+			t.Cleanup(func() { _ = store.db.Close() })
+
+			err := store.RemoveDependency(context.Background(), "dependency-source", "dependency-target", "alice")
+			if !errors.Is(err, ErrCommitIndeterminate) {
+				t.Fatalf("RemoveDependency() error = %v, want ErrCommitIndeterminate", err)
+			}
+			if !errors.Is(err, testConnectionLoss) {
+				t.Fatalf("RemoveDependency() error = %v, want cause %v", err, testConnectionLoss)
+			}
+
+			driver.mu.Lock()
+			defer driver.mu.Unlock()
+			if driver.deletes != 1 {
+				t.Fatalf("dependency delete attempts = %d, want 1", driver.deletes)
+			}
+			if driver.txAttempts != 1 || driver.commitCalls != 1 {
+				t.Fatalf("transaction attempts = %d, commit calls = %d, want 1 and 1", driver.txAttempts, driver.commitCalls)
+			}
+		})
+	}
+}
+
+var _ driver.Connector = (*dependencyCommitBoundaryDriver)(nil)
+var _ driver.ExecerContext = (*dependencyCommitBoundaryConn)(nil)
+var _ driver.QueryerContext = (*dependencyCommitBoundaryConn)(nil)

--- a/internal/storage/dolt/dependency_commit_boundary_test.go
+++ b/internal/storage/dolt/dependency_commit_boundary_test.go
@@ -118,11 +118,13 @@ func TestRemoveDependencySQLCommitResponseLossIsIndeterminateAndNotReplayed(t *t
 		{name: "wisp", activeWisp: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("BEADS_TEST_MODE", "")
+			breaker := newTestCircuitBreaker(t)
 			driver := &dependencyCommitBoundaryDriver{
 				activeWisp: tc.activeWisp,
 				commitErr:  testConnectionLoss,
 			}
-			store := &DoltStore{db: sql.OpenDB(driver)}
+			store := &DoltStore{db: sql.OpenDB(driver), breaker: breaker}
 			t.Cleanup(func() { _ = store.db.Close() })
 
 			err := store.RemoveDependency(context.Background(), "dependency-source", "dependency-target", "alice")
@@ -140,6 +142,11 @@ func TestRemoveDependencySQLCommitResponseLossIsIndeterminateAndNotReplayed(t *t
 			}
 			if driver.txAttempts != 1 || driver.commitCalls != 1 {
 				t.Fatalf("transaction attempts = %d, commit calls = %d, want 1 and 1", driver.txAttempts, driver.commitCalls)
+			}
+
+			state := breaker.readState()
+			if state.State != circuitClosed || state.Failures != 1 {
+				t.Fatalf("circuit state after one lost response = %+v, want closed with one failure", state)
 			}
 		})
 	}

--- a/internal/storage/dolt/dependency_commit_boundary_test.go
+++ b/internal/storage/dolt/dependency_commit_boundary_test.go
@@ -9,18 +9,22 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
 )
 
-// dependencyCommitBoundaryDriver models dependency removal through its SQL
+// dependencyCommitBoundaryDriver models dependency writes through their SQL
 // mutation and transaction commit. A lost commit response is returned after
-// the delete so an unsafe replay is visible as a second mutation attempt.
+// the mutation so an unsafe replay is visible as a second attempt.
 type dependencyCommitBoundaryDriver struct {
 	mu sync.Mutex
 
 	activeWisp bool
 	commitErr  error
+	newEdge    bool
 
 	deletes     int
+	inserts     int
 	txAttempts  int
 	commitCalls int
 }
@@ -62,8 +66,13 @@ func (c *dependencyCommitBoundaryConn) QueryContext(_ context.Context, query str
 			return &dependencyCommitBoundaryRows{columns: []string{"exists"}, values: [][]driver.Value{{int64(1)}}}, nil
 		}
 		return &dependencyCommitBoundaryRows{columns: []string{"exists"}}, nil
+	case strings.Contains(query, "SELECT issue_type FROM wisps WHERE id = ?"):
+		return &dependencyCommitBoundaryRows{columns: []string{"issue_type"}, values: [][]driver.Value{{"task"}}}, nil
 	case strings.Contains(query, "SELECT type FROM dependencies"),
 		strings.Contains(query, "SELECT type FROM wisp_dependencies"):
+		if c.driver.newEdge {
+			return &dependencyCommitBoundaryRows{columns: []string{"type"}}, nil
+		}
 		return &dependencyCommitBoundaryRows{columns: []string{"type"}, values: [][]driver.Value{{"related"}}}, nil
 	default:
 		return &dependencyCommitBoundaryRows{columns: []string{"value"}}, nil
@@ -75,6 +84,9 @@ func (c *dependencyCommitBoundaryConn) ExecContext(_ context.Context, query stri
 	defer c.driver.mu.Unlock()
 	if strings.Contains(query, "DELETE FROM dependencies") || strings.Contains(query, "DELETE FROM wisp_dependencies") {
 		c.driver.deletes++
+	}
+	if strings.Contains(query, "INSERT INTO wisp_dependencies") {
+		c.driver.inserts++
 	}
 	return driver.RowsAffected(1), nil
 }
@@ -149,6 +161,60 @@ func TestRemoveDependencySQLCommitResponseLossIsIndeterminateAndNotReplayed(t *t
 				t.Fatalf("circuit state after one lost response = %+v, want closed with one failure", state)
 			}
 		})
+	}
+}
+
+func TestAddExplicitIDWispDependencyIndeterminateCommitTripsCircuitBeforeNextWrite(t *testing.T) {
+	t.Setenv("BEADS_TEST_MODE", "")
+	breaker := newTestCircuitBreaker(t)
+	for range circuitFailureThreshold - 1 {
+		breaker.RecordFailure()
+	}
+	driver := &dependencyCommitBoundaryDriver{
+		activeWisp: true,
+		commitErr:  testConnectionLoss,
+		newEdge:    true,
+	}
+	store := &DoltStore{db: sql.OpenDB(driver), breaker: breaker}
+	t.Cleanup(func() { _ = store.db.Close() })
+
+	dep := &types.Dependency{
+		IssueID:     "explicit-source",
+		DependsOnID: "explicit-target",
+		Type:        types.DepRelated,
+	}
+	err := store.AddDependency(t.Context(), dep, "alice")
+	if !errors.Is(err, ErrCommitIndeterminate) {
+		t.Fatalf("AddDependency() error = %v, want ErrCommitIndeterminate", err)
+	}
+	if !errors.Is(err, testConnectionLoss) {
+		t.Fatalf("AddDependency() error = %v, want cause %v", err, testConnectionLoss)
+	}
+	if state := breaker.State(); state != circuitOpen {
+		t.Fatalf("circuit state after indeterminate wisp dependency commit = %q, want %q", state, circuitOpen)
+	}
+
+	driver.mu.Lock()
+	beforeTx := driver.txAttempts
+	beforeInserts := driver.inserts
+	commitCalls := driver.commitCalls
+	driver.mu.Unlock()
+	if beforeTx != 1 || commitCalls != 1 || beforeInserts != 1 {
+		t.Fatalf("first write attempts = transactions:%d commits:%d inserts:%d, want 1 each",
+			beforeTx, commitCalls, beforeInserts)
+	}
+
+	err = store.AddDependency(t.Context(), dep, "alice")
+	if !errors.Is(err, ErrCircuitOpen) {
+		t.Fatalf("next AddDependency() error = %v, want ErrCircuitOpen", err)
+	}
+	driver.mu.Lock()
+	afterTx := driver.txAttempts
+	afterInserts := driver.inserts
+	driver.mu.Unlock()
+	if afterTx != beforeTx || afterInserts != beforeInserts {
+		t.Fatalf("writes after circuit trip = transactions:%d inserts:%d, want unchanged %d and %d",
+			afterTx, afterInserts, beforeTx, beforeInserts)
 	}
 }
 

--- a/internal/storage/dolt/draincall_regression_test.go
+++ b/internal/storage/dolt/draincall_regression_test.go
@@ -265,6 +265,33 @@ func TestCommitCommitResponseLossIsIndeterminate(t *testing.T) {
 	}
 }
 
+func TestCommitPropagatesDoltAddFailureBeforeCommit(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	stageErr := errors.New("stage issues failed")
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT table_name FROM dolt_status")).
+		WillReturnRows(sqlmock.NewRows([]string{"table_name"}).AddRow("issues"))
+	mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_ADD(?)")).
+		WithArgs("issues").
+		WillReturnError(stageErr)
+
+	store := &DoltStore{db: db}
+	err = store.Commit(context.Background(), "bd: test commit")
+	if !errors.Is(err, stageErr) {
+		t.Fatalf("Commit() error = %v, want staging cause %v", err, stageErr)
+	}
+	if !strings.Contains(err.Error(), "stage issues") {
+		t.Fatalf("Commit() error = %q, want staging table context", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}
+
 func TestDoltAddAndCommitInTxClassifiesCommitResponses(t *testing.T) {
 	for _, tc := range []struct {
 		name              string

--- a/internal/storage/dolt/draincall_regression_test.go
+++ b/internal/storage/dolt/draincall_regression_test.go
@@ -243,7 +243,7 @@ func TestCommitCommitResponseLossIsIndeterminate(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = db.Close() })
 
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT table_name FROM dolt_status")).
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT s.table_name FROM dolt_status")).
 		WillReturnRows(sqlmock.NewRows([]string{"table_name"}).AddRow("issues"))
 	mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_ADD(?)")).
 		WithArgs("issues").
@@ -273,7 +273,7 @@ func TestCommitPropagatesDoltAddFailureBeforeCommit(t *testing.T) {
 	t.Cleanup(func() { _ = db.Close() })
 
 	stageErr := errors.New("stage issues failed")
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT table_name FROM dolt_status")).
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT s.table_name FROM dolt_status")).
 		WillReturnRows(sqlmock.NewRows([]string{"table_name"}).AddRow("issues"))
 	mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_ADD(?)")).
 		WithArgs("issues").
@@ -302,7 +302,7 @@ func TestPublicCommitAmbiguousConnectionFailuresTripCircuit(t *testing.T) {
 		{
 			name: "Commit",
 			expect: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(regexp.QuoteMeta("SELECT table_name FROM dolt_status")).
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT s.table_name FROM dolt_status")).
 					WillReturnRows(sqlmock.NewRows([]string{"table_name"}).AddRow("issues"))
 				mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_ADD(?)")).
 					WithArgs("issues").
@@ -318,7 +318,7 @@ func TestPublicCommitAmbiguousConnectionFailuresTripCircuit(t *testing.T) {
 		{
 			name: "CommitMergeResolution",
 			expect: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(regexp.QuoteMeta("SELECT table_name FROM dolt_status")).
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT s.table_name FROM dolt_status")).
 					WillReturnRows(sqlmock.NewRows([]string{"table_name"}).AddRow("issues"))
 				mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_ADD(?)")).
 					WithArgs("issues").

--- a/internal/storage/dolt/draincall_regression_test.go
+++ b/internal/storage/dolt/draincall_regression_test.go
@@ -179,3 +179,88 @@ func TestDoltAddAndCommitTreatsNothingToCommitAsSuccess(t *testing.T) {
 		t.Fatalf("unmet sqlmock expectations: %v", err)
 	}
 }
+
+func TestDoltAddAndCommitInTxClassifiesCommitResponses(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		commitErr         error
+		wantIndeterminate bool
+	}{
+		{
+			name:              "untyped response loss",
+			commitErr:         testConnectionLoss,
+			wantIndeterminate: true,
+		},
+		{
+			name:      "typed rollback response",
+			commitErr: &mysql.MySQLError{Number: 1213, Message: "deadlock"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+			if err != nil {
+				t.Fatalf("sqlmock: %v", err)
+			}
+			t.Cleanup(func() { _ = db.Close() })
+
+			mock.ExpectBegin()
+			tx, err := db.BeginTx(context.Background(), nil)
+			if err != nil {
+				t.Fatalf("begin transaction: %v", err)
+			}
+			mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_ADD(?)")).
+				WithArgs("issues").
+				WillReturnRows(sqlmock.NewRows([]string{"status"}))
+			mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_COMMIT('-m', ?, '--author', ?)")).
+				WithArgs("bd: test commit", " <>").
+				WillReturnError(tc.commitErr)
+			mock.ExpectRollback()
+
+			store := &DoltStore{}
+			err = store.doltAddAndCommitInTx(context.Background(), tx, []string{"issues"}, "bd: test commit")
+			if got := errors.Is(err, storage.ErrCommitIndeterminate); got != tc.wantIndeterminate {
+				t.Fatalf("doltAddAndCommitInTx() error = %v, ErrCommitIndeterminate = %v, want %v", err, got, tc.wantIndeterminate)
+			}
+			if !errors.Is(err, tc.commitErr) {
+				t.Fatalf("doltAddAndCommitInTx() error = %v, want cause %v", err, tc.commitErr)
+			}
+			if err := tx.Rollback(); err != nil {
+				t.Fatalf("rollback transaction: %v", err)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatalf("unmet sqlmock expectations: %v", err)
+			}
+		})
+	}
+}
+
+func TestDoltAddAndCommitInTxStopsAtStageFailure(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	stageErr := errors.New("stage failed")
+	mock.ExpectBegin()
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("begin transaction: %v", err)
+	}
+	mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_ADD(?)")).
+		WithArgs("issues").
+		WillReturnError(stageErr)
+	mock.ExpectRollback()
+
+	store := &DoltStore{}
+	err = store.doltAddAndCommitInTx(context.Background(), tx, []string{"issues", "events"}, "bd: test commit")
+	if !errors.Is(err, stageErr) {
+		t.Fatalf("doltAddAndCommitInTx() error = %v, want stage failure %v", err, stageErr)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("rollback transaction: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}

--- a/internal/storage/dolt/draincall_regression_test.go
+++ b/internal/storage/dolt/draincall_regression_test.go
@@ -2,10 +2,15 @@ package dolt
 
 import (
 	"context"
+	"errors"
 	"regexp"
+	"strings"
 	"testing"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	mysql "github.com/go-sql-driver/mysql"
+
+	"github.com/steveyegge/beads/internal/storage"
 )
 
 // TestDoltAddAndCommitDrainsCallResultSets pins doltAddAndCommit to routing its
@@ -43,6 +48,133 @@ func TestDoltAddAndCommitDrainsCallResultSets(t *testing.T) {
 		t.Fatalf("doltAddAndCommit: %v", err)
 	}
 
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestDoltAddAndCommitPostSQLFailuresAreIndeterminate(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		setup       func(sqlmock.Sqlmock)
+		closeDB     bool
+		cause       error
+		mysqlNumber uint16
+		wantContext string
+	}{
+		{
+			name:        "connection acquisition",
+			setup:       func(sqlmock.Sqlmock) {},
+			closeDB:     true,
+			wantContext: "acquire connection after SQL mutation",
+		},
+		{
+			name: "DOLT_ADD",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_ADD(?)")).
+					WithArgs("issues").
+					WillReturnError(testConnectionLoss)
+			},
+			cause:       testConnectionLoss,
+			wantContext: "dolt add issues after SQL mutation",
+		},
+		{
+			name: "untyped DOLT_COMMIT",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_ADD(?)")).
+					WithArgs("issues").
+					WillReturnRows(sqlmock.NewRows([]string{"status"}))
+				mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_COMMIT('-m', ?, '--author', ?)")).
+					WithArgs("bd: test commit", " <>").
+					WillReturnError(testConnectionLoss)
+			},
+			cause:       testConnectionLoss,
+			wantContext: "dolt commit after SQL mutation",
+		},
+		{
+			name: "typed deadlock DOLT_COMMIT",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_ADD(?)")).
+					WithArgs("issues").
+					WillReturnRows(sqlmock.NewRows([]string{"status"}))
+				mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_COMMIT('-m', ?, '--author', ?)")).
+					WithArgs("bd: test commit", " <>").
+					WillReturnError(&mysql.MySQLError{Number: 1213, Message: "deadlock"})
+			},
+			mysqlNumber: 1213,
+			wantContext: "dolt commit after SQL mutation",
+		},
+		{
+			name: "typed lock wait DOLT_COMMIT",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_ADD(?)")).
+					WithArgs("issues").
+					WillReturnRows(sqlmock.NewRows([]string{"status"}))
+				mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_COMMIT('-m', ?, '--author', ?)")).
+					WithArgs("bd: test commit", " <>").
+					WillReturnError(&mysql.MySQLError{Number: 1205, Message: "lock wait timeout"})
+			},
+			mysqlNumber: 1205,
+			wantContext: "dolt commit after SQL mutation",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+			if err != nil {
+				t.Fatalf("sqlmock: %v", err)
+			}
+			t.Cleanup(func() { _ = db.Close() })
+
+			tc.setup(mock)
+			store := &DoltStore{db: db}
+			if tc.closeDB {
+				mock.ExpectClose()
+				if err := db.Close(); err != nil {
+					t.Fatalf("close database: %v", err)
+				}
+			}
+
+			err = store.doltAddAndCommit(context.Background(), []string{"issues"}, "bd: test commit")
+			if !errors.Is(err, storage.ErrCommitIndeterminate) {
+				t.Fatalf("doltAddAndCommit() error = %v, want ErrCommitIndeterminate", err)
+			}
+			if tc.cause != nil && !errors.Is(err, tc.cause) {
+				t.Errorf("doltAddAndCommit() error = %v, want cause %v", err, tc.cause)
+			}
+			if tc.mysqlNumber != 0 {
+				var mysqlErr *mysql.MySQLError
+				if !errors.As(err, &mysqlErr) || mysqlErr.Number != tc.mysqlNumber {
+					t.Errorf("doltAddAndCommit() error = %v, want MySQL %d", err, tc.mysqlNumber)
+				}
+			}
+			if !strings.Contains(err.Error(), tc.wantContext) {
+				t.Errorf("doltAddAndCommit() error = %q, want context %q", err, tc.wantContext)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatalf("unmet sqlmock expectations: %v", err)
+			}
+		})
+	}
+}
+
+func TestDoltAddAndCommitTreatsNothingToCommitAsSuccess(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_ADD(?)")).
+		WithArgs("issues").
+		WillReturnRows(sqlmock.NewRows([]string{"status"}))
+	mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_COMMIT('-m', ?, '--author', ?)")).
+		WithArgs("bd: test commit", " <>").
+		WillReturnError(errors.New("nothing to commit"))
+
+	store := &DoltStore{db: db}
+	if err := store.doltAddAndCommit(context.Background(), []string{"issues"}, "bd: test commit"); err != nil {
+		t.Fatalf("doltAddAndCommit() error = %v, want nil", err)
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet sqlmock expectations: %v", err)
 	}

--- a/internal/storage/dolt/draincall_regression_test.go
+++ b/internal/storage/dolt/draincall_regression_test.go
@@ -292,6 +292,90 @@ func TestCommitPropagatesDoltAddFailureBeforeCommit(t *testing.T) {
 	}
 }
 
+func TestPublicCommitAmbiguousConnectionFailuresTripCircuit(t *testing.T) {
+	t.Setenv("BEADS_TEST_MODE", "")
+	tests := []struct {
+		name   string
+		expect func(sqlmock.Sqlmock)
+		commit func(*DoltStore) error
+	}{
+		{
+			name: "Commit",
+			expect: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT table_name FROM dolt_status")).
+					WillReturnRows(sqlmock.NewRows([]string{"table_name"}).AddRow("issues"))
+				mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_ADD(?)")).
+					WithArgs("issues").
+					WillReturnRows(sqlmock.NewRows([]string{"status"}))
+				mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_COMMIT('-m', ?, '--author', ?)")).
+					WithArgs("bd: test commit", " <>").
+					WillReturnError(testConnectionLoss)
+			},
+			commit: func(store *DoltStore) error {
+				return store.Commit(context.Background(), "bd: test commit")
+			},
+		},
+		{
+			name: "CommitMergeResolution",
+			expect: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT table_name FROM dolt_status")).
+					WillReturnRows(sqlmock.NewRows([]string{"table_name"}).AddRow("issues"))
+				mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_ADD(?)")).
+					WithArgs("issues").
+					WillReturnRows(sqlmock.NewRows([]string{"status"}))
+				mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_COMMIT('-m', ?, '--author', ?)")).
+					WithArgs("bd: test merge commit", " <>").
+					WillReturnError(testConnectionLoss)
+			},
+			commit: func(store *DoltStore) error {
+				return store.CommitMergeResolution(context.Background(), "bd: test merge commit")
+			},
+		},
+		{
+			name: "CommitWithConfig",
+			expect: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_COMMIT('-Am', ?, '--author', ?)")).
+					WithArgs("bd: test config commit", " <>").
+					WillReturnError(testConnectionLoss)
+			},
+			commit: func(store *DoltStore) error {
+				return store.CommitWithConfig(context.Background(), "bd: test config commit")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+			if err != nil {
+				t.Fatalf("sqlmock: %v", err)
+			}
+			t.Cleanup(func() { _ = db.Close() })
+			for range circuitFailureThreshold {
+				tt.expect(mock)
+			}
+
+			breaker := newTestCircuitBreaker(t)
+			store := &DoltStore{db: db, breaker: breaker}
+			for i := 0; i < circuitFailureThreshold; i++ {
+				err := tt.commit(store)
+				if !errors.Is(err, ErrCommitIndeterminate) {
+					t.Fatalf("attempt %d error = %v, want ErrCommitIndeterminate", i+1, err)
+				}
+				if i < circuitFailureThreshold-1 && breaker.State() != circuitClosed {
+					t.Fatalf("circuit state after %d failures = %q, want %q", i+1, breaker.State(), circuitClosed)
+				}
+			}
+			if state := breaker.State(); state != circuitOpen {
+				t.Fatalf("circuit state after %d ambiguous commit failures = %q, want %q", circuitFailureThreshold, state, circuitOpen)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatalf("unmet sqlmock expectations: %v", err)
+			}
+		})
+	}
+}
+
 func TestDoltAddAndCommitInTxClassifiesCommitResponses(t *testing.T) {
 	for _, tc := range []struct {
 		name              string

--- a/internal/storage/dolt/draincall_regression_test.go
+++ b/internal/storage/dolt/draincall_regression_test.go
@@ -157,6 +157,38 @@ func TestDoltAddAndCommitPostSQLFailuresAreIndeterminate(t *testing.T) {
 	}
 }
 
+func TestDoltAddAndCommitAmbiguousConnectionFailuresTripCircuitOnce(t *testing.T) {
+	t.Setenv("BEADS_TEST_MODE", "")
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	for range circuitFailureThreshold {
+		mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_ADD(?)")).
+			WithArgs("issues").
+			WillReturnError(testConnectionLoss)
+	}
+
+	breaker := newTestCircuitBreaker(t)
+	store := &DoltStore{db: db, breaker: breaker}
+	for i := 0; i < circuitFailureThreshold; i++ {
+		err := store.doltAddAndCommit(context.Background(), []string{"issues"}, "bd: test commit")
+		if !errors.Is(err, ErrCommitIndeterminate) {
+			t.Fatalf("attempt %d error = %v, want ErrCommitIndeterminate", i+1, err)
+		}
+		if i < circuitFailureThreshold-1 && breaker.State() != circuitClosed {
+			t.Fatalf("circuit state after %d failures = %q, want %q", i+1, breaker.State(), circuitClosed)
+		}
+	}
+	if state := breaker.State(); state != circuitOpen {
+		t.Fatalf("circuit state after %d ambiguous publication failures = %q, want %q", circuitFailureThreshold, state, circuitOpen)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}
+
 func TestDoltAddAndCommitTreatsNothingToCommitAsSuccess(t *testing.T) {
 	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
 	if err != nil {
@@ -174,6 +206,59 @@ func TestDoltAddAndCommitTreatsNothingToCommitAsSuccess(t *testing.T) {
 	store := &DoltStore{db: db}
 	if err := store.doltAddAndCommit(context.Background(), []string{"issues"}, "bd: test commit"); err != nil {
 		t.Fatalf("doltAddAndCommit() error = %v, want nil", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestCommitWithConfigCommitResponseLossIsIndeterminate(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_COMMIT('-Am', ?, '--author', ?)")).
+		WithArgs("bd: test config commit", " <>").
+		WillReturnError(testConnectionLoss)
+
+	store := &DoltStore{db: db}
+	err = store.CommitWithConfig(context.Background(), "bd: test config commit")
+	if !errors.Is(err, storage.ErrCommitIndeterminate) {
+		t.Fatalf("CommitWithConfig() error = %v, want ErrCommitIndeterminate", err)
+	}
+	if !errors.Is(err, testConnectionLoss) {
+		t.Fatalf("CommitWithConfig() error = %v, want cause %v", err, testConnectionLoss)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestCommitCommitResponseLossIsIndeterminate(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT table_name FROM dolt_status")).
+		WillReturnRows(sqlmock.NewRows([]string{"table_name"}).AddRow("issues"))
+	mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_ADD(?)")).
+		WithArgs("issues").
+		WillReturnRows(sqlmock.NewRows([]string{"status"}))
+	mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_COMMIT('-m', ?, '--author', ?)")).
+		WithArgs("bd: test commit", " <>").
+		WillReturnError(testConnectionLoss)
+
+	store := &DoltStore{db: db}
+	err = store.Commit(context.Background(), "bd: test commit")
+	if !errors.Is(err, storage.ErrCommitIndeterminate) {
+		t.Fatalf("Commit() error = %v, want ErrCommitIndeterminate", err)
+	}
+	if !errors.Is(err, testConnectionLoss) {
+		t.Fatalf("Commit() error = %v, want cause %v", err, testConnectionLoss)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet sqlmock expectations: %v", err)

--- a/internal/storage/dolt/ephemeral_routing.go
+++ b/internal/storage/dolt/ephemeral_routing.go
@@ -327,7 +327,7 @@ func (s *DoltStore) doltAddAndCommitInTx(ctx context.Context, tx *sql.Tx, tables
 	}
 	if err := schema.DrainCall(ctx, tx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
 		commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-		return fmt.Errorf("dolt commit: %w", err)
+		return wrapSQLCommitError("dolt commit", err)
 	}
 	return nil
 }

--- a/internal/storage/dolt/errors.go
+++ b/internal/storage/dolt/errors.go
@@ -105,6 +105,9 @@ func isIndeterminateCommitResponse(err error) bool {
 }
 
 func wrapSQLCommitError(op string, err error) error {
+	if err == nil {
+		return nil
+	}
 	if isIndeterminateCommitResponse(err) {
 		return fmt.Errorf("%s: %w: %w", op, err, ErrCommitIndeterminate)
 	}

--- a/internal/storage/dolt/errors.go
+++ b/internal/storage/dolt/errors.go
@@ -51,13 +51,6 @@ var (
 	// ErrCommitIndeterminate is the storage-wide no-replay sentinel. Keep this
 	// alias for server-Dolt callers while embedded Dolt returns the same value.
 	ErrCommitIndeterminate = storage.ErrCommitIndeterminate
-
-	// errCommitPhase marks an error as having occurred during tx.Commit (as
-	// opposed to BeginTx or the transaction body). A connection failure during
-	// commit is ambiguous — the commit may have landed on the server before the
-	// connection dropped — so withRetryTx must NOT blindly replay it, or it
-	// could double-apply the write. Pre-commit failures carry no such risk.
-	errCommitPhase = errors.New("write commit phase")
 )
 
 // isTableNotExistError returns true if the error indicates a MySQL/Dolt

--- a/internal/storage/dolt/errors.go
+++ b/internal/storage/dolt/errors.go
@@ -1,13 +1,9 @@
 package dolt
 
 import (
-	"context"
 	"database/sql"
-	"database/sql/driver"
 	"errors"
 	"fmt"
-	"io"
-	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -94,9 +90,9 @@ func isDoltAutocommitRollbackError(err error) bool {
 			strings.HasPrefix(mysqlErr.Message, "Merge conflict detected, @autocommit transaction rolled back."))
 }
 
-// isIndeterminateCommitResponse reports response-loss and network errors from
-// a commit-capable operation. A typed MySQL error proves the server responded,
-// even if its message contains connection-like text.
+// isIndeterminateCommitResponse reports whether a Commit error lacks a decoded
+// server response proving a definite rejection or rollback. Every untyped
+// protocol or transport error is conservatively indeterminate.
 func isIndeterminateCommitResponse(err error) bool {
 	if err == nil {
 		return false
@@ -105,34 +101,14 @@ func isIndeterminateCommitResponse(err error) bool {
 		return true
 	}
 	var mysqlErr *mysql.MySQLError
-	if errors.As(err, &mysqlErr) {
-		return false
+	return !errors.As(err, &mysqlErr)
+}
+
+func wrapSQLCommitError(op string, err error) error {
+	if isIndeterminateCommitResponse(err) {
+		return fmt.Errorf("%s: %w: %w", op, err, ErrCommitIndeterminate)
 	}
-	if errors.Is(err, driver.ErrBadConn) ||
-		errors.Is(err, context.Canceled) ||
-		errors.Is(err, context.DeadlineExceeded) ||
-		errors.Is(err, io.EOF) ||
-		errors.Is(err, io.ErrUnexpectedEOF) ||
-		errors.Is(err, net.ErrClosed) {
-		return true
-	}
-	var netErr *net.OpError
-	if errors.As(err, &netErr) {
-		return true
-	}
-	message := strings.ToLower(err.Error())
-	if strings.Contains(message, "response lost") ||
-		(strings.Contains(message, "commit response") && strings.Contains(message, "lost")) {
-		return true
-	}
-	return strings.Contains(message, "connection lost") ||
-		strings.Contains(message, "connection reset") ||
-		strings.Contains(message, "broken pipe") ||
-		strings.Contains(message, "i/o timeout") ||
-		strings.Contains(message, "bad connection") ||
-		strings.Contains(message, "invalid connection") ||
-		strings.Contains(message, "lost connection") ||
-		strings.Contains(message, "gone away")
+	return fmt.Errorf("%s: %w", op, err)
 }
 
 // wrapDBError wraps a database error with operation context.

--- a/internal/storage/dolt/errors.go
+++ b/internal/storage/dolt/errors.go
@@ -1,9 +1,13 @@
 package dolt
 
 import (
+	"context"
 	"database/sql"
+	"database/sql/driver"
 	"errors"
 	"fmt"
+	"io"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -43,6 +47,10 @@ var (
 	// sql-server); the timeout can be raised via the BEADS_FSCK_TIMEOUT
 	// environment variable.
 	ErrFSCKTimeout = errors.New("pre-push integrity check timed out")
+
+	// ErrCommitIndeterminate is the storage-wide no-replay sentinel. Keep this
+	// alias for server-Dolt callers while embedded Dolt returns the same value.
+	ErrCommitIndeterminate = storage.ErrCommitIndeterminate
 
 	// errCommitPhase marks an error as having occurred during tx.Commit (as
 	// opposed to BeginTx or the transaction body). A connection failure during
@@ -91,6 +99,47 @@ func isDoltAutocommitRollbackError(err error) bool {
 		mysqlErr.Number == 1105 &&
 		(mysqlErr.Message == "Merge conflict detected, @autocommit transaction rolled back" ||
 			strings.HasPrefix(mysqlErr.Message, "Merge conflict detected, @autocommit transaction rolled back."))
+}
+
+// isIndeterminateCommitResponse reports response-loss and network errors from
+// a commit-capable operation. A typed MySQL error proves the server responded,
+// even if its message contains connection-like text.
+func isIndeterminateCommitResponse(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrCommitIndeterminate) {
+		return true
+	}
+	var mysqlErr *mysql.MySQLError
+	if errors.As(err, &mysqlErr) {
+		return false
+	}
+	if errors.Is(err, driver.ErrBadConn) ||
+		errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, net.ErrClosed) {
+		return true
+	}
+	var netErr *net.OpError
+	if errors.As(err, &netErr) {
+		return true
+	}
+	message := strings.ToLower(err.Error())
+	if strings.Contains(message, "response lost") ||
+		(strings.Contains(message, "commit response") && strings.Contains(message, "lost")) {
+		return true
+	}
+	return strings.Contains(message, "connection lost") ||
+		strings.Contains(message, "connection reset") ||
+		strings.Contains(message, "broken pipe") ||
+		strings.Contains(message, "i/o timeout") ||
+		strings.Contains(message, "bad connection") ||
+		strings.Contains(message, "invalid connection") ||
+		strings.Contains(message, "lost connection") ||
+		strings.Contains(message, "gone away")
 }
 
 // wrapDBError wraps a database error with operation context.

--- a/internal/storage/dolt/errors_test.go
+++ b/internal/storage/dolt/errors_test.go
@@ -23,7 +23,10 @@ func TestIsIndeterminateCommitResponse(t *testing.T) {
 	}{
 		{name: "unexpected EOF", err: io.ErrUnexpectedEOF, want: true},
 		{name: "lost connection", err: errors.New("lost connection to MySQL server"), want: true},
+		{name: "packet protocol desync", err: mysql.ErrPktSync, want: true},
+		{name: "otherwise unproven untyped commit error", err: errors.New("commit rejected without typed response"), want: true},
 		{name: "typed semantic MySQL error", err: &mysql.MySQLError{Number: 1105, Message: "connection lost while validating commit"}, want: false},
+		{name: "typed rollback-guaranteed MySQL error", err: &mysql.MySQLError{Number: 1213, Message: "deadlock"}, want: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := isIndeterminateCommitResponse(tc.err); got != tc.want {

--- a/internal/storage/dolt/errors_test.go
+++ b/internal/storage/dolt/errors_test.go
@@ -36,6 +36,12 @@ func TestIsIndeterminateCommitResponse(t *testing.T) {
 	}
 }
 
+func TestWrapSQLCommitError(t *testing.T) {
+	if err := wrapSQLCommitError("commit wisp", nil); err != nil {
+		t.Fatalf("wrapSQLCommitError(nil) = %v, want nil", err)
+	}
+}
+
 func TestWrapDBError(t *testing.T) {
 	t.Run("nil error returns nil", func(t *testing.T) {
 		if err := wrapDBError("op", nil); err != nil {

--- a/internal/storage/dolt/errors_test.go
+++ b/internal/storage/dolt/errors_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,6 +14,24 @@ import (
 
 	"github.com/steveyegge/beads/internal/storage"
 )
+
+func TestIsIndeterminateCommitResponse(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "unexpected EOF", err: io.ErrUnexpectedEOF, want: true},
+		{name: "lost connection", err: errors.New("lost connection to MySQL server"), want: true},
+		{name: "typed semantic MySQL error", err: &mysql.MySQLError{Number: 1105, Message: "connection lost while validating commit"}, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isIndeterminateCommitResponse(tc.err); got != tc.want {
+				t.Errorf("isIndeterminateCommitResponse(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
 
 func TestWrapDBError(t *testing.T) {
 	t.Run("nil error returns nil", func(t *testing.T) {

--- a/internal/storage/dolt/event_commit_boundary_test.go
+++ b/internal/storage/dolt/event_commit_boundary_test.go
@@ -34,3 +34,47 @@ func TestAddCommentSQLCommitResponseLossAccountsCircuitOnce(t *testing.T) {
 		t.Fatalf("circuit state after one lost response = %+v, want closed with one failure", state)
 	}
 }
+
+func TestAddCommentRejectsWriteAfterCircuitOpens(t *testing.T) {
+	t.Setenv("BEADS_TEST_MODE", "")
+	breaker := newTestCircuitBreaker(t)
+	for range circuitFailureThreshold {
+		breaker.RecordFailure()
+	}
+	driver := &claimCommitBoundaryDriver{}
+	store := newClaimCommitBoundaryStore(driver)
+	store.breaker = breaker
+	t.Cleanup(func() { _ = store.db.Close() })
+
+	err := store.AddComment(t.Context(), "comment-boundary", "alice", "hello")
+	if !errors.Is(err, ErrCircuitOpen) {
+		t.Fatalf("AddComment() error = %v, want ErrCircuitOpen", err)
+	}
+
+	driver.mu.Lock()
+	defer driver.mu.Unlock()
+	if driver.txAttempts != 0 || driver.eventInserts != 0 || driver.doltCommits != 0 {
+		t.Fatalf("writes after open circuit = transactions:%d events:%d Dolt commits:%d, want all zero",
+			driver.txAttempts, driver.eventInserts, driver.doltCommits)
+	}
+}
+
+func TestAddCommentTerminalSuccessResetsCircuitFailures(t *testing.T) {
+	t.Setenv("BEADS_TEST_MODE", "")
+	breaker := newTestCircuitBreaker(t)
+	for range circuitFailureThreshold - 1 {
+		breaker.RecordFailure()
+	}
+	driver := &claimCommitBoundaryDriver{}
+	store := newClaimCommitBoundaryStore(driver)
+	store.breaker = breaker
+	t.Cleanup(func() { _ = store.db.Close() })
+
+	if err := store.AddComment(t.Context(), "comment-boundary", "alice", "hello"); err != nil {
+		t.Fatalf("AddComment() error = %v", err)
+	}
+	breaker.RecordFailure()
+	if state := breaker.State(); state != circuitClosed {
+		t.Fatalf("circuit state after successful comment and one failure = %q, want %q", state, circuitClosed)
+	}
+}

--- a/internal/storage/dolt/event_commit_boundary_test.go
+++ b/internal/storage/dolt/event_commit_boundary_test.go
@@ -1,0 +1,36 @@
+package dolt
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestAddCommentSQLCommitResponseLossAccountsCircuitOnce(t *testing.T) {
+	t.Setenv("BEADS_TEST_MODE", "")
+	breaker := newTestCircuitBreaker(t)
+	driver := &claimCommitBoundaryDriver{sqlCommitErr: testConnectionLoss}
+	store := newClaimCommitBoundaryStore(driver)
+	store.breaker = breaker
+	t.Cleanup(func() { _ = store.db.Close() })
+
+	err := store.AddComment(t.Context(), "comment-boundary", "alice", "hello")
+	if !errors.Is(err, ErrCommitIndeterminate) {
+		t.Fatalf("AddComment() error = %v, want ErrCommitIndeterminate", err)
+	}
+	if !errors.Is(err, testConnectionLoss) {
+		t.Fatalf("AddComment() error = %v, want cause %v", err, testConnectionLoss)
+	}
+
+	driver.mu.Lock()
+	if driver.eventInserts != 1 || driver.txAttempts != 1 || driver.txCommits != 1 {
+		driver.mu.Unlock()
+		t.Fatalf("AddComment attempts = events:%d transactions:%d commits:%d, want 1, 1, 1",
+			driver.eventInserts, driver.txAttempts, driver.txCommits)
+	}
+	driver.mu.Unlock()
+
+	state := breaker.readState()
+	if state.State != circuitClosed || state.Failures != 1 {
+		t.Fatalf("circuit state after one lost response = %+v, want closed with one failure", state)
+	}
+}

--- a/internal/storage/dolt/events.go
+++ b/internal/storage/dolt/events.go
@@ -23,8 +23,8 @@ func (s *DoltStore) AddComment(ctx context.Context, issueID, actor, comment stri
 	if err := issueops.AddCommentEventInTx(ctx, tx, issueID, actor, comment); err != nil {
 		return err
 	}
-	if err := tx.Commit(); err != nil {
-		return wrapSQLCommitError("commit add comment event", err)
+	if err := s.commitSQLTx(ctx, "commit add comment event", tx); err != nil {
+		return err
 	}
 	if isWisp {
 		return nil

--- a/internal/storage/dolt/events.go
+++ b/internal/storage/dolt/events.go
@@ -24,7 +24,7 @@ func (s *DoltStore) AddComment(ctx context.Context, issueID, actor, comment stri
 		return err
 	}
 	if err := tx.Commit(); err != nil {
-		return wrapTransactionError("commit add comment event", err)
+		return wrapSQLCommitError("commit add comment event", err)
 	}
 	if isWisp {
 		return nil

--- a/internal/storage/dolt/events.go
+++ b/internal/storage/dolt/events.go
@@ -13,23 +13,25 @@ import (
 
 // AddComment adds a comment event to an issue
 func (s *DoltStore) AddComment(ctx context.Context, issueID, actor, comment string) error {
-	isWisp := s.isActiveWisp(ctx, issueID)
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
+	return s.withCircuitWrite(ctx, func(ctx context.Context) error {
+		isWisp := s.isActiveWisp(ctx, issueID)
+		tx, err := s.db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("begin tx: %w", err)
+		}
+		defer func() { _ = tx.Rollback() }()
 
-	if err := issueops.AddCommentEventInTx(ctx, tx, issueID, actor, comment); err != nil {
-		return err
-	}
-	if err := s.commitSQLTx(ctx, "commit add comment event", tx); err != nil {
-		return err
-	}
-	if isWisp {
-		return nil
-	}
-	return s.doltAddAndCommit(ctx, []string{"events"}, fmt.Sprintf("bd: comment %s", issueID))
+		if err := issueops.AddCommentEventInTx(ctx, tx, issueID, actor, comment); err != nil {
+			return err
+		}
+		if err := s.commitSQLTx(ctx, "commit add comment event", tx); err != nil {
+			return err
+		}
+		if isWisp {
+			return nil
+		}
+		return s.doltAddAndCommit(ctx, []string{"events"}, fmt.Sprintf("bd: comment %s", issueID))
+	})
 }
 
 // GetEvents retrieves events for an issue
@@ -91,20 +93,22 @@ func (s *DoltStore) ImportIssueComment(ctx context.Context, issueID, author, tex
 // addOrImportComment is the shared wisp-routing / retry / dolt-commit tail
 // around either comment insert; insert does the write inside the transaction.
 func (s *DoltStore) addOrImportComment(ctx context.Context, issueID string, insert func(*sql.Tx) (*types.Comment, error)) (*types.Comment, error) {
-	isWisp := s.isActiveWisp(ctx, issueID)
 	var result *types.Comment
-	err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
-		var err error
-		result, err = insert(tx)
-		return err
+	err := s.withCircuitWrite(ctx, func(ctx context.Context) error {
+		isWisp := s.isActiveWisp(ctx, issueID)
+		if err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
+			var err error
+			result, err = insert(tx)
+			return err
+		}); err != nil {
+			return err
+		}
+		if isWisp {
+			return nil
+		}
+		return s.doltAddAndCommit(ctx, []string{"comments"}, fmt.Sprintf("bd: comment %s", issueID))
 	})
 	if err != nil {
-		return nil, err
-	}
-	if isWisp {
-		return result, nil
-	}
-	if err := s.doltAddAndCommit(ctx, []string{"comments"}, fmt.Sprintf("bd: comment %s", issueID)); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/internal/storage/dolt/federation.go
+++ b/internal/storage/dolt/federation.go
@@ -67,6 +67,16 @@ func (s *DoltStore) pushRefToPeer(ctx context.Context, peer string, refspec stri
 // For git-protocol remotes, uses CLI `dolt pull` to avoid MySQL connection timeouts.
 // Returns any merge conflicts if present.
 func (s *DoltStore) PullFrom(ctx context.Context, peer string) ([]storage.Conflict, error) {
+	var conflicts []storage.Conflict
+	err := s.withCircuitWrite(ctx, func(ctx context.Context) error {
+		var err error
+		conflicts, err = s.pullFromPeer(ctx, peer)
+		return err
+	})
+	return conflicts, err
+}
+
+func (s *DoltStore) pullFromPeer(ctx context.Context, peer string) ([]storage.Conflict, error) {
 	// GH#2474: Auto-commit pending changes before pull to prevent
 	// "cannot merge with uncommitted changes" errors.
 	if !s.readOnly {

--- a/internal/storage/dolt/indeterminate_commit_test.go
+++ b/internal/storage/dolt/indeterminate_commit_test.go
@@ -18,9 +18,12 @@ import (
 type failureDriver struct {
 	begins     atomic.Int32
 	prepares   atomic.Int32
+	execs      atomic.Int32
 	failBegin  atomic.Int32
 	commitMu   sync.Mutex
 	commitErrs []error
+	commitErr  error
+	commitFunc func() error
 }
 
 var testConnectionLoss = errors.New("invalid connection")
@@ -38,6 +41,10 @@ func (c *failureConn) Prepare(string) (driver.Stmt, error) {
 	return nil, errors.New("failure driver does not prepare statements")
 }
 func (c *failureConn) Close() error { return nil }
+func (c *failureConn) ExecContext(context.Context, string, []driver.NamedValue) (driver.Result, error) {
+	c.driver.execs.Add(1)
+	return driver.RowsAffected(1), nil
+}
 func (c *failureConn) Begin() (driver.Tx, error) {
 	c.driver.begins.Add(1)
 	if c.driver.failBegin.Load() > 0 {
@@ -50,6 +57,9 @@ func (c *failureConn) Begin() (driver.Tx, error) {
 type failureTx struct{ driver *failureDriver }
 
 func (t *failureTx) Commit() error {
+	if t.driver.commitFunc != nil {
+		return t.driver.commitFunc()
+	}
 	return t.driver.nextCommitError()
 }
 func (t *failureTx) Rollback() error { return nil }
@@ -58,7 +68,7 @@ func (d *failureDriver) nextCommitError() error {
 	d.commitMu.Lock()
 	defer d.commitMu.Unlock()
 	if len(d.commitErrs) == 0 {
-		return nil
+		return d.commitErr
 	}
 	err := d.commitErrs[0]
 	d.commitErrs = d.commitErrs[1:]
@@ -66,6 +76,7 @@ func (d *failureDriver) nextCommitError() error {
 }
 
 var _ driver.Connector = (*failureDriver)(nil)
+var _ driver.ExecerContext = (*failureConn)(nil)
 
 func newFailureStore(d *failureDriver) *DoltStore {
 	return &DoltStore{db: sql.OpenDB(d)}
@@ -131,7 +142,7 @@ func TestTyped1105CommitErrorIsDefiniteAndNotRetried(t *testing.T) {
 	if !errors.Is(err, cause) {
 		t.Fatalf("withRetryTx() error = %v, want %v", err, cause)
 	}
-	if errors.Is(err, errCommitPhase) {
+	if errors.Is(err, ErrCommitIndeterminate) {
 		t.Fatalf("withRetryTx() error = %v must not be marked commit-indeterminate", err)
 	}
 	if got := driver.begins.Load(); got != 1 {
@@ -139,6 +150,23 @@ func TestTyped1105CommitErrorIsDefiniteAndNotRetried(t *testing.T) {
 	}
 	if got := callbacks.Load(); got != 1 {
 		t.Errorf("callback invocations = %d, want 1", got)
+	}
+}
+
+func TestWithWriteTxPacketSyncCommitIsIndeterminate(t *testing.T) {
+	driver := &failureDriver{commitErr: mysql.ErrPktSync}
+	store := newFailureStore(driver)
+	defer func() { _ = store.db.Close() }()
+
+	err := store.withRetryTx(context.Background(), func(*sql.Tx) error { return nil })
+	if !errors.Is(err, ErrCommitIndeterminate) {
+		t.Fatalf("withRetryTx() error = %v, want ErrCommitIndeterminate", err)
+	}
+	if !errors.Is(err, mysql.ErrPktSync) {
+		t.Fatalf("withRetryTx() error = %v, want cause %v", err, mysql.ErrPktSync)
+	}
+	if got := driver.begins.Load(); got != 1 {
+		t.Fatalf("write attempts = %d, want 1", got)
 	}
 }
 
@@ -155,5 +183,35 @@ func TestPreCommitConnectionLossIsRetriedSilently(t *testing.T) {
 	}
 	if got := driver.begins.Load(); got != 3 {
 		t.Errorf("Begin calls = %d, want 3", got)
+	}
+}
+
+func TestExecContextCommitResponseLossIsIndeterminateAndMutationRunsOnce(t *testing.T) {
+	var commitCalls atomic.Int32
+	driver := &failureDriver{}
+	driver.commitFunc = func() error {
+		if commitCalls.Add(1) == 1 {
+			return testConnectionLoss
+		}
+		return nil
+	}
+	store := newFailureStore(driver)
+	defer func() { _ = store.db.Close() }()
+
+	_, err := store.execContext(context.Background(), "UPDATE issues SET title = ?", "changed")
+	if !errors.Is(err, ErrCommitIndeterminate) {
+		t.Fatalf("execContext() error = %v, want ErrCommitIndeterminate", err)
+	}
+	if !errors.Is(err, testConnectionLoss) {
+		t.Fatalf("execContext() error = %v, want cause %v", err, testConnectionLoss)
+	}
+	if got := driver.execs.Load(); got != 1 {
+		t.Fatalf("SQL mutation calls = %d, want 1", got)
+	}
+	if got := driver.begins.Load(); got != 1 {
+		t.Fatalf("transaction begins = %d, want 1", got)
+	}
+	if got := commitCalls.Load(); got != 1 {
+		t.Fatalf("commit calls = %d, want 1", got)
 	}
 }

--- a/internal/storage/dolt/indeterminate_commit_test.go
+++ b/internal/storage/dolt/indeterminate_commit_test.go
@@ -141,6 +141,78 @@ func TestWithRetryTxIndeterminateCommitFailuresTripCircuitWithoutReplay(t *testi
 			t.Fatalf("circuit state after attempt %d = %q, want %q", attempt, got, wantState)
 		}
 	}
+
+	beginCalls := driver.begins.Load()
+	callbackCalls := callbacks.Load()
+	mutationCalls := driver.execs.Load()
+	err := store.withRetryTx(ctx, func(tx *sql.Tx) error {
+		callbacks.Add(1)
+		_, execErr := tx.ExecContext(ctx, "UPDATE issues SET title = ?", "replayed")
+		return execErr
+	})
+	if !errors.Is(err, ErrCircuitOpen) {
+		t.Fatalf("withRetryTx() after circuit opened error = %v, want ErrCircuitOpen", err)
+	}
+	if got := driver.begins.Load(); got != beginCalls {
+		t.Fatalf("transaction begins after circuit opened = %d, want unchanged %d", got, beginCalls)
+	}
+	if got := callbacks.Load(); got != callbackCalls {
+		t.Fatalf("callback calls after circuit opened = %d, want unchanged %d", got, callbackCalls)
+	}
+	if got := driver.execs.Load(); got != mutationCalls {
+		t.Fatalf("SQL mutations after circuit opened = %d, want unchanged %d", got, mutationCalls)
+	}
+}
+
+func TestWithRetryTxPreCallbackConnectionFailureTripsCircuit(t *testing.T) {
+	t.Setenv("BEADS_TEST_MODE", "")
+	breaker := newTestCircuitBreaker(t)
+	for range circuitFailureThreshold - 1 {
+		breaker.RecordFailure()
+	}
+	driver := &failureDriver{}
+	driver.failBegin.Store(1)
+	store := newFailureStore(driver)
+	store.breaker = breaker
+	defer func() { _ = store.db.Close() }()
+
+	var callbacks atomic.Int32
+	err := store.withRetryTx(t.Context(), func(*sql.Tx) error {
+		callbacks.Add(1)
+		return nil
+	})
+	if !errors.Is(err, testConnectionLoss) {
+		t.Fatalf("withRetryTx() error = %v, want connection cause %v", err, testConnectionLoss)
+	}
+	if got := breaker.State(); got != circuitOpen {
+		t.Fatalf("circuit state = %q, want %q", got, circuitOpen)
+	}
+	if got := driver.begins.Load(); got != 1 {
+		t.Fatalf("transaction begins = %d, want 1", got)
+	}
+	if got := callbacks.Load(); got != 0 {
+		t.Fatalf("callback calls = %d, want 0 after pre-callback circuit trip", got)
+	}
+}
+
+func TestWithRetryTxSuccessResetsCircuitFailures(t *testing.T) {
+	t.Setenv("BEADS_TEST_MODE", "")
+	breaker := newTestCircuitBreaker(t)
+	for range circuitFailureThreshold - 1 {
+		breaker.RecordFailure()
+	}
+	driver := &failureDriver{}
+	store := newFailureStore(driver)
+	store.breaker = breaker
+	defer func() { _ = store.db.Close() }()
+
+	if err := store.withRetryTx(t.Context(), func(*sql.Tx) error { return nil }); err != nil {
+		t.Fatalf("withRetryTx() error = %v, want nil", err)
+	}
+	breaker.RecordFailure()
+	if got := breaker.State(); got != circuitClosed {
+		t.Fatalf("circuit state after success and one failure = %q, want %q", got, circuitClosed)
+	}
 }
 
 func TestDoltAutocommitRollbackCommitIsRetried(t *testing.T) {

--- a/internal/storage/dolt/indeterminate_commit_test.go
+++ b/internal/storage/dolt/indeterminate_commit_test.go
@@ -82,8 +82,8 @@ func TestIndeterminateCommitIsSurfacedNotRetried(t *testing.T) {
 	if err == nil {
 		t.Fatal("lost commit returned nil; indeterminacy must be surfaced")
 	}
-	if !errors.Is(err, errCommitPhase) {
-		t.Errorf("err = %v, want errCommitPhase", err)
+	if !errors.Is(err, ErrCommitIndeterminate) {
+		t.Errorf("err = %v, want ErrCommitIndeterminate", err)
 	}
 	if !strings.Contains(err.Error(), "indeterminate") {
 		t.Errorf("err = %q, want indeterminate outcome", err)

--- a/internal/storage/dolt/indeterminate_commit_test.go
+++ b/internal/storage/dolt/indeterminate_commit_test.go
@@ -104,6 +104,45 @@ func TestIndeterminateCommitIsSurfacedNotRetried(t *testing.T) {
 	}
 }
 
+func TestWithRetryTxIndeterminateCommitFailuresTripCircuitWithoutReplay(t *testing.T) {
+	t.Setenv("BEADS_TEST_MODE", "")
+	breaker := newTestCircuitBreaker(t)
+	driver := &failureDriver{commitErr: testConnectionLoss}
+	store := newFailureStore(driver)
+	store.breaker = breaker
+	defer func() { _ = store.db.Close() }()
+
+	ctx := t.Context()
+	var callbacks atomic.Int32
+	for attempt := 1; attempt <= circuitFailureThreshold; attempt++ {
+		err := store.withRetryTx(ctx, func(tx *sql.Tx) error {
+			callbacks.Add(1)
+			_, err := tx.ExecContext(ctx, "UPDATE issues SET title = ?", "changed")
+			return err
+		})
+		if !errors.Is(err, ErrCommitIndeterminate) {
+			t.Fatalf("withRetryTx() attempt %d error = %v, want ErrCommitIndeterminate", attempt, err)
+		}
+		if got := driver.begins.Load(); got != int32(attempt) {
+			t.Fatalf("transaction begins after attempt %d = %d, want %d", attempt, got, attempt)
+		}
+		if got := callbacks.Load(); got != int32(attempt) {
+			t.Fatalf("callback calls after attempt %d = %d, want %d", attempt, got, attempt)
+		}
+		if got := driver.execs.Load(); got != int32(attempt) {
+			t.Fatalf("SQL mutations after attempt %d = %d, want %d", attempt, got, attempt)
+		}
+
+		wantState := circuitClosed
+		if attempt == circuitFailureThreshold {
+			wantState = circuitOpen
+		}
+		if got := breaker.State(); got != wantState {
+			t.Fatalf("circuit state after attempt %d = %q, want %q", attempt, got, wantState)
+		}
+	}
+}
+
 func TestDoltAutocommitRollbackCommitIsRetried(t *testing.T) {
 	rollback := &mysql.MySQLError{
 		Number:  1105,

--- a/internal/storage/dolt/initschema_gate_test.go
+++ b/internal/storage/dolt/initschema_gate_test.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"testing"
 
-	_ "github.com/go-sql-driver/mysql"
+	mysql "github.com/go-sql-driver/mysql"
 	"github.com/steveyegge/beads/internal/storage/schema"
 )
 
@@ -44,6 +44,38 @@ func TestInitSchemaOnDBWithRetryAndGate_GateErrorClassification(t *testing.T) {
 		}
 	})
 
+	for _, tc := range []struct {
+		name string
+		err  *mysql.MySQLError
+	}{
+		{
+			name: "typed unknown database",
+			err:  &mysql.MySQLError{Number: 1049, Message: "Unknown database 'beads_test'"},
+		},
+		{
+			name: "typed missing session root",
+			err:  &mysql.MySQLError{Number: 1105, Message: "no root value found in session"},
+		},
+	} {
+		t.Run(tc.name+" is retried during setup", func(t *testing.T) {
+			calls := 0
+			gate := func(context.Context, *sql.DB) error {
+				calls++
+				if calls < 3 {
+					return fmt.Errorf("remote-migrate gate: probe schema: %w", tc.err)
+				}
+				return &schema.RemoteMigrateGateError{CurrentVersion: 1, LatestVersion: 2, Pending: 1}
+			}
+			_, err := initSchemaOnDBWithRetryAndGate(ctx, db, gate)
+			if !schema.IsRemoteMigrateGateError(err) {
+				t.Fatalf("err = %T (%v), want *schema.RemoteMigrateGateError after retries", err, err)
+			}
+			if calls != 3 {
+				t.Fatalf("gate calls = %d, want 3", calls)
+			}
+		})
+	}
+
 	t.Run("gate refusal is permanent, not retried", func(t *testing.T) {
 		calls := 0
 		gate := func(context.Context, *sql.DB) error {
@@ -71,6 +103,22 @@ func TestInitSchemaOnDBWithRetryAndGate_GateErrorClassification(t *testing.T) {
 		}
 		if calls != 1 {
 			t.Fatalf("gate calls = %d, want 1 (non-retryable must not be retried)", calls)
+		}
+	})
+
+	t.Run("unrelated typed MySQL error is permanent", func(t *testing.T) {
+		calls := 0
+		gate := func(context.Context, *sql.DB) error {
+			calls++
+			return fmt.Errorf("remote-migrate gate: probe schema: %w",
+				&mysql.MySQLError{Number: 1105, Message: "connection lost while validating commit"})
+		}
+		_, err := initSchemaOnDBWithRetryAndGate(ctx, db, gate)
+		if err == nil || schema.IsRemoteMigrateGateError(err) {
+			t.Fatalf("err = %v, want plain permanent error", err)
+		}
+		if calls != 1 {
+			t.Fatalf("gate calls = %d, want 1", calls)
 		}
 	})
 }

--- a/internal/storage/dolt/issue_claimer.go
+++ b/internal/storage/dolt/issue_claimer.go
@@ -29,17 +29,25 @@ type issueClaimer struct{ store *DoltStore }
 // either direction, and a phantom claim is a duplicated implementation. Replay
 // is safe because the CAS is re-checked inside the replayed transaction.
 func (c *issueClaimer) Claim(ctx context.Context, request issueops.ClaimRequest) (issueops.ClaimResult, error) {
+	// The write and its verify sit under withCircuitWrite so terminal circuit
+	// success is recorded once at the boundary, only after verifiedClaimWrite
+	// returns nil — matching the store's own ClaimIssue. write is defined inside
+	// the boundary so its runIssueOperationTx captures the circuit-managed ctx
+	// and defers success to the boundary.
 	var result issueops.ClaimResult
-	write := func() error {
-		return c.store.runIssueOperationTx(ctx, storageissueops.ClaimCommitMessage(request.IssueID, request.Actor),
-			func(tx *sql.Tx) (storageissueops.ChangedTables, error) {
-				var err error
-				var tables storageissueops.ChangedTables
-				result, tables, err = storageissueops.ExecuteClaim(ctx, tx, request)
-				return tables, err
-			})
-	}
-	if err := c.store.verifiedClaimWrite(ctx, request.IssueID, claimedBy(request.Actor), write); err != nil {
+	err := c.store.withCircuitWrite(ctx, func(ctx context.Context) error {
+		write := func() error {
+			return c.store.runIssueOperationTx(ctx, storageissueops.ClaimCommitMessage(request.IssueID, request.Actor),
+				func(tx *sql.Tx) (storageissueops.ChangedTables, error) {
+					var err error
+					var tables storageissueops.ChangedTables
+					result, tables, err = storageissueops.ExecuteClaim(ctx, tx, request)
+					return tables, err
+				})
+		}
+		return c.store.verifiedClaimWrite(ctx, request.IssueID, claimedBy(request.Actor), write)
+	})
+	if err != nil {
 		return issueops.ClaimResult{}, err
 	}
 	return result, nil

--- a/internal/storage/dolt/issue_operations.go
+++ b/internal/storage/dolt/issue_operations.go
@@ -62,13 +62,12 @@ func (o *issueOperations) Update(ctx context.Context, request issueops.UpdateReq
 	return result, err
 }
 
-// verifiedUpdate runs a facade update under claim-family verify-after-write
-// (bd-zccb9) when the request writes coordination state, and unwrapped
-// otherwise. The facade reaches the same writes as ClaimIssue and
-// UpdateIssueWithOptions, so under a degraded server its exit status is no more
-// trustworthy than theirs. Replay is safe: the claim CAS and the compare-and-set
-// guards are re-checked inside the replayed transaction, so a racing writer
-// makes the replay refuse rather than clobber.
+// verifiedUpdate verifies a coordination-only claim or a qualifying guarded
+// update after a write (bd-zccb9), and preserves the write outcome otherwise.
+// A re-read of assignee and status cannot prove an ordinary patch or its event
+// landed, even when the claim state already matches. The facade reaches the
+// same writes as ClaimIssue and UpdateIssueWithOptions, so under a degraded
+// server its exit status is no more trustworthy than theirs.
 func (o *issueOperations) verifiedUpdate(ctx context.Context, request issueops.UpdateRequest, write func() error) error {
 	post, verify := updateClaimPostcondition(request)
 	if !verify {
@@ -78,16 +77,26 @@ func (o *issueOperations) verifiedUpdate(ctx context.Context, request issueops.U
 }
 
 // updateClaimPostcondition derives the row state a facade update must leave
-// behind to count as applied, and whether the update is claim-family at all. A
-// claim always is; an ordinary update is only when a compare-and-set guard
-// authorizes a write to assignee or status. The postcondition describes the
-// state the request intends, so a patch that overrides the claim's own
-// assignee or status is honored rather than read as a lost write.
-//
-// A request that also moves the issue across the persistence boundary is
-// exempt: the row can legitimately leave the issues table mid-write, which the
-// re-read would report as an unverifiable claim.
+// behind to count as applied, and whether that state is enough to prove the
+// whole update. A claim is verifiable only when its patch changes no state
+// beyond assignee and status. An ordinary update is verifiable only when a
+// compare-and-set guard authorizes a write to assignee or status. The
+// postcondition honors a coordination-only claim patch that overrides the
+// claim's own assignee or status.
 func updateClaimPostcondition(request issueops.UpdateRequest) (claimPostcondition, bool) {
+	if request.Claim {
+		if hasNonCoordinationClaimPatch(request.Patch) {
+			return claimPostcondition{}, false
+		}
+		assignee, status := request.Actor, types.StatusInProgress
+		if request.Patch.Assignee.Set {
+			assignee = request.Patch.Assignee.Value
+		}
+		if request.Patch.Status.Set {
+			status = request.Patch.Status.Value
+		}
+		return claimedAs(assignee, status), true
+	}
 	if request.Patch.Persistence.Set {
 		return claimPostcondition{}, false
 	}
@@ -98,22 +107,43 @@ func updateClaimPostcondition(request issueops.UpdateRequest) (claimPostconditio
 	if request.Patch.Status.Set {
 		updates["status"] = string(request.Patch.Status.Value)
 	}
-	if request.Claim {
-		assignee, status := request.Actor, types.StatusInProgress
-		if request.Patch.Assignee.Set {
-			assignee = request.Patch.Assignee.Value
-		}
-		if request.Patch.Status.Set {
-			status = request.Patch.Status.Value
-		}
-		return claimedAs(assignee, status), true
-	}
 	opts := storage.UpdateIssueOptions{ExpectedAssignee: request.ExpectedAssignee}
 	if request.ExpectedStatus != nil {
 		expected := string(*request.ExpectedStatus)
 		opts.ExpectedStatus = &expected
 	}
 	return guardedUpdatePostcondition(opts, updates)
+}
+
+// hasNonCoordinationClaimPatch reports whether a claim also changes state that
+// an assignee/status re-read cannot prove. Keep this explicit so every patch
+// operation is visibly classified without making the request shape reflective.
+func hasNonCoordinationClaimPatch(patch issueops.IssuePatch) bool {
+	return patch.Title.Set ||
+		patch.Description.Set ||
+		patch.Design.Set ||
+		patch.AcceptanceCriteria.Set ||
+		patch.Notes.Set ||
+		patch.AppendNotes.Set ||
+		patch.SpecID.Set ||
+		patch.AwaitID.Set ||
+		patch.Priority.Set ||
+		patch.IssueType.Set ||
+		patch.Owner.Set ||
+		patch.ClosedBySession.Set ||
+		patch.EstimatedMinutes.Set ||
+		patch.ExternalRef.Set ||
+		patch.DueAt.Set ||
+		patch.DeferUntil.Set ||
+		patch.Persistence.Set ||
+		patch.ParentID.Set ||
+		len(patch.Labels.Add) != 0 ||
+		len(patch.Labels.Remove) != 0 ||
+		patch.Labels.Replace.Set ||
+		len(patch.Metadata.Set) != 0 ||
+		len(patch.Metadata.Unset) != 0 ||
+		patch.Metadata.Replace.Set ||
+		patch.Metadata.Merge.Set
 }
 
 func (o *issueOperations) Close(ctx context.Context, request issueops.CloseRequest) (issueops.CloseResult, error) {

--- a/internal/storage/dolt/issue_operations.go
+++ b/internal/storage/dolt/issue_operations.go
@@ -48,7 +48,7 @@ func (o *issueOperations) Create(ctx context.Context, request issueops.CreateReq
 func (o *issueOperations) Update(ctx context.Context, request issueops.UpdateRequest) (issueops.UpdateResult, error) {
 	snapshot := storageissueops.CloneUpdateRequest(request)
 	var result issueops.UpdateResult
-	err := o.verifiedUpdate(ctx, snapshot, func() error {
+	err := o.verifiedUpdate(ctx, snapshot, func(ctx context.Context) error {
 		// The message names the issue because that is the one `bd dolt log`
 		// affordance callers actually grep, and it is what the CLI's own
 		// per-command commit wrote before updates moved onto this path.
@@ -68,12 +68,25 @@ func (o *issueOperations) Update(ctx context.Context, request issueops.UpdateReq
 // landed, even when the claim state already matches. The facade reaches the
 // same writes as ClaimIssue and UpdateIssueWithOptions, so under a degraded
 // server its exit status is no more trustworthy than theirs.
-func (o *issueOperations) verifiedUpdate(ctx context.Context, request issueops.UpdateRequest, write func() error) error {
+//
+// A verifying update runs write and its post-write re-read under withCircuitWrite
+// so terminal circuit success is recorded once at the boundary, only after
+// verifiedClaimWrite returns nil — matching issueClaimer.Claim and the store's
+// ClaimIssue. write is invoked with the circuit-managed context so its nested
+// runIssueOperationTx defers success to that boundary instead of recording it
+// eagerly when the SQL commit lands but before the re-read can fail. A
+// non-verifying update keeps the original context and its eager accounting,
+// leaving the ordinary patch path unchanged.
+func (o *issueOperations) verifiedUpdate(ctx context.Context, request issueops.UpdateRequest, write func(context.Context) error) error {
 	post, verify := updateClaimPostcondition(request)
 	if !verify {
-		return write()
+		return write(ctx)
 	}
-	return o.store.verifiedClaimWrite(ctx, request.IssueID, post, write)
+	return o.store.withCircuitWrite(ctx, func(ctx context.Context) error {
+		return o.store.verifiedClaimWrite(ctx, request.IssueID, post, func() error {
+			return write(ctx)
+		})
+	})
 }
 
 // updateClaimPostcondition derives the row state a facade update must leave

--- a/internal/storage/dolt/issue_operations.go
+++ b/internal/storage/dolt/issue_operations.go
@@ -113,34 +113,50 @@ func updateClaimPostcondition(request issueops.UpdateRequest) (claimPostconditio
 }
 
 // hasNonCoordinationPatch reports whether an update also changes state that an
-// assignee/status re-read cannot prove. Keep this explicit so every patch
-// operation is visibly classified without making the request shape reflective.
+// assignee/status re-read cannot prove.
 func hasNonCoordinationPatch(patch issueops.IssuePatch) bool {
-	return patch.Title.Set ||
-		patch.Description.Set ||
-		patch.Design.Set ||
-		patch.AcceptanceCriteria.Set ||
-		patch.Notes.Set ||
-		patch.AppendNotes.Set ||
-		patch.SpecID.Set ||
-		patch.AwaitID.Set ||
-		patch.Priority.Set ||
-		patch.IssueType.Set ||
-		patch.Owner.Set ||
-		patch.ClosedBySession.Set ||
-		patch.EstimatedMinutes.Set ||
-		patch.ExternalRef.Set ||
-		patch.DueAt.Set ||
-		patch.DeferUntil.Set ||
-		patch.Persistence.Set ||
-		patch.ParentID.Set ||
-		len(patch.Labels.Add) != 0 ||
-		len(patch.Labels.Remove) != 0 ||
-		patch.Labels.Replace.Set ||
-		len(patch.Metadata.Set) != 0 ||
-		len(patch.Metadata.Unset) != 0 ||
-		patch.Metadata.Replace.Set ||
-		patch.Metadata.Merge.Set
+	for _, changed := range nonCoordinationPatchSignals(patch) {
+		if changed {
+			return true
+		}
+	}
+	return false
+}
+
+// nonCoordinationPatchSignals enumerates a "changed" bool for every settable
+// IssuePatch field except the coordination pair (Assignee, Status) — the only
+// two an assignee/status re-read can prove. Keep this explicit rather than
+// reflective so each field is visibly classified; add a signal here whenever
+// IssuePatch, LabelPatch, or MetadataPatch grows a field. TestNonCoordination*
+// fails until you do.
+func nonCoordinationPatchSignals(patch issueops.IssuePatch) []bool {
+	return []bool{
+		patch.Title.Set,
+		patch.Description.Set,
+		patch.Design.Set,
+		patch.AcceptanceCriteria.Set,
+		patch.Notes.Set,
+		patch.AppendNotes.Set,
+		patch.SpecID.Set,
+		patch.AwaitID.Set,
+		patch.Priority.Set,
+		patch.IssueType.Set,
+		patch.Owner.Set,
+		patch.ClosedBySession.Set,
+		patch.EstimatedMinutes.Set,
+		patch.ExternalRef.Set,
+		patch.DueAt.Set,
+		patch.DeferUntil.Set,
+		patch.Persistence.Set,
+		patch.ParentID.Set,
+		len(patch.Labels.Add) != 0,
+		len(patch.Labels.Remove) != 0,
+		patch.Labels.Replace.Set,
+		len(patch.Metadata.Set) != 0,
+		len(patch.Metadata.Unset) != 0,
+		patch.Metadata.Replace.Set,
+		patch.Metadata.Merge.Set,
+	}
 }
 
 func (o *issueOperations) Close(ctx context.Context, request issueops.CloseRequest) (issueops.CloseResult, error) {

--- a/internal/storage/dolt/issue_operations.go
+++ b/internal/storage/dolt/issue_operations.go
@@ -80,14 +80,14 @@ func (o *issueOperations) verifiedUpdate(ctx context.Context, request issueops.U
 // behind to count as applied, and whether that state is enough to prove the
 // whole update. A claim is verifiable only when its patch changes no state
 // beyond assignee and status. An ordinary update is verifiable only when a
-// compare-and-set guard authorizes a write to assignee or status. The
-// postcondition honors a coordination-only claim patch that overrides the
-// claim's own assignee or status.
+// compare-and-set guard authorizes a coordination-only write. The postcondition
+// honors a coordination-only claim patch that overrides the claim's own
+// assignee or status.
 func updateClaimPostcondition(request issueops.UpdateRequest) (claimPostcondition, bool) {
+	if hasNonCoordinationPatch(request.Patch) {
+		return claimPostcondition{}, false
+	}
 	if request.Claim {
-		if hasNonCoordinationClaimPatch(request.Patch) {
-			return claimPostcondition{}, false
-		}
 		assignee, status := request.Actor, types.StatusInProgress
 		if request.Patch.Assignee.Set {
 			assignee = request.Patch.Assignee.Value
@@ -96,9 +96,6 @@ func updateClaimPostcondition(request issueops.UpdateRequest) (claimPostconditio
 			status = request.Patch.Status.Value
 		}
 		return claimedAs(assignee, status), true
-	}
-	if request.Patch.Persistence.Set {
-		return claimPostcondition{}, false
 	}
 	updates := map[string]interface{}{}
 	if request.Patch.Assignee.Set {
@@ -115,10 +112,10 @@ func updateClaimPostcondition(request issueops.UpdateRequest) (claimPostconditio
 	return guardedUpdatePostcondition(opts, updates)
 }
 
-// hasNonCoordinationClaimPatch reports whether a claim also changes state that
-// an assignee/status re-read cannot prove. Keep this explicit so every patch
+// hasNonCoordinationPatch reports whether an update also changes state that an
+// assignee/status re-read cannot prove. Keep this explicit so every patch
 // operation is visibly classified without making the request shape reflective.
-func hasNonCoordinationClaimPatch(patch issueops.IssuePatch) bool {
+func hasNonCoordinationPatch(patch issueops.IssuePatch) bool {
 	return patch.Title.Set ||
 		patch.Description.Set ||
 		patch.Design.Set ||

--- a/internal/storage/dolt/issue_operations_claim_verify_test.go
+++ b/internal/storage/dolt/issue_operations_claim_verify_test.go
@@ -238,6 +238,34 @@ func TestIssueOperationsClaimVerifyDoesNotMaskIndeterminateMixedClaim(t *testing
 	}
 }
 
+func TestIssueOperationsClaimCoordinationPatchRetainsIndeterminate(t *testing.T) {
+	s, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+	s.serverMode = true
+
+	id := claimVerifyTestIssue(t, s)
+	if err := rawClaim(t, s, id, "alice"); err != nil {
+		t.Fatalf("seed matching claim state: %v", err)
+	}
+	operations := &issueOperations{store: s}
+	indeterminate := fmt.Errorf("write commit result indeterminate: %w", ErrCommitIndeterminate)
+	err := operations.verifiedUpdate(ctx, publicops.UpdateRequest{
+		Actor:   "alice",
+		IssueID: id,
+		Claim:   true,
+		Patch: publicops.IssuePatch{
+			Status: publicops.Field[publicops.Status]{Set: true, Value: types.StatusInProgress},
+		},
+	}, func() error {
+		return indeterminate
+	})
+	if !errors.Is(err, ErrCommitIndeterminate) {
+		t.Fatalf("coordination claim error = %v, want ErrCommitIndeterminate", err)
+	}
+}
+
 // TestIssueOperationsClaimVerifyFailsLoudlyOnLostFacadeClaim: a facade claim
 // whose transaction reports success without landing must fail loudly, exactly
 // like the store's own ClaimIssue. A silent phantom claim through the facade

--- a/internal/storage/dolt/issue_operations_claim_verify_test.go
+++ b/internal/storage/dolt/issue_operations_claim_verify_test.go
@@ -109,6 +109,27 @@ func TestIssueOperationsClaimVerifyPostcondition(t *testing.T) {
 			rejects:      [][2]string{{"", "open"}},
 		},
 		{
+			name: "guarded status write with a scalar patch is not verified",
+			request: publicops.UpdateRequest{Actor: "alice", IssueID: "bd-1", ExpectedStatus: status(types.StatusOpen), Patch: publicops.IssuePatch{
+				Status: publicops.Field[publicops.Status]{Set: true, Value: types.StatusInProgress},
+				Title:  publicops.Field[string]{Set: true, Value: "new title"},
+			}},
+		},
+		{
+			name: "guarded assignee transfer with a labels patch is not verified",
+			request: publicops.UpdateRequest{Actor: "alice", IssueID: "bd-1", ExpectedAssignee: assignee("bob"), Patch: publicops.IssuePatch{
+				Assignee: publicops.Field[string]{Set: true, Value: "carol"},
+				Labels:   publicops.LabelPatch{Add: []string{"label"}},
+			}},
+		},
+		{
+			name: "guarded status write with a metadata patch is not verified",
+			request: publicops.UpdateRequest{Actor: "alice", IssueID: "bd-1", ExpectedStatus: status(types.StatusOpen), Patch: publicops.IssuePatch{
+				Status:   publicops.Field[publicops.Status]{Set: true, Value: types.StatusInProgress},
+				Metadata: publicops.MetadataPatch{Set: map[string]json.RawMessage{"key": json.RawMessage(`"value"`)}},
+			}},
+		},
+		{
 			name: "guarded edit of ordinary fields is not claim-family",
 			request: publicops.UpdateRequest{Actor: "alice", IssueID: "bd-1", ExpectedStatus: status(types.StatusOpen), Patch: publicops.IssuePatch{
 				Title: publicops.Field[string]{Set: true, Value: "new title"},
@@ -145,6 +166,44 @@ func TestIssueOperationsClaimVerifyPostcondition(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestIssueOperationsGuardedVerifyDoesNotMaskIndeterminateMixedUpdate proves a
+// guarded facade update cannot infer that an ordinary patch landed merely from
+// matching preexisting coordination state.
+func TestIssueOperationsGuardedVerifyDoesNotMaskIndeterminateMixedUpdate(t *testing.T) {
+	s, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+	s.serverMode = true
+
+	id := claimVerifyTestIssue(t, s)
+	operations := &issueOperations{store: s}
+	expectedStatus := types.StatusOpen
+	indeterminate := fmt.Errorf("write commit result indeterminate: %w", ErrCommitIndeterminate)
+	err := operations.verifiedUpdate(ctx, publicops.UpdateRequest{
+		Actor:          "alice",
+		IssueID:        id,
+		ExpectedStatus: &expectedStatus,
+		Patch: publicops.IssuePatch{
+			Status: publicops.Field[publicops.Status]{Set: true, Value: types.StatusOpen},
+			Title:  publicops.Field[string]{Set: true, Value: "must not be inferred"},
+		},
+	}, func() error {
+		return indeterminate
+	})
+	if !errors.Is(err, ErrCommitIndeterminate) {
+		t.Fatalf("mixed guarded facade update error = %v, want ErrCommitIndeterminate", err)
+	}
+
+	issue, err := s.GetIssue(ctx, id)
+	if err != nil {
+		t.Fatalf("read issue after indeterminate update: %v", err)
+	}
+	if issue.Title == "must not be inferred" {
+		t.Fatal("ordinary title patch unexpectedly landed")
 	}
 }
 

--- a/internal/storage/dolt/issue_operations_claim_verify_test.go
+++ b/internal/storage/dolt/issue_operations_claim_verify_test.go
@@ -1,6 +1,9 @@
 package dolt
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -56,7 +59,31 @@ func TestIssueOperationsClaimVerifyPostcondition(t *testing.T) {
 			rejects:      [][2]string{{"alice", "in_progress"}},
 		},
 		{
-			name: "claim that moves the issue to a wisp is not verified",
+			name: "claim with an ordinary scalar patch is not verified",
+			request: publicops.UpdateRequest{Actor: "alice", IssueID: "bd-1", Claim: true, Patch: publicops.IssuePatch{
+				Title: publicops.Field[string]{Set: true, Value: "new title"},
+			}},
+		},
+		{
+			name: "claim with a labels patch is not verified",
+			request: publicops.UpdateRequest{Actor: "alice", IssueID: "bd-1", Claim: true, Patch: publicops.IssuePatch{
+				Labels: publicops.LabelPatch{Add: []string{"label"}},
+			}},
+		},
+		{
+			name: "claim with a metadata patch is not verified",
+			request: publicops.UpdateRequest{Actor: "alice", IssueID: "bd-1", Claim: true, Patch: publicops.IssuePatch{
+				Metadata: publicops.MetadataPatch{Set: map[string]json.RawMessage{"key": json.RawMessage(`"value"`)}},
+			}},
+		},
+		{
+			name: "claim with a parent patch is not verified",
+			request: publicops.UpdateRequest{Actor: "alice", IssueID: "bd-1", Claim: true, Patch: publicops.IssuePatch{
+				ParentID: publicops.Field[string]{Set: true, Value: "parent"},
+			}},
+		},
+		{
+			name: "claim with a persistence patch is not verified",
 			request: publicops.UpdateRequest{Actor: "alice", IssueID: "bd-1", Claim: true, Patch: publicops.IssuePatch{
 				Persistence: publicops.Field[publicops.PersistenceMode]{Set: true, Value: publicops.PersistenceModeEphemeral},
 			}},
@@ -118,6 +145,37 @@ func TestIssueOperationsClaimVerifyPostcondition(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestIssueOperationsClaimVerifyDoesNotMaskIndeterminateMixedClaim proves a
+// facade claim with an ordinary patch cannot infer that patch landed merely
+// from matching preexisting coordination state.
+func TestIssueOperationsClaimVerifyDoesNotMaskIndeterminateMixedClaim(t *testing.T) {
+	s, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+	s.serverMode = true
+
+	id := claimVerifyTestIssue(t, s)
+	if err := rawClaim(t, s, id, "alice"); err != nil {
+		t.Fatalf("seed matching coordination state: %v", err)
+	}
+	operations := &issueOperations{store: s}
+	indeterminate := fmt.Errorf("write commit result indeterminate: %w", ErrCommitIndeterminate)
+	err := operations.verifiedUpdate(ctx, publicops.UpdateRequest{
+		Actor:   "alice",
+		IssueID: id,
+		Claim:   true,
+		Patch: publicops.IssuePatch{
+			Title: publicops.Field[string]{Set: true, Value: "must not be inferred"},
+		},
+	}, func() error {
+		return indeterminate
+	})
+	if !errors.Is(err, ErrCommitIndeterminate) {
+		t.Fatalf("mixed facade claim error = %v, want ErrCommitIndeterminate", err)
 	}
 }
 

--- a/internal/storage/dolt/issue_operations_claim_verify_test.go
+++ b/internal/storage/dolt/issue_operations_claim_verify_test.go
@@ -1,6 +1,7 @@
 package dolt
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -191,7 +192,7 @@ func TestIssueOperationsGuardedVerifyDoesNotMaskIndeterminateMixedUpdate(t *test
 			Status: publicops.Field[publicops.Status]{Set: true, Value: types.StatusOpen},
 			Title:  publicops.Field[string]{Set: true, Value: "must not be inferred"},
 		},
-	}, func() error {
+	}, func(context.Context) error {
 		return indeterminate
 	})
 	if !errors.Is(err, ErrCommitIndeterminate) {
@@ -230,7 +231,7 @@ func TestIssueOperationsClaimVerifyDoesNotMaskIndeterminateMixedClaim(t *testing
 		Patch: publicops.IssuePatch{
 			Title: publicops.Field[string]{Set: true, Value: "must not be inferred"},
 		},
-	}, func() error {
+	}, func(context.Context) error {
 		return indeterminate
 	})
 	if !errors.Is(err, ErrCommitIndeterminate) {
@@ -258,7 +259,7 @@ func TestIssueOperationsClaimCoordinationPatchRetainsIndeterminate(t *testing.T)
 		Patch: publicops.IssuePatch{
 			Status: publicops.Field[publicops.Status]{Set: true, Value: types.StatusInProgress},
 		},
-	}, func() error {
+	}, func(context.Context) error {
 		return indeterminate
 	})
 	if !errors.Is(err, ErrCommitIndeterminate) {
@@ -279,7 +280,7 @@ func TestIssueOperationsClaimVerifyFailsLoudlyOnLostFacadeClaim(t *testing.T) {
 	id := claimVerifyTestIssue(t, s)
 	operations := &issueOperations{store: s}
 
-	err := operations.verifiedUpdate(ctx, publicops.UpdateRequest{Actor: "alice", IssueID: id, Claim: true}, func() error {
+	err := operations.verifiedUpdate(ctx, publicops.UpdateRequest{Actor: "alice", IssueID: id, Claim: true}, func(context.Context) error {
 		return nil // lie: report success without writing anything
 	})
 	if err == nil {
@@ -306,7 +307,7 @@ func TestIssueOperationsClaimVerifyLeavesOrdinaryUpdatesUnwrapped(t *testing.T) 
 	request := publicops.UpdateRequest{Actor: "alice", IssueID: id, Patch: publicops.IssuePatch{
 		Title: publicops.Field[string]{Set: true, Value: "retitled"},
 	}}
-	if err := operations.verifiedUpdate(ctx, request, func() error { return nil }); err != nil {
+	if err := operations.verifiedUpdate(ctx, request, func(context.Context) error { return nil }); err != nil {
 		t.Fatalf("ordinary update must keep its exit status, got: %v", err)
 	}
 }

--- a/internal/storage/dolt/issue_operations_test.go
+++ b/internal/storage/dolt/issue_operations_test.go
@@ -1,0 +1,125 @@
+package dolt
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/steveyegge/beads/issueops"
+)
+
+// coordinationFields are the only two patch fields an assignee/status re-read
+// can prove. Every other settable field must count as a non-coordination patch,
+// so a verify-by-re-read cannot launder its indeterminate commit into success.
+var coordinationFields = map[string]bool{"Assignee": true, "Status": true}
+
+// isFieldPatch reports whether a struct field is an issueops.Field[T], detected
+// by a bool member named "Set". MetadataPatch.Set is a map and LabelPatch has no
+// Set member, so both nested patches are correctly excluded here and pinned
+// instead by the count guard and the explicit nested cases below.
+func isFieldPatch(fv reflect.Value) bool {
+	if fv.Kind() != reflect.Struct {
+		return false
+	}
+	set := fv.FieldByName("Set")
+	return set.IsValid() && set.Kind() == reflect.Bool
+}
+
+// TestHasNonCoordinationPatchClassifiesEveryScalarField reflects over every
+// scalar issueops.Field[T] on IssuePatch, sets it in isolation, and asserts the
+// classifier agrees with the coordination set. A new scalar field added to
+// IssuePatch (and wired into ExecuteUpdate) but not into
+// nonCoordinationPatchSignals reclassifies a mixed update as coordination-only;
+// this test fails the moment that field appears.
+func TestHasNonCoordinationPatchClassifiesEveryScalarField(t *testing.T) {
+	typ := reflect.TypeOf(issueops.IssuePatch{})
+	scalarSeen := 0
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		probe := reflect.New(typ).Elem()
+		fv := probe.Field(i)
+		if !isFieldPatch(fv) {
+			continue
+		}
+		scalarSeen++
+		fv.FieldByName("Set").SetBool(true)
+		patch, ok := probe.Interface().(issueops.IssuePatch)
+		if !ok {
+			t.Fatalf("probe is not an issueops.IssuePatch")
+		}
+		got := hasNonCoordinationPatch(patch)
+		want := !coordinationFields[field.Name]
+		if got != want {
+			t.Errorf("hasNonCoordinationPatch with only %s set = %v, want %v", field.Name, got, want)
+		}
+	}
+	if scalarSeen == 0 {
+		t.Fatal("no scalar Field[T] members discovered on IssuePatch; reflection probe is broken")
+	}
+}
+
+// TestNonCoordinationPatchSignalsCountMatchesStruct guards against LabelPatch or
+// MetadataPatch gaining a sub-field that is wired into updates but not into
+// nonCoordinationPatchSignals — drift the scalar reflection above cannot see
+// because those sub-fields are not Field[T]. The expected length is derived from
+// the struct definitions, so it tracks the code rather than a hand-copied count.
+func TestNonCoordinationPatchSignalsCountMatchesStruct(t *testing.T) {
+	patchType := reflect.TypeOf(issueops.IssuePatch{})
+	probe := reflect.New(patchType).Elem()
+	scalar := 0
+	for i := 0; i < patchType.NumField(); i++ {
+		if isFieldPatch(probe.Field(i)) {
+			scalar++
+		}
+	}
+	labelFields := reflect.TypeOf(issueops.LabelPatch{}).NumField()
+	metadataFields := reflect.TypeOf(issueops.MetadataPatch{}).NumField()
+	want := (scalar - len(coordinationFields)) + labelFields + metadataFields
+
+	got := len(nonCoordinationPatchSignals(issueops.IssuePatch{}))
+	if got != want {
+		t.Fatalf("nonCoordinationPatchSignals length = %d, want %d "+
+			"(%d scalar Field[T] − %d coordination + %d LabelPatch + %d MetadataPatch); "+
+			"add the new patch field to nonCoordinationPatchSignals",
+			got, want, scalar, len(coordinationFields), labelFields, metadataFields)
+	}
+}
+
+// TestHasNonCoordinationPatchNestedAndCoordinationCases pins the LabelPatch and
+// MetadataPatch sub-fields (which the scalar reflection cannot set generically)
+// plus the coordination-only and empty baselines the guard relies on.
+func TestHasNonCoordinationPatchNestedAndCoordinationCases(t *testing.T) {
+	raw := json.RawMessage(`{"k":"v"}`)
+	cases := []struct {
+		name  string
+		patch issueops.IssuePatch
+		want  bool
+	}{
+		{"empty", issueops.IssuePatch{}, false},
+		{"assignee only", issueops.IssuePatch{Assignee: issueops.Field[string]{Set: true}}, false},
+		{"status only", issueops.IssuePatch{Status: issueops.Field[issueops.Status]{Set: true}}, false},
+		{"assignee and status", issueops.IssuePatch{
+			Assignee: issueops.Field[string]{Set: true},
+			Status:   issueops.Field[issueops.Status]{Set: true},
+		}, false},
+		{"labels add", issueops.IssuePatch{Labels: issueops.LabelPatch{Add: []string{"x"}}}, true},
+		{"labels remove", issueops.IssuePatch{Labels: issueops.LabelPatch{Remove: []string{"x"}}}, true},
+		{"labels replace", issueops.IssuePatch{Labels: issueops.LabelPatch{Replace: issueops.Field[[]string]{Set: true}}}, true},
+		{"metadata set", issueops.IssuePatch{Metadata: issueops.MetadataPatch{Set: map[string]json.RawMessage{"k": raw}}}, true},
+		{"metadata unset", issueops.IssuePatch{Metadata: issueops.MetadataPatch{Unset: []string{"k"}}}, true},
+		{"metadata replace", issueops.IssuePatch{Metadata: issueops.MetadataPatch{Replace: issueops.Field[json.RawMessage]{Set: true}}}, true},
+		{"metadata merge", issueops.IssuePatch{Metadata: issueops.MetadataPatch{Merge: issueops.Field[json.RawMessage]{Set: true}}}, true},
+		{"coordination plus title", issueops.IssuePatch{
+			Assignee: issueops.Field[string]{Set: true},
+			Status:   issueops.Field[issueops.Status]{Set: true},
+			Title:    issueops.Field[string]{Set: true},
+		}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasNonCoordinationPatch(tc.patch); got != tc.want {
+				t.Errorf("hasNonCoordinationPatch(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -192,6 +192,12 @@ func checkExpectedVersionInTx(ctx context.Context, tx *sql.Tx, id string, expect
 // Delegates SQL work to issueops.UpdateIssueInTx; handles Dolt-specific concerns
 // (metadata validation, DemoteToWisp, DOLT_ADD/COMMIT, cache invalidation).
 func (s *DoltStore) UpdateIssue(ctx context.Context, id string, updates map[string]interface{}, actor string) error {
+	return s.withCircuitWrite(ctx, func(ctx context.Context) error {
+		return s.updateIssue(ctx, id, updates, actor)
+	})
+}
+
+func (s *DoltStore) updateIssue(ctx context.Context, id string, updates map[string]interface{}, actor string) error {
 	// Validate metadata against schema before wisp routing (GH#1416 Phase 2).
 	if err := validateUpdateMetadata(updates); err != nil {
 		return err
@@ -243,6 +249,12 @@ func (s *DoltStore) UpdateIssue(ctx context.Context, id string, updates map[stri
 // validation, wisp routing, DemoteToWisp, DOLT_ADD/COMMIT); UpdateIssue is the
 // hot path and is left untouched.
 func (s *DoltStore) UpdateIssueChecked(ctx context.Context, id string, updates map[string]interface{}, actor string, opts storage.UpdateIssueOptions) error {
+	return s.withCircuitWrite(ctx, func(ctx context.Context) error {
+		return s.updateIssueChecked(ctx, id, updates, actor, opts)
+	})
+}
+
+func (s *DoltStore) updateIssueChecked(ctx context.Context, id string, updates map[string]interface{}, actor string, opts storage.UpdateIssueOptions) error {
 	// Validate metadata against schema before wisp routing (GH#1416 Phase 2).
 	if err := validateUpdateMetadata(updates); err != nil {
 		return err
@@ -321,6 +333,12 @@ func (s *DoltStore) UpdateIssueChecked(ctx context.Context, id string, updates m
 // Delegates SQL work to issueops.ClaimIssueInTx; handles Dolt-specific concerns
 // (wisp routing, DOLT_ADD/COMMIT, cache invalidation).
 func (s *DoltStore) ClaimIssue(ctx context.Context, id string, actor string) error {
+	return s.withCircuitWrite(ctx, func(ctx context.Context) error {
+		return s.claimIssue(ctx, id, actor)
+	})
+}
+
+func (s *DoltStore) claimIssue(ctx context.Context, id string, actor string) error {
 	// Route ephemeral IDs to wisps table (falls through for promoted wisps).
 	// Wisps skip DOLT_COMMIT since they live in dolt_ignored tables.
 	if s.isActiveWisp(ctx, id) {
@@ -529,6 +547,12 @@ func (s *DoltStore) UpdateIssueType(ctx context.Context, id string, issueType st
 // Delegates SQL work to issueops.CloseIssueInTx; handles Dolt-specific concerns
 // (wisp routing, DOLT_ADD/COMMIT, cache invalidation).
 func (s *DoltStore) CloseIssue(ctx context.Context, id string, reason string, actor string, session string) error {
+	return s.withCircuitWrite(ctx, func(ctx context.Context) error {
+		return s.closeIssue(ctx, id, reason, actor, session)
+	})
+}
+
+func (s *DoltStore) closeIssue(ctx context.Context, id string, reason string, actor string, session string) error {
 	// Route ephemeral IDs to wisps table (falls through for promoted wisps).
 	// Wisps skip DOLT_COMMIT since they live in dolt_ignored tables.
 	if s.isActiveWisp(ctx, id) {
@@ -559,6 +583,16 @@ func (s *DoltStore) CloseIssue(ctx context.Context, id string, reason string, ac
 // atomic (no TOCTOU). Mirrors CloseIssue's Dolt-specific concerns (wisp routing,
 // DOLT_ADD/COMMIT).
 func (s *DoltStore) CloseIssueChecked(ctx context.Context, id string, actor string, opts storage.CloseIssueOptions) (storage.CloseIssueResult, error) {
+	var result storage.CloseIssueResult
+	err := s.withCircuitWrite(ctx, func(ctx context.Context) error {
+		var err error
+		result, err = s.closeIssueChecked(ctx, id, actor, opts)
+		return err
+	})
+	return result, err
+}
+
+func (s *DoltStore) closeIssueChecked(ctx context.Context, id string, actor string, opts storage.CloseIssueOptions) (storage.CloseIssueResult, error) {
 	// Route ephemeral IDs to wisps table (falls through for promoted wisps).
 	// Wisps skip DOLT_COMMIT since they live in dolt_ignored tables.
 	if s.isActiveWisp(ctx, id) {
@@ -589,6 +623,12 @@ func (s *DoltStore) CloseIssueChecked(ctx context.Context, id string, actor stri
 
 // DeleteIssue permanently removes an issue
 func (s *DoltStore) DeleteIssue(ctx context.Context, id string) error {
+	return s.withCircuitWrite(ctx, func(ctx context.Context) error {
+		return s.deleteIssue(ctx, id)
+	})
+}
+
+func (s *DoltStore) deleteIssue(ctx context.Context, id string) error {
 	// Route ephemeral IDs to wisps table (falls through for promoted wisps)
 	if s.isActiveWisp(ctx, id) {
 		return s.deleteWisp(ctx, id)
@@ -604,7 +644,7 @@ func (s *DoltStore) DeleteIssue(ctx context.Context, id string) error {
 			[]string{"issues", "dependencies", "labels", "comments", "events", "child_counters", "issue_snapshots", "compaction_snapshots"},
 			commitMsg)
 	}); err != nil {
-		return err
+		return s.recordDoltPublicationFailure(ctx, err)
 	}
 	return nil
 }
@@ -629,6 +669,16 @@ const maxRecursiveResults = 10000
 const queryBatchSize = 200
 
 func (s *DoltStore) DeleteIssues(ctx context.Context, ids []string, cascade bool, force bool, dryRun bool) (*types.DeleteIssuesResult, error) {
+	var result *types.DeleteIssuesResult
+	err := s.withCircuitWrite(ctx, func(ctx context.Context) error {
+		var err error
+		result, err = s.deleteIssues(ctx, ids, cascade, force, dryRun)
+		return err
+	})
+	return result, err
+}
+
+func (s *DoltStore) deleteIssues(ctx context.Context, ids []string, cascade bool, force bool, dryRun bool) (*types.DeleteIssuesResult, error) {
 	if len(ids) == 0 {
 		return &types.DeleteIssuesResult{}, nil
 	}
@@ -680,7 +730,7 @@ func (s *DoltStore) DeleteIssues(ctx context.Context, ids []string, cascade bool
 		if result != nil {
 			result.DeletedCount += wispDeleteCount
 		}
-		return result, err
+		return result, s.recordDoltPublicationFailure(ctx, err)
 	}
 	result.DeletedCount += wispDeleteCount
 

--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -400,73 +399,33 @@ func (s *DoltStore) ClaimReadyIssue(ctx context.Context, filter types.WorkFilter
 // verifiedReadyClaim resolves a ready-claim write by verify-by-re-read
 // (bd-zccb9): the claimed ID is only known once the write body has run, so
 // this cannot ride verifiedClaimWrite's id parameter — but the resolution
-// protocol is the same. A replay after a verified rollback re-scans the ready
-// front and may legitimately claim a different issue. Split from
-// ClaimReadyIssue so injection tests can drive the write seam directly, the
-// same way the verifiedClaimWrite tests do.
+// protocol is the same. Split from ClaimReadyIssue so injection tests can
+// drive the write seam directly, the same way the verifiedClaimWrite tests do.
 //
-// The re-read is per-attempt and plane-aware (readReadyClaimState): the winner
-// may be an ephemeral row, and a replay may win a row in the other plane than
-// the first attempt selected.
+// Successful ready claims verify the winning plane because IncludeEphemeral
+// may select a wisp. An indeterminate commit response remains indeterminate:
+// assignee and status cannot prove the lease and actor-attributed event landed.
 func (s *DoltStore) verifiedReadyClaim(ctx context.Context, actor string, write func() (*types.Issue, error)) (*types.Issue, error) {
 	claimed, err := write()
-	if err != nil && !(errors.Is(err, errCommitPhase) && claimed != nil && s.serverMode) {
+	if err != nil {
 		return nil, err
 	}
 	if claimed == nil || !s.serverMode {
 		return claimed, err
 	}
-	for attempt := 0; ; attempt++ {
-		assignee, status, verr := s.readReadyClaimState(ctx, claimed.ID)
-		if verr != nil {
-			if err != nil {
-				return nil, err // the honest indeterminate error from withRetryTx
-			}
-			return nil, fmt.Errorf("ready claim of %s reported success but could not be verified (server degraded?): %w — re-read the issue before trusting the claim",
-				claimed.ID, verr)
-		}
-		post := claimedBy(actor)
-		if post.want(assignee, status) {
-			if err != nil {
-				doltMetrics.claimVerifyRecovered.Add(ctx, 1, metric.WithAttributes(
-					attribute.String("op", "ready-claim"), attribute.String("outcome", "applied")))
-			}
-			return claimed, nil
-		}
-		if err != nil && attempt < 1 {
-			// Verified rolled back: nothing landed, safe to replay once.
-			doltMetrics.claimVerifyRecovered.Add(ctx, 1, metric.WithAttributes(
-				attribute.String("op", "ready-claim"), attribute.String("outcome", "replayed")))
-			claimed, err = write()
-			// The replay carries the same commit-phase ambiguity as the first
-			// attempt: an errCommitPhase with a selection made must fall
-			// through to the verify pass — attempt is past the replay budget
-			// now, so a second verified rollback still exhausts with the
-			// honest "did not land" error — never surface the raw
-			// indeterminate error, which would reintroduce the wy-x543k
-			// false-failure and could orphan an applied claim on a DIFFERENT
-			// ready issue than the first attempt selected.
-			if err != nil && !(errors.Is(err, errCommitPhase) && claimed != nil) {
-				return nil, err
-			}
-			if claimed == nil {
-				if err != nil {
-					// Commit-phase loss before anything was selected: nothing
-					// to verify, honest indeterminate error.
-					return nil, err
-				}
-				return nil, nil
-			}
-			continue
-		}
-		if err != nil {
-			return nil, fmt.Errorf("ready claim of %s did not land (connection lost during commit; rollback verified by re-read): %w", claimed.ID, err)
-		}
-		doltMetrics.claimVerifyLost.Add(ctx, 1, metric.WithAttributes(
-			attribute.String("op", "ready-claim")))
-		return nil, fmt.Errorf("ready claim of %s reported success but did not land (found assignee=%q status=%q, want %s) — server likely degraded; treat the claim as NOT applied",
-			claimed.ID, assignee, status, post.desc)
+	assignee, status, verr := s.readReadyClaimState(ctx, claimed.ID)
+	if verr != nil {
+		return nil, fmt.Errorf("ready claim of %s reported success but could not be verified (server degraded?): %w — re-read the issue before trusting the claim",
+			claimed.ID, verr)
 	}
+	post := claimedBy(actor)
+	if post.want(assignee, status) {
+		return claimed, nil
+	}
+	doltMetrics.claimVerifyLost.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("op", "ready-claim")))
+	return nil, fmt.Errorf("ready claim of %s reported success but did not land (found assignee=%q status=%q, want %s) — server likely degraded; treat the claim as NOT applied",
+		claimed.ID, assignee, status, post.desc)
 }
 
 // HeartbeatIssue refreshes the lease on an issue actor holds in_progress,

--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -21,6 +21,12 @@ import (
 // CreateIssue creates a new issue.
 // Delegates SQL work to issueops; handles Dolt versioning for non-ephemeral issues.
 func (s *DoltStore) CreateIssue(ctx context.Context, issue *types.Issue, actor string) error {
+	return s.withCircuitWrite(ctx, func(ctx context.Context) error {
+		return s.createIssue(ctx, issue, actor)
+	})
+}
+
+func (s *DoltStore) createIssue(ctx context.Context, issue *types.Issue, actor string) error {
 	if issue == nil {
 		return fmt.Errorf("issue must not be nil")
 	}
@@ -88,6 +94,12 @@ func (s *DoltStore) CreateIssues(ctx context.Context, issues []*types.Issue, act
 // CreateIssuesWithFullOptions creates multiple issues with full options control.
 // Delegates SQL work to issueops; handles Dolt versioning for non-ephemeral batches.
 func (s *DoltStore) CreateIssuesWithFullOptions(ctx context.Context, issues []*types.Issue, actor string, opts storage.BatchCreateOptions) error {
+	return s.withCircuitWrite(ctx, func(ctx context.Context) error {
+		return s.createIssuesWithFullOptions(ctx, issues, actor, opts)
+	})
+}
+
+func (s *DoltStore) createIssuesWithFullOptions(ctx context.Context, issues []*types.Issue, actor string, opts storage.BatchCreateOptions) error {
 	if len(issues) == 0 {
 		return nil
 	}

--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -375,24 +375,39 @@ func (s *DoltStore) ClaimReadyIssue(ctx context.Context, filter types.WorkFilter
 	// no real row locking — FOR UPDATE / SKIP LOCKED are parse-only no-ops
 	// (https://www.dolthub.com/blog/2023-10-23-hold-my-beer/) — so retry is the
 	// safety net. withRetryTx owns BeginTx and the final Commit.
-	write := func() (*types.Issue, error) {
-		var claimed *types.Issue
-		err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
-			var err error
-			claimed, err = issueops.ClaimReadyIssueInTx(ctx, tx, filter, actor)
-			if err != nil {
-				return err
-			}
-			if claimed == nil {
-				return nil
-			}
+	//
+	// The write and its verify sit under withCircuitWrite so terminal circuit
+	// success is recorded once at the boundary, only after verifiedReadyClaim
+	// confirms the claim landed — not the instant withRetryTx's SQL commit
+	// returns. A commit that reports success but fails verification must leave
+	// the breaker untouched (matching ClaimIssue).
+	var claimed *types.Issue
+	err := s.withCircuitWrite(ctx, func(ctx context.Context) error {
+		write := func() (*types.Issue, error) {
+			var got *types.Issue
+			werr := s.withRetryTx(ctx, func(tx *sql.Tx) error {
+				var err error
+				got, err = issueops.ClaimReadyIssueInTx(ctx, tx, filter, actor)
+				if err != nil {
+					return err
+				}
+				if got == nil {
+					return nil
+				}
 
-			commitMsg := fmt.Sprintf("bd: claim ready %s", claimed.ID)
-			return s.doltAddAndCommitInTx(ctx, tx, []string{"issues", "events"}, commitMsg)
-		})
-		return claimed, err
+				commitMsg := fmt.Sprintf("bd: claim ready %s", got.ID)
+				return s.doltAddAndCommitInTx(ctx, tx, []string{"issues", "events"}, commitMsg)
+			})
+			return got, werr
+		}
+		var verr error
+		claimed, verr = s.verifiedReadyClaim(ctx, actor, write)
+		return verr
+	})
+	if err != nil {
+		return nil, err
 	}
-	return s.verifiedReadyClaim(ctx, actor, write)
+	return claimed, nil
 }
 
 // verifiedReadyClaim resolves a ready-claim write by verify-by-re-read
@@ -482,14 +497,20 @@ func (s *DoltStore) ReclaimExpiredLeases(ctx context.Context, olderThan time.Dur
 func (s *DoltStore) UnclaimIssue(ctx context.Context, id string, actor string, force bool) error {
 	// verify-by-re-read (bd-zccb9): a phantom unclaim leaves the caller
 	// believing the issue is released while it still holds the claim.
-	return s.verifiedClaimWrite(ctx, id, unclaimed(), func() error {
-		return s.withRetryTx(ctx, func(tx *sql.Tx) error {
-			if err := issueops.UnclaimIssueInTx(ctx, tx, id, actor, force); err != nil {
-				return err
-			}
+	//
+	// withCircuitWrite wraps the write and its verification so circuit success
+	// is recorded once at the boundary, only after verifiedClaimWrite confirms
+	// the release landed — never the moment withRetryTx's SQL commit returns.
+	return s.withCircuitWrite(ctx, func(ctx context.Context) error {
+		return s.verifiedClaimWrite(ctx, id, unclaimed(), func() error {
+			return s.withRetryTx(ctx, func(tx *sql.Tx) error {
+				if err := issueops.UnclaimIssueInTx(ctx, tx, id, actor, force); err != nil {
+					return err
+				}
 
-			commitMsg := fmt.Sprintf("bd: unclaim %s", id)
-			return s.doltAddAndCommitInTx(ctx, tx, []string{"issues", "events"}, commitMsg)
+				commitMsg := fmt.Sprintf("bd: unclaim %s", id)
+				return s.doltAddAndCommitInTx(ctx, tx, []string{"issues", "events"}, commitMsg)
+			})
 		})
 	})
 }
@@ -502,15 +523,20 @@ func (s *DoltStore) UnclaimIssue(ctx context.Context, id string, actor string, f
 // UnclaimIssue so a concurrent writer that loses Dolt's optimistic commit-time
 // merge is retried rather than surfaced as a hard failure.
 func (s *DoltStore) UnclaimIssueIfAssignee(ctx context.Context, id string, actor string, expectedAssignee string) error {
-	// verify-by-re-read (bd-zccb9), same reasoning as UnclaimIssue.
-	return s.verifiedClaimWrite(ctx, id, unclaimed(), func() error {
-		return s.withRetryTx(ctx, func(tx *sql.Tx) error {
-			if err := issueops.UnclaimIssueIfAssigneeInTx(ctx, tx, id, actor, expectedAssignee); err != nil {
-				return err
-			}
+	// verify-by-re-read (bd-zccb9), same reasoning as UnclaimIssue: the write
+	// and its verification sit under withCircuitWrite so circuit success is
+	// recorded once at the boundary, only after verifiedClaimWrite confirms the
+	// release landed.
+	return s.withCircuitWrite(ctx, func(ctx context.Context) error {
+		return s.verifiedClaimWrite(ctx, id, unclaimed(), func() error {
+			return s.withRetryTx(ctx, func(tx *sql.Tx) error {
+				if err := issueops.UnclaimIssueIfAssigneeInTx(ctx, tx, id, actor, expectedAssignee); err != nil {
+					return err
+				}
 
-			commitMsg := fmt.Sprintf("bd: unclaim %s", id)
-			return s.doltAddAndCommitInTx(ctx, tx, []string{"issues", "events"}, commitMsg)
+				commitMsg := fmt.Sprintf("bd: unclaim %s", id)
+				return s.doltAddAndCommitInTx(ctx, tx, []string{"issues", "events"}, commitMsg)
+			})
 		})
 	})
 }

--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -15,7 +15,6 @@ import (
 	"github.com/steveyegge/beads/internal/idgen"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/issueops"
-	"github.com/steveyegge/beads/internal/storage/schema"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -216,15 +215,8 @@ func (s *DoltStore) UpdateIssue(ctx context.Context, id string, updates map[stri
 			return nil
 		}
 
-		for _, table := range []string{"issues", "events"} {
-			_ = schema.DrainCall(ctx, tx, "CALL DOLT_ADD(?)", table)
-		}
 		commitMsg := fmt.Sprintf("bd: update %s", id)
-		if err := schema.DrainCall(ctx, tx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-			return fmt.Errorf("dolt commit: %w", err)
-		}
-		return nil
+		return s.doltAddAndCommitInTx(ctx, tx, []string{"issues", "events"}, commitMsg)
 	})
 }
 
@@ -294,15 +286,8 @@ func (s *DoltStore) UpdateIssueChecked(ctx context.Context, id string, updates m
 				return nil
 			}
 
-			for _, table := range []string{"issues", "events"} {
-				_ = schema.DrainCall(ctx, tx, "CALL DOLT_ADD(?)", table)
-			}
 			commitMsg := fmt.Sprintf("bd: update %s", id)
-			if err := schema.DrainCall(ctx, tx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-				commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-				return fmt.Errorf("dolt commit: %w", err)
-			}
-			return nil
+			return s.doltAddAndCommitInTx(ctx, tx, []string{"issues", "events"}, commitMsg)
 		})
 	}
 
@@ -345,17 +330,8 @@ func (s *DoltStore) ClaimIssue(ctx context.Context, id string, actor string) err
 				return err
 			}
 
-			// Dolt versioning for permanent issues.
-			// GH#2455: Stage only the tables we modified, then commit without -A.
-			for _, table := range []string{"issues", "events"} {
-				_ = schema.DrainCall(ctx, tx, "CALL DOLT_ADD(?)", table)
-			}
 			commitMsg := fmt.Sprintf("bd: claim %s", id)
-			if err := schema.DrainCall(ctx, tx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-				commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-				return fmt.Errorf("dolt commit: %w", err)
-			}
-			return nil
+			return s.doltAddAndCommitInTx(ctx, tx, []string{"issues", "events"}, commitMsg)
 		})
 	})
 }
@@ -381,15 +357,8 @@ func (s *DoltStore) ClaimReadyIssue(ctx context.Context, filter types.WorkFilter
 				return nil
 			}
 
-			for _, table := range []string{"issues", "events"} {
-				_ = schema.DrainCall(ctx, tx, "CALL DOLT_ADD(?)", table)
-			}
 			commitMsg := fmt.Sprintf("bd: claim ready %s", claimed.ID)
-			if err := schema.DrainCall(ctx, tx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-				commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-				return fmt.Errorf("dolt commit: %w", err)
-			}
-			return nil
+			return s.doltAddAndCommitInTx(ctx, tx, []string{"issues", "events"}, commitMsg)
 		})
 		return claimed, err
 	}
@@ -462,15 +431,8 @@ func (s *DoltStore) ReclaimExpiredLeases(ctx context.Context, olderThan time.Dur
 		if len(reclaimed) == 0 {
 			return nil
 		}
-		for _, table := range []string{"issues", "events"} {
-			_ = schema.DrainCall(ctx, tx, "CALL DOLT_ADD(?)", table)
-		}
 		commitMsg := fmt.Sprintf("bd: reclaim %d expired lease(s)", len(reclaimed))
-		if err := schema.DrainCall(ctx, tx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-			return fmt.Errorf("dolt commit: %w", err)
-		}
-		return nil
+		return s.doltAddAndCommitInTx(ctx, tx, []string{"issues", "events"}, commitMsg)
 	})
 	if err != nil {
 		return nil, err
@@ -496,16 +458,8 @@ func (s *DoltStore) UnclaimIssue(ctx context.Context, id string, actor string, f
 				return err
 			}
 
-			// Dolt versioning for permanent issues.
-			for _, table := range []string{"issues", "events"} {
-				_ = schema.DrainCall(ctx, tx, "CALL DOLT_ADD(?)", table)
-			}
 			commitMsg := fmt.Sprintf("bd: unclaim %s", id)
-			if err := schema.DrainCall(ctx, tx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-				commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-				return fmt.Errorf("dolt commit: %w", err)
-			}
-			return nil
+			return s.doltAddAndCommitInTx(ctx, tx, []string{"issues", "events"}, commitMsg)
 		})
 	})
 }
@@ -525,16 +479,8 @@ func (s *DoltStore) UnclaimIssueIfAssignee(ctx context.Context, id string, actor
 				return err
 			}
 
-			// Dolt versioning for permanent issues.
-			for _, table := range []string{"issues", "events"} {
-				_ = schema.DrainCall(ctx, tx, "CALL DOLT_ADD(?)", table)
-			}
 			commitMsg := fmt.Sprintf("bd: unclaim %s", id)
-			if err := schema.DrainCall(ctx, tx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-				commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-				return fmt.Errorf("dolt commit: %w", err)
-			}
-			return nil
+			return s.doltAddAndCommitInTx(ctx, tx, []string{"issues", "events"}, commitMsg)
 		})
 	})
 }
@@ -588,17 +534,8 @@ func (s *DoltStore) CloseIssue(ctx context.Context, id string, reason string, ac
 			return err
 		}
 
-		// Dolt versioning for permanent issues.
-		// GH#2455: Stage only the tables we modified, then commit without -A.
-		for _, table := range []string{"issues", "events"} {
-			_ = schema.DrainCall(ctx, tx, "CALL DOLT_ADD(?)", table)
-		}
 		commitMsg := fmt.Sprintf("bd: close %s", id)
-		if err := schema.DrainCall(ctx, tx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-			return fmt.Errorf("dolt commit: %w", err)
-		}
-		return nil
+		return s.doltAddAndCommitInTx(ctx, tx, []string{"issues", "events"}, commitMsg)
 	})
 }
 
@@ -630,17 +567,8 @@ func (s *DoltStore) CloseIssueChecked(ctx context.Context, id string, actor stri
 		}
 		result = storage.CloseIssueResult{Unchanged: res.AlreadyClosed, OpenChildren: res.OpenChildren}
 
-		// Dolt versioning for permanent issues.
-		// GH#2455: Stage only the tables we modified, then commit without -A.
-		for _, table := range []string{"issues", "events"} {
-			_ = schema.DrainCall(ctx, tx, "CALL DOLT_ADD(?)", table)
-		}
 		commitMsg := fmt.Sprintf("bd: close %s", id)
-		if err := schema.DrainCall(ctx, tx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-			return fmt.Errorf("dolt commit: %w", err)
-		}
-		return nil
+		return s.doltAddAndCommitInTx(ctx, tx, []string{"issues", "events"}, commitMsg)
 	}); err != nil {
 		return storage.CloseIssueResult{}, err
 	}
@@ -659,15 +587,10 @@ func (s *DoltStore) DeleteIssue(ctx context.Context, id string) error {
 			return err
 		}
 
-		for _, table := range []string{"issues", "dependencies", "labels", "comments", "events", "child_counters", "issue_snapshots", "compaction_snapshots"} {
-			_ = schema.DrainCall(ctx, tx, "CALL DOLT_ADD(?)", table)
-		}
 		commitMsg := fmt.Sprintf("bd: delete %s", id)
-		if err := schema.DrainCall(ctx, tx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-			return fmt.Errorf("dolt commit: %w", err)
-		}
-		return nil
+		return s.doltAddAndCommitInTx(ctx, tx,
+			[]string{"issues", "dependencies", "labels", "comments", "events", "child_counters", "issue_snapshots", "compaction_snapshots"},
+			commitMsg)
 	}); err != nil {
 		return err
 	}
@@ -736,15 +659,10 @@ func (s *DoltStore) DeleteIssues(ctx context.Context, ids []string, cascade bool
 			return nil
 		}
 
-		for _, table := range []string{"issues", "dependencies", "labels", "comments", "events", "child_counters", "issue_snapshots", "compaction_snapshots"} {
-			_ = schema.DrainCall(ctx, tx, "CALL DOLT_ADD(?)", table)
-		}
 		commitMsg := fmt.Sprintf("bd: delete %d issue(s)", result.DeletedCount)
-		if err := schema.DrainCall(ctx, tx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-			return fmt.Errorf("dolt commit: %w", err)
-		}
-		return nil
+		return s.doltAddAndCommitInTx(ctx, tx,
+			[]string{"issues", "dependencies", "labels", "comments", "events", "child_counters", "issue_snapshots", "compaction_snapshots"},
+			commitMsg)
 	}); err != nil {
 		// Preserve partial result (e.g., OrphanedIssues) on error.
 		if result != nil {

--- a/internal/storage/dolt/labels.go
+++ b/internal/storage/dolt/labels.go
@@ -11,31 +11,35 @@ import (
 
 // AddLabel adds a label to an issue
 func (s *DoltStore) AddLabel(ctx context.Context, issueID, label, actor string) error {
-	isWisp := s.isActiveWisp(ctx, issueID)
-	if err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
-		return issueops.AddLabelInTx(ctx, tx, "", "", issueID, label, actor)
-	}); err != nil {
-		return err
-	}
-	if isWisp {
-		return nil
-	}
-	return s.doltAddAndCommit(ctx, []string{"events", "labels"}, fmt.Sprintf("bd: label add %s", issueID))
+	return s.withCircuitWrite(ctx, func(ctx context.Context) error {
+		isWisp := s.isActiveWisp(ctx, issueID)
+		if err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
+			return issueops.AddLabelInTx(ctx, tx, "", "", issueID, label, actor)
+		}); err != nil {
+			return err
+		}
+		if isWisp {
+			return nil
+		}
+		return s.doltAddAndCommit(ctx, []string{"events", "labels"}, fmt.Sprintf("bd: label add %s", issueID))
+	})
 }
 
 // RemoveLabel removes a label from an issue.
 // Delegates SQL work to issueops.RemoveLabelInTx which handles wisp routing.
 func (s *DoltStore) RemoveLabel(ctx context.Context, issueID, label, actor string) error {
-	isWisp := s.isActiveWisp(ctx, issueID)
-	if err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
-		return issueops.RemoveLabelInTx(ctx, tx, "", "", issueID, label, actor)
-	}); err != nil {
-		return err
-	}
-	if isWisp {
-		return nil
-	}
-	return s.doltAddAndCommit(ctx, []string{"events", "labels"}, fmt.Sprintf("bd: label remove %s", issueID))
+	return s.withCircuitWrite(ctx, func(ctx context.Context) error {
+		isWisp := s.isActiveWisp(ctx, issueID)
+		if err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
+			return issueops.RemoveLabelInTx(ctx, tx, "", "", issueID, label, actor)
+		}); err != nil {
+			return err
+		}
+		if isWisp {
+			return nil
+		}
+		return s.doltAddAndCommit(ctx, []string{"events", "labels"}, fmt.Sprintf("bd: label remove %s", issueID))
+	})
 }
 
 // GetLabels retrieves all labels for an issue

--- a/internal/storage/dolt/public_write_circuit_test.go
+++ b/internal/storage/dolt/public_write_circuit_test.go
@@ -1,0 +1,184 @@
+package dolt
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+func TestPublicDirectWritesRejectOpenCircuitBeforeTransaction(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		run  func(*DoltStore) error
+	}{
+		{name: "update explicit-id wisp", run: func(store *DoltStore) error {
+			return store.UpdateIssue(t.Context(), "explicit-wisp", map[string]interface{}{"title": "changed"}, "alice")
+		}},
+		{name: "checked update explicit-id wisp", run: func(store *DoltStore) error {
+			return store.UpdateIssueChecked(t.Context(), "explicit-wisp", map[string]interface{}{"title": "changed"}, "alice", storage.UpdateIssueOptions{})
+		}},
+		{name: "claim explicit-id wisp", run: func(store *DoltStore) error {
+			return store.ClaimIssue(t.Context(), "explicit-wisp", "alice")
+		}},
+		{name: "close explicit-id wisp", run: func(store *DoltStore) error {
+			return store.CloseIssue(t.Context(), "explicit-wisp", "done", "alice", "session")
+		}},
+		{name: "checked close explicit-id wisp", run: func(store *DoltStore) error {
+			_, err := store.CloseIssueChecked(t.Context(), "explicit-wisp", "alice", storage.CloseIssueOptions{Reason: "done"})
+			return err
+		}},
+		{name: "delete explicit-id wisp", run: func(store *DoltStore) error {
+			return store.DeleteIssue(t.Context(), "explicit-wisp")
+		}},
+		{name: "delete issues", run: func(store *DoltStore) error {
+			_, err := store.DeleteIssues(t.Context(), []string{"explicit-wisp"}, false, true, false)
+			return err
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("BEADS_TEST_MODE", "")
+			breaker := newTestCircuitBreaker(t)
+			for range circuitFailureThreshold {
+				breaker.RecordFailure()
+			}
+			driver := &claimCommitBoundaryDriver{activeWisp: true}
+			store := newClaimCommitBoundaryStore(driver)
+			store.breaker = breaker
+			t.Cleanup(func() { _ = store.db.Close() })
+
+			err := tc.run(store)
+			if !errors.Is(err, ErrCircuitOpen) {
+				t.Fatalf("operation error = %v, want ErrCircuitOpen", err)
+			}
+			driver.mu.Lock()
+			defer driver.mu.Unlock()
+			if driver.txAttempts != 0 {
+				t.Fatalf("transactions started after circuit opened = %d, want 0", driver.txAttempts)
+			}
+		})
+	}
+}
+
+func TestExplicitIDWispUpdateTerminalSuccessResetsCircuit(t *testing.T) {
+	t.Setenv("BEADS_TEST_MODE", "")
+	breaker := newTestCircuitBreaker(t)
+	for range circuitFailureThreshold - 1 {
+		breaker.RecordFailure()
+	}
+	driver := &claimCommitBoundaryDriver{activeWisp: true}
+	store := newClaimCommitBoundaryStore(driver)
+	store.breaker = breaker
+	t.Cleanup(func() { _ = store.db.Close() })
+
+	if err := store.UpdateIssue(t.Context(), "explicit-wisp", map[string]interface{}{}, "alice"); err != nil {
+		t.Fatalf("UpdateIssue() error = %v", err)
+	}
+	breaker.RecordFailure()
+	if state := breaker.State(); state != circuitClosed {
+		t.Fatalf("circuit state after successful wisp update and one failure = %q, want %q", state, circuitClosed)
+	}
+}
+
+func TestExplicitIDWispUpdateIndeterminateCommitTripsCircuit(t *testing.T) {
+	t.Setenv("BEADS_TEST_MODE", "")
+	breaker := newTestCircuitBreaker(t)
+	for range circuitFailureThreshold - 1 {
+		breaker.RecordFailure()
+	}
+	driver := &claimCommitBoundaryDriver{activeWisp: true, sqlCommitErr: testConnectionLoss}
+	store := newClaimCommitBoundaryStore(driver)
+	store.breaker = breaker
+	t.Cleanup(func() { _ = store.db.Close() })
+
+	err := store.UpdateIssue(t.Context(), "explicit-wisp", map[string]interface{}{}, "alice")
+	if !errors.Is(err, ErrCommitIndeterminate) || !errors.Is(err, testConnectionLoss) {
+		t.Fatalf("UpdateIssue() error = %v, want indeterminate connection loss", err)
+	}
+	if state := breaker.State(); state != circuitOpen {
+		t.Fatalf("circuit state after indeterminate wisp commit = %q, want %q", state, circuitOpen)
+	}
+
+	driver.mu.Lock()
+	before := driver.txAttempts
+	driver.mu.Unlock()
+	err = store.UpdateIssue(t.Context(), "explicit-wisp", map[string]interface{}{}, "alice")
+	if !errors.Is(err, ErrCircuitOpen) {
+		t.Fatalf("next UpdateIssue() error = %v, want ErrCircuitOpen", err)
+	}
+	driver.mu.Lock()
+	defer driver.mu.Unlock()
+	if driver.txAttempts != before {
+		t.Fatalf("transactions after circuit trip = %d, want unchanged %d", driver.txAttempts, before)
+	}
+}
+
+func TestDeleteIssueIndeterminateCommitTripsCircuit(t *testing.T) {
+	t.Setenv("BEADS_TEST_MODE", "")
+	breaker := newTestCircuitBreaker(t)
+	for range circuitFailureThreshold - 1 {
+		breaker.RecordFailure()
+	}
+	driver := &claimCommitBoundaryDriver{sqlCommitErr: testConnectionLoss}
+	store := newClaimCommitBoundaryStore(driver)
+	store.breaker = breaker
+	t.Cleanup(func() { _ = store.db.Close() })
+
+	err := store.DeleteIssue(t.Context(), "delete-boundary")
+	if !errors.Is(err, ErrCommitIndeterminate) || !errors.Is(err, testConnectionLoss) {
+		t.Fatalf("DeleteIssue() error = %v, want indeterminate connection loss", err)
+	}
+	if state := breaker.State(); state != circuitOpen {
+		t.Fatalf("circuit state after indeterminate delete commit = %q, want %q", state, circuitOpen)
+	}
+
+	driver.mu.Lock()
+	before := driver.txAttempts
+	driver.mu.Unlock()
+	err = store.DeleteIssue(t.Context(), "delete-boundary")
+	if !errors.Is(err, ErrCircuitOpen) {
+		t.Fatalf("next DeleteIssue() error = %v, want ErrCircuitOpen", err)
+	}
+	driver.mu.Lock()
+	defer driver.mu.Unlock()
+	if driver.txAttempts != before {
+		t.Fatalf("transactions after circuit trip = %d, want unchanged %d", driver.txAttempts, before)
+	}
+}
+
+func TestPublicPullsRejectOpenCircuitBeforeRouting(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		run  func(*DoltStore) error
+	}{
+		{name: "default remote", run: func(store *DoltStore) error { return store.Pull(t.Context()) }},
+		{name: "named remote", run: func(store *DoltStore) error { return store.PullRemote(t.Context(), "origin") }},
+		{name: "peer remote", run: func(store *DoltStore) error {
+			_, err := store.PullFrom(t.Context(), "peer")
+			return err
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("BEADS_TEST_MODE", "")
+			breaker := newTestCircuitBreaker(t)
+			for range circuitFailureThreshold {
+				breaker.RecordFailure()
+			}
+			driver := &claimCommitBoundaryDriver{}
+			store := newClaimCommitBoundaryStore(driver)
+			store.breaker = breaker
+			store.readOnly = true
+			t.Cleanup(func() { _ = store.db.Close() })
+
+			err := tc.run(store)
+			if !errors.Is(err, ErrCircuitOpen) {
+				t.Fatalf("pull error = %v, want ErrCircuitOpen", err)
+			}
+			driver.mu.Lock()
+			defer driver.mu.Unlock()
+			if driver.txAttempts != 0 {
+				t.Fatalf("transactions started after circuit opened = %d, want 0", driver.txAttempts)
+			}
+		})
+	}
+}

--- a/internal/storage/dolt/ready_claimer.go
+++ b/internal/storage/dolt/ready_claimer.go
@@ -44,28 +44,36 @@ func (c *readyClaimer) ClaimNext(ctx context.Context, request issueops.ClaimNext
 		return issueops.ClaimNextResult{}, err
 	}
 
+	// The write and its verify sit under withCircuitWrite so terminal circuit
+	// success is recorded once at the boundary, only after verifiedReadyClaim
+	// returns nil — matching the store's own ClaimReadyIssue. write is defined
+	// inside the boundary so its runIssueOperationTxWithMessage captures the
+	// circuit-managed ctx and defers success to the boundary.
 	var result issueops.ClaimNextResult
-	write := func() (*types.Issue, error) {
-		var claimed *types.Issue
-		err := c.store.runIssueOperationTxWithMessage(ctx, func(tx *sql.Tx) (storageissueops.ChangedTables, string, error) {
-			attempt, tables, err := storageissueops.ExecuteClaimNext(ctx, tx, request.Actor, filter)
-			if err != nil {
-				return nil, "", err
-			}
-			result = attempt
-			if attempt.Claimed == nil {
-				return tables, "", nil
-			}
-			claimed = attempt.Claimed.Issue
-			// The message names the claimed issue because that is the one `bd
-			// dolt log` affordance callers actually grep, and it is what the
-			// store's own ClaimReadyIssue wrote before the claim moved here.
-			return tables, storageissueops.ClaimNextCommitMessage(attempt.Claimed.ID), nil
-		})
-		return claimed, err
-	}
-
-	if _, err := c.store.verifiedReadyClaim(ctx, request.Actor, write); err != nil {
+	err = c.store.withCircuitWrite(ctx, func(ctx context.Context) error {
+		write := func() (*types.Issue, error) {
+			var claimed *types.Issue
+			err := c.store.runIssueOperationTxWithMessage(ctx, func(tx *sql.Tx) (storageissueops.ChangedTables, string, error) {
+				attempt, tables, err := storageissueops.ExecuteClaimNext(ctx, tx, request.Actor, filter)
+				if err != nil {
+					return nil, "", err
+				}
+				result = attempt
+				if attempt.Claimed == nil {
+					return tables, "", nil
+				}
+				claimed = attempt.Claimed.Issue
+				// The message names the claimed issue because that is the one `bd
+				// dolt log` affordance callers actually grep, and it is what the
+				// store's own ClaimReadyIssue wrote before the claim moved here.
+				return tables, storageissueops.ClaimNextCommitMessage(attempt.Claimed.ID), nil
+			})
+			return claimed, err
+		}
+		_, verr := c.store.verifiedReadyClaim(ctx, request.Actor, write)
+		return verr
+	})
+	if err != nil {
 		return issueops.ClaimNextResult{}, err
 	}
 	return result, nil

--- a/internal/storage/dolt/retry_test.go
+++ b/internal/storage/dolt/retry_test.go
@@ -3,6 +3,7 @@ package dolt
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	mysql "github.com/go-sql-driver/mysql"
@@ -124,6 +125,16 @@ func TestIsRetryableError(t *testing.T) {
 			err:      &mysql.MySQLError{Number: 1105, Message: "connection lost while validating commit"},
 			expected: false,
 		},
+		{
+			name:     "typed setup 1049 is not generically retryable",
+			err:      &mysql.MySQLError{Number: 1049, Message: "Unknown database 'beads_test'"},
+			expected: false,
+		},
+		{
+			name:     "typed setup 1105 is not generically retryable",
+			err:      &mysql.MySQLError{Number: 1105, Message: "no root value found in session"},
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -131,6 +142,63 @@ func TestIsRetryableError(t *testing.T) {
 			got := isRetryableError(tt.err)
 			if got != tt.expected {
 				t.Errorf("isRetryableError(%v) = %v, want %v", tt.err, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsSetupRetryableError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "typed unknown database",
+			err:  &mysql.MySQLError{Number: 1049, Message: "Unknown database 'beads_test'"},
+			want: true,
+		},
+		{
+			name: "wrapped typed unknown database",
+			err:  fmt.Errorf("ping database after create: %w", &mysql.MySQLError{Number: 1049, Message: "Unknown database 'beads_test'"}),
+			want: true,
+		},
+		{
+			name: "typed missing session root",
+			err:  &mysql.MySQLError{Number: 1105, Message: "no root value found in session"},
+			want: true,
+		},
+		{
+			name: "wrapped case variant of missing session root",
+			err:  fmt.Errorf("schema probe: %w", &mysql.MySQLError{Number: 1105, Message: "No Root Value Found In Session"}),
+			want: true,
+		},
+		{
+			name: "typed 1105 with extra context",
+			err:  &mysql.MySQLError{Number: 1105, Message: "no root value found in session while validating commit"},
+			want: false,
+		},
+		{
+			name: "typed 1105 unrelated semantic error",
+			err:  &mysql.MySQLError{Number: 1105, Message: "connection lost while validating commit"},
+			want: false,
+		},
+		{
+			name: "typed syntax error",
+			err:  &mysql.MySQLError{Number: 1064, Message: "You have an error in your SQL syntax"},
+			want: false,
+		},
+		{
+			name: "generic connection failure",
+			err:  errors.New("driver: bad connection"),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSetupRetryableError(tt.err); got != tt.want {
+				t.Errorf("isSetupRetryableError(%v) = %v, want %v", tt.err, got, tt.want)
 			}
 		})
 	}

--- a/internal/storage/dolt/retry_test.go
+++ b/internal/storage/dolt/retry_test.go
@@ -119,6 +119,11 @@ func TestIsRetryableError(t *testing.T) {
 			err:      errors.New("Error 1146: Table 'beads.foo' doesn't exist"),
 			expected: false,
 		},
+		{
+			name:     "typed semantic 1105 with connection-like text is not retryable",
+			err:      &mysql.MySQLError{Number: 1105, Message: "connection lost while validating commit"},
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/storage/dolt/retry_test.go
+++ b/internal/storage/dolt/retry_test.go
@@ -126,6 +126,21 @@ func TestIsRetryableError(t *testing.T) {
 			expected: false,
 		},
 		{
+			name:     "typed read-only 1105 is retryable",
+			err:      &mysql.MySQLError{Number: 1105, Message: "cannot update manifest: database is read only"},
+			expected: true,
+		},
+		{
+			name:     "wrapped typed read-only 1105 is retryable case-insensitively",
+			err:      fmt.Errorf("write issue: %w", &mysql.MySQLError{Number: 1105, Message: "Cannot Update Manifest: Database Is Read Only"}),
+			expected: true,
+		},
+		{
+			name:     "read-only text on another typed code is not retryable",
+			err:      &mysql.MySQLError{Number: 1064, Message: "database is read only"},
+			expected: false,
+		},
+		{
 			name:     "typed setup 1049 is not generically retryable",
 			err:      &mysql.MySQLError{Number: 1049, Message: "Unknown database 'beads_test'"},
 			expected: false,

--- a/internal/storage/dolt/retry_test.go
+++ b/internal/storage/dolt/retry_test.go
@@ -3,7 +3,6 @@ package dolt
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	mysql "github.com/go-sql-driver/mysql"
@@ -120,36 +119,6 @@ func TestIsRetryableError(t *testing.T) {
 			err:      errors.New("Error 1146: Table 'beads.foo' doesn't exist"),
 			expected: false,
 		},
-		{
-			name:     "typed semantic 1105 with connection-like text is not retryable",
-			err:      &mysql.MySQLError{Number: 1105, Message: "connection lost while validating commit"},
-			expected: false,
-		},
-		{
-			name:     "typed read-only 1105 is retryable",
-			err:      &mysql.MySQLError{Number: 1105, Message: "cannot update manifest: database is read only"},
-			expected: true,
-		},
-		{
-			name:     "wrapped typed read-only 1105 is retryable case-insensitively",
-			err:      fmt.Errorf("write issue: %w", &mysql.MySQLError{Number: 1105, Message: "Cannot Update Manifest: Database Is Read Only"}),
-			expected: true,
-		},
-		{
-			name:     "read-only text on another typed code is not retryable",
-			err:      &mysql.MySQLError{Number: 1064, Message: "database is read only"},
-			expected: false,
-		},
-		{
-			name:     "typed setup 1049 is not generically retryable",
-			err:      &mysql.MySQLError{Number: 1049, Message: "Unknown database 'beads_test'"},
-			expected: false,
-		},
-		{
-			name:     "typed setup 1105 is not generically retryable",
-			err:      &mysql.MySQLError{Number: 1105, Message: "no root value found in session"},
-			expected: false,
-		},
 	}
 
 	for _, tt := range tests {
@@ -157,63 +126,6 @@ func TestIsRetryableError(t *testing.T) {
 			got := isRetryableError(tt.err)
 			if got != tt.expected {
 				t.Errorf("isRetryableError(%v) = %v, want %v", tt.err, got, tt.expected)
-			}
-		})
-	}
-}
-
-func TestIsSetupRetryableError(t *testing.T) {
-	tests := []struct {
-		name string
-		err  error
-		want bool
-	}{
-		{
-			name: "typed unknown database",
-			err:  &mysql.MySQLError{Number: 1049, Message: "Unknown database 'beads_test'"},
-			want: true,
-		},
-		{
-			name: "wrapped typed unknown database",
-			err:  fmt.Errorf("ping database after create: %w", &mysql.MySQLError{Number: 1049, Message: "Unknown database 'beads_test'"}),
-			want: true,
-		},
-		{
-			name: "typed missing session root",
-			err:  &mysql.MySQLError{Number: 1105, Message: "no root value found in session"},
-			want: true,
-		},
-		{
-			name: "wrapped case variant of missing session root",
-			err:  fmt.Errorf("schema probe: %w", &mysql.MySQLError{Number: 1105, Message: "No Root Value Found In Session"}),
-			want: true,
-		},
-		{
-			name: "typed 1105 with extra context",
-			err:  &mysql.MySQLError{Number: 1105, Message: "no root value found in session while validating commit"},
-			want: false,
-		},
-		{
-			name: "typed 1105 unrelated semantic error",
-			err:  &mysql.MySQLError{Number: 1105, Message: "connection lost while validating commit"},
-			want: false,
-		},
-		{
-			name: "typed syntax error",
-			err:  &mysql.MySQLError{Number: 1064, Message: "You have an error in your SQL syntax"},
-			want: false,
-		},
-		{
-			name: "generic connection failure",
-			err:  errors.New("driver: bad connection"),
-			want: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := isSetupRetryableError(tt.err); got != tt.want {
-				t.Errorf("isSetupRetryableError(%v) = %v, want %v", tt.err, got, tt.want)
 			}
 		})
 	}

--- a/internal/storage/dolt/settlement_commit_boundary_test.go
+++ b/internal/storage/dolt/settlement_commit_boundary_test.go
@@ -140,7 +140,7 @@ func TestCommitWorkingSetAfterSQLCommitResponseLossIsIndeterminate(t *testing.T)
 		{
 			name: "DOLT_ADD",
 			setup: func(mock sqlmock.Sqlmock, responseLoss error) {
-				mock.ExpectQuery(regexp.QuoteMeta("SELECT table_name FROM dolt_status")).
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT s.table_name FROM dolt_status")).
 					WillReturnRows(sqlmock.NewRows([]string{"table_name"}).AddRow("issues"))
 				mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_ADD(?)")).
 					WithArgs("issues").
@@ -150,7 +150,7 @@ func TestCommitWorkingSetAfterSQLCommitResponseLossIsIndeterminate(t *testing.T)
 		{
 			name: "DOLT_COMMIT",
 			setup: func(mock sqlmock.Sqlmock, responseLoss error) {
-				mock.ExpectQuery(regexp.QuoteMeta("SELECT table_name FROM dolt_status")).
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT s.table_name FROM dolt_status")).
 					WillReturnRows(sqlmock.NewRows([]string{"table_name"}).AddRow("issues"))
 				mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_ADD(?)")).
 					WithArgs("issues").

--- a/internal/storage/dolt/settlement_commit_boundary_test.go
+++ b/internal/storage/dolt/settlement_commit_boundary_test.go
@@ -1,0 +1,191 @@
+package dolt
+
+import (
+	"errors"
+	"regexp"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+func TestServerSettlementSQLCommitResponseLossIsIndeterminate(t *testing.T) {
+	t.Run("pull merge settlement", func(t *testing.T) {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+		if err != nil {
+			t.Fatalf("sqlmock.New: %v", err)
+		}
+		t.Cleanup(func() { _ = db.Close() })
+
+		mock.ExpectBegin()
+		tx, err := db.BeginTx(t.Context(), nil)
+		if err != nil {
+			t.Fatalf("BeginTx: %v", err)
+		}
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT `table`, num_conflicts FROM dolt_conflicts")).
+			WillReturnRows(sqlmock.NewRows([]string{"table", "num_conflicts"}))
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT `table`, num_conflicts FROM dolt_conflicts")).
+			WillReturnRows(sqlmock.NewRows([]string{"table", "num_conflicts"}))
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT `table` FROM dolt_constraint_violations WHERE num_violations > 0")).
+			WillReturnRows(sqlmock.NewRows([]string{"table"}))
+		responseLoss := errors.New("pull settlement commit response lost")
+		mock.ExpectCommit().WillReturnError(responseLoss)
+
+		store := &DoltStore{db: db}
+		err = store.settleMergeInTx(t.Context(), tx, nil)
+		assertPublicCommitIndeterminate(t, err, responseLoss)
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet sqlmock expectations: %v", err)
+		}
+	})
+
+	t.Run("full blocked recompute", func(t *testing.T) {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+		if err != nil {
+			t.Fatalf("sqlmock.New: %v", err)
+		}
+		t.Cleanup(func() { _ = db.Close() })
+
+		mock.ExpectBegin()
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT DISTINCT table_name FROM dolt_status WHERE table_name IN (?,?)")).
+			WithArgs("issues", "dependencies").
+			WillReturnRows(sqlmock.NewRows([]string{"table_name"}))
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT id FROM issues")).
+			WillReturnRows(sqlmock.NewRows([]string{"id"}))
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT id FROM wisps")).
+			WillReturnRows(sqlmock.NewRows([]string{"id"}))
+		responseLoss := errors.New("full recompute commit response lost")
+		mock.ExpectCommit().WillReturnError(responseLoss)
+
+		store := &DoltStore{db: db}
+		changed, err := store.recomputeAllBlockedWithDB(t.Context(), db)
+		if changed != 0 {
+			t.Fatalf("recomputeAllBlockedWithDB() changed = %d, want 0", changed)
+		}
+		assertPublicCommitIndeterminate(t, err, responseLoss)
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet sqlmock expectations: %v", err)
+		}
+	})
+
+	t.Run("scoped blocked recompute", func(t *testing.T) {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+		if err != nil {
+			t.Fatalf("sqlmock.New: %v", err)
+		}
+		t.Cleanup(func() { _ = db.Close() })
+
+		mock.ExpectBegin()
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT value FROM metadata WHERE `key` = ?")).
+			WithArgs("is_blocked_recompute_pending").
+			WillReturnRows(sqlmock.NewRows([]string{"value"}))
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT id FROM issues")).
+			WillReturnRows(sqlmock.NewRows([]string{"id"}))
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT id FROM wisps")).
+			WillReturnRows(sqlmock.NewRows([]string{"id"}))
+		responseLoss := errors.New("scoped recompute commit response lost")
+		mock.ExpectCommit().WillReturnError(responseLoss)
+
+		store := &DoltStore{db: db}
+		err = store.recomputeBlockedTxWithDB(t.Context(), db, "")
+		assertPublicCommitIndeterminate(t, err, responseLoss)
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet sqlmock expectations: %v", err)
+		}
+	})
+
+	t.Run("CLI conflict repair", func(t *testing.T) {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+		if err != nil {
+			t.Fatalf("sqlmock.New: %v", err)
+		}
+		t.Cleanup(func() { _ = db.Close() })
+
+		mock.ExpectExec(regexp.QuoteMeta("SET @@dolt_allow_commit_conflicts = 1")).
+			WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectBegin()
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT `table`, num_conflicts FROM dolt_conflicts")).
+			WillReturnRows(sqlmock.NewRows([]string{"table", "num_conflicts"}).AddRow("metadata", 1))
+		mock.ExpectExec(regexp.QuoteMeta("CALL DOLT_CONFLICTS_RESOLVE('--theirs', 'metadata')")).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectExec(regexp.QuoteMeta("CALL DOLT_ADD('metadata')")).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT `table` FROM dolt_constraint_violations WHERE num_violations > 0")).
+			WillReturnRows(sqlmock.NewRows([]string{"table"}))
+		mock.ExpectExec(regexp.QuoteMeta("CALL DOLT_COMMIT('-m', 'auto-resolve merge conflicts: metadata, dependencies, schema_migrations, config, issues (field-level three-way merge), labels/comments/events (union)')")).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		responseLoss := errors.New("CLI repair SQL commit response lost")
+		mock.ExpectCommit().WillReturnError(responseLoss)
+		mock.ExpectExec(regexp.QuoteMeta("SET @@dolt_allow_commit_conflicts = 0")).
+			WillReturnResult(sqlmock.NewResult(0, 0))
+
+		store := &DoltStore{db: db}
+		resolved, err := store.autoResolveConflictsAfterCLIPull(t.Context())
+		if resolved {
+			t.Fatal("autoResolveConflictsAfterCLIPull() resolved = true after lost SQL commit response")
+		}
+		assertPublicCommitIndeterminate(t, err, responseLoss)
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet sqlmock expectations: %v", err)
+		}
+	})
+}
+
+func TestCommitWorkingSetAfterSQLCommitResponseLossIsIndeterminate(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		setup func(sqlmock.Sqlmock, error)
+	}{
+		{
+			name: "DOLT_ADD",
+			setup: func(mock sqlmock.Sqlmock, responseLoss error) {
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT table_name FROM dolt_status")).
+					WillReturnRows(sqlmock.NewRows([]string{"table_name"}).AddRow("issues"))
+				mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_ADD(?)")).
+					WithArgs("issues").
+					WillReturnError(responseLoss)
+			},
+		},
+		{
+			name: "DOLT_COMMIT",
+			setup: func(mock sqlmock.Sqlmock, responseLoss error) {
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT table_name FROM dolt_status")).
+					WillReturnRows(sqlmock.NewRows([]string{"table_name"}).AddRow("issues"))
+				mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_ADD(?)")).
+					WithArgs("issues").
+					WillReturnRows(sqlmock.NewRows([]string{"status"}))
+				mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_COMMIT('-m', ?, '--author', ?)")).
+					WithArgs("bd: recompute is_blocked after pull", " <>").
+					WillReturnError(responseLoss)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+			if err != nil {
+				t.Fatalf("sqlmock.New: %v", err)
+			}
+			t.Cleanup(func() { _ = db.Close() })
+
+			responseLoss := errors.New(tc.name + " response lost after SQL commit")
+			tc.setup(mock, responseLoss)
+			store := &DoltStore{db: db}
+			err = store.commitWorkingSetAfterSQLCommit(t.Context(), "bd: recompute is_blocked after pull", configExclude)
+			assertPublicCommitIndeterminate(t, err, responseLoss)
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatalf("unmet sqlmock expectations: %v", err)
+			}
+		})
+	}
+}
+
+func assertPublicCommitIndeterminate(t *testing.T, err, cause error) {
+	t.Helper()
+	if !errors.Is(err, cause) {
+		t.Fatalf("error = %v, want cause %v", err, cause)
+	}
+	if !errors.Is(err, storage.ErrCommitIndeterminate) {
+		t.Fatalf("error = %v, want storage.ErrCommitIndeterminate", err)
+	}
+}

--- a/internal/storage/dolt/slot_commit_boundary_test.go
+++ b/internal/storage/dolt/slot_commit_boundary_test.go
@@ -21,7 +21,9 @@ type slotCommitBoundaryDriver struct {
 	metadata        string
 	stageErr        error
 	commitErr       error
+	sqlCommitErr    error
 	nothingToCommit bool
+	activeWisp      bool
 
 	metadataUpdates int
 	eventInserts    int
@@ -65,20 +67,32 @@ func (c *slotCommitBoundaryConn) QueryContext(_ context.Context, query string, _
 
 	switch {
 	case strings.Contains(query, "SELECT 1 FROM wisps WHERE id = ? LIMIT 1"):
+		if c.driver.activeWisp {
+			return &claimCommitBoundaryRows{columns: []string{"exists"}, values: [][]driver.Value{{int64(1)}}}, nil
+		}
 		return &claimCommitBoundaryRows{columns: []string{"exists"}}, nil
-	case strings.Contains(query, "SELECT metadata FROM issues WHERE id = ?"):
+	case strings.Contains(query, "SELECT metadata FROM issues WHERE id = ?"),
+		strings.Contains(query, "SELECT metadata FROM wisps WHERE id = ?"):
 		return &claimCommitBoundaryRows{
 			columns: []string{"metadata"},
 			values:  [][]driver.Value{{c.driver.metadata}},
 		}, nil
 	case strings.Contains(query, "FROM issues") && strings.Contains(query, "LEFT JOIN leases") && strings.Contains(query, "WHERE id = ?"):
+		if c.driver.activeWisp {
+			return &claimCommitBoundaryRows{columns: claimBoundaryIssueColumns()}, nil
+		}
 		return &claimCommitBoundaryRows{
 			columns: claimBoundaryIssueColumns(),
 			values:  [][]driver.Value{slotBoundaryIssueValues("slot-boundary", c.driver.metadata)},
 		}, nil
-	case strings.Contains(query, "SELECT label FROM labels"):
+	case strings.Contains(query, "FROM wisps") && strings.Contains(query, "LEFT JOIN leases") && strings.Contains(query, "WHERE id = ?"):
+		return &claimCommitBoundaryRows{
+			columns: claimBoundaryIssueColumns(),
+			values:  [][]driver.Value{slotBoundaryIssueValues("slot-boundary", c.driver.metadata)},
+		}, nil
+	case strings.Contains(query, "SELECT label FROM labels"), strings.Contains(query, "SELECT label FROM wisp_labels"):
 		return &claimCommitBoundaryRows{columns: []string{"label"}}, nil
-	case strings.Contains(query, "SELECT id FROM events"):
+	case strings.Contains(query, "SELECT id FROM events"), strings.Contains(query, "SELECT id FROM wisp_events"):
 		return &claimCommitBoundaryRows{columns: []string{"id"}}, nil
 	case strings.Contains(query, "CALL DOLT_ADD"):
 		c.driver.stageCalls++
@@ -104,9 +118,9 @@ func (c *slotCommitBoundaryConn) ExecContext(_ context.Context, query string, _ 
 	c.driver.mu.Lock()
 	defer c.driver.mu.Unlock()
 	switch {
-	case strings.Contains(query, "UPDATE issues") && strings.Contains(query, "`metadata`"):
+	case (strings.Contains(query, "UPDATE issues") || strings.Contains(query, "UPDATE wisps")) && strings.Contains(query, "`metadata`"):
 		c.driver.metadataUpdates++
-	case strings.Contains(query, "INSERT INTO events"):
+	case strings.Contains(query, "INSERT INTO events"), strings.Contains(query, "INSERT INTO wisp_events"):
 		c.driver.eventInserts++
 	}
 	return driver.RowsAffected(1), nil
@@ -120,7 +134,7 @@ func (t *slotCommitBoundaryTx) Commit() error {
 	t.driver.mu.Lock()
 	defer t.driver.mu.Unlock()
 	t.driver.txCommits++
-	return nil
+	return t.driver.sqlCommitErr
 }
 
 func (t *slotCommitBoundaryTx) Rollback() error {
@@ -235,6 +249,40 @@ func TestMetadataSlotWritesDoltCommitResponseLossIsIndeterminateAndNotReplayed(t
 			}
 			if driver.txAttempts != 1 || driver.txCommits != 0 || driver.txRollbacks != 1 {
 				t.Fatalf("SQL transaction outcomes = attempts:%d commits:%d rollbacks:%d, want attempts:1 commits:0 rollbacks:1", driver.txAttempts, driver.txCommits, driver.txRollbacks)
+			}
+		})
+	}
+}
+
+func TestWispMetadataSlotWritesSQLCommitResponseLossIsIndeterminateAndNotReplayed(t *testing.T) {
+	for _, tc := range metadataSlotWriteCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			driver := &slotCommitBoundaryDriver{
+				metadata:     tc.metadata,
+				activeWisp:   true,
+				sqlCommitErr: testConnectionLoss,
+			}
+			store := newSlotCommitBoundaryStore(driver)
+			t.Cleanup(func() { _ = store.db.Close() })
+
+			err := tc.run(store)
+			if !errors.Is(err, ErrCommitIndeterminate) {
+				t.Fatalf("wisp metadata slot write error = %v, want ErrCommitIndeterminate", err)
+			}
+			if !errors.Is(err, testConnectionLoss) {
+				t.Fatalf("wisp metadata slot write error = %v, want cause %v", err, testConnectionLoss)
+			}
+
+			driver.mu.Lock()
+			defer driver.mu.Unlock()
+			if driver.metadataUpdates != 1 || driver.eventInserts != 1 {
+				t.Fatalf("mutation attempts = updates:%d events:%d, want updates:1 events:1 (no replay)", driver.metadataUpdates, driver.eventInserts)
+			}
+			if driver.stageCalls != 0 || driver.doltCommits != 0 {
+				t.Fatalf("wisp write unexpectedly used Dolt versioning: adds:%d commits:%d", driver.stageCalls, driver.doltCommits)
+			}
+			if driver.txAttempts != 1 || driver.txCommits != 1 {
+				t.Fatalf("SQL transaction attempts = %d, commit calls = %d, want 1 and 1", driver.txAttempts, driver.txCommits)
 			}
 		})
 	}

--- a/internal/storage/dolt/slot_commit_boundary_test.go
+++ b/internal/storage/dolt/slot_commit_boundary_test.go
@@ -257,12 +257,15 @@ func TestMetadataSlotWritesDoltCommitResponseLossIsIndeterminateAndNotReplayed(t
 func TestWispMetadataSlotWritesSQLCommitResponseLossIsIndeterminateAndNotReplayed(t *testing.T) {
 	for _, tc := range metadataSlotWriteCases() {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("BEADS_TEST_MODE", "")
+			breaker := newTestCircuitBreaker(t)
 			driver := &slotCommitBoundaryDriver{
 				metadata:     tc.metadata,
 				activeWisp:   true,
 				sqlCommitErr: testConnectionLoss,
 			}
 			store := newSlotCommitBoundaryStore(driver)
+			store.breaker = breaker
 			t.Cleanup(func() { _ = store.db.Close() })
 
 			err := tc.run(store)
@@ -283,6 +286,11 @@ func TestWispMetadataSlotWritesSQLCommitResponseLossIsIndeterminateAndNotReplaye
 			}
 			if driver.txAttempts != 1 || driver.txCommits != 1 {
 				t.Fatalf("SQL transaction attempts = %d, commit calls = %d, want 1 and 1", driver.txAttempts, driver.txCommits)
+			}
+
+			state := breaker.readState()
+			if state.State != circuitClosed || state.Failures != 1 {
+				t.Fatalf("circuit state after one lost response = %+v, want closed with one failure", state)
 			}
 		})
 	}

--- a/internal/storage/dolt/slot_commit_boundary_test.go
+++ b/internal/storage/dolt/slot_commit_boundary_test.go
@@ -1,0 +1,245 @@
+package dolt
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// slotCommitBoundaryDriver models permanent metadata writes through their SQL
+// mutation, EventUpdated insert, DOLT_ADD, and DOLT_COMMIT phases. A failed
+// transaction deliberately leaves its starting metadata unchanged so an unsafe
+// retry is visible as a duplicate update and event attempt.
+type slotCommitBoundaryDriver struct {
+	mu sync.Mutex
+
+	metadata        string
+	stageErr        error
+	commitErr       error
+	nothingToCommit bool
+
+	metadataUpdates int
+	eventInserts    int
+	stageCalls      int
+	doltCommits     int
+	txAttempts      int
+	txCommits       int
+	txRollbacks     int
+}
+
+func (d *slotCommitBoundaryDriver) Open(string) (driver.Conn, error) {
+	return &slotCommitBoundaryConn{driver: d}, nil
+}
+
+func (d *slotCommitBoundaryDriver) Connect(context.Context) (driver.Conn, error) {
+	return &slotCommitBoundaryConn{driver: d}, nil
+}
+
+func (d *slotCommitBoundaryDriver) Driver() driver.Driver { return d }
+
+type slotCommitBoundaryConn struct {
+	driver *slotCommitBoundaryDriver
+}
+
+func (c *slotCommitBoundaryConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("slot commit boundary driver does not prepare statements")
+}
+
+func (c *slotCommitBoundaryConn) Close() error { return nil }
+
+func (c *slotCommitBoundaryConn) Begin() (driver.Tx, error) {
+	c.driver.mu.Lock()
+	c.driver.txAttempts++
+	c.driver.mu.Unlock()
+	return &slotCommitBoundaryTx{driver: c.driver}, nil
+}
+
+func (c *slotCommitBoundaryConn) QueryContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Rows, error) {
+	c.driver.mu.Lock()
+	defer c.driver.mu.Unlock()
+
+	switch {
+	case strings.Contains(query, "SELECT 1 FROM wisps WHERE id = ? LIMIT 1"):
+		return &claimCommitBoundaryRows{columns: []string{"exists"}}, nil
+	case strings.Contains(query, "SELECT metadata FROM issues WHERE id = ?"):
+		return &claimCommitBoundaryRows{
+			columns: []string{"metadata"},
+			values:  [][]driver.Value{{c.driver.metadata}},
+		}, nil
+	case strings.Contains(query, "FROM issues") && strings.Contains(query, "LEFT JOIN leases") && strings.Contains(query, "WHERE id = ?"):
+		return &claimCommitBoundaryRows{
+			columns: claimBoundaryIssueColumns(),
+			values:  [][]driver.Value{slotBoundaryIssueValues("slot-boundary", c.driver.metadata)},
+		}, nil
+	case strings.Contains(query, "SELECT label FROM labels"):
+		return &claimCommitBoundaryRows{columns: []string{"label"}}, nil
+	case strings.Contains(query, "SELECT id FROM events"):
+		return &claimCommitBoundaryRows{columns: []string{"id"}}, nil
+	case strings.Contains(query, "CALL DOLT_ADD"):
+		c.driver.stageCalls++
+		if c.driver.stageErr != nil {
+			return nil, c.driver.stageErr
+		}
+		return &claimCommitBoundaryRows{columns: []string{"status"}}, nil
+	case strings.Contains(query, "CALL DOLT_COMMIT"):
+		c.driver.doltCommits++
+		if c.driver.commitErr != nil && c.driver.doltCommits == 1 {
+			return nil, c.driver.commitErr
+		}
+		if c.driver.nothingToCommit {
+			return nil, errors.New("nothing to commit")
+		}
+		return &claimCommitBoundaryRows{columns: []string{"hash"}}, nil
+	default:
+		return &claimCommitBoundaryRows{columns: []string{"value"}}, nil
+	}
+}
+
+func (c *slotCommitBoundaryConn) ExecContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Result, error) {
+	c.driver.mu.Lock()
+	defer c.driver.mu.Unlock()
+	switch {
+	case strings.Contains(query, "UPDATE issues") && strings.Contains(query, "`metadata`"):
+		c.driver.metadataUpdates++
+	case strings.Contains(query, "INSERT INTO events"):
+		c.driver.eventInserts++
+	}
+	return driver.RowsAffected(1), nil
+}
+
+type slotCommitBoundaryTx struct {
+	driver *slotCommitBoundaryDriver
+}
+
+func (t *slotCommitBoundaryTx) Commit() error {
+	t.driver.mu.Lock()
+	defer t.driver.mu.Unlock()
+	t.driver.txCommits++
+	return nil
+}
+
+func (t *slotCommitBoundaryTx) Rollback() error {
+	t.driver.mu.Lock()
+	defer t.driver.mu.Unlock()
+	t.driver.txRollbacks++
+	return nil
+}
+
+func slotBoundaryIssueValues(id, metadata string) []driver.Value {
+	values := claimBoundaryIssueValues(id)
+	for i, column := range claimBoundaryIssueColumns() {
+		if column == "metadata" {
+			values[i] = metadata
+			break
+		}
+	}
+	return values
+}
+
+func newSlotCommitBoundaryStore(d *slotCommitBoundaryDriver) *DoltStore {
+	return &DoltStore{db: sql.OpenDB(d)}
+}
+
+func metadataSlotWriteCases() []struct {
+	name     string
+	metadata string
+	run      func(*DoltStore) error
+} {
+	return []struct {
+		name     string
+		metadata string
+		run      func(*DoltStore) error
+	}{
+		{
+			name:     "merge metadata",
+			metadata: `{"seed":"kept"}`,
+			run: func(store *DoltStore) error {
+				return store.MergeMetadata(context.Background(), "slot-boundary", "new", json.RawMessage(`"value"`), "alice")
+			},
+		},
+		{
+			name:     "clear metadata",
+			metadata: `{"clear":"value","keep":"yes"}`,
+			run: func(store *DoltStore) error {
+				return store.SlotClear(context.Background(), "slot-boundary", "clear", "alice")
+			},
+		},
+	}
+}
+
+func TestMetadataSlotWritesSurfaceDoltAddFailure(t *testing.T) {
+	for _, tc := range metadataSlotWriteCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			stageErr := errors.New("stage failed")
+			driver := &slotCommitBoundaryDriver{
+				metadata:        tc.metadata,
+				stageErr:        stageErr,
+				nothingToCommit: true,
+			}
+			store := newSlotCommitBoundaryStore(driver)
+			t.Cleanup(func() { _ = store.db.Close() })
+
+			err := tc.run(store)
+			if !errors.Is(err, stageErr) {
+				t.Fatalf("metadata slot write error = %v, want stage failure %v", err, stageErr)
+			}
+
+			driver.mu.Lock()
+			defer driver.mu.Unlock()
+			if driver.stageCalls != 1 {
+				t.Fatalf("DOLT_ADD calls = %d, want 1", driver.stageCalls)
+			}
+			if driver.doltCommits != 0 {
+				t.Fatalf("DOLT_COMMIT calls = %d, want 0 after staging failure", driver.doltCommits)
+			}
+			if driver.metadataUpdates != 1 || driver.eventInserts != 1 {
+				t.Fatalf("mutation attempts = updates:%d events:%d, want updates:1 events:1", driver.metadataUpdates, driver.eventInserts)
+			}
+			if driver.txAttempts != 1 || driver.txCommits != 0 || driver.txRollbacks != 1 {
+				t.Fatalf("SQL transaction outcomes = attempts:%d commits:%d rollbacks:%d, want attempts:1 commits:0 rollbacks:1", driver.txAttempts, driver.txCommits, driver.txRollbacks)
+			}
+		})
+	}
+}
+
+func TestMetadataSlotWritesDoltCommitResponseLossIsIndeterminateAndNotReplayed(t *testing.T) {
+	for _, tc := range metadataSlotWriteCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			driver := &slotCommitBoundaryDriver{
+				metadata:  tc.metadata,
+				commitErr: testConnectionLoss,
+			}
+			store := newSlotCommitBoundaryStore(driver)
+			t.Cleanup(func() { _ = store.db.Close() })
+
+			err := tc.run(store)
+			if !errors.Is(err, ErrCommitIndeterminate) {
+				t.Fatalf("metadata slot write error = %v, want ErrCommitIndeterminate", err)
+			}
+			if !errors.Is(err, testConnectionLoss) {
+				t.Fatalf("metadata slot write error = %v, want cause %v", err, testConnectionLoss)
+			}
+
+			driver.mu.Lock()
+			defer driver.mu.Unlock()
+			if driver.metadataUpdates != 1 || driver.eventInserts != 1 {
+				t.Fatalf("mutation attempts = updates:%d events:%d, want updates:1 events:1 (no replay)", driver.metadataUpdates, driver.eventInserts)
+			}
+			if driver.stageCalls != 2 || driver.doltCommits != 1 {
+				t.Fatalf("Dolt calls = adds:%d commits:%d, want adds:2 commits:1", driver.stageCalls, driver.doltCommits)
+			}
+			if driver.txAttempts != 1 || driver.txCommits != 0 || driver.txRollbacks != 1 {
+				t.Fatalf("SQL transaction outcomes = attempts:%d commits:%d rollbacks:%d, want attempts:1 commits:0 rollbacks:1", driver.txAttempts, driver.txCommits, driver.txRollbacks)
+			}
+		})
+	}
+}
+
+var _ driver.Connector = (*slotCommitBoundaryDriver)(nil)
+var _ driver.ExecerContext = (*slotCommitBoundaryConn)(nil)
+var _ driver.QueryerContext = (*slotCommitBoundaryConn)(nil)

--- a/internal/storage/dolt/slots.go
+++ b/internal/storage/dolt/slots.go
@@ -23,25 +23,27 @@ import (
 // this. Routes ephemeral IDs to the wisps table (no DOLT_COMMIT); permanent
 // issues get a Dolt commit.
 func (s *DoltStore) MergeMetadata(ctx context.Context, issueID, key string, value json.RawMessage, actor string) error {
-	// Route ephemeral IDs to wisps table (falls through for promoted wisps).
-	// Wisps skip DOLT_COMMIT since they live in dolt_ignored tables.
-	if s.isActiveWisp(ctx, issueID) {
-		return s.mergeMetadataWisp(ctx, issueID, key, value, actor)
-	}
-
-	// withRetryTx owns BeginTx and the final Commit. The read+merge+write inside
-	// the fn is a single transaction; the retry is what fixes the cross-tx
-	// clobber the old SlotSet suffered from.
-	return s.withRetryTx(ctx, func(tx *sql.Tx) error {
-		if err := issueops.MergeMetadataInTx(ctx, tx, issueID, key, value, actor); err != nil {
-			return err
+	return s.withCircuitWrite(ctx, func(ctx context.Context) error {
+		// Route ephemeral IDs to wisps table (falls through for promoted wisps).
+		// Wisps skip DOLT_COMMIT since they live in dolt_ignored tables.
+		if s.isActiveWisp(ctx, issueID) {
+			return s.mergeMetadataWisp(ctx, issueID, key, value, actor)
 		}
 
-		// Dolt versioning for permanent issues. The merge routes through
-		// UpdateIssueInTx, which also writes an EventUpdated row into events, so
-		// stage both tables before committing (mirrors CloseIssue).
-		commitMsg := fmt.Sprintf("bd: merge metadata %s.%s", issueID, key)
-		return s.doltAddAndCommitInTx(ctx, tx, []string{"issues", "events"}, commitMsg)
+		// withRetryTx owns BeginTx and the final Commit. The read+merge+write inside
+		// the fn is a single transaction; the retry is what fixes the cross-tx
+		// clobber the old SlotSet suffered from.
+		return s.withRetryTx(ctx, func(tx *sql.Tx) error {
+			if err := issueops.MergeMetadataInTx(ctx, tx, issueID, key, value, actor); err != nil {
+				return err
+			}
+
+			// Dolt versioning for permanent issues. The merge routes through
+			// UpdateIssueInTx, which also writes an EventUpdated row into events, so
+			// stage both tables before committing (mirrors CloseIssue).
+			commitMsg := fmt.Sprintf("bd: merge metadata %s.%s", issueID, key)
+			return s.doltAddAndCommitInTx(ctx, tx, []string{"issues", "events"}, commitMsg)
+		})
 	})
 }
 
@@ -123,22 +125,24 @@ func (s *DoltStore) SlotGet(ctx context.Context, issueID, key string) (string, e
 // longer clobber this write between the read and the write. Clearing an absent
 // key is a no-op that writes nothing.
 func (s *DoltStore) SlotClear(ctx context.Context, issueID, key, actor string) error {
-	// Route ephemeral IDs to wisps table (falls through for promoted wisps).
-	// Wisps skip DOLT_COMMIT since they live in dolt_ignored tables.
-	if s.isActiveWisp(ctx, issueID) {
-		return s.clearMetadataWisp(ctx, issueID, key, actor)
-	}
-
-	return s.withRetryTx(ctx, func(tx *sql.Tx) error {
-		if err := issueops.DeleteMetadataInTx(ctx, tx, issueID, key, actor); err != nil {
-			return err
+	return s.withCircuitWrite(ctx, func(ctx context.Context) error {
+		// Route ephemeral IDs to wisps table (falls through for promoted wisps).
+		// Wisps skip DOLT_COMMIT since they live in dolt_ignored tables.
+		if s.isActiveWisp(ctx, issueID) {
+			return s.clearMetadataWisp(ctx, issueID, key, actor)
 		}
 
-		// DeleteMetadataInTx routes through UpdateIssueInTx (issues + events),
-		// so stage both before committing. A no-op clear writes nothing, which
-		// DOLT_COMMIT reports as nothing-to-commit (handled by the helper).
-		commitMsg := fmt.Sprintf("bd: clear metadata %s.%s", issueID, key)
-		return s.doltAddAndCommitInTx(ctx, tx, []string{"issues", "events"}, commitMsg)
+		return s.withRetryTx(ctx, func(tx *sql.Tx) error {
+			if err := issueops.DeleteMetadataInTx(ctx, tx, issueID, key, actor); err != nil {
+				return err
+			}
+
+			// DeleteMetadataInTx routes through UpdateIssueInTx (issues + events),
+			// so stage both before committing. A no-op clear writes nothing, which
+			// DOLT_COMMIT reports as nothing-to-commit (handled by the helper).
+			commitMsg := fmt.Sprintf("bd: clear metadata %s.%s", issueID, key)
+			return s.doltAddAndCommitInTx(ctx, tx, []string{"issues", "events"}, commitMsg)
+		})
 	})
 }
 

--- a/internal/storage/dolt/slots.go
+++ b/internal/storage/dolt/slots.go
@@ -58,7 +58,10 @@ func (s *DoltStore) mergeMetadataWisp(ctx context.Context, issueID, key string, 
 	if err := issueops.MergeMetadataInTx(ctx, tx, issueID, key, value, actor); err != nil {
 		return err
 	}
-	return wrapTransactionError("commit merge metadata wisp", tx.Commit())
+	if err := tx.Commit(); err != nil {
+		return wrapSQLCommitError("commit merge metadata wisp", err)
+	}
+	return nil
 }
 
 // SlotSet sets a key-value pair in the issue's metadata JSON.
@@ -151,5 +154,8 @@ func (s *DoltStore) clearMetadataWisp(ctx context.Context, issueID, key, actor s
 	if err := issueops.DeleteMetadataInTx(ctx, tx, issueID, key, actor); err != nil {
 		return err
 	}
-	return wrapTransactionError("commit clear metadata wisp", tx.Commit())
+	if err := tx.Commit(); err != nil {
+		return wrapSQLCommitError("commit clear metadata wisp", err)
+	}
+	return nil
 }

--- a/internal/storage/dolt/slots.go
+++ b/internal/storage/dolt/slots.go
@@ -58,8 +58,8 @@ func (s *DoltStore) mergeMetadataWisp(ctx context.Context, issueID, key string, 
 	if err := issueops.MergeMetadataInTx(ctx, tx, issueID, key, value, actor); err != nil {
 		return err
 	}
-	if err := tx.Commit(); err != nil {
-		return wrapSQLCommitError("commit merge metadata wisp", err)
+	if err := s.commitSQLTx(ctx, "commit merge metadata wisp", tx); err != nil {
+		return err
 	}
 	return nil
 }
@@ -154,8 +154,8 @@ func (s *DoltStore) clearMetadataWisp(ctx context.Context, issueID, key, actor s
 	if err := issueops.DeleteMetadataInTx(ctx, tx, issueID, key, actor); err != nil {
 		return err
 	}
-	if err := tx.Commit(); err != nil {
-		return wrapSQLCommitError("commit clear metadata wisp", err)
+	if err := s.commitSQLTx(ctx, "commit clear metadata wisp", tx); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/storage/dolt/slots.go
+++ b/internal/storage/dolt/slots.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/steveyegge/beads/internal/storage/issueops"
-	"github.com/steveyegge/beads/internal/storage/schema"
 )
 
 // MergeMetadata merges a single key into an issue's metadata JSON atomically.
@@ -41,15 +40,8 @@ func (s *DoltStore) MergeMetadata(ctx context.Context, issueID, key string, valu
 		// Dolt versioning for permanent issues. The merge routes through
 		// UpdateIssueInTx, which also writes an EventUpdated row into events, so
 		// stage both tables before committing (mirrors CloseIssue).
-		for _, table := range []string{"issues", "events"} {
-			_ = schema.DrainCall(ctx, tx, "CALL DOLT_ADD(?)", table)
-		}
 		commitMsg := fmt.Sprintf("bd: merge metadata %s.%s", issueID, key)
-		if err := schema.DrainCall(ctx, tx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-			return fmt.Errorf("dolt commit: %w", err)
-		}
-		return nil
+		return s.doltAddAndCommitInTx(ctx, tx, []string{"issues", "events"}, commitMsg)
 	})
 }
 
@@ -141,16 +133,9 @@ func (s *DoltStore) SlotClear(ctx context.Context, issueID, key, actor string) e
 
 		// DeleteMetadataInTx routes through UpdateIssueInTx (issues + events),
 		// so stage both before committing. A no-op clear writes nothing, which
-		// DOLT_COMMIT reports as nothing-to-commit (handled below).
-		for _, table := range []string{"issues", "events"} {
-			_ = schema.DrainCall(ctx, tx, "CALL DOLT_ADD(?)", table)
-		}
+		// DOLT_COMMIT reports as nothing-to-commit (handled by the helper).
 		commitMsg := fmt.Sprintf("bd: clear metadata %s.%s", issueID, key)
-		if err := schema.DrainCall(ctx, tx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-			return fmt.Errorf("dolt commit: %w", err)
-		}
-		return nil
+		return s.doltAddAndCommitInTx(ctx, tx, []string{"issues", "events"}, commitMsg)
 	})
 }
 

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1025,6 +1025,11 @@ func (s *DoltStore) withRetryTx(ctx context.Context, fn func(tx *sql.Tx) error) 
 			doltMetrics.writeRetries.Add(ctx, 1, metric.WithAttributes(attribute.String("type", "serialization")))
 			return err
 		}
+		// A commit result marked indeterminate may have landed before its
+		// response was lost. Never replay the callback in that case.
+		if errors.Is(err, ErrCommitIndeterminate) {
+			return backoff.Permanent(fmt.Errorf("write commit result indeterminate after connection loss (not retried to avoid double-apply): %w", err))
+		}
 		// Serialization failures (1213/1205) guarantee a server-side rollback,
 		// so the write never landed — safe to replay at any phase.
 		if isSerializationError(err) {
@@ -1066,9 +1071,10 @@ func (s *DoltStore) withWriteTx(ctx context.Context, fn func(tx *sql.Tx) error) 
 		if errors.As(err, &mysqlErr) {
 			return fmt.Errorf("commit write tx: %w", err)
 		}
-		// Tag commit-phase failures so withRetryTx can tell an ambiguous commit
-		// loss apart from a safe-to-replay pre-commit failure.
-		return fmt.Errorf("commit write tx: %w (%w)", err, errCommitPhase)
+		if isIndeterminateCommitResponse(err) {
+			return fmt.Errorf("commit write tx: %w: %w", err, ErrCommitIndeterminate)
+		}
+		return fmt.Errorf("commit write tx: %w", err)
 	}
 	return nil
 }

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -767,6 +767,20 @@ func (s *DoltStore) withRetry(ctx context.Context, op func() error) error {
 	err := backoff.Retry(func() error {
 		attempts++
 		err := op()
+		var permanent *backoff.PermanentError
+		if err != nil && errors.As(err, &permanent) {
+			return err
+		}
+		if err != nil && errors.Is(err, ErrCommitIndeterminate) {
+			if s.breaker != nil && isConnectionError(err) {
+				s.breaker.RecordFailure()
+				if s.breaker.State() == circuitOpen {
+					doltMetrics.circuitTrips.Add(ctx, 1)
+					return backoff.Permanent(fmt.Errorf("%w (circuit breaker tripped)", err))
+				}
+			}
+			return backoff.Permanent(err)
+		}
 		if err != nil && isRetryableError(err) {
 			// Record connection-level failures to the circuit breaker
 			if s.breaker != nil && isConnectionError(err) {
@@ -1076,17 +1090,7 @@ func (s *DoltStore) withWriteTx(ctx context.Context, fn func(tx *sql.Tx) error) 
 		return errors.Join(err, tx.Rollback())
 	}
 	if err := tx.Commit(); err != nil {
-		// A decoded MySQL error is a definite server response. In particular,
-		// Dolt's rollback-guaranteed 1105 must remain eligible for full-tx
-		// replay, while unrelated typed responses must return as definite errors.
-		var mysqlErr *mysql.MySQLError
-		if errors.As(err, &mysqlErr) {
-			return fmt.Errorf("commit write tx: %w", err)
-		}
-		if isIndeterminateCommitResponse(err) {
-			return fmt.Errorf("commit write tx: %w: %w", err, ErrCommitIndeterminate)
-		}
-		return fmt.Errorf("commit write tx: %w", err)
+		return wrapSQLCommitError("commit write tx", err)
 	}
 	return nil
 }
@@ -1116,7 +1120,10 @@ func (s *DoltStore) execContext(ctx context.Context, query string, args ...any) 
 			_ = tx.Rollback()
 			return execErr
 		}
-		return tx.Commit()
+		if commitErr := tx.Commit(); commitErr != nil {
+			return wrapSQLCommitError("commit exec tx", commitErr)
+		}
+		return nil
 	})
 	finalErr := wrapLockError(err)
 	endSpan(span, finalErr)
@@ -3004,22 +3011,24 @@ func (s *DoltStore) CommitWithConfig(ctx context.Context, message string) error 
 
 // doltAddAndCommit stages the specified tables and commits on a pinned
 // connection. This prevents DOLT_COMMIT('-Am') from sweeping up stale
-// working set changes from concurrent operations (GH#2455).
+// working set changes from concurrent operations (GH#2455). Every caller has
+// already committed its SQL mutation, so any publication failure here has an
+// indeterminate durable outcome and must not be replayed.
 func (s *DoltStore) doltAddAndCommit(ctx context.Context, tables []string, commitMsg string) error {
 	conn, err := s.db.Conn(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to acquire connection: %w", err)
+		return fmt.Errorf("acquire connection after SQL mutation: %w: %w", err, ErrCommitIndeterminate)
 	}
 	defer conn.Close()
 
 	for _, table := range tables {
 		if err := schema.DrainCall(ctx, conn, "CALL DOLT_ADD(?)", table); err != nil {
-			return fmt.Errorf("dolt add %s: %w", table, err)
+			return fmt.Errorf("dolt add %s after SQL mutation: %w: %w", table, err, ErrCommitIndeterminate)
 		}
 	}
 	if err := schema.DrainCall(ctx, conn, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
 		commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-		return fmt.Errorf("dolt commit: %w", err)
+		return fmt.Errorf("dolt commit after SQL mutation: %w: %w", err, ErrCommitIndeterminate)
 	}
 	return nil
 }

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -752,9 +752,34 @@ func (s *DoltStore) withTransactionSetupRetry(ctx context.Context, op func() err
 	})
 }
 
+type circuitWriteContextKey struct{}
+
+func circuitWriteManaged(ctx context.Context) bool {
+	_, ok := ctx.Value(circuitWriteContextKey{}).(struct{})
+	return ok
+}
+
+// withCircuitWrite admits one externally visible write and records its
+// terminal success. Nested retry helpers keep failure accounting but defer
+// their success reset to this boundary.
+func (s *DoltStore) withCircuitWrite(ctx context.Context, op func(context.Context) error) error {
+	if circuitWriteManaged(ctx) {
+		return op(ctx)
+	}
+	if s.breaker != nil && !s.breaker.Allow() {
+		doltMetrics.circuitRejected.Add(ctx, 1)
+		return ErrCircuitOpen
+	}
+	err := op(context.WithValue(ctx, circuitWriteContextKey{}, struct{}{}))
+	if err == nil && s.breaker != nil {
+		s.breaker.RecordSuccess()
+	}
+	return err
+}
+
 func (s *DoltStore) withRetryClassified(ctx context.Context, op func() error, retryable func(error) bool) error {
 	// Circuit breaker: fail-fast if the server is known to be down.
-	if s.breaker != nil && !s.breaker.Allow() {
+	if !circuitWriteManaged(ctx) && s.breaker != nil && !s.breaker.Allow() {
 		doltMetrics.circuitRejected.Add(ctx, 1)
 		return ErrCircuitOpen
 	}
@@ -794,7 +819,7 @@ func (s *DoltStore) withRetryClassified(ctx context.Context, op func() error, re
 			return backoff.Permanent(err) // Non-retryable - stop immediately
 		}
 		// Success — reset the circuit breaker
-		if s.breaker != nil {
+		if !circuitWriteManaged(ctx) && s.breaker != nil {
 			s.breaker.RecordSuccess()
 		}
 		return nil
@@ -1036,7 +1061,7 @@ func (s *DoltStore) withRetryTx(ctx context.Context, fn func(tx *sql.Tx) error) 
 	// Keep circuit admission at the transaction retry boundary. Calling
 	// withRetry from here would multiply retries and could replay a write after
 	// an indeterminate commit.
-	if s.breaker != nil && !s.breaker.Allow() {
+	if !circuitWriteManaged(ctx) && s.breaker != nil && !s.breaker.Allow() {
 		doltMetrics.circuitRejected.Add(ctx, 1)
 		return ErrCircuitOpen
 	}
@@ -1050,7 +1075,7 @@ func (s *DoltStore) withRetryTx(ctx context.Context, fn func(tx *sql.Tx) error) 
 	return backoff.Retry(func() error {
 		err := s.withWriteTx(ctx, fn)
 		if err == nil {
-			if s.breaker != nil {
+			if !circuitWriteManaged(ctx) && s.breaker != nil {
 				s.breaker.RecordSuccess()
 			}
 			return nil
@@ -2801,7 +2826,9 @@ const (
 // Callers that intentionally modify config (e.g., CommitPending after
 // 'bd config set') must call CommitWithConfig instead.
 func (s *DoltStore) Commit(ctx context.Context, message string) error {
-	return s.commitWorkingSet(ctx, message, configExclude)
+	return s.withCircuitWrite(ctx, func(ctx context.Context) error {
+		return s.commitWorkingSet(ctx, message, configExclude)
+	})
 }
 
 // commitBeforePull commits the working set ahead of a pull's merge, INCLUDING
@@ -2842,7 +2869,9 @@ func (s *DoltStore) commitBeforePull(ctx context.Context, message string) error 
 // concludes bd vc merge --strategy through the same config-inclusive commit
 // instead of the config-excluding Commit that would drop the resolution.
 func (s *DoltStore) CommitMergeResolution(ctx context.Context, message string) error {
-	return s.commitWorkingSet(ctx, message, configIncludeAll)
+	return s.withCircuitWrite(ctx, func(ctx context.Context) error {
+		return s.commitWorkingSet(ctx, message, configIncludeAll)
+	})
 }
 
 // commitWorkingSet stages the dirty tables reported by dolt_status and commits
@@ -3022,19 +3051,21 @@ func (s *DoltStore) assertDirtyConfigUserKVOnly(ctx context.Context, conn *sql.C
 // (e.g., CommitPending after 'bd config set', 'bd init', or 'bd rename-prefix').
 // GH#2455: Commit() excludes config to prevent sweeping up stale changes.
 func (s *DoltStore) CommitWithConfig(ctx context.Context, message string) error {
-	conn, err := s.db.Conn(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to acquire connection: %w", err)
-	}
-	defer conn.Close()
-
-	if err := schema.DrainCall(ctx, conn, "CALL DOLT_COMMIT('-Am', ?, '--author', ?)", message, s.commitAuthorString()); err != nil {
-		if isDoltNothingToCommit(err) {
-			return nil
+	return s.withCircuitWrite(ctx, func(ctx context.Context) error {
+		conn, err := s.db.Conn(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to acquire connection: %w", err)
 		}
-		return s.wrapDoltPublicationFailure(ctx, "failed to commit", err)
-	}
-	return nil
+		defer conn.Close()
+
+		if err := schema.DrainCall(ctx, conn, "CALL DOLT_COMMIT('-Am', ?, '--author', ?)", message, s.commitAuthorString()); err != nil {
+			if isDoltNothingToCommit(err) {
+				return nil
+			}
+			return s.wrapDoltPublicationFailure(ctx, "failed to commit", err)
+		}
+		return nil
+	})
 }
 
 // doltAddAndCommit stages the specified tables and commits on a pinned
@@ -3043,25 +3074,27 @@ func (s *DoltStore) CommitWithConfig(ctx context.Context, message string) error 
 // already committed its SQL mutation, so any publication failure here has an
 // indeterminate durable outcome and must not be replayed.
 func (s *DoltStore) doltAddAndCommit(ctx context.Context, tables []string, commitMsg string) error {
-	conn, err := s.db.Conn(ctx)
-	if err != nil {
-		return s.recordDoltPublicationFailure(ctx,
-			fmt.Errorf("acquire connection after SQL mutation: %w: %w", err, ErrCommitIndeterminate))
-	}
-	defer conn.Close()
-
-	for _, table := range tables {
-		if err := schema.DrainCall(ctx, conn, "CALL DOLT_ADD(?)", table); err != nil {
+	return s.withCircuitWrite(ctx, func(ctx context.Context) error {
+		conn, err := s.db.Conn(ctx)
+		if err != nil {
 			return s.recordDoltPublicationFailure(ctx,
-				fmt.Errorf("dolt add %s after SQL mutation: %w: %w", table, err, ErrCommitIndeterminate))
+				fmt.Errorf("acquire connection after SQL mutation: %w: %w", err, ErrCommitIndeterminate))
 		}
-	}
-	if err := schema.DrainCall(ctx, conn, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-		commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-		return s.recordDoltPublicationFailure(ctx,
-			fmt.Errorf("dolt commit after SQL mutation: %w: %w", err, ErrCommitIndeterminate))
-	}
-	return nil
+		defer conn.Close()
+
+		for _, table := range tables {
+			if err := schema.DrainCall(ctx, conn, "CALL DOLT_ADD(?)", table); err != nil {
+				return s.recordDoltPublicationFailure(ctx,
+					fmt.Errorf("dolt add %s after SQL mutation: %w: %w", table, err, ErrCommitIndeterminate))
+			}
+		}
+		if err := schema.DrainCall(ctx, conn, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
+			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
+			return s.recordDoltPublicationFailure(ctx,
+				fmt.Errorf("dolt commit after SQL mutation: %w: %w", err, ErrCommitIndeterminate))
+		}
+		return nil
+	})
 }
 
 func (s *DoltStore) wrapDoltPublicationFailure(ctx context.Context, op string, err error) error {
@@ -3827,6 +3860,12 @@ func (s *DoltStore) openLongTimeoutConn() (*sql.DB, error) {
 // fallback targets it directly, so pulls from non-default remotes (PullRemote,
 // federation peers) no longer fall back to s.remote.
 func (s *DoltStore) pullWithAutoResolve(ctx context.Context, remote string, query string, args ...any) error {
+	return s.withCircuitWrite(ctx, func(ctx context.Context) error {
+		return s.pullWithAutoResolveUnchecked(ctx, remote, query, args...)
+	})
+}
+
+func (s *DoltStore) pullWithAutoResolveUnchecked(ctx context.Context, remote string, query string, args ...any) error {
 	db, err := s.openLongTimeoutConn()
 	if err != nil {
 		return err
@@ -3957,6 +3996,12 @@ func (s *DoltStore) settleMergeInTx(ctx context.Context, tx *sql.Tx, pullErr err
 // could not be read, which degrades to a full recompute. A pull that merged
 // nothing (HEAD unchanged) is a no-op.
 func (s *DoltStore) recomputeBlockedAfterPull(ctx context.Context, fromCommit string) error {
+	return s.withCircuitWrite(ctx, func(ctx context.Context) error {
+		return s.recomputeBlockedAfterPullUnchecked(ctx, fromCommit)
+	})
+}
+
+func (s *DoltStore) recomputeBlockedAfterPullUnchecked(ctx context.Context, fromCommit string) error {
 	if err := s.recomputeBlockedTx(ctx, fromCommit); err != nil {
 		// The merge this recompute covers is already committed, so a plain
 		// retry on the next pull would skip as "nothing merged" — leave a
@@ -3982,6 +4027,16 @@ func (s *DoltStore) recomputeBlockedAfterPull(ctx context.Context, fromCommit st
 // operator resolved by hand — leaves is_blocked stale until this full pass runs.
 // Idempotent: a consistent database corrects nothing.
 func (s *DoltStore) RecomputeAllBlocked(ctx context.Context) (int, error) {
+	var changed int
+	err := s.withCircuitWrite(ctx, func(ctx context.Context) error {
+		var err error
+		changed, err = s.recomputeAllBlocked(ctx)
+		return err
+	})
+	return changed, err
+}
+
+func (s *DoltStore) recomputeAllBlocked(ctx context.Context) (int, error) {
 	// The full pass's batched UPDATEs carry five correlated EXISTS subqueries
 	// each; on a loaded shared server a single batch can outlive the pool's
 	// per-I/O deadline (default 10s, see buildServerDSN), killing the repair

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -740,6 +740,19 @@ func lockProcessHint() string {
 // If a circuit breaker is configured, it checks the breaker before each attempt
 // and records connection failures/successes to coordinate fail-fast across processes.
 func (s *DoltStore) withRetry(ctx context.Context, op func() error) error {
+	return s.withRetryClassified(ctx, op, isRetryableError)
+}
+
+// withTransactionSetupRetry extends the general connection retry policy with
+// rollback-guaranteed transaction errors. Public transaction wrappers use it
+// only before their callback begins; callback-entered errors are permanent.
+func (s *DoltStore) withTransactionSetupRetry(ctx context.Context, op func() error) error {
+	return s.withRetryClassified(ctx, op, func(err error) bool {
+		return isRetryableError(err) || isDoltAutocommitRollbackError(err) || isSerializationError(err)
+	})
+}
+
+func (s *DoltStore) withRetryClassified(ctx context.Context, op func() error, retryable func(error) bool) error {
 	// Circuit breaker: fail-fast if the server is known to be down.
 	if s.breaker != nil && !s.breaker.Allow() {
 		doltMetrics.circuitRejected.Add(ctx, 1)
@@ -765,7 +778,7 @@ func (s *DoltStore) withRetry(ctx context.Context, op func() error) error {
 			}
 			return backoff.Permanent(err)
 		}
-		if err != nil && isRetryableError(err) {
+		if err != nil && retryable(err) {
 			// Record connection-level failures to the circuit breaker
 			if s.breaker != nil && isConnectionError(err) {
 				s.breaker.RecordFailure()

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1033,6 +1033,14 @@ func (s *DoltStore) withReadTxLongTimeout(ctx context.Context, fn func(tx *sql.T
 }
 
 func (s *DoltStore) withRetryTx(ctx context.Context, fn func(tx *sql.Tx) error) error {
+	// Keep circuit admission at the transaction retry boundary. Calling
+	// withRetry from here would multiply retries and could replay a write after
+	// an indeterminate commit.
+	if s.breaker != nil && !s.breaker.Allow() {
+		doltMetrics.circuitRejected.Add(ctx, 1)
+		return ErrCircuitOpen
+	}
+
 	bo := backoff.NewExponentialBackOff()
 	bo.InitialInterval = 25 * time.Millisecond
 	bo.MaxElapsedTime = 5 * time.Second
@@ -1042,6 +1050,9 @@ func (s *DoltStore) withRetryTx(ctx context.Context, fn func(tx *sql.Tx) error) 
 	return backoff.Retry(func() error {
 		err := s.withWriteTx(ctx, fn)
 		if err == nil {
+			if s.breaker != nil {
+				s.breaker.RecordSuccess()
+			}
 			return nil
 		}
 		// Dolt's exact 1105 autocommit rollback proves the transaction did not
@@ -1070,6 +1081,13 @@ func (s *DoltStore) withRetryTx(ctx context.Context, fn func(tx *sql.Tx) error) 
 		// ErrCommitIndeterminate sentinel above.
 		if isRetryableError(err) {
 			doltMetrics.writeRetries.Add(ctx, 1, metric.WithAttributes(attribute.String("type", "connection")))
+			if s.breaker != nil && isConnectionError(err) {
+				s.breaker.RecordFailure()
+				if s.breaker.State() == circuitOpen {
+					doltMetrics.circuitTrips.Add(ctx, 1)
+					return backoff.Permanent(fmt.Errorf("%w (circuit breaker tripped)", err))
+				}
+			}
 			return err // pre-commit transient: retryable
 		}
 		return backoff.Permanent(err)
@@ -1089,6 +1107,13 @@ func (s *DoltStore) withWriteTx(ctx context.Context, fn func(tx *sql.Tx) error) 
 	}
 	if err := tx.Commit(); err != nil {
 		return wrapSQLCommitError("commit write tx", err)
+	}
+	return nil
+}
+
+func (s *DoltStore) commitSQLTx(ctx context.Context, op string, tx *sql.Tx) error {
+	if err := tx.Commit(); err != nil {
+		return s.recordDoltPublicationFailure(ctx, wrapSQLCommitError(op, err))
 	}
 	return nil
 }

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -788,46 +788,62 @@ func (s *DoltStore) withRetryClassified(ctx context.Context, op func() error, re
 	bo := newServerRetryBackoff()
 	err := backoff.Retry(func() error {
 		attempts++
-		err := op()
-		var permanent *backoff.PermanentError
-		if err != nil && errors.As(err, &permanent) {
-			return err
-		}
-		if err != nil && errors.Is(err, ErrCommitIndeterminate) {
-			if s.breaker != nil && isConnectionError(err) {
-				s.breaker.RecordFailure()
-				if s.breaker.State() == circuitOpen {
-					doltMetrics.circuitTrips.Add(ctx, 1)
-					return backoff.Permanent(fmt.Errorf("%w (circuit breaker tripped)", err))
-				}
-			}
-			return backoff.Permanent(err)
-		}
-		if err != nil && retryable(err) {
-			// Record connection-level failures to the circuit breaker
-			if s.breaker != nil && isConnectionError(err) {
-				s.breaker.RecordFailure()
-				// Check if the breaker just tripped — if so, stop retrying
-				if s.breaker.State() == circuitOpen {
-					doltMetrics.circuitTrips.Add(ctx, 1)
-					return backoff.Permanent(fmt.Errorf("%w (circuit breaker tripped)", err))
-				}
-			}
-			return err // Retryable - backoff will retry
-		}
-		if err != nil {
-			return backoff.Permanent(err) // Non-retryable - stop immediately
-		}
-		// Success — reset the circuit breaker
-		if !circuitWriteManaged(ctx) && s.breaker != nil {
-			s.breaker.RecordSuccess()
-		}
-		return nil
+		return s.classifyManagedRetry(ctx, op(), retryable)
 	}, backoff.WithContext(bo, ctx))
 	if attempts > 1 {
 		doltMetrics.retryCount.Add(ctx, int64(attempts-1))
 	}
 	return err
+}
+
+// classifyManagedRetry maps one attempt's result to a backoff decision: nil to
+// stop on success, a bare error to retry, or a backoff.Permanent to stop on
+// failure. It owns the attempt's breaker accounting, deferring the success reset
+// to an outer withCircuitWrite boundary when one is active (circuitWriteManaged).
+func (s *DoltStore) classifyManagedRetry(ctx context.Context, err error, retryable func(error) bool) error {
+	if err == nil {
+		if !circuitWriteManaged(ctx) && s.breaker != nil {
+			s.breaker.RecordSuccess()
+		}
+		return nil
+	}
+	// An already-permanent error (e.g. a callback-entered RunInTransaction
+	// failure) is terminal and must not be re-wrapped.
+	var permanent *backoff.PermanentError
+	if errors.As(err, &permanent) {
+		return err
+	}
+	// An indeterminate commit is never replayed — replay could double-apply —
+	// but a connection loss still feeds the breaker before we stop.
+	if errors.Is(err, ErrCommitIndeterminate) {
+		if tripped := s.recordRetryFailure(ctx, err); tripped != nil {
+			return tripped
+		}
+		return backoff.Permanent(err)
+	}
+	if retryable(err) {
+		if tripped := s.recordRetryFailure(ctx, err); tripped != nil {
+			return tripped
+		}
+		return err // backoff will retry
+	}
+	return backoff.Permanent(err) // non-retryable — stop immediately
+}
+
+// recordRetryFailure records a connection-level failure to the breaker. It
+// returns a permanent "circuit breaker tripped" error when this failure trips
+// the breaker — signaling the retry loop to stop — and nil otherwise, including
+// when err is not a connection error or no breaker is configured.
+func (s *DoltStore) recordRetryFailure(ctx context.Context, err error) error {
+	if s.breaker == nil || !isConnectionError(err) {
+		return nil
+	}
+	s.breaker.RecordFailure()
+	if s.breaker.State() == circuitOpen {
+		doltMetrics.circuitTrips.Add(ctx, 1)
+		return backoff.Permanent(fmt.Errorf("%w (circuit breaker tripped)", err))
+	}
+	return nil
 }
 
 // doltTracer is the OTel tracer for SQL-level spans.

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -671,6 +671,22 @@ func isRetryableError(err error) bool {
 	return false
 }
 
+// isSetupRetryableError extends the generic transient classifier with two
+// decoded Dolt setup races. Typed MySQL responses remain non-retryable during
+// normal operations; these responses are safe to retry only while a newly
+// created database and its schema are becoming available.
+func isSetupRetryableError(err error) bool {
+	if isRetryableError(err) {
+		return true
+	}
+	var mysqlErr *mysql.MySQLError
+	if !errors.As(err, &mysqlErr) {
+		return false
+	}
+	return mysqlErr.Number == 1049 ||
+		(mysqlErr.Number == 1105 && strings.EqualFold(strings.TrimSpace(mysqlErr.Message), "no root value found in session"))
+}
+
 // isLockError returns true if the error indicates a Dolt lock contention problem.
 // These can occur when the Dolt server's storage layer is locked by another
 // process or a stale LOCK file was left behind by a crashed server.
@@ -1037,14 +1053,10 @@ func (s *DoltStore) withRetryTx(ctx context.Context, fn func(tx *sql.Tx) error) 
 			doltMetrics.writeRetries.Add(ctx, 1, metric.WithAttributes(attribute.String("type", "serialization")))
 			return err // retryable
 		}
-		// Connection failures are only safe to replay BEFORE commit (BeginTx or
-		// the body): nothing was committed. A failure tagged errCommitPhase is
-		// ambiguous — the commit may have landed before the connection dropped —
-		// so replaying could double-apply the write. Surface it instead.
+		// Connection failures reaching this branch happened before commit;
+		// withWriteTx marks ambiguous commit response loss with the public
+		// ErrCommitIndeterminate sentinel above.
 		if isRetryableError(err) {
-			if errors.Is(err, errCommitPhase) {
-				return backoff.Permanent(fmt.Errorf("write commit result indeterminate after connection loss (not retried to avoid double-apply): %w", err))
-			}
 			doltMetrics.writeRetries.Add(ctx, 1, metric.WithAttributes(attribute.String("type", "connection")))
 			return err // pre-commit transient: retryable
 		}
@@ -2326,7 +2338,7 @@ func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, se
 	bo.MaxElapsedTime = 10 * time.Second
 	if err := backoff.Retry(func() error {
 		pingErr := db.PingContext(ctx)
-		if pingErr != nil && isRetryableError(pingErr) {
+		if pingErr != nil && isSetupRetryableError(pingErr) {
 			return pingErr // retryable — backoff will retry
 		}
 		if pingErr != nil {
@@ -2464,7 +2476,7 @@ func initSchemaOnDBWithRetryAndGateBootstrapHeal(
 	err := backoff.Retry(func() error {
 		if gate != nil {
 			if gateErr := gate(ctx, db); gateErr != nil {
-				if !schema.IsRemoteMigrateGateError(gateErr) && isRetryableError(gateErr) {
+				if !schema.IsRemoteMigrateGateError(gateErr) && isSetupRetryableError(gateErr) {
 					return gateErr
 				}
 				return backoff.Permanent(gateErr)
@@ -2472,7 +2484,7 @@ func initSchemaOnDBWithRetryAndGateBootstrapHeal(
 		}
 		var schemaErr error
 		applied, schemaErr = initSchemaOnDBWithBootstrapHeal(ctx, db, bootstrapHeal, endpoint)
-		if schemaErr != nil && isRetryableError(schemaErr) {
+		if schemaErr != nil && isSetupRetryableError(schemaErr) {
 			return schemaErr
 		}
 		if schemaErr != nil {

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -2900,7 +2900,7 @@ func (s *DoltStore) commitWorkingSet(ctx context.Context, message string, mode c
 		if isDoltNothingToCommit(err) {
 			return nil
 		}
-		return fmt.Errorf("failed to commit: %w", err)
+		return wrapSQLCommitError("failed to commit", err)
 	}
 
 	return nil
@@ -2926,7 +2926,7 @@ func (s *DoltStore) concludeOpenMerge(ctx context.Context, conn *sql.Conn, messa
 		if isDoltNothingToCommit(err) {
 			return nil
 		}
-		return fmt.Errorf("failed to conclude merge: %w", err)
+		return wrapSQLCommitError("failed to conclude merge", err)
 	}
 	return nil
 }
@@ -2988,7 +2988,7 @@ func (s *DoltStore) CommitWithConfig(ctx context.Context, message string) error 
 		if isDoltNothingToCommit(err) {
 			return nil
 		}
-		return fmt.Errorf("failed to commit: %w", err)
+		return wrapSQLCommitError("failed to commit", err)
 	}
 	return nil
 }
@@ -3001,20 +3001,39 @@ func (s *DoltStore) CommitWithConfig(ctx context.Context, message string) error 
 func (s *DoltStore) doltAddAndCommit(ctx context.Context, tables []string, commitMsg string) error {
 	conn, err := s.db.Conn(ctx)
 	if err != nil {
-		return fmt.Errorf("acquire connection after SQL mutation: %w: %w", err, ErrCommitIndeterminate)
+		return s.recordDoltPublicationFailure(ctx,
+			fmt.Errorf("acquire connection after SQL mutation: %w: %w", err, ErrCommitIndeterminate))
 	}
 	defer conn.Close()
 
 	for _, table := range tables {
 		if err := schema.DrainCall(ctx, conn, "CALL DOLT_ADD(?)", table); err != nil {
-			return fmt.Errorf("dolt add %s after SQL mutation: %w: %w", table, err, ErrCommitIndeterminate)
+			return s.recordDoltPublicationFailure(ctx,
+				fmt.Errorf("dolt add %s after SQL mutation: %w: %w", table, err, ErrCommitIndeterminate))
 		}
 	}
 	if err := schema.DrainCall(ctx, conn, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
 		commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-		return fmt.Errorf("dolt commit after SQL mutation: %w: %w", err, ErrCommitIndeterminate)
+		return s.recordDoltPublicationFailure(ctx,
+			fmt.Errorf("dolt commit after SQL mutation: %w: %w", err, ErrCommitIndeterminate))
 	}
 	return nil
+}
+
+// recordDoltPublicationFailure accounts for a connection loss after a durable
+// SQL write. doltAddAndCommit is intentionally outside withRetry: replaying it
+// could publish an already-applied write, so this is the single accounting
+// boundary for those direct publication failures.
+func (s *DoltStore) recordDoltPublicationFailure(ctx context.Context, err error) error {
+	if s.breaker == nil || !errors.Is(err, ErrCommitIndeterminate) || !isConnectionError(err) {
+		return err
+	}
+	s.breaker.RecordFailure()
+	if s.breaker.State() == circuitOpen {
+		doltMetrics.circuitTrips.Add(ctx, 1)
+		return fmt.Errorf("%w (circuit breaker tripped)", err)
+	}
+	return err
 }
 
 // HasCommittablePending reports whether the working set holds committable

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -2905,7 +2905,7 @@ func (s *DoltStore) commitWorkingSet(ctx context.Context, message string, mode c
 		if isDoltNothingToCommit(err) {
 			return nil
 		}
-		return wrapSQLCommitError("failed to commit", err)
+		return s.wrapDoltPublicationFailure(ctx, "failed to commit", err)
 	}
 
 	return nil
@@ -2931,7 +2931,7 @@ func (s *DoltStore) concludeOpenMerge(ctx context.Context, conn *sql.Conn, messa
 		if isDoltNothingToCommit(err) {
 			return nil
 		}
-		return wrapSQLCommitError("failed to conclude merge", err)
+		return s.wrapDoltPublicationFailure(ctx, "failed to conclude merge", err)
 	}
 	return nil
 }
@@ -2993,7 +2993,7 @@ func (s *DoltStore) CommitWithConfig(ctx context.Context, message string) error 
 		if isDoltNothingToCommit(err) {
 			return nil
 		}
-		return wrapSQLCommitError("failed to commit", err)
+		return s.wrapDoltPublicationFailure(ctx, "failed to commit", err)
 	}
 	return nil
 }
@@ -3025,10 +3025,13 @@ func (s *DoltStore) doltAddAndCommit(ctx context.Context, tables []string, commi
 	return nil
 }
 
-// recordDoltPublicationFailure accounts for a connection loss after a durable
-// SQL write. doltAddAndCommit is intentionally outside withRetry: replaying it
-// could publish an already-applied write, so this is the single accounting
-// boundary for those direct publication failures.
+func (s *DoltStore) wrapDoltPublicationFailure(ctx context.Context, op string, err error) error {
+	return s.recordDoltPublicationFailure(ctx, wrapSQLCommitError(op, err))
+}
+
+// recordDoltPublicationFailure accounts once for an ambiguous connection loss
+// at a direct Dolt publication boundary. These paths deliberately stay outside
+// withRetry because replay could report an already-applied commit as a new one.
 func (s *DoltStore) recordDoltPublicationFailure(ctx context.Context, err error) error {
 	if s.breaker == nil || !errors.Is(err, ErrCommitIndeterminate) || !isConnectionError(err) {
 		return err

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1055,6 +1055,7 @@ func (s *DoltStore) withRetryTx(ctx context.Context, fn func(tx *sql.Tx) error) 
 		// A commit result marked indeterminate may have landed before its
 		// response was lost. Never replay the callback in that case.
 		if errors.Is(err, ErrCommitIndeterminate) {
+			err = s.recordDoltPublicationFailure(ctx, err)
 			return backoff.Permanent(fmt.Errorf("write commit result indeterminate after connection loss (not retried to avoid double-apply): %w", err))
 		}
 		// Serialization failures (1213/1205) guarantee a server-side rollback,
@@ -3030,8 +3031,8 @@ func (s *DoltStore) wrapDoltPublicationFailure(ctx context.Context, op string, e
 }
 
 // recordDoltPublicationFailure accounts once for an ambiguous connection loss
-// at a direct Dolt publication boundary. These paths deliberately stay outside
-// withRetry because replay could report an already-applied commit as a new one.
+// at a Dolt publication boundary. Direct publication helpers stay outside
+// withRetryTx; transaction-backed writes call this from withRetryTx itself.
 func (s *DoltStore) recordDoltPublicationFailure(ctx context.Context, err error) error {
 	if s.breaker == nil || !errors.Is(err, ErrCommitIndeterminate) || !isConnectionError(err) {
 		return err

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -2895,15 +2895,7 @@ func (s *DoltStore) commitWorkingSet(ctx context.Context, message string, mode c
 
 	for _, table := range tables {
 		if err := schema.DrainCall(ctx, conn, "CALL DOLT_ADD(?)", table); err != nil {
-			// config when the mode intentionally includes it is the whole reason
-			// we stage here: silently skipping a failed DOLT_ADD('config') would
-			// leave config dirty and re-wedge the merge, so surface it instead.
-			if table == "config" && mode != configExclude {
-				return fmt.Errorf("failed to stage config before commit: %w", err)
-			}
-			// Best effort: some tables may be dolt_ignore'd (e.g., wisps).
-			// DOLT_ADD fails for ignored tables; skip silently.
-			continue
+			return fmt.Errorf("failed to stage %s before commit: %w", table, err)
 		}
 	}
 

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -671,22 +671,6 @@ func isRetryableError(err error) bool {
 	return false
 }
 
-// isSetupRetryableError extends the generic transient classifier with two
-// decoded Dolt setup races. Typed MySQL responses remain non-retryable during
-// normal operations; these responses are safe to retry only while a newly
-// created database and its schema are becoming available.
-func isSetupRetryableError(err error) bool {
-	if isRetryableError(err) {
-		return true
-	}
-	var mysqlErr *mysql.MySQLError
-	if !errors.As(err, &mysqlErr) {
-		return false
-	}
-	return mysqlErr.Number == 1049 ||
-		(mysqlErr.Number == 1105 && strings.EqualFold(strings.TrimSpace(mysqlErr.Message), "no root value found in session"))
-}
-
 // isLockError returns true if the error indicates a Dolt lock contention problem.
 // These can occur when the Dolt server's storage layer is locked by another
 // process or a stale LOCK file was left behind by a crashed server.
@@ -2345,7 +2329,7 @@ func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, se
 	bo.MaxElapsedTime = 10 * time.Second
 	if err := backoff.Retry(func() error {
 		pingErr := db.PingContext(ctx)
-		if pingErr != nil && isSetupRetryableError(pingErr) {
+		if pingErr != nil && isRetryableError(pingErr) {
 			return pingErr // retryable — backoff will retry
 		}
 		if pingErr != nil {
@@ -2483,7 +2467,7 @@ func initSchemaOnDBWithRetryAndGateBootstrapHeal(
 	err := backoff.Retry(func() error {
 		if gate != nil {
 			if gateErr := gate(ctx, db); gateErr != nil {
-				if !schema.IsRemoteMigrateGateError(gateErr) && isSetupRetryableError(gateErr) {
+				if !schema.IsRemoteMigrateGateError(gateErr) && isRetryableError(gateErr) {
 					return gateErr
 				}
 				return backoff.Permanent(gateErr)
@@ -2491,7 +2475,7 @@ func initSchemaOnDBWithRetryAndGateBootstrapHeal(
 		}
 		var schemaErr error
 		applied, schemaErr = initSchemaOnDBWithBootstrapHeal(ctx, db, bootstrapHeal, endpoint)
-		if schemaErr != nil && isSetupRetryableError(schemaErr) {
+		if schemaErr != nil && isRetryableError(schemaErr) {
 			return schemaErr
 		}
 		if schemaErr != nil {

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -2913,8 +2913,20 @@ func (s *DoltStore) commitWorkingSet(ctx context.Context, message string, mode c
 
 	// GH#2455: stage each dirty table individually, skipping config unless the
 	// mode opts it in, to avoid sweeping up stale issue_prefix changes from
-	// concurrent operations. Query dolt_status first.
-	rows, err := conn.QueryContext(ctx, "SELECT table_name FROM dolt_status")
+	// concurrent operations. Exclude dolt_ignore'd tables (wisps, wisp_%, leases)
+	// with the same anti-join HasCommittablePending uses: they surface in
+	// dolt_status but are never stageable, and the fail-hard DOLT_ADD loop below
+	// must see only tables it can actually stage. A dirty wisp or lease row is the
+	// normal steady state; staging it depends on Dolt's version-specific
+	// ignored-table DOLT_ADD behavior (a silent no-op on 2.2.0), so filtering here
+	// keeps ordinary commits from failing whenever an ignored table is dirty.
+	rows, err := conn.QueryContext(ctx, `
+		SELECT s.table_name FROM dolt_status s
+		WHERE NOT EXISTS (
+			SELECT 1 FROM dolt_ignore di
+			WHERE di.ignored = 1
+			AND s.table_name LIKE di.pattern
+		)`)
 	if err != nil {
 		// If dolt_status fails, fall back to nothing (rare edge case).
 		return fmt.Errorf("failed to query dolt_status: %w", err)

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -3734,6 +3734,12 @@ func (s *DoltStore) PullRemote(ctx context.Context, remote string) error {
 // pullFromRemote is the internal implementation for all pull operations.
 // It routes through CLI or SQL based on the remote's protocol and credentials.
 func (s *DoltStore) pullFromRemote(ctx context.Context, remote string) (retErr error) {
+	return s.withCircuitWrite(ctx, func(ctx context.Context) error {
+		return s.pullFromRemoteUnchecked(ctx, remote)
+	})
+}
+
+func (s *DoltStore) pullFromRemoteUnchecked(ctx context.Context, remote string) (retErr error) {
 	ctx, span := doltTracer.Start(ctx, "dolt.pull",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(append(s.doltSpanAttrs(),

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -2937,6 +2937,19 @@ func (s *DoltStore) commitWorkingSet(ctx context.Context, message string, mode c
 	return nil
 }
 
+// commitWorkingSetAfterSQLCommit preserves the no-replay boundary for a Dolt
+// publication that follows an already-visible SQL mutation. commitWorkingSet
+// classifies DOLT_COMMIT response loss itself; this wrapper adds the same
+// sentinel to earlier publication failures such as a lost DOLT_ADD response.
+func (s *DoltStore) commitWorkingSetAfterSQLCommit(ctx context.Context, message string, mode configCommitMode) error {
+	err := s.commitWorkingSet(ctx, message, mode)
+	if err == nil || errors.Is(err, ErrCommitIndeterminate) || !isIndeterminateCommitResponse(err) {
+		return err
+	}
+	return s.recordDoltPublicationFailure(ctx,
+		fmt.Errorf("publish working set after SQL commit: %w: %w", err, ErrCommitIndeterminate))
+}
+
 // concludeOpenMerge commits an open merge whose resolution left the working
 // set clean, so the merge is actually concluded rather than left open with
 // nothing to show for it. It is a no-op when no merge is in progress, and it
@@ -3933,7 +3946,7 @@ func (s *DoltStore) settleMergeInTx(ctx context.Context, tx *sql.Tx, pullErr err
 		}
 	}
 
-	return tx.Commit()
+	return s.commitSQLTx(ctx, "commit pull merge settlement", tx)
 }
 
 // recomputeBlockedAfterPull recomputes the denormalized is_blocked column for
@@ -3955,7 +3968,7 @@ func (s *DoltStore) recomputeBlockedAfterPull(ctx context.Context, fromCommit st
 	// Derived state converges: every clone computes the same values from the
 	// same merged graph, so committing is merge-safe. Commit no-ops when the
 	// recompute changed nothing.
-	if err := s.Commit(ctx, "bd: recompute is_blocked after pull"); err != nil && !isDoltNothingToCommit(err) {
+	if err := s.commitWorkingSetAfterSQLCommit(ctx, "bd: recompute is_blocked after pull", configExclude); err != nil && !isDoltNothingToCommit(err) {
 		return fmt.Errorf("commit is_blocked recompute: %w", err)
 	}
 	return nil
@@ -3980,6 +3993,10 @@ func (s *DoltStore) RecomputeAllBlocked(ctx context.Context) (int, error) {
 		return 0, err
 	}
 	defer db.Close()
+	return s.recomputeAllBlockedWithDB(ctx, db)
+}
+
+func (s *DoltStore) recomputeAllBlockedWithDB(ctx context.Context, db *sql.DB) (int, error) {
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return 0, fmt.Errorf("begin is_blocked recompute: %w", err)
@@ -3993,8 +4010,8 @@ func (s *DoltStore) RecomputeAllBlocked(ctx context.Context) (int, error) {
 		_ = tx.Rollback()
 		return 0, err
 	}
-	if err := tx.Commit(); err != nil {
-		return 0, fmt.Errorf("commit is_blocked recompute: %w", err)
+	if err := s.commitSQLTx(ctx, "commit is_blocked recompute", tx); err != nil {
+		return 0, err
 	}
 	if changed > 0 {
 		// Stage only issues — the synced table is_blocked lives on (wisps are
@@ -4031,6 +4048,10 @@ func (s *DoltStore) recomputeBlockedTx(ctx context.Context, fromCommit string) e
 		return err
 	}
 	defer db.Close()
+	return s.recomputeBlockedTxWithDB(ctx, db, fromCommit)
+}
+
+func (s *DoltStore) recomputeBlockedTxWithDB(ctx context.Context, db *sql.DB, fromCommit string) error {
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin is_blocked recompute: %w", err)
@@ -4039,8 +4060,8 @@ func (s *DoltStore) recomputeBlockedTx(ctx context.Context, fromCommit string) e
 		_ = tx.Rollback()
 		return err
 	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit is_blocked recompute: %w", err)
+	if err := s.commitSQLTx(ctx, "commit is_blocked recompute", tx); err != nil {
+		return err
 	}
 	return nil
 }
@@ -4159,8 +4180,8 @@ func (s *DoltStore) autoResolveConflictsAfterCLIPull(ctx context.Context) (bool,
 			return false, err
 		}
 	}
-	if err := tx.Commit(); err != nil {
-		return false, fmt.Errorf("failed to commit resolved conflicts: %w", err)
+	if err := s.commitSQLTx(ctx, "commit resolved CLI pull conflicts", tx); err != nil {
+		return false, err
 	}
 	return true, nil
 }

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -68,9 +68,18 @@ func (t *doltTransaction) CreateIssueImport(ctx context.Context, issue *types.Is
 // Wisp routing is handled by individual transaction methods based on
 // ID/Ephemeral.
 func (s *DoltStore) RunInTransaction(ctx context.Context, commitMsg string, fn func(tx storage.Transaction) error) error {
+	return s.runInTransaction(ctx, commitMsg, fn, s.runDoltTransaction)
+}
+
+func (s *DoltStore) runInTransaction(
+	ctx context.Context,
+	commitMsg string,
+	fn func(storage.Transaction) error,
+	run func(context.Context, string, func(storage.Transaction) error) error,
+) error {
 	return s.withRetry(ctx, func() error {
 		invoked := false
-		err := s.runDoltTransaction(ctx, commitMsg, func(tx storage.Transaction) error {
+		err := run(ctx, commitMsg, func(tx storage.Transaction) error {
 			invoked = true
 			return fn(tx)
 		})

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -189,13 +189,7 @@ func (s *DoltStore) runDoltTransaction(ctx context.Context, commitMsg string, fn
 func (s *DoltStore) finishDoltTransaction(ctx context.Context, conn *sql.Conn, tx *doltTransaction, commitMsg string) error {
 	if err := tx.regularTx.Commit(); err != nil {
 		_ = tx.ignoredTx.Rollback()
-		if isSerializationError(err) {
-			return fmt.Errorf("sql commit (regular): %w", err)
-		}
-		if isIndeterminateCommitResponse(err) {
-			return fmt.Errorf("sql commit (regular): %w: %w", err, ErrCommitIndeterminate)
-		}
-		return fmt.Errorf("sql commit (regular): %w", err)
+		return wrapSQLCommitError("sql commit (regular)", err)
 	}
 
 	if err := versioncontrolops.StageAndCommit(ctx, conn, tx.dirty.DirtyTables(), commitMsg, s.commitAuthorString()); err != nil {

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -103,16 +103,42 @@ func (s *DoltStore) runInTransaction(
 // RunInIssueLifecycleTransaction runs a lifecycle transition and its durable
 // side effects through one SQL transaction and one Dolt commit attempt.
 func (s *DoltStore) RunInIssueLifecycleTransaction(ctx context.Context, commitMsg string, fn func(tx storage.IssueLifecycleTransaction) error) error {
-	return s.withRetryTx(ctx, func(sqlTx *sql.Tx) error {
-		tx := &doltTransaction{regularTx: sqlTx, ignoredTx: sqlTx, store: s, lifecycle: true}
-		if err := fn(tx); err != nil {
-			return err
+	return s.runInIssueLifecycleTransaction(ctx, commitMsg, fn, s.withWriteTx)
+}
+
+// runInIssueLifecycleTransaction retries only failures that occur before the
+// public callback starts. Once fn has run, its caller-owned work must never be
+// replayed, even when Dolt proves that the SQL transaction rolled back.
+func (s *DoltStore) runInIssueLifecycleTransaction(
+	ctx context.Context,
+	commitMsg string,
+	fn func(tx storage.IssueLifecycleTransaction) error,
+	run func(context.Context, func(*sql.Tx) error) error,
+) error {
+	return s.withRetry(ctx, func() error {
+		invoked := false
+		var callbackErr error
+		err := run(ctx, func(sqlTx *sql.Tx) error {
+			invoked = true
+			tx := &doltTransaction{regularTx: sqlTx, ignoredTx: sqlTx, store: s, lifecycle: true}
+			if callbackErr = fn(tx); callbackErr != nil {
+				return callbackErr
+			}
+			tables := tx.dirtyTableNames()
+			if len(tables) == 0 {
+				return nil
+			}
+			return s.doltAddAndCommitInTx(ctx, sqlTx, tables, commitMsg)
+		})
+		if invoked && err != nil {
+			// An ambiguous commit reaches withRetry so connection failures still
+			// count toward the circuit breaker, but it is never replayed.
+			if callbackErr == nil && errors.Is(err, ErrCommitIndeterminate) {
+				return err
+			}
+			return backoff.Permanent(err)
 		}
-		tables := tx.dirtyTableNames()
-		if len(tables) == 0 {
-			return nil
-		}
-		return s.doltAddAndCommitInTx(ctx, sqlTx, tables, commitMsg)
+		return err
 	})
 }
 

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -79,11 +79,21 @@ func (s *DoltStore) runInTransaction(
 ) error {
 	return s.withRetry(ctx, func() error {
 		invoked := false
+		var callbackErr error
 		err := run(ctx, commitMsg, func(tx storage.Transaction) error {
 			invoked = true
-			return fn(tx)
+			callbackErr = fn(tx)
+			return callbackErr
 		})
 		if invoked && err != nil {
+			// Callback failures are caller-owned and must not affect server
+			// health accounting. Infrastructure failures after a successful
+			// callback keep the at-most-once boundary too, except an explicitly
+			// indeterminate commit reaches withRetry so it can record the lost
+			// connection before stopping without replay.
+			if callbackErr == nil && errors.Is(err, ErrCommitIndeterminate) {
+				return err
+			}
 			return backoff.Permanent(err)
 		}
 		return err

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -77,7 +77,7 @@ func (s *DoltStore) runInTransaction(
 	fn func(storage.Transaction) error,
 	run func(context.Context, string, func(storage.Transaction) error) error,
 ) error {
-	return s.withRetry(ctx, func() error {
+	return s.withTransactionSetupRetry(ctx, func() error {
 		invoked := false
 		var callbackErr error
 		err := run(ctx, commitMsg, func(tx storage.Transaction) error {
@@ -115,7 +115,7 @@ func (s *DoltStore) runInIssueLifecycleTransaction(
 	fn func(tx storage.IssueLifecycleTransaction) error,
 	run func(context.Context, func(*sql.Tx) error) error,
 ) error {
-	return s.withRetry(ctx, func() error {
+	return s.withTransactionSetupRetry(ctx, func() error {
 		invoked := false
 		var callbackErr error
 		err := run(ctx, func(sqlTx *sql.Tx) error {

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
+
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/storage/issueops"
@@ -59,13 +61,23 @@ func (t *doltTransaction) CreateIssueImport(ctx context.Context, issue *types.Is
 	return t.CreateIssue(ctx, issue, actor)
 }
 
-// RunInTransaction executes a function within a database transaction.
-// The commitMsg is used for the DOLT_COMMIT that occurs inside the transaction,
-// making the write atomically visible in Dolt's version history.
-// Wisp routing is handled within individual transaction methods based on ID/Ephemeral flag.
+// RunInTransaction executes a function within a database transaction. Its
+// callback is invoked at most once per call; callers retry explicitly after a
+// callback has started when their operation is safe to repeat. The commitMsg is
+// used for the DOLT_COMMIT that makes regular writes visible in Dolt history.
+// Wisp routing is handled by individual transaction methods based on
+// ID/Ephemeral.
 func (s *DoltStore) RunInTransaction(ctx context.Context, commitMsg string, fn func(tx storage.Transaction) error) error {
 	return s.withRetry(ctx, func() error {
-		return s.runDoltTransaction(ctx, commitMsg, fn)
+		invoked := false
+		err := s.runDoltTransaction(ctx, commitMsg, func(tx storage.Transaction) error {
+			invoked = true
+			return fn(tx)
+		})
+		if invoked && err != nil {
+			return backoff.Permanent(err)
+		}
+		return err
 	})
 }
 
@@ -159,18 +171,31 @@ func (s *DoltStore) runDoltTransaction(ctx context.Context, commitMsg string, fn
 		return err
 	}
 
-	if err := regularTx.Commit(); err != nil {
-		_ = ignoredTx.Rollback()
+	return s.finishDoltTransaction(ctx, conn, tx, commitMsg)
+}
+
+// finishDoltTransaction commits the regular SQL transaction, its associated
+// Dolt revision, and then the ignored-table transaction. Once the regular SQL
+// transaction succeeds, later failures have an indeterminate durable outcome.
+func (s *DoltStore) finishDoltTransaction(ctx context.Context, conn *sql.Conn, tx *doltTransaction, commitMsg string) error {
+	if err := tx.regularTx.Commit(); err != nil {
+		_ = tx.ignoredTx.Rollback()
+		if isSerializationError(err) {
+			return fmt.Errorf("sql commit (regular): %w", err)
+		}
+		if isIndeterminateCommitResponse(err) {
+			return fmt.Errorf("sql commit (regular): %w: %w", err, ErrCommitIndeterminate)
+		}
 		return fmt.Errorf("sql commit (regular): %w", err)
 	}
 
 	if err := versioncontrolops.StageAndCommit(ctx, conn, tx.dirty.DirtyTables(), commitMsg, s.commitAuthorString()); err != nil {
-		_ = ignoredTx.Rollback()
-		return err
+		_ = tx.ignoredTx.Rollback()
+		return fmt.Errorf("stage and commit after regular SQL commit: %w: %w", err, ErrCommitIndeterminate)
 	}
 
-	if err := ignoredTx.Commit(); err != nil {
-		return fmt.Errorf("sql commit (ignored, regular already committed): %w", err)
+	if err := tx.ignoredTx.Commit(); err != nil {
+		return fmt.Errorf("sql commit (ignored, regular already committed): %w: %w", err, ErrCommitIndeterminate)
 	}
 	return nil
 }

--- a/internal/storage/dolt/transaction_phase_test.go
+++ b/internal/storage/dolt/transaction_phase_test.go
@@ -1,0 +1,91 @@
+package dolt
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+func newTransactionPhaseFixture(t *testing.T) (*DoltStore, *sql.Conn, *doltTransaction, sqlmock.Sqlmock, sqlmock.Sqlmock) {
+	t.Helper()
+	ctx := context.Background()
+
+	regularDB, regularMock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("new regular sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = regularDB.Close() })
+	regularConn, err := regularDB.Conn(ctx)
+	if err != nil {
+		t.Fatalf("acquire regular sqlmock connection: %v", err)
+	}
+	t.Cleanup(func() { _ = regularConn.Close() })
+	regularMock.ExpectBegin()
+	regularTx, err := regularConn.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin regular sqlmock transaction: %v", err)
+	}
+
+	ignoredDB, ignoredMock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("new ignored sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = ignoredDB.Close() })
+	ignoredMock.ExpectBegin()
+	ignoredTx, err := ignoredDB.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin ignored sqlmock transaction: %v", err)
+	}
+
+	return &DoltStore{}, regularConn, &doltTransaction{
+		regularTx: regularTx,
+		ignoredTx: ignoredTx,
+	}, regularMock, ignoredMock
+}
+
+func requireTransactionPhaseMocks(t *testing.T, regularMock, ignoredMock sqlmock.Sqlmock) {
+	t.Helper()
+	if err := regularMock.ExpectationsWereMet(); err != nil {
+		t.Errorf("regular SQL expectations: %v", err)
+	}
+	if err := ignoredMock.ExpectationsWereMet(); err != nil {
+		t.Errorf("ignored SQL expectations: %v", err)
+	}
+}
+
+func TestRunInTransactionStageFailureAfterRegularCommitIsIndeterminateAndNotReplayed(t *testing.T) {
+	store, conn, tx, regularMock, ignoredMock := newTransactionPhaseFixture(t)
+	tx.dirty.MarkDirty("issues")
+	regularMock.ExpectCommit()
+	regularMock.ExpectExec("CALL DOLT_ADD\\(\\?\\)").WithArgs("issues").
+		WillReturnError(errors.New("invalid connection"))
+	ignoredMock.ExpectRollback()
+
+	callbackCalls := 0
+	runnerCalls := 0
+	err := store.runInTransaction(context.Background(), "test: phase boundary", func(storage.Transaction) error {
+		callbackCalls++
+		return nil
+	}, func(ctx context.Context, commitMsg string, fn func(storage.Transaction) error) error {
+		runnerCalls++
+		if err := fn(tx); err != nil {
+			return err
+		}
+		return store.finishDoltTransaction(ctx, conn, tx, commitMsg)
+	})
+	if !errors.Is(err, ErrCommitIndeterminate) {
+		t.Fatalf("error = %v, want ErrCommitIndeterminate", err)
+	}
+	if callbackCalls != 1 {
+		t.Fatalf("callback calls = %d, want 1", callbackCalls)
+	}
+	if runnerCalls != 1 {
+		t.Fatalf("transaction runner calls = %d, want 1", runnerCalls)
+	}
+	requireTransactionPhaseMocks(t, regularMock, ignoredMock)
+}

--- a/internal/storage/dolt/transaction_phase_test.go
+++ b/internal/storage/dolt/transaction_phase_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	mysql "github.com/go-sql-driver/mysql"
 
 	"github.com/steveyegge/beads/internal/storage"
 )
@@ -80,6 +81,38 @@ func TestRunInTransactionStageFailureAfterRegularCommitIsIndeterminateAndNotRepl
 	})
 	if !errors.Is(err, ErrCommitIndeterminate) {
 		t.Fatalf("error = %v, want ErrCommitIndeterminate", err)
+	}
+	if callbackCalls != 1 {
+		t.Fatalf("callback calls = %d, want 1", callbackCalls)
+	}
+	if runnerCalls != 1 {
+		t.Fatalf("transaction runner calls = %d, want 1", runnerCalls)
+	}
+	requireTransactionPhaseMocks(t, regularMock, ignoredMock)
+}
+
+func TestRunInTransactionRegularPacketSyncCommitIsIndeterminateAndNotReplayed(t *testing.T) {
+	store, conn, tx, regularMock, ignoredMock := newTransactionPhaseFixture(t)
+	regularMock.ExpectCommit().WillReturnError(mysql.ErrPktSync)
+	ignoredMock.ExpectRollback()
+
+	callbackCalls := 0
+	runnerCalls := 0
+	err := store.runInTransaction(context.Background(), "test: packet sync", func(storage.Transaction) error {
+		callbackCalls++
+		return nil
+	}, func(ctx context.Context, commitMsg string, fn func(storage.Transaction) error) error {
+		runnerCalls++
+		if err := fn(tx); err != nil {
+			return err
+		}
+		return store.finishDoltTransaction(ctx, conn, tx, commitMsg)
+	})
+	if !errors.Is(err, ErrCommitIndeterminate) {
+		t.Fatalf("error = %v, want ErrCommitIndeterminate", err)
+	}
+	if !errors.Is(err, mysql.ErrPktSync) {
+		t.Fatalf("error = %v, want cause %v", err, mysql.ErrPktSync)
 	}
 	if callbackCalls != 1 {
 		t.Fatalf("callback calls = %d, want 1", callbackCalls)

--- a/internal/storage/dolt/transaction_test.go
+++ b/internal/storage/dolt/transaction_test.go
@@ -3,6 +3,7 @@ package dolt
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -13,6 +14,32 @@ import (
 	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/types"
 )
+
+// TestRunInTransactionCallbackConnectionErrorIsNotReplayed establishes the
+// public at-most-once callback contract. The callback's error looks transient,
+// but the caller may have performed external work before returning it.
+func TestRunInTransactionCallbackConnectionErrorIsNotReplayed(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	calls := 0
+	err := store.RunInTransaction(ctx, "test: callback at most once", func(storage.Transaction) error {
+		calls++
+		if calls == 1 {
+			return errors.New("invalid connection")
+		}
+		return nil
+	})
+	if err == nil {
+		t.Fatal("callback connection error returned nil")
+	}
+	if calls != 1 {
+		t.Fatalf("callback calls = %d, want 1", calls)
+	}
+}
 
 func TestRunInTransactionIgnoredWritesStayOnActiveBranch(t *testing.T) {
 	store, cleanup := setupTestStore(t)

--- a/internal/storage/dolt/transaction_test.go
+++ b/internal/storage/dolt/transaction_test.go
@@ -77,6 +77,84 @@ func TestRunInIssueLifecycleTransactionRollbackDoesNotReplayCallback(t *testing.
 	}
 }
 
+func TestPublicTransactionSetupRetriesRollbackSafeErrorsBeforeCallback(t *testing.T) {
+	rollback1105 := &mysql.MySQLError{
+		Number:  1105,
+		Message: "Merge conflict detected, @autocommit transaction rolled back",
+	}
+	tests := []struct {
+		name string
+		err  error
+		run  func(*DoltStore, error, *int, *int) error
+	}{
+		{
+			name: "transaction exact Dolt rollback",
+			err:  rollback1105,
+			run: func(store *DoltStore, setupErr error, attempts, callbacks *int) error {
+				return store.runInTransaction(context.Background(), "test: setup retry", func(storage.Transaction) error {
+					*callbacks++
+					return nil
+				}, func(_ context.Context, _ string, fn func(storage.Transaction) error) error {
+					*attempts++
+					if *attempts == 1 {
+						return setupErr
+					}
+					return fn(nil)
+				})
+			},
+		},
+		{
+			name: "transaction deadlock",
+			err:  &mysql.MySQLError{Number: 1213, Message: "deadlock"},
+			run: func(store *DoltStore, setupErr error, attempts, callbacks *int) error {
+				return store.runInTransaction(context.Background(), "test: setup retry", func(storage.Transaction) error {
+					*callbacks++
+					return nil
+				}, func(_ context.Context, _ string, fn func(storage.Transaction) error) error {
+					*attempts++
+					if *attempts == 1 {
+						return setupErr
+					}
+					return fn(nil)
+				})
+			},
+		},
+		{
+			name: "lifecycle lock timeout",
+			err:  &mysql.MySQLError{Number: 1205, Message: "lock wait timeout"},
+			run: func(store *DoltStore, setupErr error, attempts, callbacks *int) error {
+				return store.runInIssueLifecycleTransaction(context.Background(), "test: setup retry", func(storage.IssueLifecycleTransaction) error {
+					*callbacks++
+					return nil
+				}, func(_ context.Context, fn func(*sql.Tx) error) error {
+					*attempts++
+					if *attempts == 1 {
+						return setupErr
+					}
+					return fn(nil)
+				})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &DoltStore{}
+			attempts := 0
+			callbacks := 0
+			if err := tt.run(store, tt.err, &attempts, &callbacks); err != nil {
+				t.Fatalf("transaction wrapper error = %v, want nil", err)
+			}
+			if attempts != 2 {
+				t.Fatalf("setup attempts = %d, want 2", attempts)
+			}
+			if callbacks != 1 {
+				t.Fatalf("callback calls = %d, want 1", callbacks)
+			}
+		})
+	}
+}
+
 // TestRunInTransactionSerializationConflictInvokesCallbacksOnce orders two
 // independent handles so the stale transaction loses at commit. The public
 // callbacks must still each run once, and the winner's content must survive.

--- a/internal/storage/dolt/transaction_test.go
+++ b/internal/storage/dolt/transaction_test.go
@@ -6,9 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	mysql "github.com/go-sql-driver/mysql"
 	"github.com/google/uuid"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/issueops"
@@ -38,6 +40,134 @@ func TestRunInTransactionCallbackConnectionErrorIsNotReplayed(t *testing.T) {
 	}
 	if calls != 1 {
 		t.Fatalf("callback calls = %d, want 1", calls)
+	}
+}
+
+// TestRunInTransactionSerializationConflictInvokesCallbacksOnce orders two
+// independent handles so the stale transaction loses at commit. The public
+// callbacks must still each run once, and the winner's content must survive.
+func TestRunInTransactionSerializationConflictInvokesCallbacksOnce(t *testing.T) {
+	storeA, cleanupA := setupConcurrentTestStore(t)
+	defer cleanupA()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	storeB, err := New(ctx, &Config{
+		Path:           t.TempDir(),
+		CommitterName:  "test",
+		CommitterEmail: "test@example.com",
+		ServerHost:     "127.0.0.1",
+		ServerPort:     testServerPort,
+		Database:       storeA.database,
+		MaxOpenConns:   2,
+	})
+	if err != nil {
+		t.Fatalf("open second store for %s: %v", storeA.database, err)
+	}
+	defer storeB.Close()
+
+	issue := &types.Issue{
+		ID:          "test-tx-at-most-once",
+		Title:       "at-most-once transaction",
+		Description: "initial",
+		Status:      types.StatusOpen,
+		Priority:    2,
+		IssueType:   types.TypeTask,
+	}
+	if err := storeA.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+
+	var callsA, callsB atomic.Int32
+	aPrepared := make(chan struct{})
+	bPrepared := make(chan struct{})
+	releaseA := make(chan struct{})
+	releaseB := make(chan struct{})
+	errA := make(chan error, 1)
+	errB := make(chan error, 1)
+
+	go func() {
+		errA <- storeA.RunInTransaction(ctx, "test: winner transaction", func(tx storage.Transaction) error {
+			callsA.Add(1)
+			if err := tx.UpdateIssue(ctx, issue.ID, map[string]interface{}{
+				"description": "winner",
+			}, "winner"); err != nil {
+				return err
+			}
+			close(aPrepared)
+			return waitForTransactionRelease(ctx, releaseA)
+		})
+	}()
+
+	go func() {
+		errB <- storeB.RunInTransaction(ctx, "test: stale transaction", func(tx storage.Transaction) error {
+			callsB.Add(1)
+			if err := tx.UpdateIssue(ctx, issue.ID, map[string]interface{}{
+				"description": "stale",
+			}, "stale"); err != nil {
+				return err
+			}
+			close(bPrepared)
+			return waitForTransactionRelease(ctx, releaseB)
+		})
+	}()
+
+	waitForTransactionPrepared(t, ctx, aPrepared, "winner")
+	waitForTransactionPrepared(t, ctx, bPrepared, "stale")
+	close(releaseA)
+	if err := <-errA; err != nil {
+		t.Fatalf("winner transaction: %v", err)
+	}
+	close(releaseB)
+	err = <-errB
+	if err == nil {
+		t.Fatal("stale transaction succeeded, want serialization conflict")
+	}
+	var mysqlErr *mysql.MySQLError
+	if !errors.As(err, &mysqlErr) || (mysqlErr.Number != 1213 && mysqlErr.Number != 1205) {
+		t.Fatalf("stale transaction error = %v, want MySQL 1213 or 1205", err)
+	}
+	if errors.Is(err, ErrCommitIndeterminate) {
+		t.Fatalf("stale transaction error = %v unexpectedly marks an indeterminate commit", err)
+	}
+	if got := callsA.Load(); got != 1 {
+		t.Errorf("winner callback calls = %d, want 1", got)
+	}
+	if got := callsB.Load(); got != 1 {
+		t.Errorf("stale callback calls = %d, want 1", got)
+	}
+
+	freshDB, err := sql.Open("mysql", storeA.connStr)
+	if err != nil {
+		t.Fatalf("open fresh SQL handle: %v", err)
+	}
+	defer freshDB.Close()
+	var description string
+	if err := freshDB.QueryRowContext(ctx,
+		"SELECT description FROM issues WHERE id = ?", issue.ID).Scan(&description); err != nil {
+		t.Fatalf("read winner result from fresh SQL handle: %v", err)
+	}
+	if description != "winner" {
+		t.Errorf("fresh SQL description = %q, want winner", description)
+	}
+}
+
+func waitForTransactionPrepared(t *testing.T, ctx context.Context, prepared <-chan struct{}, name string) {
+	t.Helper()
+	select {
+	case <-prepared:
+	case <-ctx.Done():
+		t.Fatalf("%s transaction was not prepared: %v", name, ctx.Err())
+	}
+}
+
+func waitForTransactionRelease(ctx context.Context, release <-chan struct{}) error {
+	select {
+	case <-release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 

--- a/internal/storage/dolt/transaction_test.go
+++ b/internal/storage/dolt/transaction_test.go
@@ -43,6 +43,40 @@ func TestRunInTransactionCallbackConnectionErrorIsNotReplayed(t *testing.T) {
 	}
 }
 
+// TestRunInIssueLifecycleTransactionRollbackDoesNotReplayCallback keeps the
+// public lifecycle callback outside withRetryTx's rollback-safe retry loop.
+// The SQL transaction may safely be retried internally elsewhere, but this
+// callback can perform caller-owned work and therefore runs at most once.
+func TestRunInIssueLifecycleTransactionRollbackDoesNotReplayCallback(t *testing.T) {
+	rollback := &mysql.MySQLError{
+		Number:  1105,
+		Message: "Merge conflict detected, @autocommit transaction rolled back",
+	}
+	store := &DoltStore{}
+	calls := 0
+	runnerCalls := 0
+
+	err := store.runInIssueLifecycleTransaction(context.Background(), "test: lifecycle callback at most once", func(storage.IssueLifecycleTransaction) error {
+		calls++
+		return nil
+	}, func(_ context.Context, fn func(*sql.Tx) error) error {
+		runnerCalls++
+		if err := fn(nil); err != nil {
+			return err
+		}
+		return rollback
+	})
+	if !errors.Is(err, rollback) {
+		t.Fatalf("RunInIssueLifecycleTransaction() error = %v, want %v", err, rollback)
+	}
+	if calls != 1 {
+		t.Fatalf("lifecycle callback calls = %d, want 1", calls)
+	}
+	if runnerCalls != 1 {
+		t.Fatalf("lifecycle transaction attempts = %d, want 1", runnerCalls)
+	}
+}
+
 // TestRunInTransactionSerializationConflictInvokesCallbacksOnce orders two
 // independent handles so the stale transaction loses at commit. The public
 // callbacks must still each run once, and the winner's content must survive.

--- a/internal/storage/dolt/wisps.go
+++ b/internal/storage/dolt/wisps.go
@@ -603,7 +603,7 @@ func (s *DoltStore) addWispDependency(ctx context.Context, dep *types.Dependency
 		return err
 	}
 
-	return wrapSQLCommitError("commit add wisp dependency", tx.Commit())
+	return s.commitSQLTx(ctx, "commit add wisp dependency", tx)
 }
 
 // getWispDependencies retrieves issues that a wisp depends on.

--- a/internal/storage/dolt/wisps.go
+++ b/internal/storage/dolt/wisps.go
@@ -196,7 +196,7 @@ func (s *DoltStore) updateWisp(ctx context.Context, id string, updates map[strin
 		return err
 	}
 
-	return wrapSQLCommitError("commit update wisp", tx.Commit())
+	return s.commitSQLTx(ctx, "commit update wisp", tx)
 }
 
 // updateWispChecked updates a wisp with the optional atomic preconditions of
@@ -228,7 +228,7 @@ func (s *DoltStore) updateWispChecked(ctx context.Context, id string, updates ma
 		return err
 	}
 
-	return wrapSQLCommitError("commit update wisp", tx.Commit())
+	return s.commitSQLTx(ctx, "commit update wisp", tx)
 }
 
 // closeWisp closes a wisp in the wisps table.
@@ -245,7 +245,7 @@ func (s *DoltStore) closeWisp(ctx context.Context, id string, reason string, act
 		return err
 	}
 
-	return wrapSQLCommitError("commit close wisp", tx.Commit())
+	return s.commitSQLTx(ctx, "commit close wisp", tx)
 }
 
 // closeWispChecked closes a wisp with the is_blocked guard, mirroring closeWisp
@@ -276,7 +276,7 @@ func (s *DoltStore) closeWispChecked(ctx context.Context, id string, actor strin
 		return storage.CloseIssueResult{}, err
 	}
 
-	if err := wrapSQLCommitError("commit close wisp", tx.Commit()); err != nil {
+	if err := s.commitSQLTx(ctx, "commit close wisp", tx); err != nil {
 		return storage.CloseIssueResult{}, err
 	}
 	return storage.CloseIssueResult{Unchanged: res.AlreadyClosed, OpenChildren: res.OpenChildren}, nil
@@ -316,7 +316,7 @@ func (s *DoltStore) deleteWisp(ctx context.Context, id string) error {
 		return fmt.Errorf("recompute is_blocked after wisp delete for %s: %w", id, err)
 	}
 
-	return wrapSQLCommitError("commit delete wisp", tx.Commit())
+	return s.commitSQLTx(ctx, "commit delete wisp", tx)
 }
 
 // deleteWispBatch permanently removes multiple wisps using one transaction per
@@ -387,8 +387,8 @@ func (s *DoltStore) deleteWispBatchTx(ctx context.Context, ids []string) (int, e
 		return 0, fmt.Errorf("recompute is_blocked after batched wisp delete: %w", err)
 	}
 
-	if err := tx.Commit(); err != nil {
-		return 0, wrapSQLCommitError("commit batch wisp delete", err)
+	if err := s.commitSQLTx(ctx, "commit batch wisp delete", tx); err != nil {
+		return 0, err
 	}
 
 	return int(rowsAffected), nil
@@ -408,7 +408,7 @@ func (s *DoltStore) claimWisp(ctx context.Context, id string, actor string) erro
 		return err
 	}
 
-	return wrapSQLCommitError("commit claim wisp", tx.Commit())
+	return s.commitSQLTx(ctx, "commit claim wisp", tx)
 }
 
 // ListWisps returns ephemeral issues matching the filter.

--- a/internal/storage/dolt/wisps.go
+++ b/internal/storage/dolt/wisps.go
@@ -196,7 +196,7 @@ func (s *DoltStore) updateWisp(ctx context.Context, id string, updates map[strin
 		return err
 	}
 
-	return wrapTransactionError("commit update wisp", tx.Commit())
+	return wrapSQLCommitError("commit update wisp", tx.Commit())
 }
 
 // updateWispChecked updates a wisp with the optional atomic preconditions of
@@ -228,7 +228,7 @@ func (s *DoltStore) updateWispChecked(ctx context.Context, id string, updates ma
 		return err
 	}
 
-	return wrapTransactionError("commit update wisp", tx.Commit())
+	return wrapSQLCommitError("commit update wisp", tx.Commit())
 }
 
 // closeWisp closes a wisp in the wisps table.
@@ -245,7 +245,7 @@ func (s *DoltStore) closeWisp(ctx context.Context, id string, reason string, act
 		return err
 	}
 
-	return wrapTransactionError("commit close wisp", tx.Commit())
+	return wrapSQLCommitError("commit close wisp", tx.Commit())
 }
 
 // closeWispChecked closes a wisp with the is_blocked guard, mirroring closeWisp
@@ -276,7 +276,7 @@ func (s *DoltStore) closeWispChecked(ctx context.Context, id string, actor strin
 		return storage.CloseIssueResult{}, err
 	}
 
-	if err := wrapTransactionError("commit close wisp", tx.Commit()); err != nil {
+	if err := wrapSQLCommitError("commit close wisp", tx.Commit()); err != nil {
 		return storage.CloseIssueResult{}, err
 	}
 	return storage.CloseIssueResult{Unchanged: res.AlreadyClosed, OpenChildren: res.OpenChildren}, nil
@@ -316,7 +316,7 @@ func (s *DoltStore) deleteWisp(ctx context.Context, id string) error {
 		return fmt.Errorf("recompute is_blocked after wisp delete for %s: %w", id, err)
 	}
 
-	return wrapTransactionError("commit delete wisp", tx.Commit())
+	return wrapSQLCommitError("commit delete wisp", tx.Commit())
 }
 
 // deleteWispBatch permanently removes multiple wisps using one transaction per
@@ -388,7 +388,7 @@ func (s *DoltStore) deleteWispBatchTx(ctx context.Context, ids []string) (int, e
 	}
 
 	if err := tx.Commit(); err != nil {
-		return 0, fmt.Errorf("failed to commit batch wisp delete: %w", err)
+		return 0, wrapSQLCommitError("commit batch wisp delete", err)
 	}
 
 	return int(rowsAffected), nil
@@ -408,7 +408,7 @@ func (s *DoltStore) claimWisp(ctx context.Context, id string, actor string) erro
 		return err
 	}
 
-	return wrapTransactionError("commit claim wisp", tx.Commit())
+	return wrapSQLCommitError("commit claim wisp", tx.Commit())
 }
 
 // ListWisps returns ephemeral issues matching the filter.
@@ -603,7 +603,7 @@ func (s *DoltStore) addWispDependency(ctx context.Context, dep *types.Dependency
 		return err
 	}
 
-	return wrapTransactionError("commit add wisp dependency", tx.Commit())
+	return wrapSQLCommitError("commit add wisp dependency", tx.Commit())
 }
 
 // getWispDependencies retrieves issues that a wisp depends on.

--- a/internal/storage/embeddeddolt/commit_all_internal_test.go
+++ b/internal/storage/embeddeddolt/commit_all_internal_test.go
@@ -1,0 +1,50 @@
+//go:build cgo
+
+package embeddeddolt
+
+import (
+	"errors"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+func TestDoltCommitResponseLossIsIndeterminate(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	mock.ExpectBegin()
+	tx, err := db.BeginTx(t.Context(), nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+
+	responseLoss := errors.New("connection lost before DOLT_COMMIT response")
+	mock.ExpectExec("CALL DOLT_COMMIT('-Am', ?)").
+		WithArgs("test: publish working set").
+		WillReturnError(responseLoss)
+
+	committed, err := commitAllInTx(t.Context(), tx, "test: publish working set", true)
+	if committed {
+		t.Fatal("commitAllInTx() committed = true after response loss, want false")
+	}
+	if !errors.Is(err, responseLoss) {
+		t.Fatalf("commitAllInTx() error = %v, want cause %v", err, responseLoss)
+	}
+	if !errors.Is(err, storage.ErrCommitIndeterminate) {
+		t.Fatalf("commitAllInTx() error = %v, want ErrCommitIndeterminate", err)
+	}
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}

--- a/internal/storage/embeddeddolt/post_sql_commit_test.go
+++ b/internal/storage/embeddeddolt/post_sql_commit_test.go
@@ -1,0 +1,68 @@
+//go:build cgo
+
+package embeddeddolt
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+func TestStageAndCommitAfterSQLCommitResponseLossIsIndeterminateAndNotReplayed(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		failCall   int
+		wantCalls  int
+		lastSQLHas string
+	}{
+		{name: "DOLT_ADD", failCall: 1, wantCalls: 1, lastSQLHas: "DOLT_ADD"},
+		{name: "DOLT_COMMIT", failCall: 2, wantCalls: 2, lastSQLHas: "DOLT_COMMIT"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			responseLoss := errors.New(tc.name + " response lost after SQL commit")
+			conn := &postSQLCommitFailureConn{failCall: tc.failCall, err: responseLoss}
+
+			err := stageAndCommitAfterSQLCommit(t.Context(), conn,
+				map[string]bool{"issues": true}, "bd: commit derived state", "tester <tester@example.com>")
+			if !errors.Is(err, responseLoss) {
+				t.Fatalf("stageAndCommitAfterSQLCommit() error = %v, want cause %v", err, responseLoss)
+			}
+			if !errors.Is(err, storage.ErrCommitIndeterminate) {
+				t.Fatalf("stageAndCommitAfterSQLCommit() error = %v, want storage.ErrCommitIndeterminate", err)
+			}
+			if len(conn.calls) != tc.wantCalls {
+				t.Fatalf("version-control calls = %d, want %d (no replay): %v", len(conn.calls), tc.wantCalls, conn.calls)
+			}
+			if !strings.Contains(conn.calls[len(conn.calls)-1], tc.lastSQLHas) {
+				t.Fatalf("last version-control call = %q, want %s", conn.calls[len(conn.calls)-1], tc.lastSQLHas)
+			}
+		})
+	}
+}
+
+type postSQLCommitFailureConn struct {
+	failCall int
+	err      error
+	calls    []string
+}
+
+func (c *postSQLCommitFailureConn) ExecContext(_ context.Context, query string, _ ...any) (sql.Result, error) {
+	c.calls = append(c.calls, query)
+	if len(c.calls) == c.failCall {
+		return nil, c.err
+	}
+	return driver.RowsAffected(1), nil
+}
+
+func (*postSQLCommitFailureConn) QueryContext(context.Context, string, ...any) (*sql.Rows, error) {
+	return nil, errors.New("unexpected QueryContext")
+}
+
+func (*postSQLCommitFailureConn) QueryRowContext(context.Context, string, ...any) *sql.Row {
+	return nil
+}

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -227,8 +227,9 @@ func (s *EmbeddedDoltStore) withConn(ctx context.Context, commit bool, fn func(t
 		return
 	}
 
+	committed := false
 	defer func() {
-		err = errors.Join(err, cleanup())
+		err = joinTransactionCleanupError(err, cleanup(), committed)
 	}()
 
 	var tx *sql.Tx
@@ -252,7 +253,15 @@ func (s *EmbeddedDoltStore) withConn(ctx context.Context, commit bool, fn func(t
 		err = fmt.Errorf("embeddeddolt: commit tx: %w", cErr)
 		return
 	}
+	committed = true
 	return
+}
+
+func joinTransactionCleanupError(operationErr, cleanupErr error, committed bool) error {
+	if committed && cleanupErr != nil {
+		cleanupErr = wrapCommitIndeterminate("embeddeddolt: cleanup after SQL commit", cleanupErr)
+	}
+	return errors.Join(operationErr, cleanupErr)
 }
 
 func (s *EmbeddedDoltStore) ApplySchemaMigrations(ctx context.Context) (int, error) {

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -249,12 +249,21 @@ func (s *EmbeddedDoltStore) withConn(ctx context.Context, commit bool, fn func(t
 		return
 	}
 
-	if cErr := tx.Commit(); cErr != nil {
-		err = fmt.Errorf("embeddeddolt: commit tx: %w", cErr)
+	if cErr := commitEmbeddedTx(tx); cErr != nil {
+		err = cErr
 		return
 	}
 	committed = true
 	return
+}
+
+// commitEmbeddedTx classifies an unconfirmed SQL commit response as
+// indeterminate: the engine may have applied it before the connection failed.
+func commitEmbeddedTx(tx *sql.Tx) error {
+	if err := tx.Commit(); err != nil {
+		return wrapCommitIndeterminate("embeddeddolt: commit tx", err)
+	}
+	return nil
 }
 
 func joinTransactionCleanupError(operationErr, cleanupErr error, committed bool) error {

--- a/internal/storage/embeddeddolt/transaction.go
+++ b/internal/storage/embeddeddolt/transaction.go
@@ -14,9 +14,12 @@ import (
 	"github.com/steveyegge/beads/internal/types"
 )
 
-// RunInTransaction executes a function within a database transaction.
-// After the SQL transaction commits, dirty tables are selectively staged
-// and a Dolt version commit is created with the given message.
+// RunInTransaction executes a function within a database transaction. Its
+// callback is invoked at most once per call; callers retry explicitly after a
+// callback has started when their operation is safe to repeat. An error
+// wrapping storage.ErrCommitIndeterminate must not be blindly replayed.
+// After the SQL transaction commits, dirty tables are selectively staged and a
+// Dolt version commit is created with the given message.
 func (s *EmbeddedDoltStore) RunInTransaction(ctx context.Context, commitMsg string, fn func(tx storage.Transaction) error) error {
 	return s.runTransaction(ctx, commitMsg, func(tx *embeddedTransaction) error { return fn(tx) })
 }

--- a/internal/storage/embeddeddolt/transaction.go
+++ b/internal/storage/embeddeddolt/transaction.go
@@ -53,11 +53,17 @@ func (s *EmbeddedDoltStore) runTransactionWithMessage(ctx context.Context, fn fu
 
 	// Create a Dolt version commit from the working set changes.
 	if commitMsg != "" && len(tracker.DirtyTables()) > 0 {
-		return s.withMutatingDBConn(ctx, func(db versioncontrolops.DBConn) error {
+		if err := s.withMutatingDBConn(ctx, func(db versioncontrolops.DBConn) error {
 			return versioncontrolops.StageAndCommit(ctx, db, tracker.DirtyTables(), commitMsg, commitAuthor)
-		})
+		}); err != nil {
+			return wrapCommitIndeterminate("embeddeddolt: stage and commit after SQL commit", err)
+		}
 	}
 	return nil
+}
+
+func wrapCommitIndeterminate(op string, err error) error {
+	return fmt.Errorf("%s: %w: %w", op, err, storage.ErrCommitIndeterminate)
 }
 
 type embeddedTransaction struct {

--- a/internal/storage/embeddeddolt/transaction_indeterminate_test.go
+++ b/internal/storage/embeddeddolt/transaction_indeterminate_test.go
@@ -1,0 +1,45 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/steveyegge/beads"
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestRunInTransactionPostCommitStageFailureIsIndeterminate(t *testing.T) {
+	te := newTestEnv(t, "eci")
+	ctx := context.Background()
+	calls := 0
+
+	err := te.store.RunInTransaction(ctx, "test: indeterminate staged commit", func(tx storage.Transaction) error {
+		calls++
+		if err := tx.CreateIssue(ctx, &types.Issue{
+			ID:        "eci-post-commit",
+			Title:     "post-commit failure",
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+		}, "tester"); err != nil {
+			return err
+		}
+		// Closing the store leaves this transaction's pinned SQL connection
+		// intact, but deterministically rejects the later staging connection.
+		return te.store.Close()
+	})
+	if err == nil {
+		t.Fatal("post-commit stage failure returned nil")
+	}
+	if !errors.Is(err, beads.ErrCommitIndeterminate) {
+		t.Fatalf("errors.Is(err, beads.ErrCommitIndeterminate) = false; err = %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("callback calls = %d, want 1", calls)
+	}
+	te.assertRowExists(t, ctx, "issues", "eci-post-commit")
+}

--- a/internal/storage/embeddeddolt/transaction_phase_internal_test.go
+++ b/internal/storage/embeddeddolt/transaction_phase_internal_test.go
@@ -1,0 +1,36 @@
+//go:build cgo
+
+package embeddeddolt
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+func TestTransactionCleanupAfterSQLCommitIsIndeterminate(t *testing.T) {
+	cleanupErr := errors.New("connection cleanup failed")
+	err := joinTransactionCleanupError(nil, cleanupErr, true)
+	if !errors.Is(err, cleanupErr) {
+		t.Fatalf("error = %v, want cleanup cause", err)
+	}
+	if !errors.Is(err, storage.ErrCommitIndeterminate) {
+		t.Fatalf("error = %v, want ErrCommitIndeterminate", err)
+	}
+}
+
+func TestTransactionCleanupBeforeSQLCommitRemainsDefinite(t *testing.T) {
+	callbackErr := errors.New("callback failed")
+	cleanupErr := errors.New("connection cleanup failed")
+	err := joinTransactionCleanupError(callbackErr, cleanupErr, false)
+	if !errors.Is(err, callbackErr) {
+		t.Fatalf("error = %v, want callback cause", err)
+	}
+	if !errors.Is(err, cleanupErr) {
+		t.Fatalf("error = %v, want cleanup cause", err)
+	}
+	if errors.Is(err, storage.ErrCommitIndeterminate) {
+		t.Fatalf("error = %v must remain definite before SQL commit", err)
+	}
+}

--- a/internal/storage/embeddeddolt/transaction_phase_internal_test.go
+++ b/internal/storage/embeddeddolt/transaction_phase_internal_test.go
@@ -3,8 +3,11 @@
 package embeddeddolt
 
 import (
+	"context"
 	"errors"
 	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
 
 	"github.com/steveyegge/beads/internal/storage"
 )
@@ -32,5 +35,32 @@ func TestTransactionCleanupBeforeSQLCommitRemainsDefinite(t *testing.T) {
 	}
 	if errors.Is(err, storage.ErrCommitIndeterminate) {
 		t.Fatalf("error = %v must remain definite before SQL commit", err)
+	}
+}
+
+func TestEmbeddedSQLCommitResponseLossIsIndeterminate(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	mock.ExpectBegin()
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	commitLoss := errors.New("i/o timeout")
+	mock.ExpectCommit().WillReturnError(commitLoss)
+
+	err = commitEmbeddedTx(tx)
+	if !errors.Is(err, commitLoss) {
+		t.Fatalf("commitEmbeddedTx() error = %v, want cause %v", err, commitLoss)
+	}
+	if !errors.Is(err, storage.ErrCommitIndeterminate) {
+		t.Fatalf("commitEmbeddedTx() error = %v, want ErrCommitIndeterminate", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
 	}
 }

--- a/internal/storage/embeddeddolt/version_control.go
+++ b/internal/storage/embeddeddolt/version_control.go
@@ -112,17 +112,24 @@ func (s *EmbeddedDoltStore) withMutatingPinnedDBConn(ctx context.Context, fn fun
 // if anything else writes concurrently.
 func (s *EmbeddedDoltStore) commitAll(ctx context.Context, message string, tolerateEmpty bool) (committed bool, err error) {
 	err = s.withConn(ctx, true, func(tx *sql.Tx) error {
-		if _, execErr := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-Am', ?)", message); execErr != nil {
-			if tolerateEmpty && issueops.IsNothingToCommitError(execErr) {
-				committed = false
-				return nil
-			}
-			return fmt.Errorf("dolt commit: %w", execErr)
-		}
-		committed = true
-		return nil
+		var commitErr error
+		committed, commitErr = commitAllInTx(ctx, tx, message, tolerateEmpty)
+		return commitErr
 	})
 	return committed, err
+}
+
+func commitAllInTx(ctx context.Context, tx *sql.Tx, message string, tolerateEmpty bool) (bool, error) {
+	if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-Am', ?)", message); err != nil {
+		if issueops.IsNothingToCommitError(err) {
+			if tolerateEmpty {
+				return false, nil
+			}
+			return false, fmt.Errorf("dolt commit: %w", err)
+		}
+		return false, wrapCommitIndeterminate("dolt commit", err)
+	}
+	return true, nil
 }
 
 // Commit stages and commits the full working set. A clean working set is not

--- a/internal/storage/embeddeddolt/version_control.go
+++ b/internal/storage/embeddeddolt/version_control.go
@@ -132,6 +132,15 @@ func commitAllInTx(ctx context.Context, tx *sql.Tx, message string, tolerateEmpt
 	return true, nil
 }
 
+// stageAndCommitAfterSQLCommit preserves the no-replay boundary for version
+// publication after an already-visible SQL mutation.
+func stageAndCommitAfterSQLCommit(ctx context.Context, db versioncontrolops.DBConn, dirtyTables map[string]bool, commitMsg, author string) error {
+	if err := versioncontrolops.StageAndCommit(ctx, db, dirtyTables, commitMsg, author); err != nil {
+		return wrapCommitIndeterminate("embeddeddolt: stage and commit after SQL commit", err)
+	}
+	return nil
+}
+
 // Commit stages and commits the full working set. A clean working set is not
 // an error here: the server store (DoltStore.Commit et al., via
 // isDoltNothingToCommit) has always tolerated Dolt's "nothing to commit"
@@ -361,7 +370,7 @@ func (s *EmbeddedDoltStore) RecomputeAllBlocked(ctx context.Context) (int, error
 		// Stage only issues (wisps are dolt_ignore'd), matching the post-pull
 		// recompute, so an unrelated dirty working set is not swept in.
 		if err := s.withMutatingDBConn(ctx, func(db versioncontrolops.DBConn) error {
-			return versioncontrolops.StageAndCommit(ctx, db,
+			return stageAndCommitAfterSQLCommit(ctx, db,
 				versioncontrolops.BlockedRecomputeStagedTables(),
 				versioncontrolops.BlockedRecomputeCommitMsg, commitAuthor)
 		}); err != nil {
@@ -630,7 +639,7 @@ func (s *EmbeddedDoltStore) recomputeBlockedAfterPull(ctx context.Context, preHe
 		return err
 	}
 	return s.withMutatingDBConn(ctx, func(db versioncontrolops.DBConn) error {
-		return versioncontrolops.StageAndCommit(ctx, db,
+		return stageAndCommitAfterSQLCommit(ctx, db,
 			map[string]bool{"issues": true}, "bd: recompute is_blocked after pull", commitAuthor)
 	})
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -44,6 +44,12 @@ type CloseOpenChildrenError = issueops.CloseOpenChildrenError
 // escape hatch (bd unclaim --force), reserved for admin/reaper use.
 var ErrNotOwner = errors.New("issue claimed by a different actor")
 
+// ErrCommitIndeterminate marks a write error whose durable outcome may be
+// unknown. Such errors must not be replayed because the write may already have
+// landed; retry layers must check this sentinel before classifying a wrapped
+// cause as transient.
+var ErrCommitIndeterminate = errors.New("write commit result indeterminate")
+
 // ClaimedByFragment and NotClaimableStatusFragment are the exact message
 // fragments a claim refusal puts after the sentinel to carry the conflicting
 // assignee/status: ErrAlreadyClaimed reads "<sentinel> by <assignee>" and
@@ -331,7 +337,11 @@ type Storage interface {
 	SetLocalMetadata(ctx context.Context, key, value string) error
 	GetLocalMetadata(ctx context.Context, key string) (string, error)
 
-	// Transactions
+	// RunInTransaction may retry setup failures before fn is entered. Once fn
+	// starts, it is invoked at most once for this public call: callers retry
+	// explicitly when repeating their work is safe. An error wrapping
+	// ErrCommitIndeterminate means the durable outcome may be unknown and must
+	// not be blindly replayed.
 	RunInTransaction(ctx context.Context, commitMsg string, fn func(tx Transaction) error) error
 
 	// MergeSlot — serialized conflict resolution primitive.


### PR DESCRIPTION
## What

Make Dolt-backed write outcomes truthful across server and embedded storage:

- public transaction callbacks run at most once after entry;
- only rollback-safe setup failures can retry;
- ambiguous SQL commit or Dolt publication outcomes expose `ErrCommitIndeterminate`;
- direct and retry-backed writes share exact-once circuit admission, failure, and success accounting.

This also closes the affected claim, dependency, slot, wisp, settlement, recompute, and pull publication paths. It does not change Gas City or add an orchestration-specific API.

## Why

A server-Dolt transaction could commit its SQL mutation, lose or fail during the later publication phase, and then replay the caller callback. Downstream code could therefore receive a false precondition failure after its mutation had already landed. Other direct write families either failed to classify response loss as indeterminate or bypassed circuit admission/accounting.

The safe contract is at-most-once callback execution with an explicit indeterminate result whenever Beads cannot prove whether publication landed. Callers may verify that result, but must not blindly replay it.

## Risk and review

This is a protected storage-path change spanning server and embedded Dolt transaction/publication behavior. The PR is intentionally explicit about the risk and requires substantive human storage review before merge. It must not be auto-merged.

## Verification

- Focused deterministic RED/GREEN tests for post-commit response loss, callback replay, claim verification, direct-write circuit admission/reset, and every repaired server/embedded publication boundary.
- Uncached affected-package suites for `internal/storage/dolt` and `internal/storage/embeddeddolt`.
- Race suites for both storage packages.
- Exact final-SHA `make test`: pass, 39.4% total coverage.
- `go vet ./...`: pass.
- Go 1.26.5 `golangci-lint run ./...`: 0 issues.
- `git diff --check origin/main...HEAD`: pass.
- Two independent final-SHA Sol reviews: 0 Blockers / 0 Majors each.
- PR preflight and broader open-PR search found no competing contributor PR.

Tracking context: `ga-f7v2ft.79.1`.

_codex-unknown-model-unknown-reasoning on behalf of CI Bot_
