### PR TITLE
feat(kv): port kv + memory surface to proxied-server mode (bd-dnzjy)

### DIFF
--- a/.github/scripts/proxied-cmd-test-shards.txt
+++ b/.github/scripts/proxied-cmd-test-shards.txt
@@ -112,12 +112,14 @@
 15 13 TestProxiedServerConfig
 15 13 TestProxiedServerConfigConcurrent
 15 13 TestProxiedServerGateList
+15 13 TestProxiedServerMemory
 15 13 TestProxiedServerMultiStatementSQL
 15 13 TestProxiedServerReopen
 15 13 TestProxiedServerStatuses
 
 15 14 TestProxiedServerComment
 15 14 TestProxiedServerContext
+15 14 TestProxiedServerKV
 15 14 TestProxiedServerNote
 15 14 TestProxiedServerSearch
 15 14 TestProxiedServerShow

--- a/cmd/bd/kv.go
+++ b/cmd/bd/kv.go
@@ -47,6 +47,95 @@ func validateKVKey(key string) error {
 	return nil
 }
 
+// printKVSetResult renders the `bd kv set` success output. Shared by the
+// classic and proxied-server paths so the output shape cannot drift.
+func printKVSetResult(key, value string) error {
+	if jsonOutput {
+		return outputJSON(map[string]string{
+			"key":   key,
+			"value": value,
+		})
+	}
+	fmt.Printf("Set %s = %s\n", key, value)
+	return nil
+}
+
+// printKVGetResult renders the `bd kv get` output (including the not-found
+// SilentExit contract). Shared by the classic and proxied-server paths.
+func printKVGetResult(key, value string) error {
+	if jsonOutput {
+		if jerr := outputJSON(map[string]interface{}{
+			"key":   key,
+			"value": value,
+			"found": value != "",
+		}); jerr != nil {
+			return jerr
+		}
+		if value == "" {
+			return SilentExit()
+		}
+		return nil
+	}
+	if value == "" {
+		fmt.Fprintf(os.Stderr, "%s (not set)\n", key)
+		return SilentExit()
+	}
+	fmt.Printf("%s\n", value)
+	return nil
+}
+
+// printKVClearResult renders the `bd kv clear` success output. Shared by the
+// classic and proxied-server paths.
+func printKVClearResult(key string) error {
+	if jsonOutput {
+		return outputJSON(map[string]string{
+			"key":     key,
+			"deleted": "true",
+		})
+	}
+	fmt.Printf("Cleared %s\n", key)
+	return nil
+}
+
+// kvPairsFromConfig filters a full config map down to the kv.* namespace,
+// stripping the prefix. Shared by the classic and proxied-server paths.
+func kvPairsFromConfig(allConfig map[string]string) map[string]string {
+	kvPairs := make(map[string]string)
+	for k, v := range allConfig {
+		if strings.HasPrefix(k, kvPrefix) {
+			userKey := strings.TrimPrefix(k, kvPrefix)
+			kvPairs[userKey] = v
+		}
+	}
+	return kvPairs
+}
+
+// printKVListResult renders the `bd kv list` output. Shared by the classic
+// and proxied-server paths (a mail client parses the --json shape; keep it
+// byte-identical across modes).
+func printKVListResult(kvPairs map[string]string) error {
+	if jsonOutput {
+		return outputJSON(kvPairs)
+	}
+
+	if len(kvPairs) == 0 {
+		fmt.Println("No key-value pairs set")
+		return nil
+	}
+
+	keys := make([]string, 0, len(kvPairs))
+	for k := range kvPairs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	fmt.Println("\nKey-Value Store:")
+	for _, k := range keys {
+		fmt.Printf("  %s = %s\n", k, kvPairs[k])
+	}
+	return nil
+}
+
 // kvCmd is the parent command for kv subcommands
 var kvCmd = &cobra.Command{
 	Use:     "kv",
@@ -81,9 +170,6 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if usesProxiedServer() {
-			return HandleErrorRespectJSON("kv set is not supported in proxied-server mode")
-		}
 		CheckReadonly("kv set")
 
 		evt := metrics.NewCommandEvent("kv-set")
@@ -93,15 +179,20 @@ Examples:
 			}
 		}()
 
-		if err := ensureDirectMode("kv set requires direct database access"); err != nil {
-			return HandleError("%v", err)
-		}
-
 		key := args[0]
 		if err := validateKVKey(key); err != nil {
 			return HandleErrorRespectJSON("invalid key: %v", err)
 		}
 		value := args[1]
+
+		if usesProxiedServer() {
+			return runKVSetProxiedServer(rootCtx, key, value)
+		}
+
+		if err := ensureDirectMode("kv set requires direct database access"); err != nil {
+			return HandleError("%v", err)
+		}
+
 		storageKey := kvPrefix + key
 
 		ctx := rootCtx
@@ -109,14 +200,7 @@ Examples:
 			return HandleErrorRespectJSON("setting key: %v", err)
 		}
 
-		if jsonOutput {
-			return outputJSON(map[string]string{
-				"key":   key,
-				"value": value,
-			})
-		}
-		fmt.Printf("Set %s = %s\n", key, value)
-		return nil
+		return printKVSetResult(key, value)
 	},
 }
 
@@ -133,9 +217,6 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if usesProxiedServer() {
-			return HandleErrorRespectJSON("kv get is not supported in proxied-server mode")
-		}
 		evt := metrics.NewCommandEvent("kv-get")
 		defer func() {
 			if c := metrics.Global(); c != nil {
@@ -143,11 +224,16 @@ Examples:
 			}
 		}()
 
+		key := args[0]
+
+		if usesProxiedServer() {
+			return runKVGetProxiedServer(rootCtx, key)
+		}
+
 		if err := ensureDirectMode("kv get requires direct database access"); err != nil {
 			return HandleError("%v", err)
 		}
 
-		key := args[0]
 		storageKey := kvPrefix + key
 
 		ctx := rootCtx
@@ -156,25 +242,7 @@ Examples:
 			return HandleErrorRespectJSON("getting key: %v", err)
 		}
 
-		if jsonOutput {
-			if jerr := outputJSON(map[string]interface{}{
-				"key":   key,
-				"value": value,
-				"found": value != "",
-			}); jerr != nil {
-				return jerr
-			}
-			if value == "" {
-				return SilentExit()
-			}
-			return nil
-		}
-		if value == "" {
-			fmt.Fprintf(os.Stderr, "%s (not set)\n", key)
-			return SilentExit()
-		}
-		fmt.Printf("%s\n", value)
-		return nil
+		return printKVGetResult(key, value)
 	},
 }
 
