### PR TITLE
fix(dolt): make filtered federation staging reliable

### DIFF
--- a/internal/storage/dolt/federation.go
+++ b/internal/storage/dolt/federation.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"time"
 
+	mysql "github.com/go-sql-driver/mysql"
 	"github.com/google/uuid"
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/storage"
@@ -463,11 +464,6 @@ func (s *DoltStore) filteredPushToPeer(ctx context.Context, peer string, exclude
 	}
 	defer conn.Close()
 
-	// Create staging branch from the current branch.
-	if _, err := conn.ExecContext(ctx, "CALL DOLT_BRANCH(?, ?)", stagingBranch, sourceBranch); err != nil {
-		return fmt.Errorf("federation filter: create staging branch: %w", err)
-	}
-
 	// Ensure cleanup on a fresh connection: canceling an in-flight query makes
 	// go-sql-driver/mysql invalidate the operation connection.
 	defer func() {
@@ -485,7 +481,7 @@ func (s *DoltStore) filteredPushToPeer(ctx context.Context, peer string, exclude
 			if err := schema.DrainCall(cleanupCtx, cleanupConn, "CALL DOLT_CHECKOUT(?)", sourceBranch); err != nil {
 				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("restore branch %s: %w", sourceBranch, err))
 			}
-			if err := schema.DrainCall(cleanupCtx, cleanupConn, "CALL DOLT_BRANCH('-Df', ?)", stagingBranch); err != nil {
+			if err := deleteFederationStagingBranch(cleanupCtx, cleanupConn, stagingBranch); err != nil {
 				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("delete staging branch: %w", err))
 			}
 		}
@@ -493,6 +489,12 @@ func (s *DoltStore) filteredPushToPeer(ctx context.Context, peer string, exclude
 			retErr = errors.Join(retErr, fmt.Errorf("federation filter: cleanup: %w", cleanupErr))
 		}
 	}()
+
+	// Create staging branch from the current branch. Cleanup is already armed:
+	// a lost response can make this call fail after Dolt created the branch.
+	if _, err := conn.ExecContext(ctx, "CALL DOLT_BRANCH(?, ?)", stagingBranch, sourceBranch); err != nil {
+		return fmt.Errorf("federation filter: create staging branch: %w", err)
+	}
 
 	// Checkout staging branch.
 	if err := versioncontrolops.CheckoutBranch(ctx, conn, stagingBranch); err != nil {
@@ -530,6 +532,15 @@ func (s *DoltStore) filteredPushToPeer(ctx context.Context, peer string, exclude
 	// Push staging branch to peer, mapped to the peer's expected branch name.
 	refspec := stagingBranch + ":" + sourceBranch
 	return s.pushRefToPeer(ctx, peer, refspec)
+}
+
+func deleteFederationStagingBranch(ctx context.Context, conn *sql.Conn, stagingBranch string) error {
+	err := schema.DrainCall(ctx, conn, "CALL DOLT_BRANCH('-Df', ?)", stagingBranch)
+	var mysqlErr *mysql.MySQLError
+	if errors.As(err, &mysqlErr) && mysqlErr.Number == 1105 && mysqlErr.Message == "branch not found" {
+		return nil
+	}
+	return err
 }
 
 // commitFilteredStaging repairs and commits the filtered graph on the staging

--- a/internal/storage/dolt/federation.go
+++ b/internal/storage/dolt/federation.go
@@ -20,6 +20,10 @@ import (
 // issue types before pushing to a federation peer.
 const federationStagingBranch = "__federation_push_staging"
 
+// federationStagingCleanupTimeout bounds best-effort cleanup after the caller
+// has canceled or its deadline has expired.
+const federationStagingCleanupTimeout = 30 * time.Second
+
 // FederatedStorage implementation for DoltStore
 // These methods enable peer-to-peer synchronization between workspaces.
 
@@ -432,7 +436,7 @@ func (s *DoltStore) Sync(ctx context.Context, peer string, strategy string) (*Sy
 // The special type "wisp" matches issues with ephemeral=true in the committed
 // issues table. Wisps normally live in dolt_ignore'd tables and are not pushed,
 // so this acts as a defense-in-depth safety net.
-func (s *DoltStore) filteredPushToPeer(ctx context.Context, peer string, excludeTypes []string) error {
+func (s *DoltStore) filteredPushToPeer(ctx context.Context, peer string, excludeTypes []string) (retErr error) {
 	if len(excludeTypes) == 0 {
 		return s.PushTo(ctx, peer)
 	}
@@ -461,8 +465,18 @@ func (s *DoltStore) filteredPushToPeer(ctx context.Context, peer string, exclude
 
 	// Ensure cleanup: restore original branch and delete staging.
 	defer func() {
-		_ = schema.DrainCall(ctx, conn, "CALL DOLT_CHECKOUT(?)", s.branch)
-		_ = schema.DrainCall(ctx, conn, "CALL DOLT_BRANCH('-Df', ?)", federationStagingBranch)
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), federationStagingCleanupTimeout)
+		defer cancel()
+		var cleanupErr error
+		if err := schema.DrainCall(cleanupCtx, conn, "CALL DOLT_CHECKOUT(?)", s.branch); err != nil {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("restore branch %s: %w", s.branch, err))
+		}
+		if err := schema.DrainCall(cleanupCtx, conn, "CALL DOLT_BRANCH('-Df', ?)", federationStagingBranch); err != nil {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("delete staging branch: %w", err))
+		}
+		if cleanupErr != nil {
+			retErr = errors.Join(retErr, fmt.Errorf("federation filter: cleanup: %w", cleanupErr))
+		}
 	}()
 
 	// Checkout staging branch.

--- a/internal/storage/dolt/federation.go
+++ b/internal/storage/dolt/federation.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/doltutil"
@@ -16,9 +17,9 @@ import (
 	"github.com/steveyegge/beads/internal/storage/versioncontrolops"
 )
 
-// federationStagingBranch is the temporary branch used to filter excluded
-// issue types before pushing to a federation peer.
-const federationStagingBranch = "__federation_push_staging"
+// federationStagingBranchPrefix identifies temporary filtered-push branches.
+// Each operation appends a UUID so concurrent pushes cannot collide.
+const federationStagingBranchPrefix = "__federation_push_staging_"
 
 // federationStagingCleanupTimeout bounds best-effort cleanup after the caller
 // has canceled or its deadline has expired.
@@ -441,6 +442,11 @@ func (s *DoltStore) filteredPushToPeer(ctx context.Context, peer string, exclude
 		return s.PushTo(ctx, peer)
 	}
 	sourceBranch := s.branch
+	operationID, err := uuid.NewRandom()
+	if err != nil {
+		return fmt.Errorf("federation filter: generate staging branch: %w", err)
+	}
+	stagingBranch := federationStagingBranchPrefix + operationID.String()
 
 	// Pin a single long-timeout connection for the session-scoped staging
 	// operation. RecomputeAllIsBlockedInTx can exceed the shared pool's
@@ -457,11 +463,8 @@ func (s *DoltStore) filteredPushToPeer(ctx context.Context, peer string, exclude
 	}
 	defer conn.Close()
 
-	// Clean up any leftover staging branch from a previous failed run.
-	_ = schema.DrainCall(ctx, conn, "CALL DOLT_BRANCH('-Df', ?)", federationStagingBranch)
-
 	// Create staging branch from the current branch.
-	if _, err := conn.ExecContext(ctx, "CALL DOLT_BRANCH(?, ?)", federationStagingBranch, sourceBranch); err != nil {
+	if _, err := conn.ExecContext(ctx, "CALL DOLT_BRANCH(?, ?)", stagingBranch, sourceBranch); err != nil {
 		return fmt.Errorf("federation filter: create staging branch: %w", err)
 	}
 
@@ -482,7 +485,7 @@ func (s *DoltStore) filteredPushToPeer(ctx context.Context, peer string, exclude
 			if err := schema.DrainCall(cleanupCtx, cleanupConn, "CALL DOLT_CHECKOUT(?)", sourceBranch); err != nil {
 				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("restore branch %s: %w", sourceBranch, err))
 			}
-			if err := schema.DrainCall(cleanupCtx, cleanupConn, "CALL DOLT_BRANCH('-Df', ?)", federationStagingBranch); err != nil {
+			if err := schema.DrainCall(cleanupCtx, cleanupConn, "CALL DOLT_BRANCH('-Df', ?)", stagingBranch); err != nil {
 				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("delete staging branch: %w", err))
 			}
 		}
@@ -492,7 +495,7 @@ func (s *DoltStore) filteredPushToPeer(ctx context.Context, peer string, exclude
 	}()
 
 	// Checkout staging branch.
-	if err := versioncontrolops.CheckoutBranch(ctx, conn, federationStagingBranch); err != nil {
+	if err := versioncontrolops.CheckoutBranch(ctx, conn, stagingBranch); err != nil {
 		return fmt.Errorf("federation filter: checkout staging: %w", err)
 	}
 
@@ -525,7 +528,7 @@ func (s *DoltStore) filteredPushToPeer(ctx context.Context, peer string, exclude
 	}
 
 	// Push staging branch to peer, mapped to the peer's expected branch name.
-	refspec := federationStagingBranch + ":" + sourceBranch
+	refspec := stagingBranch + ":" + sourceBranch
 	return s.pushRefToPeer(ctx, peer, refspec)
 }
 

--- a/internal/storage/dolt/federation.go
+++ b/internal/storage/dolt/federation.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	mysql "github.com/go-sql-driver/mysql"
@@ -464,32 +465,31 @@ func (s *DoltStore) filteredPushToPeer(ctx context.Context, peer string, exclude
 	}
 	defer conn.Close()
 
-	// Ensure cleanup on a fresh connection: canceling an in-flight query makes
-	// go-sql-driver/mysql invalidate the operation connection.
+	// Arm cleanup before creating the branch: a lost create response can make
+	// the branch exist even when the call fails, and canceling an in-flight
+	// query makes go-sql-driver/mysql invalidate the operation connection, so
+	// cleanup reopens a fresh one.
 	defer func() {
-		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), federationStagingCleanupTimeout)
-		defer cancel()
-		var cleanupErr error
-		if err := conn.Close(); err != nil {
-			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("discard operation connection: %w", err))
-		}
-		cleanupConn, err := db.Conn(cleanupCtx)
-		if err != nil {
-			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("acquire cleanup connection: %w", err))
-		} else {
-			defer cleanupConn.Close()
-			if err := schema.DrainCall(cleanupCtx, cleanupConn, "CALL DOLT_CHECKOUT(?)", sourceBranch); err != nil {
-				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("restore branch %s: %w", sourceBranch, err))
-			}
-			if err := deleteFederationStagingBranch(cleanupCtx, cleanupConn, stagingBranch); err != nil {
-				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("delete staging branch: %w", err))
-			}
-		}
-		if cleanupErr != nil {
+		if cleanupErr := cleanupFilteredStaging(ctx, db, conn, sourceBranch, stagingBranch); cleanupErr != nil {
 			retErr = errors.Join(retErr, fmt.Errorf("federation filter: cleanup: %w", cleanupErr))
 		}
 	}()
 
