### PR TITLE
fix(proxied): corrupt sidecar/client-info aborts instead of silent fresh-DB fallback (bd-aj3g5)

### DIFF
--- a/cmd/bd/uow_factory.go
+++ b/cmd/bd/uow_factory.go
@@ -103,18 +103,21 @@ func newSQLServerUOWProvider(ctx context.Context, beadsDir string, topology sqlS
 }
 
 // resolveProxiedServerUOWTopology reads a proxied-server workspace's topology
-// out of metadata.json and the proxied-server sidecar. Neither read is fatal:
-// an absent or unreadable one leaves the defaults, which is the behavior every
-// proxied command has had, and the provider construction below is where a
-// workspace that cannot be reached actually fails. The one refusal it can
-// return is the team-server workspace with no identity to assert.
+// out of metadata.json and the proxied-server sidecar. An ABSENT file is not
+// fatal — both loads return (nil, nil) then, the defaults apply, and the
+// provider construction below is where a workspace that cannot be reached
+// actually fails. A file that EXISTS but cannot be read or parsed IS fatal
+// (restores f880a985b, reverted in #4418; bd-aj3g5): swallowing it silently
+// falls back to a fresh managed local database — reads return zero issues and
+// writes land in the wrong database (split-brain) — and the identity assertion
+// below silently degrades to no assertion at all.
 func resolveProxiedServerUOWTopology(beadsDir, databaseOverride string, posture identityPosture) (sqlServerUOWTopology, error) {
-	// NOTE: a load error is swallowed here (pre-existing behavior), which
-	// leaves persisted == nil and therefore silently falls back to the default
-	// database with teamServer=false. The identity assertion below inherits
-	// that: an unreadable metadata.json degrades to no assertion rather than a
-	// refusal. Tracked separately with the wider silent-fallback smell.
-	persisted, _ := configfile.Load(beadsDir)
+	persisted, err := configfile.Load(beadsDir)
+	if err != nil {
+		return sqlServerUOWTopology{}, fmt.Errorf(
+			"corrupt workspace config %s: %w — refusing to fall back to a fresh database; repair or remove the file to proceed",
+			configfile.ConfigPath(beadsDir), err)
+	}
 	topology := sqlServerUOWTopology{database: configfile.DefaultDoltDatabase}
 	if persisted != nil {
 		topology.database = persisted.GetDoltDatabase()
@@ -137,7 +140,12 @@ func resolveProxiedServerUOWTopology(beadsDir, databaseOverride string, posture 
 		topology.database = databaseOverride
 	}
 
-	info, _ := configfile.LoadProxiedServerClientInfo(beadsDir)
+	info, err := configfile.LoadProxiedServerClientInfo(beadsDir)
+	if err != nil {
+		return sqlServerUOWTopology{}, fmt.Errorf(
+			"corrupt proxied-server sidecar %s: %w — refusing to fall back to a fresh database; repair or remove the file to proceed",
+			configfile.ProxiedServerClientInfoPath(beadsDir), err)
+	}
 	if info != nil {
 		topology.proxyPort = info.Port
 		topology.proxyIdle = info.IdleTimeout

--- a/cmd/bd/uow_factory_test.go
+++ b/cmd/bd/uow_factory_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -45,6 +46,75 @@ func TestNewProxiedServerUOWProvider_RoutesExternalConfigToExternalProvider(t *t
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Host requires Port",
 		"expected external validation error proving the external code path was taken; got: %v", err)
+}
+
+// A corrupted sidecar must abort provider construction, not silently fall
+// back to a fresh managed local database (bd-aj3g5, restoring f880a985b;
+// split-brain: reads return zero issues, writes land in the wrong database).
+func TestNewProxiedServerUOWProvider_CorruptSidecarErrorsInsteadOfManagedFallback(t *testing.T) {
+	beadsDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(beadsDir, configfile.ProxiedServerClientInfoFileName),
+		[]byte("{not json"), 0o600))
+
+	_, err := newProxiedServerUOWProvider(context.Background(), beadsDir, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), configfile.ProxiedServerClientInfoPath(beadsDir),
+		"error must name the unreadable sidecar path; got: %v", err)
+	assert.Contains(t, err.Error(), "refusing to fall back",
+		"must refuse the managed-local fallback; got: %v", err)
+}
+
+// An unparseable workspace config must abort too — defaulting the database
+// name sends writes to the wrong database, and the team-server identity
+// assertion silently degrades to no assertion at all.
+func TestNewProxiedServerUOWProvider_CorruptWorkspaceConfigErrors(t *testing.T) {
+	beadsDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(beadsDir, configfile.ConfigFileName),
+		[]byte("{not json"), 0o600))
+
+	_, err := newProxiedServerUOWProvider(context.Background(), beadsDir, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), configfile.ConfigPath(beadsDir),
+		"error must name the unreadable workspace config path; got: %v", err)
+	assert.Contains(t, err.Error(), "refusing to fall back",
+		"must refuse the fresh-database fallback; got: %v", err)
+}
+
+// An UNREADABLE (permission-denied) sidecar is the same hazard as an
+// unparseable one: the file exists, so falling back would fork a fresh
+// database while the real one sits behind the perms error.
+func TestNewProxiedServerUOWProvider_UnreadableSidecarErrors(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root; chmod 000 does not deny reads")
+	}
+	beadsDir := t.TempDir()
+	sidecar := filepath.Join(beadsDir, configfile.ProxiedServerClientInfoFileName)
+	require.NoError(t, os.WriteFile(sidecar, []byte("{}"), 0o600))
+	require.NoError(t, os.Chmod(sidecar, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(sidecar, 0o600) })
+
+	_, err := newProxiedServerUOWProvider(context.Background(), beadsDir, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), configfile.ProxiedServerClientInfoPath(beadsDir),
+		"error must name the unreadable sidecar path; got: %v", err)
+	assert.Contains(t, err.Error(), "refusing to fall back",
+		"must refuse the managed-local fallback; got: %v", err)
+}
+
+// ABSENT files are the legal fresh-workspace path: both loads return
+// (nil, nil) and the topology resolves to the defaults with no error. Pinned
+// at the resolver level because the full provider would go on to start a
+// managed dolt server.
+func TestResolveProxiedServerUOWTopology_AbsentFilesResolveDefaults(t *testing.T) {
+	beadsDir := t.TempDir()
+
+	topology, err := resolveProxiedServerUOWTopology(beadsDir, "", assertWorkspaceIdentity)
+	require.NoError(t, err, "absent metadata.json and sidecar must not be an error")
+	assert.Equal(t, configfile.DefaultDoltDatabase, topology.database)
+	assert.False(t, topology.teamServer)
+	assert.Nil(t, topology.external)
 }
 
 func TestNewExternalProxiedServerUOWProvider_CreatesRootDir(t *testing.T) {

--- a/internal/configfile/configfile_test.go
+++ b/internal/configfile/configfile_test.go
@@ -58,6 +58,21 @@ func TestLoadNonexistent(t *testing.T) {
 	}
 }
 