@@ -191,9 +259,6 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if usesProxiedServer() {
-			return HandleErrorRespectJSON("kv clear is not supported in proxied-server mode")
-		}
 		CheckReadonly("kv clear")
 
 		evt := metrics.NewCommandEvent("kv-clear")
@@ -203,14 +268,19 @@ Examples:
 			}
 		}()
 
-		if err := ensureDirectMode("kv clear requires direct database access"); err != nil {
-			return HandleError("%v", err)
-		}
-
 		key := args[0]
 		if err := validateKVKey(key); err != nil {
 			return HandleErrorRespectJSON("invalid key: %v", err)
 		}
+
+		if usesProxiedServer() {
+			return runKVClearProxiedServer(rootCtx, key)
+		}
+
+		if err := ensureDirectMode("kv clear requires direct database access"); err != nil {
+			return HandleError("%v", err)
+		}
+
 		storageKey := kvPrefix + key
 
 		ctx := rootCtx
@@ -218,14 +288,7 @@ Examples:
 			return HandleErrorRespectJSON("deleting key: %v", err)
 		}
 
-		if jsonOutput {
-			return outputJSON(map[string]string{
-				"key":     key,
-				"deleted": "true",
-			})
-		}
-		fmt.Printf("Cleared %s\n", key)
-		return nil
+		return printKVClearResult(key)
 	},
 }
 
@@ -241,15 +304,16 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if usesProxiedServer() {
-			return HandleErrorRespectJSON("kv list is not supported in proxied-server mode")
-		}
 		evt := metrics.NewCommandEvent("kv-list")
 		defer func() {
 			if c := metrics.Global(); c != nil {
 				c.CloseEventAndAdd(evt)
 			}
 		}()
+
+		if usesProxiedServer() {
+			return runKVListProxiedServer(rootCtx)
+		}
 
 		if err := ensureDirectMode("kv list requires direct database access"); err != nil {
 			return HandleError("%v", err)
@@ -261,34 +325,7 @@ Examples:
 			return HandleErrorRespectJSON("listing keys: %v", err)
 		}
 
-		kvPairs := make(map[string]string)
-		for k, v := range allConfig {
-			if strings.HasPrefix(k, kvPrefix) {
-				userKey := strings.TrimPrefix(k, kvPrefix)
-				kvPairs[userKey] = v
-			}
-		}
-
-		if jsonOutput {
-			return outputJSON(kvPairs)
-		}
-
-		if len(kvPairs) == 0 {
-			fmt.Println("No key-value pairs set")
-			return nil
-		}
-
-		keys := make([]string, 0, len(kvPairs))
-		for k := range kvPairs {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-
-		fmt.Println("\nKey-Value Store:")
-		for _, k := range keys {
-			fmt.Printf("  %s = %s\n", k, kvPairs[k])
-		}
-		return nil
+		return printKVListResult(kvPairsFromConfig(allConfig))
 	},
 }
 