+	if err := s.stageFilteredBranch(ctx, conn, sourceBranch, stagingBranch, excludeTypes); err != nil {
+		return err
+	}
+
+	// Push staging branch to peer, mapped to the peer's expected branch name.
+	refspec := stagingBranch + ":" + sourceBranch
+	return s.pushRefToPeer(ctx, peer, refspec)
+}
+
+// stageFilteredBranch creates the UUID staging branch from sourceBranch on the
+// pinned connection, deletes the excluded issue types on it, recomputes and
+// commits is_blocked when any rows were removed, and restores sourceBranch so
+// the caller can push the staging ref. Branch state is session-scoped, so every
+// step stays on conn.
+func (s *DoltStore) stageFilteredBranch(ctx context.Context, conn *sql.Conn, sourceBranch, stagingBranch string, excludeTypes []string) error {
 	// Create staging branch from the current branch. Cleanup is already armed:
 	// a lost response can make this call fail after Dolt created the branch.
 	if _, err := conn.ExecContext(ctx, "CALL DOLT_BRANCH(?, ?)", stagingBranch, sourceBranch); err != nil {
@@ -501,7 +501,26 @@ func (s *DoltStore) filteredPushToPeer(ctx context.Context, peer string, exclude
 		return fmt.Errorf("federation filter: checkout staging: %w", err)
 	}
 
-	// Delete excluded issues from the committed issues table.
+	if deleteExcludedIssues(ctx, conn, excludeTypes) {
+		if err := s.commitFilteredStaging(ctx, conn); err != nil {
+			return err
+		}
+	}
+
+	// Restore original branch context before pushing.
+	if err := versioncontrolops.CheckoutBranch(ctx, conn, sourceBranch); err != nil {
+		return fmt.Errorf("federation filter: restore branch %s: %w", sourceBranch, err)
+	}
+	return nil
+}
+
+// deleteExcludedIssues removes issues matching excludeTypes from the committed
+// issues table on conn's current (staging) branch and reports whether any rows
+// were deleted. The special type "wisp" matches ephemeral rows. A DELETE error
+// is intentionally ignored (deleted stays false for that type), preserving the
+// pre-existing best-effort filtering behavior; the caller only recomputes and
+// commits when something was actually removed.
+func deleteExcludedIssues(ctx context.Context, conn *sql.Conn, excludeTypes []string) bool {
 	deleted := false
 	for _, excludeType := range excludeTypes {
 		var result interface{ RowsAffected() (int64, error) }
@@ -517,27 +536,43 @@ func (s *DoltStore) filteredPushToPeer(ctx context.Context, peer string, exclude
 			}
 		}
 	}
+	return deleted
+}
 
-	if deleted {
-		if err := s.commitFilteredStaging(ctx, conn); err != nil {
-			return err
+// cleanupFilteredStaging discards the operation connection (an in-flight cancel
+// invalidates it), then restores sourceBranch and deletes stagingBranch on a
+// fresh, uncanceled, bounded connection. Errors are joined; a non-nil result is
+// wrapped by the caller with the "federation filter: cleanup" context.
+func cleanupFilteredStaging(ctx context.Context, db *sql.DB, conn *sql.Conn, sourceBranch, stagingBranch string) error {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), federationStagingCleanupTimeout)
+	defer cancel()
+	var cleanupErr error
+	if err := conn.Close(); err != nil {
+		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("discard operation connection: %w", err))
+	}
+	cleanupConn, err := db.Conn(cleanupCtx)
+	if err != nil {
+		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("acquire cleanup connection: %w", err))
+	} else {
+		defer cleanupConn.Close()
+		if err := schema.DrainCall(cleanupCtx, cleanupConn, "CALL DOLT_CHECKOUT(?)", sourceBranch); err != nil {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("restore branch %s: %w", sourceBranch, err))
+		}
+		if err := deleteFederationStagingBranch(cleanupCtx, cleanupConn, stagingBranch); err != nil {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("delete staging branch: %w", err))
 		}
 	}
