### PR TITLE
Fix: wisp delete never cascades to auxiliary tables (orphan row leak)

### DIFF
--- a/internal/storage/dolt/wisp_delete_cascade_integration_test.go
+++ b/internal/storage/dolt/wisp_delete_cascade_integration_test.go
@@ -1,0 +1,209 @@
+//go:build integration && !windows
+
+package dolt
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/doltserver"
+	"github.com/steveyegge/beads/internal/testutil/integration"
+)
+
+// setupWispCascadeStore starts a real, standalone dolt sql-server (no Docker)
+// via doltserver.Start and returns a store on a fresh, fully
+// schema-initialized database. This mirrors TestFreshBootstrapHealIncarnation's
+// setup rather than the package's default setupTestStore (dolt_test.go),
+// which requires a Docker-testcontainer Dolt server that this sandbox does
+// not have available.
+func setupWispCascadeStore(t *testing.T) *DoltStore {
+	t.Helper()
+	integration.RequireDolt(t)
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "0")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_PORT", "")
+
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
+		t.Fatalf("mkdir beads dir: %v", err)
+	}
+	state, err := doltserver.Start(beadsDir)
+	if err != nil {
+		t.Fatalf("start local dolt server: %v", err)
+	}
+	t.Cleanup(func() {
+		current, stateErr := doltserver.IsRunning(beadsDir)
+		if stateErr != nil || current == nil || !current.Running {
+			return
+		}
+		if err := doltserver.Stop(beadsDir); err != nil {
+			t.Errorf("stop local dolt server: %v", err)
+		}
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	cfg := &Config{
+		Path:            filepath.Join(beadsDir, "store"),
+		BeadsDir:        beadsDir,
+		ServerHost:      "127.0.0.1",
+		ServerPort:      state.Port,
+		ServerUser:      "root",
+		Database:        "wisp_cascade_test",
+		CreateIfMissing: true,
+		MaxOpenConns:    1,
+		CommitterName:   "Beads Test",
+		CommitterEmail:  "beads@example.com",
+	}
+	store, err := New(ctx, cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	if err := store.SetConfig(ctx, "issue_prefix", "test"); err != nil {
+		t.Fatalf("SetConfig(issue_prefix): %v", err)
+	}
+
+	// A freshly bootstrapped store picks up FK constraints on the four wisp
+	// aux tables via cli_migrations.go, but the live production store (hq)
+	// this bug was filed against does not: the migration that would add them
+	// (migrations/ignored/0004_add_wisp_aux_fks.up.sql) was never promoted
+	// into the applied migrations/ track. That gap is exactly what produced
+	// the 3.03M orphan rows in the bug report. Drop the constraints here so
+	// this test exercises deleteWisp/deleteWispBatchTx's own cascade
+	// responsibility instead of passing only because a fresh store's FK
+	// happens to do the cleanup for it.
+	dropWispAuxFKs(t, ctx, store.db)
+
+	return store
+}
+
+// dropWispAuxFKs removes the wisp auxiliary-table FK constraints so the test
+// store's schema matches the live hq store. See setupWispCascadeStore.
+func dropWispAuxFKs(t *testing.T, ctx context.Context, db *sql.DB) {
+	t.Helper()
+	for _, stmt := range []string{
+		"ALTER TABLE wisp_labels DROP FOREIGN KEY fk_wisp_labels_issue",
+		"ALTER TABLE wisp_events DROP FOREIGN KEY fk_wisp_events_issue",
+		"ALTER TABLE wisp_comments DROP FOREIGN KEY fk_wisp_comments_issue",
+		"ALTER TABLE wisp_child_counters DROP FOREIGN KEY fk_wisp_child_counters_parent",
+	} {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			t.Fatalf("drop wisp aux FK (%s): %v", stmt, err)
+		}
+	}
+}
+
+// wispAuxTables lists the four wisp auxiliary tables a wisp delete must
+// cascade into. This mirrors issueops.DeleteCascadeTables(true), which
+// already documents this exact set as belonging to a wisp delete — separate
+// from wisps itself and the wisp_dependencies/dependencies pair, which have
+// their own regression coverage in TestDeleteWispBatch_CleansUpDependencies.
+var wispAuxTables = []struct{ table, column string }{
+	{"wisp_labels", "issue_id"},
+	{"wisp_events", "issue_id"},
+	{"wisp_comments", "issue_id"},
+	{"wisp_child_counters", "parent_id"},
+}
+
+// seedWispAuxRows inserts one row into each wisp auxiliary table, keyed to
+// id. wisp_child_counters is keyed on parent_id, simulating that this wisp
+// was itself a parent whose children were assigned sequential IDs.
+func seedWispAuxRows(t *testing.T, ctx context.Context, db *sql.DB, id string) {
+	t.Helper()
+	if _, err := db.ExecContext(ctx,
+		"INSERT INTO wisp_labels (issue_id, label) VALUES (?, ?)", id, "aux-test-label"); err != nil {
+		t.Fatalf("seed wisp_labels: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		"INSERT INTO wisp_events (id, issue_id, event_type, actor) VALUES (UUID(), ?, ?, ?)",
+		id, "test_event", "test"); err != nil {
+		t.Fatalf("seed wisp_events: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		"INSERT INTO wisp_comments (id, issue_id, author, text) VALUES (UUID(), ?, ?, ?)",
+		id, "test", "aux test comment"); err != nil {
+		t.Fatalf("seed wisp_comments: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		"INSERT INTO wisp_child_counters (parent_id, last_child) VALUES (?, ?)", id, 3); err != nil {
+		t.Fatalf("seed wisp_child_counters: %v", err)
+	}
+}
+
+// assertWispAuxRowsGone fails the test if any row remains in the four wisp
+// auxiliary tables for id.
+func assertWispAuxRowsGone(t *testing.T, ctx context.Context, db *sql.DB, id string) {
+	t.Helper()
+	for _, tc := range wispAuxTables {
+		var count int
+		//nolint:gosec // G201: tc.table/tc.column come from the fixed wispAuxTables literal, not input.
+		q := fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE %s = ?", tc.table, tc.column)
+		if err := db.QueryRowContext(ctx, q, id).Scan(&count); err != nil {
+			t.Fatalf("count %s: %v", tc.table, err)
+		}
+		if count != 0 {
+			t.Errorf("expected 0 rows in %s for %s after delete, got %d", tc.table, id, count)
+		}
+	}
+}
+
+// TestWispDeleteCascade_CleansUpAuxiliaryTables is the regression test for
+// be-zdqyl: deleteWisp and deleteWispBatchTx only ever removed rows from the
+// wisps table itself (plus an explicit wisp_dependencies cleanup), leaving
+// orphaned rows behind in wisp_labels, wisp_events, wisp_comments, and
+// wisp_child_counters — exactly the table set issueops.DeleteCascadeTables
+// (true) already documents a wisp delete as owning. Covers both the
+// single-delete path (deleteWisp) and the batch path (deleteWispBatch, which
+// chunks through deleteWispBatchTx).
+func TestWispDeleteCascade_CleansUpAuxiliaryTables(t *testing.T) {
+	store := setupWispCascadeStore(t)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	t.Run("single delete", func(t *testing.T) {
+		wisp := createTestWisp(t, ctx, store, "single-delete wisp")
+		t.Logf("DEBUG wisp.ID = %q", wisp.ID)
+		seedWispAuxRows(t, ctx, store.db, wisp.ID)
+
+		for _, tc := range wispAuxTables {
+			var count int
+			q := fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE %s = ?", tc.table, tc.column)
+			if err := store.db.QueryRowContext(ctx, q, wisp.ID).Scan(&count); err != nil {
+				t.Fatalf("pre-delete count %s: %v", tc.table, err)
+			}
+			t.Logf("DEBUG pre-delete %s count = %d", tc.table, count)
+		}
+
+		if err := store.deleteWisp(ctx, wisp.ID); err != nil {
+			t.Fatalf("deleteWisp: %v", err)
+		}
+
+		assertWispAuxRowsGone(t, ctx, store.db, wisp.ID)
+	})
+
+	t.Run("batch delete", func(t *testing.T) {
+		wispA := createTestWisp(t, ctx, store, "batch-delete wisp A")
+		wispB := createTestWisp(t, ctx, store, "batch-delete wisp B")
+		seedWispAuxRows(t, ctx, store.db, wispA.ID)
+		seedWispAuxRows(t, ctx, store.db, wispB.ID)
+
+		deleted, err := store.deleteWispBatch(ctx, []string{wispA.ID, wispB.ID})
+		if err != nil {
+			t.Fatalf("deleteWispBatch: %v", err)
+		}
+		if deleted != 2 {
+			t.Fatalf("expected 2 deleted, got %d", deleted)
+		}
+
+		assertWispAuxRowsGone(t, ctx, store.db, wispA.ID)
+		assertWispAuxRowsGone(t, ctx, store.db, wispB.ID)
+	})
+}

--- a/internal/storage/dolt/wisp_delete_cascade_integration_test.go
+++ b/internal/storage/dolt/wisp_delete_cascade_integration_test.go
@@ -207,3 +207,50 @@ func TestWispDeleteCascade_CleansUpAuxiliaryTables(t *testing.T) {
 		assertWispAuxRowsGone(t, ctx, store.db, wispB.ID)
 	})
 }
+
+// assertWispAuxTablesTotalZero fails the test if any row remains anywhere in
+// the four wisp auxiliary tables — a store-wide total, not scoped to a single
+// id. Used by TestWispDeleteCascade_RepeatedCyclesLeaveNoOrphans, where the
+// property under test is that orphan counts across the whole store stay at 0
+// cycle over cycle, not just that a single known id's rows are gone.
+func assertWispAuxTablesTotalZero(t *testing.T, ctx context.Context, db *sql.DB, cycle int) {
+	t.Helper()
+	for _, tc := range wispAuxTables {
+		var count int
+		//nolint:gosec // G201: tc.table comes from the fixed wispAuxTables literal, not input.
+		q := fmt.Sprintf("SELECT COUNT(*) FROM %s", tc.table)
+		if err := db.QueryRowContext(ctx, q).Scan(&count); err != nil {
+			t.Fatalf("cycle %d: count %s: %v", cycle, tc.table, err)
+		}
+		if count != 0 {
+			t.Errorf("cycle %d: expected 0 total rows in %s, got %d", cycle, tc.table, count)
+		}
+	}
+}
+
+// TestWispDeleteCascade_RepeatedCyclesLeaveNoOrphans is the round-2 regression
+// test for be-wnuyt's uncovered acceptance criterion: "orphan counts on a
+// fresh store stay at 0 after a reap cycle." TestWispDeleteCascade_CleansUpAuxiliaryTables
+// only ever takes a single before/after snapshot scoped to one wisp id; it
+// cannot catch a bug that only shows up across repeated create/delete
+// cycles (e.g. delete scoping that leaves a previous cycle's rows behind
+// once several wisps have passed through the table). This test runs several
+// create-seed-delete cycles and asserts the aux tables' store-wide totals —
+// not per-id existence — are 0 after every single cycle.
+func TestWispDeleteCascade_RepeatedCyclesLeaveNoOrphans(t *testing.T) {
+	store := setupWispCascadeStore(t)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	const cycles = 5
+	for i := 0; i < cycles; i++ {
+		wisp := createTestWisp(t, ctx, store, fmt.Sprintf("repeat-cycle wisp %d", i))
+		seedWispAuxRows(t, ctx, store.db, wisp.ID)
+
+		if err := store.deleteWisp(ctx, wisp.ID); err != nil {
+			t.Fatalf("cycle %d: deleteWisp: %v", i, err)
+		}
+
+		assertWispAuxTablesTotalZero(t, ctx, store.db, i)
+	}
+}

--- a/internal/storage/dolt/wisps.go
+++ b/internal/storage/dolt/wisps.go
@@ -282,6 +282,40 @@ func (s *DoltStore) closeWispChecked(ctx context.Context, id string, actor strin
 	return storage.CloseIssueResult{Unchanged: res.AlreadyClosed, OpenChildren: res.OpenChildren}, nil
 }
 
+// wispAuxCascadeTables lists the wisp auxiliary tables a wisp delete must
+// also clean up, mirroring internal/storage/schema/cli_migrations.go:300-315.
+// wisp_child_counters is keyed on parent_id (a wisp can be a parent whose
+// children hold the counter row); the other three are keyed on issue_id.
+// Some deployed stores enforce this via FK ON DELETE CASCADE and some do not
+// (be-zdqyl: the migration adding those FKs was never promoted out of
+// migrations/ignored/), so the delete paths below must not rely on the
+// database to do it for them.
+var wispAuxCascadeTables = []struct{ table, column string }{
+	{"wisp_labels", "issue_id"},
+	{"wisp_events", "issue_id"},
+	{"wisp_comments", "issue_id"},
+	{"wisp_child_counters", "parent_id"},
+}
+
+// deleteWispAuxRowsInTx removes every row the given wisp ids own across
+// wispAuxCascadeTables. Shared by deleteWisp and deleteWispBatchTx so the
+// table set cannot drift between the two paths.
+func deleteWispAuxRowsInTx(ctx context.Context, tx *sql.Tx, ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	inClause, args := doltBuildSQLInClause(ids)
+	for _, aux := range wispAuxCascadeTables {
+		//nolint:gosec // G201: aux.table/aux.column come from the fixed wispAuxCascadeTables literal; inClause contains only ? markers
+		if _, err := tx.ExecContext(ctx,
+			fmt.Sprintf("DELETE FROM %s WHERE %s IN (%s)", aux.table, aux.column, inClause),
+			args...); err != nil {
+			return fmt.Errorf("delete wisp aux rows from %s: %w", aux.table, err)
+		}
+	}
+	return nil
+}
+
 // deleteWisp permanently removes a wisp and its related data.
 func (s *DoltStore) deleteWisp(ctx context.Context, id string) error {
 	tx, err := s.db.BeginTx(ctx, nil)
@@ -310,6 +344,10 @@ func (s *DoltStore) deleteWisp(ctx context.Context, id string) error {
 
 	if err := issueops.DeleteWispFromDependenciesInTx(ctx, tx, id); err != nil {
 		return err
+	}
+
+	if err := deleteWispAuxRowsInTx(ctx, tx, []string{id}); err != nil {
+		return fmt.Errorf("delete wisp aux rows for %s: %w", id, err)
 	}
 
 	if err := issueops.RecomputeIsBlockedInTx(ctx, tx, affectedIssues, affectedWisps); err != nil {
@@ -381,6 +419,10 @@ func (s *DoltStore) deleteWispBatchTx(ctx context.Context, ids []string) (int, e
 
 	if err := issueops.DeleteWispsFromDependenciesInTx(ctx, tx, ids); err != nil {
 		return 0, err
+	}
+
+	if err := deleteWispAuxRowsInTx(ctx, tx, ids); err != nil {
+		return 0, fmt.Errorf("delete wisp aux rows: %w", err)
 	}
 
 	if err := issueops.RecomputeIsBlockedInTx(ctx, tx, affectedIssues, affectedWisps); err != nil {

--- a/release-gates/be-1gd16-wisp-delete-cascade-gate.md
+++ b/release-gates/be-1gd16-wisp-delete-cascade-gate.md
@@ -1,0 +1,120 @@
+# Release gate — wisp delete cascade to auxiliary tables (be-1gd16)
+
+- **Original bead (CLOSED):** be-zdqyl — Fix: wisp delete never cascades to
+  `wisp_labels`/`wisp_events` — 3.03M orphan rows on the city store
+- **Round-2 build bead (CLOSED):** be-wnuyt — added repeated-cycle test
+  coverage requested by round-1 review
+- **Review bead (CLOSED):** be-u4s3y — Verdict **PASS** (round 2, responding
+  to round-1 request-changes) on commit `fe76a21ea5c375c6a5790aa501f214a4e5d33b63`
+- **Deploy bead:** be-1gd16
+- **Commit shipped:** `fe76a21ea5c375c6a5790aa501f214a4e5d33b63` (deploy
+  source SHA recorded in be-1gd16), 3 commits over `origin/main` @
+  `d801ec43dc9b46ffc960eb2793933bbe725ddde4` (2 files, +298), merge-base
+  is `origin/main`'s exact current tip
+- **Source branch:** `builder/be-zdqyl` (provenance only, not a push target)
+- **Deploy branch:** `deploy/be-1gd16-gate`, cut from the commit above
+- **Evaluated:** 2026-08-04 by beads/deployer
+
+## Scope
+
+Fixes a data-integrity bug in `internal/storage/dolt/wisps.go`: both wisp
+delete paths (`deleteWisp`, `deleteWispBatchTx`) deleted the `wisps` row and
+its dependency edges but never the wisp's rows in the four auxiliary tables
+(`wisp_labels`, `wisp_events`, `wisp_comments`, `wisp_child_counters`),
+leaking ~3.03M orphan rows on the live `hq` city store (91.7% of
+`wisp_labels`, 89.2% of `wisp_events`). Some stores enforce this via FK `ON
+DELETE CASCADE` and some do not, so the delete paths cannot rely on the
+database to do it for them.
+
+Fix: a new shared helper `deleteWispAuxRowsInTx`, called from both delete
+paths inside their existing transaction, deletes matching rows from all four
+tables (three keyed on `issue_id`, `wisp_child_counters` keyed on
+`parent_id`). Table/column identifiers are a fixed literal slice, not user
+input; row-scoping ids go through the existing parameterized `?`
+placeholder helper — same `//nolint:gosec // G201` pattern already used
+elsewhere in this file.
+
+**Explicitly out of scope (documented in be-zdqyl, not a gate concern):**
+backfilling the existing 3.03M orphan rows on the live `hq` store — that is
+a live-prod data operation belonging to mayor/operator authority, to be
+filed separately. This bead is the code fix that stops the leak from
+growing further.
+
+## Gate criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Review PASS present | **PASS** | be-u4s3y recorded `verdict: pass` (round 2, 2026-08-04T23:25Z), responding to round-1's (be-wnuyt's predecessor review) request-changes. Single-pass (Claude); gemini second-pass currently disabled. |
+| 2 | Acceptance criteria met | **PASS** | Independently re-checked all 3 be-zdqyl done-when items against the diff myself (not just the reviewer's restatement) — see "Acceptance" below. |
+| 3 | Tests pass | **PASS** | See "Tests run on release branch" below — re-run independently by the deployer, not just trusted from the review. |
+| 4 | No high-severity review findings open | **PASS** | Zero HIGH findings. be-u4s3y's style_findings and security_findings both conclude "no blockers or majors, PASS." Independently spot-checked `gofmt -l`, `go vet`, `go build` myself — all clean. |
+| 5 | Final branch is clean | **PASS** | `git status` on `deploy/be-1gd16-gate` shows "nothing to commit, working tree clean." |
+| 6 | Branch diverges cleanly from main | **PASS** | `git merge-base fe76a21ea5c375c6a5790aa501f214a4e5d33b63 origin/main` = `d801ec43dc9b46ffc960eb2793933bbe725ddde4`, which is `origin/main`'s exact current HEAD — the reviewed commit is a direct 3-commit fast-forward descendant of current `origin/main`. Zero conflict risk; no self-rebase needed. |
+| 7 | Single feature theme | **PASS** | Diff touches exactly 2 files, both in `internal/storage/dolt/` (`wisps.go` + its integration test) — one subsystem, one bug, purely additive (+298/-0). |
+
+## Acceptance (per be-zdqyl done-when, independently re-verified against the diff)
+
+| Criterion | Status | Evidence |
+|---|---|---|
+| Both delete paths remove rows from all four wisp side-tables in-transaction | ✓ | `deleteWispAuxRowsInTx` called from both `deleteWisp` (wisps.go:349) and `deleteWispBatchTx` (wisps.go:424), inside the same `*sql.Tx` as the existing wisp-row delete, before `RecomputeIsBlockedInTx`. Table set: `wisp_labels`, `wisp_events`, `wisp_comments` (on `issue_id`), `wisp_child_counters` (on `parent_id`) — matches `internal/storage/schema/cli_migrations.go:300-315`. |
+| A test creates a wisp with labels + events + comments, deletes it, and asserts zero residual rows in every side-table (single and batch paths) | ✓ | `TestWispDeleteCascade_CleansUpAuxiliaryTables`, subtests `single_delete` and `batch_delete`, both PASS. |
+| Orphan counts on a fresh store stay at 0 after a reap cycle | ✓ | `TestWispDeleteCascade_RepeatedCyclesLeaveNoOrphans` — 5 create-seed-delete cycles asserting store-wide total aux-row counts are 0 after every cycle. PASS. Added in round 2 in direct response to round-1 review's request-changes on this exact criterion. |
+| One shared helper used by both paths so the table set cannot drift | ✓ | `deleteWispAuxRowsInTx` is the single call site for both `deleteWisp` and `deleteWispBatchTx`. |
+
+## Tests run on release branch
+
+Ran independently by the deployer on `deploy/be-1gd16-gate` (not copied from
+the review) — native `dolt` v2.2.1 present on `PATH`, so
+`BEADS_TEST_SKIP=dolt` is not force-set and the diff's own standalone
+Dolt-server-backed tests are not skipped.
+
+| Test | Result | Notes |
+|------|--------|-------|
+| `go build ./...` | success | clean build. |
+| `gofmt -l internal/storage/dolt/wisps.go internal/storage/dolt/wisp_delete_cascade_integration_test.go` | clean | no output, no formatting diffs. |
+| `go vet -tags=integration,gms_pure_go ./internal/storage/dolt/...` | clean | no findings. |
+| `go test -tags=integration,gms_pure_go -race -timeout=15m -v ./internal/storage/dolt/...` | **575 PASS / 0 FAIL / 951 SKIP** (ok, 69.128s) | Exact match to be-u4s3y's independently-run counts (575/0/951). |
+| `TestWispDeleteCascade_CleansUpAuxiliaryTables` (diff-owned) | **PASS** (12.75s) | single_delete + batch_delete subtests both ran for real. |
+| `TestWispDeleteCascade_RepeatedCyclesLeaveNoOrphans` (diff-owned) | **PASS** (11.42s) | 5 cycles, ran for real. |
+
+`diff_tests_executed`: `TestWispDeleteCascade_CleansUpAuxiliaryTables` PASS,
+`TestWispDeleteCascade_RepeatedCyclesLeaveNoOrphans` PASS. Both use their own
+standalone `dolt` sql-server (`doltserver.Start` on the native binary), so
+they are not subject to the container-runtime gate below.
+
+`skip_justification`: all 951 skips trace to
+`internal/storage/dolt/testmain_test.go:60`
+(`EnsureDoltContainerForTestMain` — no container runtime in this sandbox);
+every test keyed to that shared package-level fixture self-skips. This is a
+pre-existing sandbox gap, not introduced by this diff, and does not touch
+either diff-owned test (which start their own server independent of that
+fixture). `waiver_ref`: none needed — no diff-owned test was skipped.
+
+## Findings from review (no action required)
+
+From be-u4s3y (round 2): no blockers or majors in either style or security
+review.
+
+- Injection (OWASP A03): `deleteWispAuxRowsInTx` builds SQL via
+  `fmt.Sprintf` for table/column names, but both come only from the fixed
+  `wispAuxCascadeTables` literal — not attacker- or caller-controlled. Row
+  ids go through parameterized `?` placeholders. No injection vector.
+  Independently confirmed by reading the diff.
+- Data integrity / TOCTOU: all four aux-table deletes plus the wisps-row
+  delete plus `RecomputeIsBlockedInTx` execute inside the same transaction —
+  atomic, no window where a wisp is gone but aux rows survive.
+
+## Push target
+
+`origin` (`gastownhall/beads`) has push deliberately disabled
+(`DISABLED-upstream-is-fetch-only-push-to-fork-and-PR`); `fork`
+(`quad341/beads`) accepts. PR opens cross-repo against
+`gastownhall/beads:main` with head `quad341:deploy/be-1gd16-gate`.
+
+`gastownhall/beads` is upstream-only for this deployer — we are
+contributors, not maintainers. Per standing policy, job ends at PR-open; no
+merge-request is routed, merge belongs to the upstream maintainers.
+
+## Verdict
+
+**PASS (7/7)** — push the gate-file commit to `fork`, open PR.


### PR DESCRIPTION
## What this changes

Deleting a wisp (`bd` issue) previously removed only the `wisps` row and its
dependency edges — it never removed the wisp's rows in `wisp_labels`,
`wisp_events`, `wisp_comments`, or `wisp_child_counters`. On the live `hq`
city store this leaked ~3.03M orphan rows (92% of `wisp_labels`, 89% of
`wisp_events`), contributing materially to store size and to the row counts
scanned by unfiltered reads over those tables.

Both delete paths (`deleteWisp` and the batch path `deleteWispBatchTx`) now
delete a wisp's rows from all four auxiliary tables inside the same
transaction as the wisp delete itself, via one shared helper so the table
set can't drift between the two paths again.

## Design note

Some deployed stores enforce this cleanup via FK `ON DELETE CASCADE` and
some do not (the migration adding those FKs was never promoted out of
`migrations/ignored/`), so the delete paths can't rely on the database to
do it for them — the fix has to be explicit at the call site, which is why
it's a small shared helper rather than a schema change.

## Review notes

- Table/column identifiers in the new helper come from a fixed literal
  slice, not user input; row-scoping ids use the existing parameterized
  `?` placeholder helper — same `//nolint:gosec // G201` pattern already
  used elsewhere in this file.
- Backfilling the ~3.03M existing orphan rows on the live `hq` store is
  intentionally out of scope here — that's a live-prod data operation for
  operator authority, handled separately. This PR only stops the leak from
  growing further.

## Test plan

- [x] `go test -tags=integration,gms_pure_go -race -timeout=15m ./internal/storage/dolt/...` — 575 PASS / 0 FAIL / 951 SKIP (skips are a pre-existing container-runtime gap in the test sandbox, unrelated to this diff)
- [x] New coverage: a test creates a wisp with labels/events/comments, deletes it via both the single and batch paths, and asserts zero residual rows in every auxiliary table
- [x] New coverage: 5 repeated create/delete cycles assert orphan counts stay at 0 store-wide after every cycle
- [x] Release gate: [`release-gates/be-1gd16-wisp-delete-cascade-gate.md`](release-gates/be-1gd16-wisp-delete-cascade-gate.md)

## Bead

be-1gd16 — deploy tracking

🤖 Deployed by actual-factory