--- a/cmd/bd/kv_proxied_integration_test.go
+++ b/cmd/bd/kv_proxied_integration_test.go
@@ -1,0 +1,238 @@
+//go:build cgo
+
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func bdProxiedKV(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	fullArgs := append([]string{"kv"}, args...)
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, dir, fullArgs...)
+	if err != nil {
+		t.Fatalf("bd kv %s failed: %v\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), err, stdout, stderr)
+	}
+	return stdout
+}
+
+func bdProxiedKVFail(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	fullArgs := append([]string{"kv"}, args...)
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, dir, fullArgs...)
+	if err == nil {
+		t.Fatalf("expected bd kv %s to fail; got stdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), stdout, stderr)
+	}
+	return stdout + stderr
+}
+
+// kvListJSONRaw runs `bd kv list --json` and returns the raw JSON object
+// text plus the parsed pairs. It pins the wire shape the wyvern wheelhouse
+// mail transport parses: a flat JSON object whose only non-string member is
+// the outputJSON-injected numeric "schema_version" (present in classic mode
+// too — see bdKVListJSON in kv_embedded_test.go); every kv pair is a plain
+// string-to-string entry with no envelope.
+func kvListJSONRaw(t *testing.T, bd, dir string) (string, map[string]string) {
+	t.Helper()
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, dir, "kv", "list", "--json")
+	if err != nil {
+		t.Fatalf("bd kv list --json failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+	s := strings.TrimSpace(stdout)
+	start := strings.Index(s, "{")
+	if start < 0 {
+		t.Fatalf("no JSON object in kv list output: %s", s)
+	}
+	raw := s[start:]
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		t.Fatalf("kv list --json did not parse: %v\n%s", err, raw)
+	}
+	m := make(map[string]string, len(parsed))
+	for k, v := range parsed {
+		if k == "schema_version" {
+			continue
+		}
+		sv, ok := v.(string)
+		if !ok {
+			t.Fatalf("kv list --json pair %q is not a string (shape drift): %v\n%s", k, v, raw)
+		}
+		m[k] = sv
+	}
+	return raw, m
+}
+
+// mailEnvelope is a representative wheelhouse mail payload: one argv element
+// containing spaces, newlines, and JSON punctuation. kv is the constellation's
+// mail transport, so this must round-trip byte-for-byte.
+const mailEnvelope = "{\n  \"to\": \"marshal\",\n  \"subject\": \"fleet status\",\n  \"body\": \"line one\nline two with  double spaces\n\ttabbed line\"\n}"
+
+func TestProxiedServerKV(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+
+	t.Run("set_get_roundtrip", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "pkv")
+
+		bdProxiedKV(t, bd, p.dir, "set", "mykey", "myvalue")
+		out := bdProxiedKV(t, bd, p.dir, "get", "mykey")
+		if out != "myvalue\n" {
+			t.Errorf("get after set: expected %q, got %q", "myvalue\n", out)
+		}
+
+		// Overwrite
+		bdProxiedKV(t, bd, p.dir, "set", "mykey", "second")
+		out = bdProxiedKV(t, bd, p.dir, "get", "mykey")
+		if out != "second\n" {
+			t.Errorf("get after overwrite: expected %q, got %q", "second\n", out)
+		}
+	})
+
+	t.Run("multiline_json_envelope_roundtrip", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "pkvm")
+
+		// The whole envelope is ONE argv element; no trimming or re-encoding
+		// may happen anywhere on the path.
+		bdProxiedKV(t, bd, p.dir, "set", "mail/inbox/marshal", mailEnvelope)
+
+		out := bdProxiedKV(t, bd, p.dir, "get", "mail/inbox/marshal")
+		if out != mailEnvelope+"\n" {
+			t.Errorf("envelope did not round-trip byte-for-byte:\nwant: %q\ngot:  %q", mailEnvelope+"\n", out)
+		}
+
+		// The same bytes must come back through list --json.
+		_, m := kvListJSONRaw(t, bd, p.dir)
+		if got, ok := m["mail/inbox/marshal"]; !ok || got != mailEnvelope {
+			t.Errorf("list --json envelope mismatch (exists=%v):\nwant: %q\ngot:  %q", ok, mailEnvelope, got)
+		}
+	})
+
+	t.Run("list_json_shape", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "pkvl")
+
+		bdProxiedKV(t, bd, p.dir, "set", "alpha", "1")
+		bdProxiedKV(t, bd, p.dir, "set", "beta", "two words")
+
+		raw, m := kvListJSONRaw(t, bd, p.dir)
+		want := map[string]string{"alpha": "1", "beta": "two words"}
+		if len(m) != len(want) {
+			t.Errorf("expected exactly %d kv pairs, got %d: %s", len(want), len(m), raw)
+		}
+		for k, v := range want {
+			if got, ok := m[k]; !ok || got != v {
+				t.Errorf("list --json: %s expected %q, got %q (exists=%v)", k, v, got, ok)
+			}
+		}
+		// Keys are user keys — the storage prefix must be stripped.
+		for k := range m {
+			if strings.HasPrefix(k, "kv.") {
+				t.Errorf("list --json leaked storage prefix on key %q", k)
+			}
+		}
+	})
+
+	t.Run("list_json_shape_matches_classic", func(t *testing.T) {
+		t.Parallel()
+		// Same binary, same commands, classic embedded project: the JSON
+		// documents (parsed) must be identical — a mail client parses this.
+		proxied := newSharedProxiedProject(t, bd, "pkvc")
+		classicDir, _, _ := bdInit(t, bd, "--prefix", "kvc")
+
+		for _, kvp := range [][2]string{
+			{"plain", "value"},
+			{"envelope", mailEnvelope},
+		} {
+			bdProxiedKV(t, bd, proxied.dir, "set", kvp[0], kvp[1])
+			bdKV(t, bd, classicDir, "set", kvp[0], kvp[1])
+		}
+
+		_, proxiedMap := kvListJSONRaw(t, bd, proxied.dir)
+		classicMap := bdKVListJSON(t, bd, classicDir)
+
+		if len(proxiedMap) != len(classicMap) {
+			t.Fatalf("map size mismatch: proxied=%v classic=%v", proxiedMap, classicMap)
+		}
+		for k, v := range classicMap {
+			if got, ok := proxiedMap[k]; !ok || got != v {
+				t.Errorf("key %q: classic %q, proxied %q (exists=%v)", k, v, got, ok)
+			}
+		}
+	})
+
+	t.Run("get_missing_key", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "pkvg")
+		out := bdProxiedKVFail(t, bd, p.dir, "get", "never_set_key")
+		if !strings.Contains(out, "not set") {
+			t.Errorf("expected 'not set' for missing key, got: %s", out)
+		}
+	})
+
+	t.Run("clear", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "pkvd")
+
+		bdProxiedKV(t, bd, p.dir, "set", "clearme", "temporary")
+		out := bdProxiedKV(t, bd, p.dir, "clear", "clearme")
+		if !strings.Contains(out, "Cleared clearme") {
+			t.Errorf("expected 'Cleared clearme', got: %s", out)
+		}
+
+		bdProxiedKVFail(t, bd, p.dir, "get", "clearme")
+		_, m := kvListJSONRaw(t, bd, p.dir)
+		if _, ok := m["clearme"]; ok {
+			t.Error("expected clearme absent from kv list after clear")
+		}
+
+		// Idempotent-friendly: clearing an already-absent key succeeds,
+		// exactly like the classic path (DELETE of a missing row is a no-op
+		// and the empty tx commits as nothing-to-commit).
+		out = bdProxiedKV(t, bd, p.dir, "clear", "clearme")
+		if !strings.Contains(out, "Cleared clearme") {
+			t.Errorf("expected idempotent 'Cleared clearme' on second clear, got: %s", out)
+		}
+	})
+
+	t.Run("invalid_keys_refused", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "pkvi")
+
+		out := bdProxiedKVFail(t, bd, p.dir, "set", "kv.nested", "v")
+		if !strings.Contains(out, "nested prefix") {
+			t.Errorf("expected nested-prefix refusal, got: %s", out)
+		}
+		out = bdProxiedKVFail(t, bd, p.dir, "set", "memory.sneaky", "v")
+		if !strings.Contains(out, "reserved for persistent memories") {
+			t.Errorf("expected memory-namespace refusal, got: %s", out)
+		}
+		out = bdProxiedKVFail(t, bd, p.dir, "set", "sync.mode", "v")
+		if !strings.Contains(out, "reserved prefix") {
+			t.Errorf("expected reserved-prefix refusal, got: %s", out)
+		}
+	})
+
+	t.Run("set_creates_dolt_commit", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "pkvh")
+		db := openProxiedDB(t, p)
+		before := proxiedDoltHead(t, db)
+
+		bdProxiedKV(t, bd, p.dir, "set", "committed", "v1")
+
+		after := proxiedDoltHead(t, db)
+		if after == before {
+			t.Errorf("HEAD did not advance on kv set: before=%s after=%s", before, after)
+		}
+		if n := proxiedDoltCommitCountSince(t, db, before); n != 1 {
+			t.Errorf("expected exactly 1 Dolt commit for kv set, got %d", n)
+		}
+	})
+}