-
-	// Restore original branch context before pushing.
-	if err := versioncontrolops.CheckoutBranch(ctx, conn, sourceBranch); err != nil {
-		return fmt.Errorf("federation filter: restore branch %s: %w", sourceBranch, err)
-	}
-
-	// Push staging branch to peer, mapped to the peer's expected branch name.
-	refspec := stagingBranch + ":" + sourceBranch
-	return s.pushRefToPeer(ctx, peer, refspec)
+	return cleanupErr
 }
 
 func deleteFederationStagingBranch(ctx context.Context, conn *sql.Conn, stagingBranch string) error {
 	err := schema.DrainCall(ctx, conn, "CALL DOLT_BRANCH('-Df', ?)", stagingBranch)
 	var mysqlErr *mysql.MySQLError
-	if errors.As(err, &mysqlErr) && mysqlErr.Number == 1105 && mysqlErr.Message == "branch not found" {
+	// Dolt reports a missing branch as generic error 1105; match the message as
+	// a case-insensitive substring (as RemoteRefUnavailableErr does) because
+	// Dolt may append the branch/ref name to this class of error.
+	if errors.As(err, &mysqlErr) && mysqlErr.Number == 1105 &&
+		strings.Contains(strings.ToLower(mysqlErr.Message), "branch not found") {
 		return nil
 	}
 	return err

--- a/internal/storage/dolt/federation.go
+++ b/internal/storage/dolt/federation.go
@@ -437,10 +437,17 @@ func (s *DoltStore) filteredPushToPeer(ctx context.Context, peer string, exclude
 		return s.PushTo(ctx, peer)
 	}
 
-	// Pin a single connection for session-scoped branch operations.
-	conn, err := s.db.Conn(ctx)
+	// Pin a single long-timeout connection for the complete session-scoped
+	// staging lifecycle. RecomputeAllIsBlockedInTx can exceed the shared
+	// pool's 10-second I/O deadline, and branch state is connection-scoped.
+	db, err := s.openLongTimeoutConn()
 	if err != nil {
-		return fmt.Errorf("federation filter: acquire connection: %w", err)
+		return fmt.Errorf("federation filter: open long-timeout connection: %w", err)
+	}
+	defer db.Close()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("federation filter: acquire long-timeout connection: %w", err)
 	}
 	defer conn.Close()
 

--- a/internal/storage/dolt/federation.go
+++ b/internal/storage/dolt/federation.go
@@ -2,6 +2,7 @@ package dolt
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"os"
@@ -480,9 +481,8 @@ func (s *DoltStore) filteredPushToPeer(ctx context.Context, peer string, exclude
 	}
 
 	if deleted {
-		if _, err := conn.ExecContext(ctx, "CALL DOLT_COMMIT('-Am', ?)",
-			"federation: exclude private issue types"); err != nil {
-			return fmt.Errorf("federation filter: commit filtered state: %w", err)
+		if err := s.commitFilteredStaging(ctx, conn); err != nil {
+			return err
 		}
 	}
 
@@ -494,6 +494,28 @@ func (s *DoltStore) filteredPushToPeer(ctx context.Context, peer string, exclude
 	// Push staging branch to peer, mapped to the peer's expected branch name.
 	refspec := federationStagingBranch + ":" + s.branch
 	return s.pushRefToPeer(ctx, peer, refspec)
+}
+
+// commitFilteredStaging repairs and commits the filtered graph on the staging
+// branch selected by conn. Dolt branch state is session-scoped, so every step
+// stays on that pinned connection.
+func (s *DoltStore) commitFilteredStaging(ctx context.Context, conn *sql.Conn) error {
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("federation filter: begin staged is_blocked recompute: %w", err)
+	}
+	if _, err := issueops.RecomputeAllIsBlockedInTx(ctx, tx); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("federation filter: recompute staged is_blocked: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("federation filter: commit staged is_blocked recompute: %w", err)
+	}
+	if _, err := conn.ExecContext(ctx, "CALL DOLT_COMMIT('-Am', ?)",
+		"federation: exclude private issue types"); err != nil {
+		return fmt.Errorf("federation filter: commit filtered state: %w", err)
+	}
+	return nil
 }
 
 // prepareCLIRouteForPeerGitProtocol reports whether the SQL-visible peer

--- a/internal/storage/dolt/federation.go
+++ b/internal/storage/dolt/federation.go
@@ -440,15 +440,17 @@ func (s *DoltStore) filteredPushToPeer(ctx context.Context, peer string, exclude
 	if len(excludeTypes) == 0 {
 		return s.PushTo(ctx, peer)
 	}
+	sourceBranch := s.branch
 
-	// Pin a single long-timeout connection for the complete session-scoped
-	// staging lifecycle. RecomputeAllIsBlockedInTx can exceed the shared
-	// pool's 10-second I/O deadline, and branch state is connection-scoped.
+	// Pin a single long-timeout connection for the session-scoped staging
+	// operation. RecomputeAllIsBlockedInTx can exceed the shared pool's
+	// 10-second I/O deadline, and branch state is connection-scoped.
 	db, err := s.openLongTimeoutConn()
 	if err != nil {
 		return fmt.Errorf("federation filter: open long-timeout connection: %w", err)
 	}
 	defer db.Close()
+	db.SetMaxIdleConns(0)
 	conn, err := db.Conn(ctx)
 	if err != nil {
 		return fmt.Errorf("federation filter: acquire long-timeout connection: %w", err)
@@ -459,20 +461,30 @@ func (s *DoltStore) filteredPushToPeer(ctx context.Context, peer string, exclude
 	_ = schema.DrainCall(ctx, conn, "CALL DOLT_BRANCH('-Df', ?)", federationStagingBranch)
 
 	// Create staging branch from the current branch.
-	if _, err := conn.ExecContext(ctx, "CALL DOLT_BRANCH(?, ?)", federationStagingBranch, s.branch); err != nil {
+	if _, err := conn.ExecContext(ctx, "CALL DOLT_BRANCH(?, ?)", federationStagingBranch, sourceBranch); err != nil {
 		return fmt.Errorf("federation filter: create staging branch: %w", err)
 	}
 
-	// Ensure cleanup: restore original branch and delete staging.
+	// Ensure cleanup on a fresh connection: canceling an in-flight query makes
+	// go-sql-driver/mysql invalidate the operation connection.
 	defer func() {
 		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), federationStagingCleanupTimeout)
 		defer cancel()
 		var cleanupErr error
-		if err := schema.DrainCall(cleanupCtx, conn, "CALL DOLT_CHECKOUT(?)", s.branch); err != nil {
-			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("restore branch %s: %w", s.branch, err))
+		if err := conn.Close(); err != nil {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("discard operation connection: %w", err))
 		}
-		if err := schema.DrainCall(cleanupCtx, conn, "CALL DOLT_BRANCH('-Df', ?)", federationStagingBranch); err != nil {
-			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("delete staging branch: %w", err))
+		cleanupConn, err := db.Conn(cleanupCtx)
+		if err != nil {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("acquire cleanup connection: %w", err))
+		} else {
+			defer cleanupConn.Close()
+			if err := schema.DrainCall(cleanupCtx, cleanupConn, "CALL DOLT_CHECKOUT(?)", sourceBranch); err != nil {
+				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("restore branch %s: %w", sourceBranch, err))
+			}
+			if err := schema.DrainCall(cleanupCtx, cleanupConn, "CALL DOLT_BRANCH('-Df', ?)", federationStagingBranch); err != nil {
+				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("delete staging branch: %w", err))
+			}
 		}
 		if cleanupErr != nil {
 			retErr = errors.Join(retErr, fmt.Errorf("federation filter: cleanup: %w", cleanupErr))
@@ -508,12 +520,12 @@ func (s *DoltStore) filteredPushToPeer(ctx context.Context, peer string, exclude
 	}
 
 	// Restore original branch context before pushing.
-	if err := versioncontrolops.CheckoutBranch(ctx, conn, s.branch); err != nil {
-		return fmt.Errorf("federation filter: restore branch %s: %w", s.branch, err)
+	if err := versioncontrolops.CheckoutBranch(ctx, conn, sourceBranch); err != nil {
+		return fmt.Errorf("federation filter: restore branch %s: %w", sourceBranch, err)
 	}
 
 	// Push staging branch to peer, mapped to the peer's expected branch name.
-	refspec := federationStagingBranch + ":" + s.branch
+	refspec := federationStagingBranch + ":" + sourceBranch
 	return s.pushRefToPeer(ctx, peer, refspec)
 }
 

--- a/internal/storage/dolt/federation_test.go
+++ b/internal/storage/dolt/federation_test.go
@@ -486,11 +486,12 @@ func TestFederationPushPullMethods(t *testing.T) {
 // 3. Non-excluded issues remain intact
 // 4. The original branch is unchanged after the operation
 func TestFilteredPushExcludesWisp(t *testing.T) {
-	store, cleanup := setupTestStore(t)
+	store, cleanup := setupConcurrentTestStore(t)
 	defer cleanup()
 
 	ctx, cancel := testContext(t)
 	defer cancel()
+	versionWispTablesForFilteredPush(t, ctx, store)
 
 	// Create a regular task (should survive filtering)
 	task := &types.Issue{
@@ -1048,7 +1049,7 @@ func listFederationStagingBranches(t *testing.T, ctx context.Context, db *sql.DB
 // TestFilteredPushOptOut verifies that setting federation.exclude_types to
 // an empty list disables filtering (backward-compatible opt-out).
 func TestFilteredPushOptOut(t *testing.T) {
-	store, cleanup := setupTestStore(t)
+	store, cleanup := setupConcurrentTestStore(t)
 	defer cleanup()
 
 	ctx, cancel := testContext(t)
@@ -1252,11 +1253,12 @@ func TestFilteredStagingPublishesRetainedWaiterUnblocked(t *testing.T) {
 // TestFilteredPushStagingBranchCleanupOnError verifies that the staging
 // branch is always cleaned up, even when the push operation fails.
 func TestFilteredPushStagingBranchCleanupOnError(t *testing.T) {
-	store, cleanup := setupTestStore(t)
+	store, cleanup := setupConcurrentTestStore(t)
 	defer cleanup()
 
 	ctx, cancel := testContext(t)
 	defer cancel()
+	versionWispTablesForFilteredPush(t, ctx, store)
 
 	// Run filtered push to a nonexistent peer — will fail, but staging
 	// branch should still be cleaned up.

--- a/internal/storage/dolt/federation_test.go
+++ b/internal/storage/dolt/federation_test.go
@@ -610,11 +610,10 @@ func TestFilteredPushUsesDedicatedLongTimeoutConnection(t *testing.T) {
 	assertFederationStagingBranchAbsent(t, ctx, observer)
 }
 
-// TestFilteredPushCleanupSurvivesCallerCancellation cancels the caller only
-// after the durable filtered staging commit and the subsequent peer lookup are
-// observable. Cleanup must still restore/delete on its pinned connection. A
-// deliberately invalid restore target also proves its cleanup error is joined
-// without masking the caller's cancellation, while deletion still runs.
+// TestFilteredPushCleanupSurvivesCallerCancellation cancels the caller while
+// the staging DELETE is executing. go-sql-driver/mysql invalidates that
+// operation connection on cancellation, so cleanup must discard it, reopen a
+// connection, restore the source branch, and delete the staging branch.
 func TestFilteredPushCleanupSurvivesCallerCancellation(t *testing.T) {
 	store, cleanup := setupConcurrentTestStore(t)
 	defer cleanup()
@@ -622,11 +621,102 @@ func TestFilteredPushCleanupSurvivesCallerCancellation(t *testing.T) {
 	defer cancel()
 
 	waiterID, blockerID := seedFilteredPushGraph(t, ctx, store, "fed-cancel-cleanup")
+	sourceBranch := store.branch
+	setupConn, err := store.db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("pin cancellation fixture connection: %v", err)
+	}
+	if _, err := setupConn.ExecContext(ctx,
+		"CREATE TABLE federation_cancel_gate (slept INT NOT NULL)"); err != nil {
+		_ = setupConn.Close()
+		t.Fatalf("create cancellation gate table: %v", err)
+	}
+	if _, err := setupConn.ExecContext(ctx, `CREATE TRIGGER federation_cancel_delete
+		BEFORE DELETE ON issues FOR EACH ROW
+		INSERT INTO federation_cancel_gate VALUES (SLEEP(60))`); err != nil {
+		_ = setupConn.Close()
+		t.Fatalf("create cancellation gate trigger: %v", err)
+	}
+	if err := schema.DrainCall(ctx, setupConn,
+		"CALL DOLT_COMMIT('-Am', 'test: block filtered delete for cancellation')"); err != nil {
+		_ = setupConn.Close()
+		t.Fatalf("commit cancellation fixture: %v", err)
+	}
+	if err := setupConn.Close(); err != nil {
+		t.Fatalf("close cancellation fixture connection: %v", err)
+	}
+
 	observer, err := store.openLongTimeoutConn()
 	if err != nil {
 		t.Fatalf("open staging observer: %v", err)
 	}
 	defer observer.Close()
+
+	pushCtx, cancelPush := context.WithCancel(ctx)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- store.filteredPushToPeer(pushCtx, "nonexistent-peer", []string{"wisp"})
+	}()
+
+	waitForFederationQuery(t, ctx, observer, errCh, store.database, "DELETE FROM issues WHERE ephemeral = 1")
+	cancelPush()
+	select {
+	case err = <-errCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("filtered push did not return after canceling its staging query")
+	}
+	if err == nil {
+		t.Fatal("filtered push succeeded after canceling its staging query")
+	}
+	if !errors.Is(err, context.Canceled) && !strings.Contains(err.Error(), "bad connection") {
+		t.Fatalf("filtered push error = %v, want cancellation or invalidated connection", err)
+	}
+
+	if err := versioncontrolops.CheckoutBranch(ctx, observer, sourceBranch); err != nil {
+		t.Fatalf("checkout source branch after cancellation: %v", err)
+	}
+	var activeBranch string
+	if err := observer.QueryRowContext(ctx, "SELECT active_branch()").Scan(&activeBranch); err != nil {
+		t.Fatalf("read branch after cancellation: %v", err)
+	}
+	if activeBranch != sourceBranch {
+		t.Fatalf("active branch after cancellation = %q, want source %q", activeBranch, sourceBranch)
+	}
+	var blockerCount int
+	if err := observer.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM issues WHERE id = ?", blockerID).Scan(&blockerCount); err != nil {
+		t.Fatalf("read excluded blocker on source branch: %v", err)
+	}
+	waiterBlocked := isBlocked(ctx, t, observer, waiterID)
+	if blockerCount != 1 || !waiterBlocked {
+		t.Fatalf("source state changed after cancellation: blocker count = %d, waiter blocked = %t, want 1, true",
+			blockerCount, waiterBlocked)
+	}
+	assertFederationStagingBranchAbsent(t, ctx, observer)
+}
+
+// TestFilteredPushCleanupDeletesStagingAfterRestoreFailure proves cleanup
+// attempts branch deletion even when restoring the captured source fails, and
+// joins that cleanup failure with the caller's cancellation.
+func TestFilteredPushCleanupDeletesStagingAfterRestoreFailure(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	waiterID, blockerID := seedFilteredPushGraph(t, ctx, store, "fed-cleanup-join")
+	observer, err := store.openLongTimeoutConn()
+	if err != nil {
+		t.Fatalf("open staging observer: %v", err)
+	}
+	defer observer.Close()
+
+	sourceBranch := "federation-cleanup-missing-source"
+	if err := schema.DrainCall(ctx, observer,
+		"CALL DOLT_BRANCH(?, ?)", sourceBranch, store.branch); err != nil {
+		t.Fatalf("create disposable source branch: %v", err)
+	}
+	store.branch = sourceBranch
 
 	store.db.SetMaxOpenConns(1)
 	held, err := store.db.Conn(ctx)
@@ -644,17 +734,93 @@ func TestFilteredPushCleanupSurvivesCallerCancellation(t *testing.T) {
 
 	waitForFilteredStagingCommit(t, ctx, observer, errCh, waiterID, blockerID)
 	waitForPoolWait(t, ctx, store.db, initialWaitCount)
-	store.branch = "missing-cleanup-branch"
+	if err := schema.DrainCall(ctx, observer,
+		"CALL DOLT_BRANCH('-Df', ?)", sourceBranch); err != nil {
+		t.Fatalf("delete disposable source branch: %v", err)
+	}
 	cancelPush()
-	err = <-errCh
+	select {
+	case err = <-errCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("filtered push did not return after caller cancellation")
+	}
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("filtered push error = %v, want context canceled", err)
 	}
 	if !strings.Contains(err.Error(), "federation filter: cleanup") ||
-		!strings.Contains(err.Error(), "restore branch missing-cleanup-branch") {
-		t.Fatalf("filtered push error omitted cleanup failure: %v", err)
+		!strings.Contains(err.Error(), "restore branch "+sourceBranch) {
+		t.Fatalf("filtered push error omitted cleanup restore failure: %v", err)
 	}
 	assertFederationStagingBranchAbsent(t, ctx, observer)
+}
+
+func waitForFederationQuery(t *testing.T, ctx context.Context, observer *sql.DB, errCh <-chan error, database, querySnippet string) {
+	t.Helper()
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case err := <-errCh:
+			t.Fatalf("filtered push returned before staging query was observable: %v", err)
+		default:
+		}
+		visible, err := processlistContainsQuery(ctx, observer, database, querySnippet)
+		if err != nil {
+			t.Fatalf("observe staging query: %v", err)
+		}
+		if visible {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("waiting for staging query: %v", ctx.Err())
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	t.Fatalf("staging query %q was not observable", querySnippet)
+}
+
+func processlistContainsQuery(ctx context.Context, observer *sql.DB, database, querySnippet string) (bool, error) {
+	rows, err := observer.QueryContext(ctx, "SHOW PROCESSLIST")
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+	columns, err := rows.Columns()
+	if err != nil {
+		return false, err
+	}
+	infoIndex := -1
+	databaseIndex := -1
+	for i, column := range columns {
+		switch {
+		case strings.EqualFold(column, "info"):
+			infoIndex = i
+		case strings.EqualFold(column, "db"):
+			databaseIndex = i
+		}
+	}
+	if infoIndex < 0 || databaseIndex < 0 {
+		return false, errors.New("SHOW PROCESSLIST has no db or info column")
+	}
+	values := make([]sql.NullString, len(columns))
+	scanArgs := make([]any, len(columns))
+	for i := range values {
+		scanArgs[i] = &values[i]
+	}
+	querySnippet = strings.ToLower(querySnippet)
+	for rows.Next() {
+		for i := range values {
+			values[i] = sql.NullString{}
+		}
+		if err := rows.Scan(scanArgs...); err != nil {
+			return false, err
+		}
+		if values[databaseIndex].Valid && values[databaseIndex].String == database &&
+			values[infoIndex].Valid && strings.Contains(strings.ToLower(values[infoIndex].String), querySnippet) {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
 }
 
 func seedFilteredPushGraph(t *testing.T, ctx context.Context, store *DoltStore, prefix string) (string, string) {

--- a/internal/storage/dolt/federation_test.go
+++ b/internal/storage/dolt/federation_test.go
@@ -3,16 +3,21 @@
 package dolt
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	mysql "github.com/go-sql-driver/mysql"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/storage/schema"
@@ -671,6 +676,93 @@ func TestFilteredPushConcurrentOperationsUseDistinctStagingBranches(t *testing.T
 	}
 }
 
+// TestFilteredPushCleanupSurvivesLostBranchCreateResponse proves cleanup is
+// armed before branch creation becomes externally visible. The test dialer
+// forwards the real DOLT_BRANCH call, withholds its response until another
+// connection observes the branch, then drops that response after cancellation.
+func TestFilteredPushCleanupSurvivesLostBranchCreateResponse(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	observer, err := store.openLongTimeoutConn()
+	if err != nil {
+		t.Fatalf("open staging observer: %v", err)
+	}
+	defer observer.Close()
+
+	loss := installFederationBranchResponseLossDialer(t, store)
+	defer loss.drop()
+	pushCtx, cancelPush := context.WithCancel(ctx)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- store.filteredPushToPeer(pushCtx, "nonexistent-peer", []string{"wisp"})
+	}()
+
+	select {
+	case <-loss.responseBlocked:
+	case err := <-errCh:
+		t.Fatalf("filtered push returned before branch response was blocked: %v", err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("filtered push did not issue staging branch creation")
+	}
+
+	deadline := time.Now().Add(10 * time.Second)
+	var stagingBranches []string
+	for time.Now().Before(deadline) {
+		stagingBranches = listFederationStagingBranches(t, ctx, observer)
+		if len(stagingBranches) == 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if len(stagingBranches) != 1 {
+		t.Fatalf("server-side staging branches = %v, want one before response loss", stagingBranches)
+	}
+
+	cancelPush()
+	loss.drop()
+	select {
+	case err = <-errCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("filtered push did not return after dropping branch response")
+	}
+	if err == nil || !strings.Contains(err.Error(), "federation filter: create staging branch") {
+		t.Fatalf("filtered push error = %v, want original branch-create failure", err)
+	}
+	if strings.Contains(err.Error(), "federation filter: cleanup") {
+		t.Fatalf("cleanup masked branch-create failure: %v", err)
+	}
+	assertFederationStagingBranchAbsent(t, ctx, observer)
+}
+
+func TestDeleteFederationStagingBranchIgnoresOnlyMissingBranch(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+	conn, err := store.db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("acquire cleanup test connection: %v", err)
+	}
+	defer conn.Close()
+
+	t.Run("missing branch", func(t *testing.T) {
+		err := deleteFederationStagingBranch(ctx, conn, federationStagingBranchPrefix+"missing")
+		if err != nil {
+			t.Fatalf("delete missing staging branch: %v", err)
+		}
+	})
+
+	t.Run("real delete error", func(t *testing.T) {
+		err := deleteFederationStagingBranch(ctx, conn, "")
+		if err == nil {
+			t.Fatal("delete empty staging branch succeeded, want error")
+		}
+	})
+}
+
 // TestFilteredPushCleanupSurvivesCallerCancellation cancels the caller while
 // the staging DELETE is executing. go-sql-driver/mysql invalidates that
 // operation connection on cancellation, so cleanup must discard it, reopen a
@@ -1044,6 +1136,70 @@ func listFederationStagingBranches(t *testing.T, ctx context.Context, db *sql.DB
 		t.Fatalf("iterate federation staging branches: %v", err)
 	}
 	return branches
+}
+
+type federationBranchResponseLossDialer struct {
+	armed           atomic.Bool
+	responseBlocked chan struct{}
+	dropResponse    chan struct{}
+	blockedOnce     sync.Once
+	dropOnce        sync.Once
+}
+
+func installFederationBranchResponseLossDialer(t *testing.T, store *DoltStore) *federationBranchResponseLossDialer {
+	t.Helper()
+	cfg, err := mysql.ParseDSN(store.connStr)
+	if err != nil {
+		t.Fatalf("parse store DSN: %v", err)
+	}
+	if cfg.Net != "tcp" {
+		t.Fatalf("response-loss dialer requires TCP, got %q", cfg.Net)
+	}
+	dialer := &federationBranchResponseLossDialer{
+		responseBlocked: make(chan struct{}),
+		dropResponse:    make(chan struct{}),
+	}
+	network := fmt.Sprintf("federation_response_loss_%d", time.Now().UnixNano())
+	mysql.RegisterDialContext(network, func(ctx context.Context, addr string) (net.Conn, error) {
+		conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", addr)
+		if err != nil {
+			return nil, err
+		}
+		return &federationBranchResponseLossConn{Conn: conn, dialer: dialer}, nil
+	})
+	t.Cleanup(func() { mysql.DeregisterDialContext(network) })
+	cfg.Net = network
+	store.connStr = cfg.FormatDSN()
+	return dialer
+}
+
+func (d *federationBranchResponseLossDialer) drop() {
+	d.dropOnce.Do(func() { close(d.dropResponse) })
+}
+
+type federationBranchResponseLossConn struct {
+	net.Conn
+	dialer        *federationBranchResponseLossDialer
+	blockResponse atomic.Bool
+}
+
+func (c *federationBranchResponseLossConn) Write(p []byte) (int, error) {
+	n, err := c.Conn.Write(p)
+	if err == nil && bytes.Contains(bytes.ToLower(p), []byte("call dolt_branch(")) &&
+		bytes.Contains(p, []byte(federationStagingBranchPrefix)) && c.dialer.armed.CompareAndSwap(false, true) {
+		c.blockResponse.Store(true)
+	}
+	return n, err
+}
+
+func (c *federationBranchResponseLossConn) Read(p []byte) (int, error) {
+	if !c.blockResponse.Load() {
+		return c.Conn.Read(p)
+	}
+	c.dialer.blockedOnce.Do(func() { close(c.dialer.responseBlocked) })
+	<-c.dialer.dropResponse
+	_ = c.Conn.Close()
+	return 0, net.ErrClosed
 }
 
 // TestFilteredPushOptOut verifies that setting federation.exclude_types to

--- a/internal/storage/dolt/federation_test.go
+++ b/internal/storage/dolt/federation_test.go
@@ -515,8 +515,9 @@ func TestFilteredPushExcludesWisp(t *testing.T) {
 	// Create an ephemeral issue directly in the issues table (simulates the
 	// edge case where an ephemeral issue leaks into committed data).
 	_, err := store.db.ExecContext(ctx, `INSERT INTO issues
-		(id, title, issue_type, status, priority, ephemeral, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, 1, NOW(), NOW())`,
+		(id, title, description, design, acceptance_criteria, notes,
+		 issue_type, status, priority, ephemeral, created_at, updated_at)
+		VALUES (?, ?, '', '', '', '', ?, ?, ?, 1, NOW(), NOW())`,
 		"fed-filter-wisp", "Leaked wisp", "task", "open", 1)
 	if err != nil {
 		t.Fatalf("insert ephemeral issue: %v", err)
@@ -1213,8 +1214,9 @@ func TestFilteredPushOptOut(t *testing.T) {
 
 	// Create an ephemeral issue in the committed issues table.
 	_, err := store.db.ExecContext(ctx, `INSERT INTO issues
-		(id, title, issue_type, status, priority, ephemeral, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, 1, NOW(), NOW())`,
+		(id, title, description, design, acceptance_criteria, notes,
+		 issue_type, status, priority, ephemeral, created_at, updated_at)
+		VALUES (?, ?, '', '', '', '', ?, ?, ?, 1, NOW(), NOW())`,
 		"fed-optout-wisp", "Wisp for opt-out test", "task", "open", 1)
 	if err != nil {
 		t.Fatalf("insert ephemeral issue: %v", err)
@@ -1248,13 +1250,19 @@ func TestFilteredPushOptOut(t *testing.T) {
 // TestFilteredPushExcludesCustomType verifies that non-wisp types in
 // federation.exclude_types are filtered by issue_type column.
 func TestFilteredPushExcludesCustomType(t *testing.T) {
-	store, cleanup := setupTestStore(t)
+	store, cleanup := setupConcurrentTestStore(t)
 	defer cleanup()
 
 	ctx, cancel := testContext(t)
 	defer cancel()
+	versionWispTablesForFilteredPush(t, ctx, store)
+	observer, err := store.openLongTimeoutConn()
+	if err != nil {
+		t.Fatalf("open staging observer: %v", err)
+	}
+	defer observer.Close()
 
-	// Create a task and a message.
+	// Create a task and a permanent non-infrastructure issue type.
 	task := &types.Issue{
 		ID:        "fed-custom-task",
 		Title:     "Regular task",
@@ -1264,10 +1272,10 @@ func TestFilteredPushExcludesCustomType(t *testing.T) {
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
 	}
-	msg := &types.Issue{
-		ID:        "fed-custom-msg",
-		Title:     "Internal message",
-		IssueType: types.TypeMessage,
+	chore := &types.Issue{
+		ID:        "fed-custom-chore",
+		Title:     "Internal chore",
+		IssueType: types.TypeChore,
 		Status:    types.StatusOpen,
 		Priority:  1,
 		CreatedAt: time.Now(),
@@ -1276,8 +1284,8 @@ func TestFilteredPushExcludesCustomType(t *testing.T) {
 	if err := store.CreateIssue(ctx, task, "test"); err != nil {
 		t.Fatalf("create task: %v", err)
 	}
-	if err := store.CreateIssue(ctx, msg, "test"); err != nil {
-		t.Fatalf("create message: %v", err)
+	if err := store.CreateIssue(ctx, chore, "test"); err != nil {
+		t.Fatalf("create chore: %v", err)
 	}
 	if err := store.Commit(ctx, "create test issues"); err != nil {
 		if !isDoltNothingToCommit(err) {
@@ -1285,21 +1293,66 @@ func TestFilteredPushExcludesCustomType(t *testing.T) {
 		}
 	}
 
-	// Exclude "message" type — task should remain, message should be filtered.
-	pushErr := store.filteredPushToPeer(ctx, "nonexistent-peer", []string{"message"})
-	if pushErr == nil {
-		t.Fatal("expected push error for nonexistent peer")
+	// Hold the shared pool after staging is committed and before peer lookup so
+	// the staging ref can be inspected before its cleanup runs.
+	store.db.SetMaxIdleConns(0)
+	store.db.SetMaxOpenConns(1)
+	held, err := store.db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("exhaust shared pool: %v", err)
+	}
+	defer held.Close()
+	initialWaitCount := store.db.Stats().WaitCount
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- store.filteredPushToPeer(ctx, "nonexistent-peer", []string{"chore"})
+	}()
+	waitForPoolWait(t, ctx, store.db, initialWaitCount)
+
+	stagingBranches := listFederationStagingBranches(t, ctx, observer)
+	if len(stagingBranches) != 1 {
+		t.Fatalf("staging branches = %v, want exactly one", stagingBranches)
+	}
+	stagingBranch := stagingBranches[0]
+	if err := issueops.ValidateRef(stagingBranch); err != nil {
+		t.Fatalf("generated staging branch %q is invalid: %v", stagingBranch, err)
+	}
+	//nolint:gosec // stagingBranch is generated internally and validated as a Dolt ref above.
+	taskQuery := fmt.Sprintf("SELECT COUNT(*) FROM issues AS OF '%s' WHERE id = ?", stagingBranch)
+	//nolint:gosec // stagingBranch is generated internally and validated as a Dolt ref above.
+	choreQuery := fmt.Sprintf("SELECT COUNT(*) FROM issues AS OF '%s' WHERE id = ?", stagingBranch)
+	var stagedTaskCount, stagedChoreCount int
+	if err := observer.QueryRowContext(ctx, taskQuery, "fed-custom-task").Scan(&stagedTaskCount); err != nil {
+		t.Fatalf("count task on staging branch: %v", err)
+	}
+	if err := observer.QueryRowContext(ctx, choreQuery, "fed-custom-chore").Scan(&stagedChoreCount); err != nil {
+		t.Fatalf("count chore on staging branch: %v", err)
+	}
+	if stagedTaskCount != 1 || stagedChoreCount != 0 {
+		t.Fatalf("staging branch task count = %d, chore count = %d, want 1, 0", stagedTaskCount, stagedChoreCount)
 	}
 
+	if err := held.Close(); err != nil {
+		t.Fatalf("release shared pool: %v", err)
+	}
+	if pushErr := <-errCh; pushErr == nil {
+		t.Fatal("expected push error for nonexistent peer")
+	}
+	assertFederationStagingBranchAbsent(t, ctx, observer)
+
 	// Verify original branch still has both issues.
-	var taskCount, msgCount int
-	store.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM issues WHERE id = ?", "fed-custom-task").Scan(&taskCount)
-	store.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM issues WHERE id = ?", "fed-custom-msg").Scan(&msgCount)
+	var taskCount, choreCount int
+	if err := store.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM issues WHERE id = ?", "fed-custom-task").Scan(&taskCount); err != nil {
+		t.Fatalf("count task: %v", err)
+	}
+	if err := store.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM issues WHERE id = ?", "fed-custom-chore").Scan(&choreCount); err != nil {
+		t.Fatalf("count chore: %v", err)
+	}
 	if taskCount != 1 {
 		t.Errorf("task should survive on original branch")
 	}
-	if msgCount != 1 {
-		t.Errorf("message should survive on original branch (filter is non-destructive)")
+	if choreCount != 1 {
+		t.Errorf("chore should survive on original branch (filter is non-destructive)")
 	}
 }
 

--- a/internal/storage/dolt/federation_test.go
+++ b/internal/storage/dolt/federation_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -560,6 +561,50 @@ func TestFilteredPushExcludesWisp(t *testing.T) {
 	}
 	if wispCount != 1 {
 		t.Errorf("ephemeral issue should still exist on original branch, got count=%d", wispCount)
+	}
+}
+
+// TestFilteredPushUsesDedicatedLongTimeoutConnection proves the full staging
+// lifecycle does not borrow the shared pool. RecomputeAllIsBlockedInTx can
+// exceed the pool's 10-second I/O deadline, so branch creation, checkout,
+// deletion, recompute, DOLT_COMMIT, and restoration must all run through one
+// pinned connection from the dedicated long-timeout DB before the push begins.
+func TestFilteredPushUsesDedicatedLongTimeoutConnection(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	// Ensure filtering takes the delete/recompute/DOLT_COMMIT path rather than
+	// skipping it because there was nothing to exclude.
+	if err := store.CreateIssue(ctx, &types.Issue{
+		ID:        "fed-long-timeout-wisp",
+		Title:     "Wisp for long-timeout staging",
+		IssueType: types.TypeTask,
+		Status:    types.StatusOpen,
+		Priority:  1,
+	}, "test"); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, "UPDATE issues SET ephemeral = 1 WHERE id = ?", "fed-long-timeout-wisp"); err != nil {
+		t.Fatalf("mark issue ephemeral: %v", err)
+	}
+	if err := store.Commit(ctx, "seed long-timeout filtered staging"); err != nil && !isDoltNothingToCommit(err) {
+		t.Fatalf("commit filtered staging seed: %v", err)
+	}
+
+	// The previous implementation acquired conn from this pool, so closing it
+	// made the first staging step fail. The staging lifecycle must instead use
+	// openLongTimeoutConn and reach the post-staging peer-credential lookup only
+	// after it has restored the source branch.
+	if err := store.db.Close(); err != nil {
+		t.Fatalf("close shared pool: %v", err)
+	}
+	if err := store.filteredPushToPeer(ctx, "nonexistent-peer", []string{"wisp"}); err == nil {
+		t.Fatal("expected peer credential error with shared pool closed")
+	} else if !strings.Contains(err.Error(), "failed to get peer credentials") {
+		t.Fatalf("staging lifecycle did not complete on dedicated long-timeout connection before peer lookup: %v", err)
 	}
 }
 

--- a/internal/storage/dolt/federation_test.go
+++ b/internal/storage/dolt/federation_test.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/schema"
+	"github.com/steveyegge/beads/internal/storage/versioncontrolops"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -659,6 +661,107 @@ func TestFilteredPushExcludesCustomType(t *testing.T) {
 	}
 	if msgCount != 1 {
 		t.Errorf("message should survive on original branch (filter is non-destructive)")
+	}
+}
+
+// TestFilteredStagingPublishesRetainedWaiterUnblocked proves the staging HEAD
+// derives blocked state from its filtered graph: removing X and W->X must
+// publish retained waiter W with is_blocked=false.
+func TestFilteredStagingPublishesRetainedWaiterUnblocked(t *testing.T) {
+	if os.Getenv("BEADS_TEST_ENV_RUN_DOLT") == "1" && testServerPort == 0 {
+		t.Fatal("BEADS_TEST_ENV_RUN_DOLT=1 but real-Dolt test infrastructure is unavailable")
+	}
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	waiter := &types.Issue{ID: "fed-filter-w", Title: "retained waiter", IssueType: types.TypeBug, Status: types.StatusOpen, Priority: 1}
+	blocker := &types.Issue{ID: "fed-filter-x", Title: "excluded blocker", IssueType: types.TypeTask, Status: types.StatusOpen, Priority: 1, Labels: []string{"private"}}
+	if err := store.CreateIssue(ctx, waiter, "test"); err != nil {
+		t.Fatalf("create waiter: %v", err)
+	}
+	if err := store.CreateIssue(ctx, blocker, "test"); err != nil {
+		t.Fatalf("create blocker: %v", err)
+	}
+	if err := store.AddDependency(ctx, &types.Dependency{IssueID: waiter.ID, DependsOnID: blocker.ID, Type: types.DepBlocks}, "test"); err != nil {
+		t.Fatalf("add blocking dependency: %v", err)
+	}
+	if !isBlocked(ctx, t, store.db, waiter.ID) {
+		t.Fatal("precondition: waiter must be blocked by X")
+	}
+
+	conn, err := store.db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("acquire staging connection: %v", err)
+	}
+	defer conn.Close()
+	var sourceBranch string
+	if err := conn.QueryRowContext(ctx, "SELECT active_branch()").Scan(&sourceBranch); err != nil {
+		t.Fatalf("read source branch: %v", err)
+	}
+	for _, table := range []string{"issues", "dependencies", "labels"} {
+		if err := schema.DrainCall(ctx, conn, "CALL DOLT_ADD(?)", table); err != nil {
+			t.Fatalf("stage seed %s: %v", table, err)
+		}
+	}
+	if err := schema.DrainCall(ctx, conn, "CALL DOLT_COMMIT('--allow-empty', '-m', 'test: filtered staging seed')"); err != nil {
+		t.Fatalf("commit staging seed: %v", err)
+	}
+	var seedBlockerCount int
+	if err := conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM issues AS OF 'HEAD' WHERE id = ?", blocker.ID).Scan(&seedBlockerCount); err != nil {
+		t.Fatalf("count source blocker at HEAD: %v", err)
+	}
+	if seedBlockerCount != 1 {
+		t.Fatalf("source blocker count at HEAD = %d, want 1", seedBlockerCount)
+	}
+	var seedLabelCount int
+	if err := conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM labels AS OF 'HEAD' WHERE issue_id = ?", blocker.ID).Scan(&seedLabelCount); err != nil {
+		t.Fatalf("count source blocker labels at HEAD: %v", err)
+	}
+	if seedLabelCount != 1 {
+		t.Fatalf("source blocker label count at HEAD = %d, want 1", seedLabelCount)
+	}
+	if _, err := conn.ExecContext(ctx, "CALL DOLT_BRANCH(?, ?)", federationStagingBranch, sourceBranch); err != nil {
+		t.Fatalf("create staging branch: %v", err)
+	}
+	defer func() {
+		_ = schema.DrainCall(ctx, conn, "CALL DOLT_CHECKOUT(?)", sourceBranch)
+		_ = schema.DrainCall(ctx, conn, "CALL DOLT_BRANCH('-Df', ?)", federationStagingBranch)
+	}()
+	if err := versioncontrolops.CheckoutBranch(ctx, conn, federationStagingBranch); err != nil {
+		t.Fatalf("checkout staging branch: %v", err)
+	}
+	result, err := conn.ExecContext(ctx, "DELETE FROM issues WHERE issue_type = ?", types.TypeTask)
+	if err != nil {
+		t.Fatalf("delete excluded blocker: %v", err)
+	}
+	if deleted, err := result.RowsAffected(); err != nil || deleted != 1 {
+		t.Fatalf("deleted blockers = %d, err = %v, want 1, nil", deleted, err)
+	}
+	if err := store.commitFilteredStaging(ctx, conn); err != nil {
+		t.Fatalf("commit filtered staging: %v", err)
+	}
+
+	var blocked bool
+	if err := conn.QueryRowContext(ctx, "SELECT is_blocked FROM issues AS OF 'HEAD' WHERE id = ?", waiter.ID).Scan(&blocked); err != nil {
+		t.Fatalf("read retained waiter at staging HEAD: %v", err)
+	}
+	if blocked {
+		t.Fatal("staging HEAD published retained waiter as blocked after excluding its only blocker")
+	}
+	var blockerCount, edgeCount, labelCount int
+	if err := conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM issues AS OF 'HEAD' WHERE id = ?", blocker.ID).Scan(&blockerCount); err != nil {
+		t.Fatalf("count blocker at staging HEAD: %v", err)
+	}
+	if err := conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM dependencies AS OF 'HEAD' WHERE issue_id = ? AND depends_on_issue_id = ?", waiter.ID, blocker.ID).Scan(&edgeCount); err != nil {
+		t.Fatalf("count edge at staging HEAD: %v", err)
+	}
+	if err := conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM labels AS OF 'HEAD' WHERE issue_id = ?", blocker.ID).Scan(&labelCount); err != nil {
+		t.Fatalf("count blocker labels at staging HEAD: %v", err)
+	}
+	if blockerCount != 0 || edgeCount != 0 || labelCount != 0 {
+		t.Fatalf("staging HEAD blocker count = %d, edge count = %d, label count = %d, want 0, 0, 0", blockerCount, edgeCount, labelCount)
 	}
 }
 

--- a/internal/storage/dolt/federation_test.go
+++ b/internal/storage/dolt/federation_test.go
@@ -4,6 +4,8 @@ package dolt
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -565,46 +567,227 @@ func TestFilteredPushExcludesWisp(t *testing.T) {
 }
 
 // TestFilteredPushUsesDedicatedLongTimeoutConnection proves the full staging
-// lifecycle does not borrow the shared pool. RecomputeAllIsBlockedInTx can
-// exceed the pool's 10-second I/O deadline, so branch creation, checkout,
-// deletion, recompute, DOLT_COMMIT, and restoration must all run through one
-// pinned connection from the dedicated long-timeout DB before the push begins.
+// lifecycle does not borrow the shared pool. The pool is deliberately
+// exhausted while a separate connection observes the staging branch's durable
+// state: the blocker is deleted, the retained waiter is recomputed unblocked,
+// and the filtering commit is present before peer lookup waits on the pool.
 func TestFilteredPushUsesDedicatedLongTimeoutConnection(t *testing.T) {
-	store, cleanup := setupTestStore(t)
+	store, cleanup := setupConcurrentTestStore(t)
 	defer cleanup()
-
 	ctx, cancel := testContext(t)
 	defer cancel()
 
-	// Ensure filtering takes the delete/recompute/DOLT_COMMIT path rather than
-	// skipping it because there was nothing to exclude.
-	if err := store.CreateIssue(ctx, &types.Issue{
-		ID:        "fed-long-timeout-wisp",
-		Title:     "Wisp for long-timeout staging",
-		IssueType: types.TypeTask,
-		Status:    types.StatusOpen,
-		Priority:  1,
-	}, "test"); err != nil {
-		t.Fatalf("create issue: %v", err)
+	waiterID, blockerID := seedFilteredPushGraph(t, ctx, store, "fed-long-timeout")
+	observer, err := store.openLongTimeoutConn()
+	if err != nil {
+		t.Fatalf("open staging observer: %v", err)
 	}
-	if _, err := store.db.ExecContext(ctx, "UPDATE issues SET ephemeral = 1 WHERE id = ?", "fed-long-timeout-wisp"); err != nil {
-		t.Fatalf("mark issue ephemeral: %v", err)
-	}
-	if err := store.Commit(ctx, "seed long-timeout filtered staging"); err != nil && !isDoltNothingToCommit(err) {
-		t.Fatalf("commit filtered staging seed: %v", err)
-	}
+	defer observer.Close()
 
-	// The previous implementation acquired conn from this pool, so closing it
-	// made the first staging step fail. The staging lifecycle must instead use
-	// openLongTimeoutConn and reach the post-staging peer-credential lookup only
-	// after it has restored the source branch.
-	if err := store.db.Close(); err != nil {
-		t.Fatalf("close shared pool: %v", err)
+	store.db.SetMaxOpenConns(1)
+	held, err := store.db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("exhaust shared pool: %v", err)
 	}
-	if err := store.filteredPushToPeer(ctx, "nonexistent-peer", []string{"wisp"}); err == nil {
-		t.Fatal("expected peer credential error with shared pool closed")
+	defer held.Close()
+	initialWaitCount := store.db.Stats().WaitCount
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- store.filteredPushToPeer(ctx, "nonexistent-peer", []string{"wisp"})
+	}()
+
+	waitForFilteredStagingCommit(t, ctx, observer, errCh, waiterID, blockerID)
+	waitForPoolWait(t, ctx, store.db, initialWaitCount)
+	if err := held.Close(); err != nil {
+		t.Fatalf("release shared pool: %v", err)
+	}
+	if err := <-errCh; err == nil {
+		t.Fatal("expected peer credential error for nonexistent peer")
 	} else if !strings.Contains(err.Error(), "failed to get peer credentials") {
-		t.Fatalf("staging lifecycle did not complete on dedicated long-timeout connection before peer lookup: %v", err)
+		t.Fatalf("filtered push failed before peer lookup: %v", err)
+	}
+	assertFederationStagingBranchAbsent(t, ctx, observer)
+}
+
+// TestFilteredPushCleanupSurvivesCallerCancellation cancels the caller only
+// after the durable filtered staging commit and the subsequent peer lookup are
+// observable. Cleanup must still restore/delete on its pinned connection. A
+// deliberately invalid restore target also proves its cleanup error is joined
+// without masking the caller's cancellation, while deletion still runs.
+func TestFilteredPushCleanupSurvivesCallerCancellation(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	waiterID, blockerID := seedFilteredPushGraph(t, ctx, store, "fed-cancel-cleanup")
+	observer, err := store.openLongTimeoutConn()
+	if err != nil {
+		t.Fatalf("open staging observer: %v", err)
+	}
+	defer observer.Close()
+
+	store.db.SetMaxOpenConns(1)
+	held, err := store.db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("exhaust shared pool: %v", err)
+	}
+	defer held.Close()
+	initialWaitCount := store.db.Stats().WaitCount
+
+	pushCtx, cancelPush := context.WithCancel(ctx)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- store.filteredPushToPeer(pushCtx, "nonexistent-peer", []string{"wisp"})
+	}()
+
+	waitForFilteredStagingCommit(t, ctx, observer, errCh, waiterID, blockerID)
+	waitForPoolWait(t, ctx, store.db, initialWaitCount)
+	store.branch = "missing-cleanup-branch"
+	cancelPush()
+	err = <-errCh
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("filtered push error = %v, want context canceled", err)
+	}
+	if !strings.Contains(err.Error(), "federation filter: cleanup") ||
+		!strings.Contains(err.Error(), "restore branch missing-cleanup-branch") {
+		t.Fatalf("filtered push error omitted cleanup failure: %v", err)
+	}
+	assertFederationStagingBranchAbsent(t, ctx, observer)
+}
+
+func seedFilteredPushGraph(t *testing.T, ctx context.Context, store *DoltStore, prefix string) (string, string) {
+	t.Helper()
+
+	if err := store.db.QueryRowContext(ctx, "SELECT active_branch()").Scan(&store.branch); err != nil {
+		t.Fatalf("align store source branch: %v", err)
+	}
+	versionWispTablesForFilteredPush(t, ctx, store)
+	waiterID := prefix + "-waiter"
+	blockerID := prefix + "-blocker"
+	if err := store.CreateIssue(ctx, &types.Issue{
+		ID: waiterID, Title: "retained waiter", IssueType: types.TypeBug,
+		Status: types.StatusOpen, Priority: 1,
+	}, "test"); err != nil {
+		t.Fatalf("create waiter: %v", err)
+	}
+	if err := store.CreateIssue(ctx, &types.Issue{
+		ID: blockerID, Title: "excluded blocker", IssueType: types.TypeTask,
+		Status: types.StatusOpen, Priority: 1,
+	}, "test"); err != nil {
+		t.Fatalf("create blocker: %v", err)
+	}
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID: waiterID, DependsOnID: blockerID, Type: types.DepBlocks,
+	}, "test"); err != nil {
+		t.Fatalf("add blocking dependency: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, "UPDATE issues SET ephemeral = 1 WHERE id = ?", blockerID); err != nil {
+		t.Fatalf("mark blocker ephemeral: %v", err)
+	}
+	if err := store.Commit(ctx, "seed filtered staging graph"); err != nil && !isDoltNothingToCommit(err) {
+		t.Fatalf("commit filtered staging graph: %v", err)
+	}
+	if !isBlocked(ctx, t, store.db, waiterID) {
+		t.Fatal("precondition: retained waiter must be blocked on source branch")
+	}
+	return waiterID, blockerID
+}
+
+// versionWispTablesForFilteredPush makes the empty clone-local wisp plane
+// visible to fresh sessions in this fixture. Production databases retain
+// their dolt_ignore'd working set, but setupConcurrentTestStore deliberately
+// closes idle sessions; without this fixture commit a newly opened staging
+// connection sees no wisps table and cannot exercise the recompute seam.
+func versionWispTablesForFilteredPush(t *testing.T, ctx context.Context, store *DoltStore) {
+	t.Helper()
+	db, err := store.openLongTimeoutConn()
+	if err != nil {
+		t.Fatalf("open wisp fixture database: %v", err)
+	}
+	defer db.Close()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("pin wisp fixture connection: %v", err)
+	}
+	defer conn.Close()
+	if err := versioncontrolops.CheckoutBranch(ctx, conn, store.branch); err != nil {
+		t.Fatalf("checkout source branch for wisp fixture: %v", err)
+	}
+	if _, err := schema.MigrateUp(ctx, conn); err != nil {
+		t.Fatalf("materialize ignored schema for wisp fixture: %v", err)
+	}
+	if _, err := conn.ExecContext(ctx,
+		"DELETE FROM dolt_ignore WHERE pattern IN ('wisps', 'wisp_%')"); err != nil {
+		t.Fatalf("make wisp fixture tables versionable: %v", err)
+	}
+	if err := schema.DrainCall(ctx, conn, "CALL DOLT_ADD('-A')"); err != nil {
+		t.Fatalf("stage wisp fixture tables: %v", err)
+	}
+	if err := schema.DrainCall(ctx, conn,
+		"CALL DOLT_COMMIT('-m', 'test: version empty wisp plane for filtered push')"); err != nil {
+		t.Fatalf("commit wisp fixture tables: %v", err)
+	}
+}
+
+func waitForFilteredStagingCommit(t *testing.T, ctx context.Context, observer *sql.DB, errCh <-chan error, waiterID, blockerID string) {
+	t.Helper()
+	deadline := time.Now().Add(15 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		select {
+		case err := <-errCh:
+			t.Fatalf("filtered push returned before publishing staging commit: %v", err)
+		default:
+		}
+		var blockerCount, commitCount int
+		var blocked bool
+		blockerErr := observer.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM issues AS OF '__federation_push_staging' WHERE id = ?", blockerID,
+		).Scan(&blockerCount)
+		blockedErr := observer.QueryRowContext(ctx,
+			"SELECT is_blocked FROM issues AS OF '__federation_push_staging' WHERE id = ?", waiterID,
+		).Scan(&blocked)
+		commitErr := observer.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM dolt_log('__federation_push_staging') WHERE message = ?",
+			"federation: exclude private issue types",
+		).Scan(&commitCount)
+		lastErr = errors.Join(blockerErr, blockedErr, commitErr)
+		if lastErr == nil && blockerCount == 0 && !blocked && commitCount == 1 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("filtered staging commit was not durably observable: %v", lastErr)
+}
+
+func waitForPoolWait(t *testing.T, ctx context.Context, db *sql.DB, initialWaitCount int64) {
+	t.Helper()
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		if db.Stats().WaitCount > initialWaitCount {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("waiting for peer lookup to block on shared pool: %v", ctx.Err())
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	t.Fatal("peer lookup did not block on the exhausted shared pool")
+}
+
+func assertFederationStagingBranchAbsent(t *testing.T, ctx context.Context, db *sql.DB) {
+	t.Helper()
+	var count int
+	if err := db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM dolt_branches WHERE name = ?", federationStagingBranch,
+	).Scan(&count); err != nil {
+		t.Fatalf("query federation staging branch: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("federation staging branch count = %d, want 0", count)
 	}
 }
 

--- a/internal/storage/dolt/federation_test.go
+++ b/internal/storage/dolt/federation_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/storage/schema"
 	"github.com/steveyegge/beads/internal/storage/versioncontrolops"
 	"github.com/steveyegge/beads/internal/types"
@@ -543,8 +545,8 @@ func TestFilteredPushExcludesWisp(t *testing.T) {
 		t.Fatalf("list branches: %v", err)
 	}
 	for _, b := range branches {
-		if b == federationStagingBranch {
-			t.Errorf("staging branch %s was not cleaned up", federationStagingBranch)
+		if strings.HasPrefix(b, federationStagingBranchPrefix) {
+			t.Errorf("staging branch %s was not cleaned up", b)
 		}
 	}
 
@@ -608,6 +610,64 @@ func TestFilteredPushUsesDedicatedLongTimeoutConnection(t *testing.T) {
 		t.Fatalf("filtered push failed before peer lookup: %v", err)
 	}
 	assertFederationStagingBranchAbsent(t, ctx, observer)
+}
+
+// TestFilteredPushConcurrentOperationsUseDistinctStagingBranches proves two
+// overlapping product calls cannot delete or replace each other's staging
+// branch. Both calls finish staging and block on the exhausted shared pool
+// before their branch names are observed.
+func TestFilteredPushConcurrentOperationsUseDistinctStagingBranches(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	seedFilteredPushGraph(t, ctx, store, "fed-concurrent-staging")
+	observer, err := store.openLongTimeoutConn()
+	if err != nil {
+		t.Fatalf("open staging observer: %v", err)
+	}
+	defer observer.Close()
+
+	store.db.SetMaxOpenConns(1)
+	held, err := store.db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("exhaust shared pool: %v", err)
+	}
+	defer held.Close()
+	initialWaitCount := store.db.Stats().WaitCount
+
+	firstCtx, cancelFirst := context.WithCancel(ctx)
+	defer cancelFirst()
+	secondCtx, cancelSecond := context.WithCancel(ctx)
+	defer cancelSecond()
+	errCh := make(chan error, 2)
+	go func() {
+		errCh <- store.filteredPushToPeer(firstCtx, "nonexistent-peer", []string{"wisp"})
+	}()
+	waitForPoolWait(t, ctx, store.db, initialWaitCount)
+	go func() {
+		errCh <- store.filteredPushToPeer(secondCtx, "nonexistent-peer", []string{"wisp"})
+	}()
+	waitForPoolWait(t, ctx, store.db, initialWaitCount+1)
+
+	stagingBranches := listFederationStagingBranches(t, ctx, observer)
+	cancelFirst()
+	cancelSecond()
+	for range 2 {
+		select {
+		case err := <-errCh:
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("overlapping filtered push error = %v, want context canceled", err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("overlapping filtered push did not return after cancellation")
+		}
+	}
+	assertFederationStagingBranchAbsent(t, ctx, observer)
+	if len(stagingBranches) != 2 {
+		t.Fatalf("overlapping filtered pushes exposed staging branches %v, want 2 distinct branches", stagingBranches)
+	}
 }
 
 // TestFilteredPushCleanupSurvivesCallerCancellation cancels the caller while
@@ -907,18 +967,28 @@ func waitForFilteredStagingCommit(t *testing.T, ctx context.Context, observer *s
 			t.Fatalf("filtered push returned before publishing staging commit: %v", err)
 		default:
 		}
+		branches := listFederationStagingBranches(t, ctx, observer)
+		if len(branches) != 1 {
+			lastErr = fmt.Errorf("found staging branches %v, want exactly one", branches)
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		stagingBranch := branches[0]
+		if err := issueops.ValidateRef(stagingBranch); err != nil {
+			t.Fatalf("generated staging branch %q is invalid: %v", stagingBranch, err)
+		}
+		//nolint:gosec // stagingBranch is generated internally and validated as a Dolt ref above.
+		blockerQuery := fmt.Sprintf("SELECT COUNT(*) FROM issues AS OF '%s' WHERE id = ?", stagingBranch)
+		//nolint:gosec // stagingBranch is generated internally and validated as a Dolt ref above.
+		blockedQuery := fmt.Sprintf("SELECT is_blocked FROM issues AS OF '%s' WHERE id = ?", stagingBranch)
+		//nolint:gosec // stagingBranch is generated internally and validated as a Dolt ref above.
+		commitQuery := fmt.Sprintf("SELECT COUNT(*) FROM dolt_log('%s') WHERE message = ?", stagingBranch)
 		var blockerCount, commitCount int
 		var blocked bool
-		blockerErr := observer.QueryRowContext(ctx,
-			"SELECT COUNT(*) FROM issues AS OF '__federation_push_staging' WHERE id = ?", blockerID,
-		).Scan(&blockerCount)
-		blockedErr := observer.QueryRowContext(ctx,
-			"SELECT is_blocked FROM issues AS OF '__federation_push_staging' WHERE id = ?", waiterID,
-		).Scan(&blocked)
-		commitErr := observer.QueryRowContext(ctx,
-			"SELECT COUNT(*) FROM dolt_log('__federation_push_staging') WHERE message = ?",
-			"federation: exclude private issue types",
-		).Scan(&commitCount)
+		blockerErr := observer.QueryRowContext(ctx, blockerQuery, blockerID).Scan(&blockerCount)
+		blockedErr := observer.QueryRowContext(ctx, blockedQuery, waiterID).Scan(&blocked)
+		commitErr := observer.QueryRowContext(ctx, commitQuery,
+			"federation: exclude private issue types").Scan(&commitCount)
 		lastErr = errors.Join(blockerErr, blockedErr, commitErr)
 		if lastErr == nil && blockerCount == 0 && !blocked && commitCount == 1 {
 			return
@@ -946,15 +1016,33 @@ func waitForPoolWait(t *testing.T, ctx context.Context, db *sql.DB, initialWaitC
 
 func assertFederationStagingBranchAbsent(t *testing.T, ctx context.Context, db *sql.DB) {
 	t.Helper()
-	var count int
-	if err := db.QueryRowContext(ctx,
-		"SELECT COUNT(*) FROM dolt_branches WHERE name = ?", federationStagingBranch,
-	).Scan(&count); err != nil {
-		t.Fatalf("query federation staging branch: %v", err)
+	if branches := listFederationStagingBranches(t, ctx, db); len(branches) != 0 {
+		t.Fatalf("federation staging branches = %v, want none", branches)
 	}
-	if count != 0 {
-		t.Fatalf("federation staging branch count = %d, want 0", count)
+}
+
+func listFederationStagingBranches(t *testing.T, ctx context.Context, db *sql.DB) []string {
+	t.Helper()
+	rows, err := db.QueryContext(ctx, `
+		SELECT name FROM dolt_branches
+		WHERE LEFT(name, ?) = ?
+		ORDER BY name`, len(federationStagingBranchPrefix), federationStagingBranchPrefix)
+	if err != nil {
+		t.Fatalf("query federation staging branches: %v", err)
 	}
+	defer rows.Close()
+	var branches []string
+	for rows.Next() {
+		var branch string
+		if err := rows.Scan(&branch); err != nil {
+			t.Fatalf("scan federation staging branch: %v", err)
+		}
+		branches = append(branches, branch)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate federation staging branches: %v", err)
+	}
+	return branches
 }
 
 // TestFilteredPushOptOut verifies that setting federation.exclude_types to
@@ -994,7 +1082,7 @@ func TestFilteredPushOptOut(t *testing.T) {
 		t.Fatalf("list branches: %v", err)
 	}
 	for _, b := range branches {
-		if b == federationStagingBranch {
+		if strings.HasPrefix(b, federationStagingBranchPrefix) {
 			t.Errorf("staging branch should not exist when exclude_types is empty")
 		}
 	}
@@ -1116,14 +1204,15 @@ func TestFilteredStagingPublishesRetainedWaiterUnblocked(t *testing.T) {
 	if seedLabelCount != 1 {
 		t.Fatalf("source blocker label count at HEAD = %d, want 1", seedLabelCount)
 	}
-	if _, err := conn.ExecContext(ctx, "CALL DOLT_BRANCH(?, ?)", federationStagingBranch, sourceBranch); err != nil {
+	stagingBranch := federationStagingBranchPrefix + "recompute-test"
+	if _, err := conn.ExecContext(ctx, "CALL DOLT_BRANCH(?, ?)", stagingBranch, sourceBranch); err != nil {
 		t.Fatalf("create staging branch: %v", err)
 	}
 	defer func() {
 		_ = schema.DrainCall(ctx, conn, "CALL DOLT_CHECKOUT(?)", sourceBranch)
-		_ = schema.DrainCall(ctx, conn, "CALL DOLT_BRANCH('-Df', ?)", federationStagingBranch)
+		_ = schema.DrainCall(ctx, conn, "CALL DOLT_BRANCH('-Df', ?)", stagingBranch)
 	}()
-	if err := versioncontrolops.CheckoutBranch(ctx, conn, federationStagingBranch); err != nil {
+	if err := versioncontrolops.CheckoutBranch(ctx, conn, stagingBranch); err != nil {
 		t.Fatalf("checkout staging branch: %v", err)
 	}
 	result, err := conn.ExecContext(ctx, "DELETE FROM issues WHERE issue_type = ?", types.TypeTask)
@@ -1177,8 +1266,8 @@ func TestFilteredPushStagingBranchCleanupOnError(t *testing.T) {
 		t.Fatalf("list branches: %v", err)
 	}
 	for _, b := range branches {
-		if b == federationStagingBranch {
-			t.Errorf("staging branch %s should be cleaned up after push error", federationStagingBranch)
+		if strings.HasPrefix(b, federationStagingBranchPrefix) {
+			t.Errorf("staging branch %s should be cleaned up after push error", b)
 		}
 	}
 }

--- a/internal/storage/dolt/federation_test.go
+++ b/internal/storage/dolt/federation_test.go
@@ -1153,10 +1153,11 @@ func TestFilteredStagingPublishesRetainedWaiterUnblocked(t *testing.T) {
 	if os.Getenv("BEADS_TEST_ENV_RUN_DOLT") == "1" && testServerPort == 0 {
 		t.Fatal("BEADS_TEST_ENV_RUN_DOLT=1 but real-Dolt test infrastructure is unavailable")
 	}
-	store, cleanup := setupTestStore(t)
+	store, cleanup := setupConcurrentTestStore(t)
 	defer cleanup()
 	ctx, cancel := testContext(t)
 	defer cancel()
+	versionWispTablesForFilteredPush(t, ctx, store)
 
 	waiter := &types.Issue{ID: "fed-filter-w", Title: "retained waiter", IssueType: types.TypeBug, Status: types.StatusOpen, Priority: 1}
 	blocker := &types.Issue{ID: "fed-filter-x", Title: "excluded blocker", IssueType: types.TypeTask, Status: types.StatusOpen, Priority: 1, Labels: []string{"private"}}


### PR DESCRIPTION
## What

Make filtered federation pushes publish a correct, isolated staging snapshot:

- recompute retained `is_blocked` state after excluded rows and edges are removed;
- keep staging work on a dedicated branch-pinned connection with a unique branch per operation;
- arm cleanup before branch creation can ambiguously succeed;
- restore and delete staging branches through a fresh bounded connection after cancellation or response loss;
- prove retained/excluded staging contents, source preservation, and prefix-wide cleanup under concurrency.

## Why

Filtered pushes could remove an issue that was the sole blocker of a retained issue, then publish the retained row with stale derived `is_blocked` state. Shared staging names and cancellation-sensitive cleanup also allowed concurrent operations or lost responses to leak or collide with staging branches.

This change keeps filtering and derived-state recomputation on the same pinned staging branch and makes cleanup conservative across cancellation and ambiguous branch-creation responses.

## Risk and review

This changes a protected Dolt sync/federation path. It requires substantive human storage/sync review before merge and must not be auto-merged.

The separate pre-existing bug where exclusion `DELETE`/`RowsAffected` errors are swallowed is intentionally not bundled here; it remains tracked as `ga-f7v2ft.79.1.1`.

## Verification

- Focused real-Dolt federation suite: pass.
- Real-Dolt race, concurrency, cancellation, response-loss, restore-failure, and staging-prefix cleanup cohorts: pass.
- Exact final-SHA `make test`: pass, 39.0% total coverage.
- `go vet ./...`: pass.
- Go 1.26.5 `golangci-lint run ./...`: 0 issues.
- `git diff --check origin/main...HEAD`: pass.
- Two independent final-SHA Sol reviews: 0 Blockers / 0 Majors each.
- PR preflight and broader open-PR search found no competing contributor PR.

Tracking context: `ga-f7v2ft.79.1.6`.

_codex-unknown-model-unknown-reasoning on behalf of CI Bot_