+// Corrupt must never be conflated with absent (bd-aj3g5): the proxied
+// provider takes the fresh-workspace defaults on (nil, nil), so a parse
+// failure that returned nil would silently reroute it to the wrong database.
+func TestLoadCorruptIsError(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(ConfigPath(tmpDir), []byte("{not json"), 0o600); err != nil {
+		t.Fatalf("seed corrupt: %v", err)
+	}
+
+	cfg, err := Load(tmpDir)
+	if err == nil {
+		t.Fatalf("Load() of corrupt config returned nil error (cfg=%+v); corrupt must not be conflated with absent", cfg)
+	}
+}
+
 func TestDatabasePath(t *testing.T) {
 	beadsDir := "/home/user/project/.beads"
 	// DatabasePath always returns dolt path regardless of Database field
@@ -790,6 +805,24 @@ func TestProxiedServerClientInfo_RoundTrip(t *testing.T) {
 		}
 		if got.External == nil || got.External.Socket != "/var/run/dolt.sock" {
 			t.Errorf("External round-trip lost data: %+v", got.External)
+		}
+	})
+
+	// The absent-vs-corrupt distinction is load-bearing for the proxied
+	// provider (bd-aj3g5): absent means (nil, nil) and the caller may take
+	// the fresh-workspace defaults; a file that EXISTS but cannot be parsed
+	// must be an error, or the caller silently forks a fresh database.
+	t.Run("corrupt sidecar is an error, not nil", func(t *testing.T) {
+		sub := t.TempDir()
+		if err := os.WriteFile(ProxiedServerClientInfoPath(sub), []byte("{not json"), 0o600); err != nil {
+			t.Fatalf("seed corrupt: %v", err)
+		}
+		got, err := LoadProxiedServerClientInfo(sub)
+		if err == nil {
+			t.Fatalf("Load of corrupt sidecar returned nil error (got=%+v); corrupt must not be conflated with absent", got)
+		}
+		if !strings.Contains(err.Error(), ProxiedServerClientInfoFileName) {
+			t.Errorf("error should name the file: %v", err)
 		}
 	})
 


### PR DESCRIPTION
## Summary

Restores the corrupt-sidecar hard-error guard in proxied-server mode (bd-aj3g5, program bd-vxavz; regression of bd-6dnrw.44 item 6).