--- a/cmd/bd/kv_proxied_server.go
+++ b/cmd/bd/kv_proxied_server.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/steveyegge/beads/internal/storage/uow"
+)
+
+// Proxied-server handlers for `bd kv`. The kv store is a thin prefix layer
+// (kv.*) over the config table, so these mirror config_proxied_server.go:
+// one RunTx per write invocation with a real commit message, RunTxRead for
+// reads. Key validation happens in the RunE before dispatch; presentation
+// goes through the shared printKV* helpers so output cannot drift from the
+// classic path (downstream mail transports parse `kv list --json`).
+//
+// Error handling note: the underlying storage error is passed through %v
+// unmodified — callers retry on the 'Merge conflict detected' /
+// 'constraint violation, transaction rolled back' substrings, which must
+// survive to the CLI surface.
+
+func runKVSetProxiedServer(ctx context.Context, key, value string) error {
+	if uowProvider == nil {
+		return HandleErrorRespectJSON("proxied-server UOW provider not initialized")
+	}
+
+	storageKey := kvPrefix + key
+	err := uow.RunTx(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (string, error) {
+		if err := uw.ConfigUseCase().SetConfig(ctx, storageKey, value); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("bd: kv set %s", key), nil
+	})
+	if err != nil {
+		return HandleErrorRespectJSON("setting key: %v", err)
+	}
+
+	return printKVSetResult(key, value)
+}
+
+func runKVGetProxiedServer(ctx context.Context, key string) error {
+	if uowProvider == nil {
+		return HandleErrorRespectJSON("proxied-server UOW provider not initialized")
+	}
+
+	storageKey := kvPrefix + key
+	value, err := uow.RunTxRead(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (string, error) {
+		return uw.ConfigUseCase().GetConfig(ctx, storageKey)
+	})
+	if err != nil {
+		return HandleErrorRespectJSON("getting key: %v", err)
+	}
+
+	return printKVGetResult(key, value)
+}
+
+func runKVClearProxiedServer(ctx context.Context, key string) error {
+	if uowProvider == nil {
+		return HandleErrorRespectJSON("proxied-server UOW provider not initialized")
+	}
+
+	storageKey := kvPrefix + key
+	err := uow.RunTx(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (string, error) {
+		if err := uw.ConfigUseCase().DeleteConfig(ctx, storageKey); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("bd: kv clear %s", key), nil
+	})
+	if err != nil {
+		return HandleErrorRespectJSON("deleting key: %v", err)
+	}
+
+	return printKVClearResult(key)
+}
+
+func runKVListProxiedServer(ctx context.Context) error {
+	if uowProvider == nil {
+		return HandleErrorRespectJSON("proxied-server UOW provider not initialized")
+	}
+
+	allConfig, err := uow.RunTxRead(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (map[string]string, error) {
+		return uw.ConfigUseCase().GetAllConfig(ctx)
+	})
+	if err != nil {
+		return HandleErrorRespectJSON("listing keys: %v", err)
+	}
+
+	return printKVListResult(kvPairsFromConfig(allConfig))
+}

--- a/cmd/bd/memory.go
+++ b/cmd/bd/memory.go
@@ -67,6 +67,162 @@ func matchesKnownCommand(cmd *cobra.Command, insight string) (string, bool) {
 	return "", false
 }
 
+// rememberBareKeyPath implements the desire-path / footgun guard for
+// `bd remember <bare-slug>` (no --key): a bare slug naming an EXISTING memory
+// is recalled instead of stored; a bare slug naming nothing is refused.
+// Shared by the classic and proxied-server paths. The caller only invokes it
+// when memoryKeyFlag == "" and slugify(insight) == insight.
+func rememberBareKeyPath(key, insight, existing string) error {
+	if existing != "" {
+		if jsonOutput {
+			return outputJSON(map[string]interface{}{
+				"key":    key,
+				"value":  existing,
+				"found":  true,
+				"action": "recalled",
+			})
+		}
+		fmt.Fprintf(os.Stderr,
+			"(recalled %q -- a bare existing key READS. To overwrite: `bd remember \"<new content>\" --key %s`)\n",
+			key, key)
+		fmt.Printf("%s\n", existing)
+		return nil
+	}
+	return HandleErrorRespectJSON(
+		"no memory named %q to recall -- and refusing to store a bare key-like token as its own content. "+
+			"`bd remember` WRITES (its positional arg is CONTENT, not a key). "+
+			"To store it anyway: `bd remember %q --key %s`. To browse keys: `bd memories`",
+		key, insight, key)
+}
+
+// printRememberResult renders the `bd remember` success output. Shared by
+// the classic and proxied-server paths.
+func printRememberResult(verb, key, insight string) error {
+	if jsonOutput {
+		return outputJSON(map[string]string{
+			"key":    key,
+			"value":  insight,
+			"action": strings.ToLower(verb),
+		})
+	}
+	fmt.Printf("%s [%s]: %s\n", verb, key, truncateMemory(insight, 80))
+	return nil
+}
+
+// memoriesFromConfig filters a full config map down to the kv.memory.*
+// namespace (stripping the prefix), optionally filtered by a lowercase
+// search term matched against key or value. Shared by the classic and
+// proxied-server paths.
+func memoriesFromConfig(allConfig map[string]string, search string) map[string]string {
+	fullPrefix := kvkeys.MemoryConfigKeyPrefix
+	memories := make(map[string]string)
+	for k, v := range allConfig {
+		if strings.HasPrefix(k, fullPrefix) {
+			userKey := strings.TrimPrefix(k, fullPrefix)
+			memories[userKey] = v
+		}
+	}
+	if search != "" {
+		filtered := make(map[string]string)
+		for k, v := range memories {
+			if strings.Contains(strings.ToLower(k), search) ||
+				strings.Contains(strings.ToLower(v), search) {
+				filtered[k] = v
+			}
+		}
+		memories = filtered
+	}
+	return memories
+}
+
+// printMemoriesResult renders the `bd memories` output. Shared by the
+// classic and proxied-server paths.
+func printMemoriesResult(memories map[string]string, search string) error {
+	if jsonOutput {
+		return outputJSON(memories)
+	}
+
+	if len(memories) == 0 {
+		if search != "" {
+			fmt.Printf("No memories matching %q\n", search)
+		} else {
+			fmt.Println("No memories stored. Use 'bd remember \"insight\"' to add one.")
+		}
+		return nil
+	}
+
+	keys := make([]string, 0, len(memories))
+	for k := range memories {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	if search != "" {
+		fmt.Printf("Memories matching %q:\n\n", search)
+	} else {
+		fmt.Printf("Memories (%d):\n\n", len(memories))
+	}
+	for _, k := range keys {
+		v := memories[k]
+		fmt.Printf("  %s\n", k)
+		fmt.Printf("    %s\n\n", truncateMemory(v, 120))
+	}
+	return nil
+}
+
+// printForgetNotFound renders the `bd forget` missing-key output (including
+// the SilentExit contract). Shared by the classic and proxied-server paths.
+func printForgetNotFound(key string) error {
+	if jsonOutput {
+		if jerr := outputJSON(map[string]string{
+			"key":   key,
+			"found": "false",
+		}); jerr != nil {
+			return jerr
+		}
+		return SilentExit()
+	}
+	fmt.Fprintf(os.Stderr, "No memory with key %q\n", key)
+	return SilentExit()
+}
+
+// printForgetResult renders the `bd forget` success output. Shared by the
+// classic and proxied-server paths.
+func printForgetResult(key, existing string) error {
+	if jsonOutput {
+		return outputJSON(map[string]string{
+			"key":     key,
+			"deleted": "true",
+		})
+	}
+	fmt.Printf("Forgot [%s]: %s\n", key, truncateMemory(existing, 80))
+	return nil
+}
+
+// printRecallResult renders the `bd recall` output (including the not-found
+// SilentExit contract). Shared by the classic and proxied-server paths.
+func printRecallResult(key, value string) error {
+	if jsonOutput {
+		if jerr := outputJSON(map[string]interface{}{
+			"key":   key,
+			"value": value,
+			"found": value != "",
+		}); jerr != nil {
+			return jerr
+		}
+		if value == "" {
+			return SilentExit()
+		}
+		return nil
+	}
+	if value == "" {
+		fmt.Fprintf(os.Stderr, "No memory with key %q\n", key)
+		return SilentExit()
+	}
+	fmt.Printf("%s\n", value)
+	return nil
+}
+
 // rememberCmd stores a memory.
 var rememberCmd = &cobra.Command{
 	Use:   `remember "<insight>"`,
@@ -91,9 +247,6 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if usesProxiedServer() {
-			return HandleErrorRespectJSON("remember is not supported in proxied-server mode")
-		}
 		CheckReadonly("remember")
 
 		evt := metrics.NewCommandEvent("remember")
@@ -102,10 +255,6 @@ Examples:
 				c.CloseEventAndAdd(evt)
 			}
 		}()
-
-		if err := ensureDirectMode("remember requires direct database access"); err != nil {
-			return HandleError("%v", err)
-		}
 
 		insight := args[0]
 		if strings.TrimSpace(insight) == "" {
@@ -137,6 +286,14 @@ Examples:
 			return HandleErrorRespectJSON("could not generate key from content; use --key to specify one")
 		}
 
+		if usesProxiedServer() {
+			return runRememberProxiedServer(rootCtx, key, insight)
+		}
+
+		if err := ensureDirectMode("remember requires direct database access"); err != nil {
+			return HandleError("%v", err)
+		}
+
 		storageKey := kvPrefix + memoryPrefix + key
 
 		ctx := rootCtx
@@ -157,26 +314,7 @@ Examples:
 		//                        create a junk memory that hides the mistake
 		// Passing --key states write intent and bypasses both branches.
 		if memoryKeyFlag == "" && slugify(insight) == insight {
-			if existing != "" {
-				if jsonOutput {
-					return outputJSON(map[string]interface{}{
-						"key":    key,
-						"value":  existing,
-						"found":  true,
-						"action": "recalled",
-					})
-				}
-				fmt.Fprintf(os.Stderr,
-					"(recalled %q -- a bare existing key READS. To overwrite: `bd remember \"<new content>\" --key %s`)\n",
-					key, key)
-				fmt.Printf("%s\n", existing)
-				return nil
-			}
-			return HandleErrorRespectJSON(
-				"no memory named %q to recall -- and refusing to store a bare key-like token as its own content. "+
-					"`bd remember` WRITES (its positional arg is CONTENT, not a key). "+
-					"To store it anyway: `bd remember %q --key %s`. To browse keys: `bd memories`",
-				key, insight, key)
+			return rememberBareKeyPath(key, insight, existing)
 		}
 
 		if err := store.SetConfig(ctx, storageKey, insight); err != nil {
@@ -184,15 +322,7 @@ Examples:
 		}
 		commandDidWrite.Store(true)
 
-		if jsonOutput {
-			return outputJSON(map[string]string{
-				"key":    key,
-				"value":  insight,
-				"action": strings.ToLower(verb),
-			})
-		}
-		fmt.Printf("%s [%s]: %s\n", verb, key, truncateMemory(insight, 80))
-		return nil
+		return printRememberResult(verb, key, insight)
 	},
 }
 
@@ -211,15 +341,21 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if usesProxiedServer() {
-			return HandleErrorRespectJSON("memories is not supported in proxied-server mode")
-		}
 		evt := metrics.NewCommandEvent("memories")
 		defer func() {
 			if c := metrics.Global(); c != nil {
 				c.CloseEventAndAdd(evt)
 			}
 		}()
+
+		var search string
+		if len(args) > 0 {
+			search = strings.ToLower(args[0])
+		}
+
+		if usesProxiedServer() {
+			return runMemoriesProxiedServer(rootCtx, search)
+		}
 
 		if err := ensureDirectMode("memories requires direct database access"); err != nil {
 			return HandleError("%v", err)
@@ -231,61 +367,7 @@ Examples:
 			return HandleErrorRespectJSON("listing memories: %v", err)
 		}
 
-		// Filter for kv.memory.* keys
-		fullPrefix := kvkeys.MemoryConfigKeyPrefix
-		memories := make(map[string]string)
-		for k, v := range allConfig {
-			if strings.HasPrefix(k, fullPrefix) {
-				userKey := strings.TrimPrefix(k, fullPrefix)
-				memories[userKey] = v
-			}
-		}
-
-		var search string
-		if len(args) > 0 {
-			search = strings.ToLower(args[0])
-		}
-		if search != "" {
-			filtered := make(map[string]string)
-			for k, v := range memories {
-				if strings.Contains(strings.ToLower(k), search) ||
-					strings.Contains(strings.ToLower(v), search) {
-					filtered[k] = v
-				}
-			}
-			memories = filtered
-		}
-
-		if jsonOutput {
-			return outputJSON(memories)
-		}
-
-		if len(memories) == 0 {
-			if search != "" {
-				fmt.Printf("No memories matching %q\n", search)
-			} else {
-				fmt.Println("No memories stored. Use 'bd remember \"insight\"' to add one.")
-			}
-			return nil
-		}
-
-		keys := make([]string, 0, len(memories))
-		for k := range memories {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-
-		if search != "" {
-			fmt.Printf("Memories matching %q:\n\n", search)
-		} else {
-			fmt.Printf("Memories (%d):\n\n", len(memories))
-		}
-		for _, k := range keys {
-			v := memories[k]
-			fmt.Printf("  %s\n", k)
-			fmt.Printf("    %s\n\n", truncateMemory(v, 120))
-		}
-		return nil
+		return printMemoriesResult(memoriesFromConfig(allConfig, search), search)
 	},
 }
 