`resolveProxiedServerUOWTopology` (cmd/bd/uow_factory.go) discarded the load errors for both `metadata.json` (`configfile.Load`) and `proxied_server_client_info.json` (`configfile.LoadProxiedServerClientInfo`). Both loaders return `(nil, nil)` when the file is **absent**, so a non-nil error means the file **exists but cannot be read or parsed** — and swallowing it made bd silently fall back to a FRESH managed local database.

### The split-brain failure mode

For a multi-clone constellation pointed at an external/shared Dolt server, a corrupted or permission-broken sidecar does not make the clone fail — it makes it *fork*: reads return zero issues, writes land in a brand-new empty local database, and the clone looks alive while diverging from the shared truth. A corrupted `metadata.json` additionally silently defaults the database name and degrades the team-server identity assertion to no assertion at all.

### History: restore of a reverted fix

- `f880a985b` (2026-06-12) fixed exactly this: "corrupt sidecar/config aborts instead of silent fresh-DB fallback (bd-6dnrw.44 item 6)", with regression tests.
- `a59e75325` (#4418, 2026-06-15) reverted it wholesale as part of "Triage and clean up an unreviewed automated commit stream".
- The code has since been restructured (loads moved into `resolveProxiedServerUOWTopology`), and the comment at the call site described the swallow as "pre-existing behavior... tracked separately", unaware a fix had existed. This PR re-applies the fix adapted to the current structure and replaces that comment with the actual contract.

### Absent-vs-corrupt matrix

| File | Absent | Present but corrupt/unreadable |
|---|---|---|
| `metadata.json` | defaults (fresh init / managed fallback legal) — unchanged | hard error naming the path, refusing the fallback — **restored** |
| `proxied_server_client_info.json` | defaults — unchanged | hard error naming the path, refusing the fallback — **restored** |

Error shape: `corrupt proxied-server sidecar <path>: <underlying err> — refusing to fall back to a fresh database; repair or remove the file to proceed` (and the `corrupt workspace config <path>: ...` sibling).

### Audit of other swallowed loads on the proxied path

- `cmd/bd/uow_factory.go` — the two call sites above were the only `_ :=` loads; `resolveServerModeUOWTopology` already propagates its `configfile.Load` error.
- `cmd/bd/proxied_server.go` — `resolveProxiedServerConfigPath` / `resolveProxiedServerLogPath` already propagate; the only remaining `persisted, _ :=` is inside a commented-out legacy function (line ~613).
- `internal/doltserver/physical_root.go` `ResolveProxiedServerRootPath` — already propagates.
- `internal/configfile` loaders already distinguish `os.IsNotExist` → `(nil, nil)` from corrupt → error, so no loader-layer change was needed; the previously-unpinned corrupt→error contract is now pinned by tests.

### Tests

New (all in this PR):
- `TestNewProxiedServerUOWProvider_CorruptSidecarErrorsInsteadOfManagedFallback` — garbage JSON sidecar → hard error naming the path, "refusing to fall back" (resurrected from f880a985b, adapted).
- `TestNewProxiedServerUOWProvider_CorruptWorkspaceConfigErrors` — garbage JSON `metadata.json` → hard error naming the path (resurrected, adapted).
- `TestNewProxiedServerUOWProvider_UnreadableSidecarErrors` — chmod 000 sidecar → hard error (skips as root).
- `TestResolveProxiedServerUOWTopology_AbsentFilesResolveDefaults` — absent files → defaults, no error (pinned at the resolver level; the full provider would go on to start a managed dolt server).
- `internal/configfile`: `TestLoadCorruptIsError` + "corrupt sidecar is an error, not nil" subtest — pin the loader-layer absent-vs-corrupt contract the call-site fix relies on.

Evidence (local, verified exit codes):
- `go build ./... && go vet ./...` — clean (exit 0).
- `go test ./cmd/bd -run 'Sidecar|UOWFactory|Factory|ConfigFile|ProxiedServerUOW|LoadCorrupt' -count=1` — ok, exit 0 (~25s; all five new cmd/bd tests plus neighboring factory/sidecar tests, each individually PASS in a `-v` run).
- `go test ./internal/configfile/... -count=1` — ok, exit 0.
- The full `go test ./cmd/bd -count=1 -short` was attempted three times locally and the execution environment was recycled out from under it each time (~10 min runtime); no complete local run was observed, so no claim is made about it here — CI's required lanes are the authority for the full suite.

Refs: bd-aj3g5, bd-vxavz, bd-6dnrw.44 item 6. Restores f880a985b, reverted by a59e75325 (#4418).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