@@ -305,9 +387,6 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if usesProxiedServer() {
-			return HandleErrorRespectJSON("forget is not supported in proxied-server mode")
-		}
 		CheckReadonly("forget")
 
 		evt := metrics.NewCommandEvent("forget")
@@ -317,28 +396,23 @@ Examples:
 			}
 		}()
 
+		key := args[0]
+
+		if usesProxiedServer() {
+			return runForgetProxiedServer(rootCtx, key)
+		}
+
 		if err := ensureDirectMode("forget requires direct database access"); err != nil {
 			return HandleError("%v", err)
 		}
 
-		key := args[0]
 		storageKey := kvPrefix + memoryPrefix + key
 
 		ctx := rootCtx
 
 		existing, _ := store.GetConfig(ctx, storageKey)
 		if existing == "" {
-			if jsonOutput {
-				if jerr := outputJSON(map[string]string{
-					"key":   key,
-					"found": "false",
-				}); jerr != nil {
-					return jerr
-				}
-				return SilentExit()
-			}
-			fmt.Fprintf(os.Stderr, "No memory with key %q\n", key)
-			return SilentExit()
+			return printForgetNotFound(key)
 		}
 
 		if err := store.DeleteConfig(ctx, storageKey); err != nil {
@@ -346,14 +420,7 @@ Examples:
 		}
 		commandDidWrite.Store(true)
 
-		if jsonOutput {
-			return outputJSON(map[string]string{
-				"key":     key,
-				"deleted": "true",
-			})
-		}
-		fmt.Printf("Forgot [%s]: %s\n", key, truncateMemory(existing, 80))
-		return nil
+		return printForgetResult(key, existing)
 	},
 }
 
@@ -371,9 +438,6 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if usesProxiedServer() {
-			return HandleErrorRespectJSON("recall is not supported in proxied-server mode")
-		}
 		evt := metrics.NewCommandEvent("recall")
 		defer func() {
 			if c := metrics.Global(); c != nil {
@@ -381,11 +445,16 @@ Examples:
 			}
 		}()
 
+		key := args[0]
+
+		if usesProxiedServer() {
+			return runRecallProxiedServer(rootCtx, key)
+		}
+
 		if err := ensureDirectMode("recall requires direct database access"); err != nil {
 			return HandleError("%v", err)
 		}
 
-		key := args[0]
 		storageKey := kvPrefix + memoryPrefix + key
 
 		ctx := rootCtx
@@ -394,25 +463,7 @@ Examples:
 			return HandleErrorRespectJSON("recalling memory: %v", err)
 		}
 
-		if jsonOutput {
-			if jerr := outputJSON(map[string]interface{}{
-				"key":   key,
-				"value": value,
-				"found": value != "",
-			}); jerr != nil {
-				return jerr
-			}
-			if value == "" {
-				return SilentExit()
-			}
-			return nil
-		}
-		if value == "" {
-			fmt.Fprintf(os.Stderr, "No memory with key %q\n", key)
-			return SilentExit()
-		}
-		fmt.Printf("%s\n", value)
-		return nil
+		return printRecallResult(key, value)
 	},
 }
 

--- a/cmd/bd/memory_proxied_integration_test.go
+++ b/cmd/bd/memory_proxied_integration_test.go
@@ -1,0 +1,170 @@
+//go:build cgo
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func bdProxiedMem(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, dir, args...)
+	if err != nil {
+		t.Fatalf("bd %s failed: %v\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), err, stdout, stderr)
+	}
+	return stdout
+}
+
+func bdProxiedMemFail(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, dir, args...)
+	if err == nil {
+		t.Fatalf("expected bd %s to fail; got stdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), stdout, stderr)
+	}
+	return stdout + stderr
+}
+
+func TestProxiedServerMemory(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+
+	t.Run("remember_memories_forget_recall_journey", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "pmem")
+
+		// Multi-line content must round-trip byte-for-byte through recall.
+		content := "Dolt phantom DBs hide in three places:\n  1. the data dir\n  2. the global config\n  3. the server cache"
+		out := bdProxiedMem(t, bd, p.dir, "remember", content, "--key", "dolt-phantoms")
+		if !strings.Contains(out, "Remembered [dolt-phantoms]") {
+			t.Errorf("expected 'Remembered [dolt-phantoms]', got: %s", out)
+		}
+
+		// Auto-generated key from prose content.
+		out = bdProxiedMem(t, bd, p.dir, "remember", "always run tests with -race flag")
+		if !strings.Contains(out, "Remembered [always-run-tests-with-race-flag]") {
+			t.Errorf("expected slug key in output, got: %s", out)
+		}
+
+		// Memories land under kv.memory.<key> in the config table — the
+		// namespace `bd export --all` sweeps — visible via bd config get.
+		out = bdProxiedMem(t, bd, p.dir, "config", "get", "kv.memory.dolt-phantoms")
+		if strings.TrimSpace(out) != content {
+			t.Errorf("expected memory at kv.memory.dolt-phantoms, got: %q", out)
+		}
+
+		// List all.
+		out = bdProxiedMem(t, bd, p.dir, "memories")
+		if !strings.Contains(out, "Memories (2):") {
+			t.Errorf("expected 'Memories (2):', got: %s", out)
+		}
+		for _, key := range []string{"dolt-phantoms", "always-run-tests-with-race-flag"} {
+			if !strings.Contains(out, key) {
+				t.Errorf("expected %q in memories listing: %s", key, out)
+			}
+		}
+
+		// Keyword search matches content, not just keys.
+		out = bdProxiedMem(t, bd, p.dir, "memories", "phantom")
+		if !strings.Contains(out, "dolt-phantoms") {
+			t.Errorf("expected search hit for 'phantom': %s", out)
+		}
+		if strings.Contains(out, "always-run-tests-with-race-flag") {
+			t.Errorf("search should not match unrelated memory: %s", out)
+		}
+
+		// Recall returns the full content byte-for-byte (listing truncates).
+		out = bdProxiedMem(t, bd, p.dir, "recall", "dolt-phantoms")
+		if out != content+"\n" {
+			t.Errorf("recall not byte-preserving:\nwant: %q\ngot:  %q", content+"\n", out)
+		}
+
+		// Update in place via explicit --key.
+		out = bdProxiedMem(t, bd, p.dir, "remember", "updated insight", "--key", "dolt-phantoms")
+		if !strings.Contains(out, "Updated [dolt-phantoms]") {
+			t.Errorf("expected 'Updated [dolt-phantoms]', got: %s", out)
+		}
+		out = bdProxiedMem(t, bd, p.dir, "recall", "dolt-phantoms")
+		if out != "updated insight\n" {
+			t.Errorf("expected updated content, got: %q", out)
+		}
+
+		// Forget removes it.
+		out = bdProxiedMem(t, bd, p.dir, "forget", "dolt-phantoms")
+		if !strings.Contains(out, "Forgot [dolt-phantoms]") {
+			t.Errorf("expected 'Forgot [dolt-phantoms]', got: %s", out)
+		}
+		out = bdProxiedMem(t, bd, p.dir, "memories")
+		if strings.Contains(out, "dolt-phantoms") {
+			t.Errorf("expected dolt-phantoms gone after forget: %s", out)
+		}
+
+		// Forget of a missing key reports not-found and exits nonzero,
+		// same as classic.
+		out = bdProxiedMemFail(t, bd, p.dir, "forget", "dolt-phantoms")
+		if !strings.Contains(out, "No memory with key") {
+			t.Errorf("expected 'No memory with key' on double forget, got: %s", out)
+		}
+
+		// Recall of a missing key likewise.
+		out = bdProxiedMemFail(t, bd, p.dir, "recall", "dolt-phantoms")
+		if !strings.Contains(out, "No memory with key") {
+			t.Errorf("expected 'No memory with key' on missing recall, got: %s", out)
+		}
+	})
+
+	t.Run("remember_bare_key_desire_path", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "pmemb")
+
+		bdProxiedMem(t, bd, p.dir, "remember", "the auth module uses JWT not sessions", "--key", "auth-jwt")
+
+		// A bare existing key READS instead of writing (= bd recall).
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "remember", "auth-jwt")
+		if err != nil {
+			t.Fatalf("bare-existing-key remember should recall, got error: %v\n%s%s", err, stdout, stderr)
+		}
+		if stdout != "the auth module uses JWT not sessions\n" {
+			t.Errorf("expected recalled content on stdout, got: %q", stdout)
+		}
+		if !strings.Contains(stderr, "a bare existing key READS") {
+			t.Errorf("expected desire-path notice on stderr, got: %q", stderr)
+		}
+
+		// A bare key naming nothing is refused, not stored.
+		out := bdProxiedMemFail(t, bd, p.dir, "remember", "no-such-memory-key")
+		if !strings.Contains(out, "refusing to store a bare key-like token") {
+			t.Errorf("expected bare-key refusal, got: %s", out)
+		}
+		out = bdProxiedMem(t, bd, p.dir, "memories")
+		if strings.Contains(out, "no-such-memory-key") {
+			t.Errorf("refused bare key must not be stored: %s", out)
+		}
+
+		// A bare bd command name is caught by the command guard.
+		out = bdProxiedMemFail(t, bd, p.dir, "remember", "list")
+		if !strings.Contains(out, "looks like a command") {
+			t.Errorf("expected command-word guard, got: %s", out)
+		}
+	})
+
+	t.Run("remember_creates_dolt_commit", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "pmemc")
+		db := openProxiedDB(t, p)
+		before := proxiedDoltHead(t, db)
+
+		bdProxiedMem(t, bd, p.dir, "remember", "one write is one commit", "--key", "tx-shape")
+
+		after := proxiedDoltHead(t, db)
+		if after == before {
+			t.Errorf("HEAD did not advance on remember: before=%s after=%s", before, after)
+		}
+		if n := proxiedDoltCommitCountSince(t, db, before); n != 1 {
+			t.Errorf("expected exactly 1 Dolt commit for remember, got %d", n)
+		}
+	})
+}

--- a/cmd/bd/memory_proxied_server.go
+++ b/cmd/bd/memory_proxied_server.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/steveyegge/beads/internal/storage/uow"
+)
+
+// Proxied-server handlers for the memory surface (`bd remember`, `bd
+// memories`, `bd forget`, `bd recall`). Memories are a thin prefix layer
+// (kv.memory.*) over the config table, so these mirror
+// config_proxied_server.go / kv_proxied_server.go: one RunTx per write
+// invocation with a real commit message, RunTxRead for reads. Validation and
+// key derivation happen in the RunE before dispatch; presentation goes
+// through the shared helpers in memory.go so output cannot drift from the
+// classic path. Storage keys stay kv.memory.<key> so export tooling picks
+// memories up alongside the rest of the kv namespace.
+//
+// Error handling note: the underlying storage error is passed through %v
+// unmodified — callers retry on the 'Merge conflict detected' /
+// 'constraint violation, transaction rolled back' substrings, which must
+// survive to the CLI surface.
+
+// memoryGetProxied reads one kv.memory.* value; mirrors the classic path's
+// tolerant read (`existing, _ := store.GetConfig(...)`) where noted.
+func memoryGetProxied(ctx context.Context, storageKey string) (string, error) {
+	return uow.RunTxRead(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (string, error) {
+		return uw.ConfigUseCase().GetConfig(ctx, storageKey)
+	})
+}
+
+func runRememberProxiedServer(ctx context.Context, key, insight string) error {
+	if uowProvider == nil {
+		return HandleErrorRespectJSON("proxied-server UOW provider not initialized")
+	}
+
+	storageKey := kvPrefix + memoryPrefix + key
+
+	// Classic path ignores the existence-check error; mirror that.
+	existing, _ := memoryGetProxied(ctx, storageKey)
+	verb := "Remembered"
+	if existing != "" {
+		verb = "Updated"
+	}
+
+	// Desire path + footgun guard (see the classic RunE in memory.go): a bare
+	// slug with no --key is a mistyped READ — recall it if it exists, refuse
+	// to store it as its own content if it doesn't. No write happens on this
+	// branch, so it runs before the RunTx.
+	if memoryKeyFlag == "" && slugify(insight) == insight {
+		return rememberBareKeyPath(key, insight, existing)
+	}
+
+	err := uow.RunTx(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (string, error) {
+		if err := uw.ConfigUseCase().SetConfig(ctx, storageKey, insight); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("bd: remember %s", key), nil
+	})
+	if err != nil {
+		return HandleErrorRespectJSON("storing memory: %v", err)
+	}
+
+	return printRememberResult(verb, key, insight)
+}
+
+func runMemoriesProxiedServer(ctx context.Context, search string) error {
+	if uowProvider == nil {
+		return HandleErrorRespectJSON("proxied-server UOW provider not initialized")
+	}
+
+	allConfig, err := uow.RunTxRead(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (map[string]string, error) {
+		return uw.ConfigUseCase().GetAllConfig(ctx)
+	})
+	if err != nil {
+		return HandleErrorRespectJSON("listing memories: %v", err)
+	}
+
+	return printMemoriesResult(memoriesFromConfig(allConfig, search), search)
+}
+
+func runForgetProxiedServer(ctx context.Context, key string) error {
+	if uowProvider == nil {
+		return HandleErrorRespectJSON("proxied-server UOW provider not initialized")
+	}
+
+	storageKey := kvPrefix + memoryPrefix + key
+
+	// Classic path ignores the existence-check error; mirror that.
+	existing, _ := memoryGetProxied(ctx, storageKey)
+	if existing == "" {
+		return printForgetNotFound(key)
+	}
+
+	err := uow.RunTx(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (string, error) {
+		if err := uw.ConfigUseCase().DeleteConfig(ctx, storageKey); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("bd: forget %s", key), nil
+	})
+	if err != nil {
+		return HandleErrorRespectJSON("forgetting memory: %v", err)
+	}
+
+	return printForgetResult(key, existing)
+}
+
+func runRecallProxiedServer(ctx context.Context, key string) error {
+	if uowProvider == nil {
+		return HandleErrorRespectJSON("proxied-server UOW provider not initialized")
+	}
+
+	storageKey := kvPrefix + memoryPrefix + key
+	value, err := memoryGetProxied(ctx, storageKey)
+	if err != nil {
+		return HandleErrorRespectJSON("recalling memory: %v", err)
+	}
+
+	return printRecallResult(key, value)
+}


### PR DESCRIPTION
## What

Ports `bd kv` (set/get/clear/list) and the memory surface (`bd remember`, `bd memories`, `bd forget`, `bd recall`) to proxied-server mode, removing all eight "not supported in proxied-server mode" gates. Part of program **bd-vxavz**; bead **bd-dnzjy**.

## Why

kv/memory are a thin prefix layer (`kv.*` / `kv.memory.*`) over the config table, whose four verbs (`GetConfig`/`SetConfig`/`DeleteConfig`/`GetAllConfig`) already exist on `domain.ConfigUseCase` and are already proxied for `bd config`. This is pure routing — and kv is the wyvern constellation's mail transport, so the proxied gate was blocking the wheelhouse cutover.

## How

- **Handlers** in `cmd/bd/kv_proxied_server.go` and `cmd/bd/memory_proxied_server.go`, modeled literally on `config_proxied_server.go`: ONE `uow.RunTx` per write invocation, reads via `uow.RunTxRead`. The proxied path never enters `ensureDirectMode`; classic keeps it.
- **Commit-message convention** (matching `bd: config set %s`): `bd: kv set <key>`, `bd: kv clear <key>`, `bd: remember <key>`, `bd: forget <key>`.
- **Shared presentation**: output rendering and namespace filtering are extracted into helpers used by both classic and proxied paths (`printKV*`, `kvPairsFromConfig`, `printRemember*`/`printForget*`/`printRecall*`, `memoriesFromConfig`, `rememberBareKeyPath`), so the `kv list --json` shape a mail client parses cannot drift between modes.
- **Validation before dispatch**: `validateKVKey`, the remember empty/command-word guards, and key derivation run in the RunE before the mode branch — identical refusals in both modes. The remember bare-key desire path (recall-instead-of-write / refuse-junk-memory) is shared verbatim.
- **Error text**: storage errors pass through `%v` unmodified — the `Merge conflict detected` and `constraint violation, transaction rolled back` substrings callers retry on survive to the CLI surface. `kv clear` of an absent key stays idempotent-friendly (RunTx already tolerates nothing-to-commit).
- Memory keys still land at `kv.memory.<key>` (verified in-test via `bd config get`), so the export port in the sibling PR picks them up; `export.go` untouched.

## Tests

- `TestProxiedServerKV` — set/get round-trip; **byte-preserving multi-line JSON mail-envelope round-trip** (one argv element with spaces, newlines, tabs); `list --json` shape pinned (flat string map + numeric `schema_version`, storage prefix stripped) **and compared against a classic embedded project running the same commands**; idempotent clear; invalid-key refusals; exactly one Dolt commit per write (HEAD advance + commit count).
- `TestProxiedServerMemory` — remember (explicit + auto-slug key) → memories list/search → recall (byte-preserving) → update-in-place → forget → not-found tails; `kv.memory.<key>` storage-key check; bare-existing-key recalls / bare-missing-key refuses / command-word guard; one Dolt commit per remember.
- Manifest entries in `.github/scripts/proxied-cmd-test-shards.txt` at the shards the hash fallback already assigns (Memory→13, KV→14), so nothing reshuffles; `proxied-test-shard.sh` list-only mode verified for both shards.
- No existing test asserted the "not supported" string for these eight commands (searched `cmd/bd/*_test.go`), so nothing to invert.

Evidence (local, OrbStack docker + testcontainers dolt 2.2.0):
- `go build ./...` + `go vet ./cmd/bd/...` clean; `CGO_ENABLED=0` build clean
- `go test ./cmd/bd -run 'KV|Kv|Memory' -count=1` → ok (44s)
- `BEADS_TEST_PROXIED_SERVER=1 go test ./cmd/bd -run 'TestProxiedServerKV$|TestProxiedServerMemory$' -count=1` → PASS, all 11 subtests

Refs: bd-dnzjy, bd-vxavz

🤖 Generated with [Claude Code](https://claude.com/claude-code)