### PR TITLE
feat(gate): port create/add-waiter/resolve/show to proxied-server mode (bd-v50ru)

### DIFF
--- a/.github/scripts/proxied-cmd-test-shards.txt
+++ b/.github/scripts/proxied-cmd-test-shards.txt
@@ -17,7 +17,9 @@
 
 15 1 TestProxiedServerCount
 15 1 TestProxiedServerDelete
+15 1 TestProxiedServerDelete
 15 1 TestProxiedServerDoltRemoteRemove
+15 1 TestProxiedServerGateLifecycle
 15 1 TestProxiedServerMolCurrent
 15 1 TestProxiedServerPathHelpers
 15 1 TestProxiedServerTodo

--- a/.github/scripts/proxied-cmd-test-shards.txt
+++ b/.github/scripts/proxied-cmd-test-shards.txt
@@ -17,7 +17,6 @@
 
 15 1 TestProxiedServerCount
 15 1 TestProxiedServerDelete
-15 1 TestProxiedServerDelete
 15 1 TestProxiedServerDoltRemoteRemove
 15 1 TestProxiedServerGateLifecycle
 15 1 TestProxiedServerMolCurrent

--- a/cmd/bd/gate.go
+++ b/cmd/bd/gate.go
@@ -233,7 +233,7 @@ This is used by 'bd done --phase-complete' to register for gate wake notificatio
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if usesProxiedServer() {
-			return HandleErrorRespectJSON("gate add-waiter is not supported in proxied-server mode")
+			return runGateAddWaiterProxiedServer(cmd, rootCtx, args)
 		}
 		CheckReadonly("gate add-waiter")
 
@@ -262,7 +262,7 @@ This is used by 'bd done --phase-complete' to register for gate wake notificatio
 
 		for _, w := range issue.Waiters {
 			if w == waiter {
-				fmt.Printf("Waiter already registered on gate %s\n", gateID)
+				renderGateWaiterAlready(gateID)
 				return nil
 			}
 		}
@@ -278,9 +278,19 @@ This is used by 'bd done --phase-complete' to register for gate wake notificatio
 
 		commandDidWrite.Store(true)
 
-		fmt.Printf("%s Added waiter to gate %s: %s\n", ui.RenderPass("✓"), gateID, waiter)
+		renderGateWaiterAdded(gateID, waiter)
 		return nil
 	},
+}
+
+// renderGateWaiterAlready and renderGateWaiterAdded are shared by the direct
+// and proxied-server routes so `bd gate add-waiter` prints identically on both.
+func renderGateWaiterAlready(gateID string) {
+	fmt.Printf("Waiter already registered on gate %s\n", gateID)
+}
+
+func renderGateWaiterAdded(gateID, waiter string) {
+	fmt.Printf("%s Added waiter to gate %s: %s\n", ui.RenderPass("✓"), gateID, waiter)
 }
 
 // gateCreateCmd creates an ad-hoc gate issue that blocks another issue
@@ -308,7 +318,7 @@ Examples:
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if usesProxiedServer() {
-			return HandleErrorRespectJSON("gate create is not supported in proxied-server mode")
+			return runGateCreateProxiedServer(cmd, rootCtx)
 		}
 		CheckReadonly("gate create")
 
@@ -319,54 +329,19 @@ Examples:
 			}
 		}()
 
-		blocksID, _ := cmd.Flags().GetString("blocks")
-		gateType, _ := cmd.Flags().GetString("type")
-		reason, _ := cmd.Flags().GetString("reason")
-		awaitID, _ := cmd.Flags().GetString("await-id")
-		timeoutStr, _ := cmd.Flags().GetString("timeout")
-		titleFlag, _ := cmd.Flags().GetString("title")
+		in, err := gatherGateCreateInput(cmd)
+		if err != nil {
+			return HandleErrorRespectJSON("%v", err)
+		}
 
 		ctx := rootCtx
 
-		targetIssue, err := store.GetIssue(ctx, blocksID)
+		targetIssue, err := store.GetIssue(ctx, in.blocksID)
 		if err != nil {
-			return HandleErrorRespectJSON("issue not found: %s", blocksID)
+			return HandleErrorRespectJSON("issue not found: %s", in.blocksID)
 		}
 
-		var timeout time.Duration
-		if timeoutStr != "" {
-			parsed, err := time.ParseDuration(timeoutStr)
-			if err != nil {
-				return HandleErrorRespectJSON("invalid timeout: %v", err)
-			}
-			timeout = parsed
-		}
-
-		title := fmt.Sprintf("Gate: %s", gateType)
-		if awaitID != "" {
-			title = fmt.Sprintf("Gate: %s %s", gateType, awaitID)
-		}
-		if titleFlag != "" {
-			title = titleFlag
-		}
-
-		desc := fmt.Sprintf("Ad-hoc gate blocking %s", targetIssue.ID)
-		if reason != "" {
-			desc = fmt.Sprintf("%s\n\nReason: %s", desc, reason)
-		}
-
-		gate := &types.Issue{
-			Title:       title,
-			Description: desc,
-			Status:      types.StatusOpen,
-			Priority:    2,
-			IssueType:   types.IssueType("gate"),
-			AwaitType:   gateType,
-			AwaitID:     awaitID,
-			Timeout:     timeout,
-			CreatedBy:   getActorWithGit(),
-			Owner:       getOwner(),
-		}
+		gate := buildGateIssue(in, targetIssue.ID)
 
 		if err := store.CreateIssue(ctx, gate, actor); err != nil {
 			return HandleErrorRespectJSON("creating gate: %v", err)
@@ -390,17 +365,84 @@ Examples:
 			return outputJSON(gate)
 		}
 
-		fmt.Printf("%s Created gate %s (type: %s)\n", ui.RenderPass("✓"), ui.RenderID(gate.ID), gateType)
-		fmt.Printf("  Blocks: %s (%s)\n", targetIssue.ID, targetIssue.Title)
-		if reason != "" {
-			fmt.Printf("  Reason: %s\n", reason)
-		}
-		if timeout > 0 {
-			fmt.Printf("  Timeout: %s\n", timeout)
-		}
-		fmt.Printf("\nResolve with: bd gate resolve %s\n", gate.ID)
+		renderGateCreated(gate, targetIssue, in)
 		return nil
 	},
+}
+
+// gateCreateInput carries `bd gate create`'s parsed flags. Both routes gather
+// it through gatherGateCreateInput so they cannot drift on flag semantics.
+type gateCreateInput struct {
+	blocksID  string
+	gateType  string
+	reason    string
+	awaitID   string
+	titleFlag string
+	timeout   time.Duration
+}
+
+func gatherGateCreateInput(cmd *cobra.Command) (gateCreateInput, error) {
+	in := gateCreateInput{}
+	in.blocksID, _ = cmd.Flags().GetString("blocks")
+	in.gateType, _ = cmd.Flags().GetString("type")
+	in.reason, _ = cmd.Flags().GetString("reason")
+	in.awaitID, _ = cmd.Flags().GetString("await-id")
+	in.titleFlag, _ = cmd.Flags().GetString("title")
+	timeoutStr, _ := cmd.Flags().GetString("timeout")
+	if timeoutStr != "" {
+		parsed, err := time.ParseDuration(timeoutStr)
+		if err != nil {
+			return in, fmt.Errorf("invalid timeout: %v", err)
+		}
+		in.timeout = parsed
+	}
+	return in, nil
+}
+
+// buildGateIssue constructs the ad-hoc gate issue exactly the way the direct
+// route always has; the proxied route reuses it for the same reason the
+// renderers are shared.
+func buildGateIssue(in gateCreateInput, targetID string) *types.Issue {
+	title := fmt.Sprintf("Gate: %s", in.gateType)
+	if in.awaitID != "" {
+		title = fmt.Sprintf("Gate: %s %s", in.gateType, in.awaitID)
+	}
+	if in.titleFlag != "" {
+		title = in.titleFlag
+	}
+
+	desc := fmt.Sprintf("Ad-hoc gate blocking %s", targetID)
+	if in.reason != "" {
+		desc = fmt.Sprintf("%s\n\nReason: %s", desc, in.reason)
+	}
+
+	return &types.Issue{
+		Title:       title,
+		Description: desc,
+		Status:      types.StatusOpen,
+		Priority:    2,
+		IssueType:   types.IssueType("gate"),
+		AwaitType:   in.gateType,
+		AwaitID:     in.awaitID,
+		Timeout:     in.timeout,
+		CreatedBy:   getActorWithGit(),
+		Owner:       getOwner(),
+	}
+}
+
+// renderGateCreated is shared by the direct and proxied-server routes; the
+// first line's "Created gate <id>" is parsed by downstream scripts, so both
+// routes must print it identically.
+func renderGateCreated(gate, targetIssue *types.Issue, in gateCreateInput) {
+	fmt.Printf("%s Created gate %s (type: %s)\n", ui.RenderPass("✓"), ui.RenderID(gate.ID), in.gateType)
+	fmt.Printf("  Blocks: %s (%s)\n", targetIssue.ID, targetIssue.Title)
+	if in.reason != "" {
+		fmt.Printf("  Reason: %s\n", in.reason)
+	}
+	if in.timeout > 0 {
+		fmt.Printf("  Timeout: %s\n", in.timeout)
+	}
+	fmt.Printf("\nResolve with: bd gate resolve %s\n", gate.ID)
 }
 
 // gateShowCmd shows a gate issue
@@ -415,7 +457,7 @@ This is similar to 'bd show' but validates that the issue is a gate.`,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if usesProxiedServer() {
-			return HandleErrorRespectJSON("gate show is not supported in proxied-server mode")
+			return runGateShowProxiedServer(cmd, rootCtx, args)
 		}
 		evt := metrics.NewCommandEvent("gate-show")
 		defer func() {
@@ -443,31 +485,38 @@ This is similar to 'bd show' but validates that the issue is a gate.`,
 			return outputJSON(issue)
 		}
 
-		statusSym := "○"
-		if issue.Status == types.StatusClosed {
-			statusSym = "●"
-		}
-
-		fmt.Printf("%s %s - %s\n", statusSym, ui.RenderID(issue.ID), issue.Title)
-		fmt.Printf("  Status: %s\n", issue.Status)
-		fmt.Printf("  Await Type: %s\n", issue.AwaitType)
-		if issue.AwaitID != "" {
-			fmt.Printf("  Await ID: %s\n", issue.AwaitID)
-		}
-		if issue.Timeout > 0 {
-			fmt.Printf("  Timeout: %s\n", issue.Timeout)
-		}
-		if len(issue.Waiters) > 0 {
-			fmt.Printf("  Waiters:\n")
-			for _, w := range issue.Waiters {
-				fmt.Printf("    - %s\n", w)
-			}
-		}
-		if issue.Description != "" {
-			fmt.Printf("  Description: %s\n", issue.Description)
-		}
+		renderGateShow(issue)
 		return nil
 	},
+}
+
+// renderGateShow is shared by the direct and proxied-server routes; downstream
+// scripts grep this plain-text output for markers, so both routes must print
+// it identically.
+func renderGateShow(issue *types.Issue) {
+	statusSym := "○"
+	if issue.Status == types.StatusClosed {
+		statusSym = "●"
+	}
+
+	fmt.Printf("%s %s - %s\n", statusSym, ui.RenderID(issue.ID), issue.Title)
+	fmt.Printf("  Status: %s\n", issue.Status)
+	fmt.Printf("  Await Type: %s\n", issue.AwaitType)
+	if issue.AwaitID != "" {
+		fmt.Printf("  Await ID: %s\n", issue.AwaitID)
+	}
+	if issue.Timeout > 0 {
+		fmt.Printf("  Timeout: %s\n", issue.Timeout)
+	}
+	if len(issue.Waiters) > 0 {
+		fmt.Printf("  Waiters:\n")
+		for _, w := range issue.Waiters {
+			fmt.Printf("    - %s\n", w)
+		}
+	}
+	if issue.Description != "" {
+		fmt.Printf("  Description: %s\n", issue.Description)
+	}
 }
 
 // gateResolveCmd manually closes a gate
@@ -483,7 +532,7 @@ Use --reason to provide context for why the gate was resolved.`,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if usesProxiedServer() {
-			return HandleErrorRespectJSON("gate resolve is not supported in proxied-server mode")
+			return runGateResolveProxiedServer(cmd, rootCtx, args)
 		}
 		CheckReadonly("gate resolve")
 
@@ -516,12 +565,18 @@ Use --reason to provide context for why the gate was resolved.`,
 
 		commandDidWrite.Store(true)
 
-		fmt.Printf("%s Gate resolved: %s\n", ui.RenderPass("✓"), gateID)
-		if reason != "" {
-			fmt.Printf("  Reason: %s\n", reason)
-		}
+		renderGateResolved(gateID, reason)
 		return nil
 	},
+}
+
+// renderGateResolved is shared by the direct and proxied-server routes so
+// `bd gate resolve` prints identically on both.
+func renderGateResolved(gateID, reason string) {
+	fmt.Printf("%s Gate resolved: %s\n", ui.RenderPass("✓"), gateID)
+	if reason != "" {
+		fmt.Printf("  Reason: %s\n", reason)
+	}
 }
 
 // gateCheckCmd evaluates gates and closes those that are resolved

--- a/cmd/bd/gate_lifecycle_proxied_integration_test.go
+++ b/cmd/bd/gate_lifecycle_proxied_integration_test.go
@@ -1,0 +1,260 @@
+//go:build cgo
+
+package main
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+var gateCreatedIDRe = regexp.MustCompile(`Created gate (\S+) \(type:`)
+
+// parseCreatedGateID extracts the gate id from `bd gate create`'s first output
+// line. Downstream scripts parse the id from exactly this line, so the test
+// deliberately goes through the printed text rather than --json.
+func parseCreatedGateID(t *testing.T, out string) string {
+	t.Helper()
+	m := gateCreatedIDRe.FindStringSubmatch(out)
+	if m == nil {
+		t.Fatalf("no 'Created gate <id>' line in gate create output:\n%s", out)
+	}
+	return m[1]
+}
+
+func gateReadyIDs(t *testing.T, bd string, p proxiedProject) map[string]bool {
+	t.Helper()
+	ids := map[string]bool{}
+	for _, r := range bdProxiedReadyJSON(t, bd, p) {
+		ids[r.ID] = true
+	}
+	return ids
+}
+
+// TestProxiedServerGateLifecycle journeys the newly-ported gate subcommands
+// (create, show, add-waiter, resolve) end to end against a proxied server,
+// pinning the exact output shapes the wyvern wheelhouse scripts consume.
+func TestProxiedServerGateLifecycle(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+
+	// The wh-heartbeat/wh-gate-sweep shape: a human gate blocks a bead until
+	// someone resolves it; waiters registered on the gate are woken at resolve.
+	t.Run("human_gate_journey", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "ghj")
+		target := bdProxiedCreate(t, bd, p.dir, "Blocked by human gate")
+
+		if ids := gateReadyIDs(t, bd, p); !ids[target.ID] {
+			t.Fatalf("target %s should be ready before the gate exists", target.ID)
+		}
+
+		out, stderr, err := bdProxiedRunBuffers(t, bd, p.dir,
+			"gate", "create", "--type=human", "--blocks", target.ID, "--reason", "Need design review")
+		if err != nil {
+			t.Fatalf("gate create failed: %v\nstderr:\n%s", err, stderr)
+		}
+		gateID := parseCreatedGateID(t, out)
+		for _, want := range []string{
+			"Blocks: " + target.ID,
+			"Reason: Need design review",
+			"Resolve with: bd gate resolve " + gateID,
+		} {
+			if !strings.Contains(out, want) {
+				t.Errorf("gate create output missing %q:\n%s", want, out)
+			}
+		}
+
+		// ONE dolt commit for the whole create (issue + blocking edge).
+		if ids := gateReadyIDs(t, bd, p); ids[target.ID] {
+			t.Errorf("target %s must not be ready while the gate is open", target.ID)
+		}
+
+		// gate show: plain text markers the wheelhouse greps for.
+		out, stderr, err = bdProxiedRunBuffers(t, bd, p.dir, "gate", "show", gateID)
+		if err != nil {
+			t.Fatalf("gate show failed: %v\nstderr:\n%s", err, stderr)
+		}
+		for _, want := range []string{
+			gateID,
+			"Status: open",
+			"Await Type: human",
+			"Reason: Need design review",
+		} {
+			if !strings.Contains(out, want) {
+				t.Errorf("gate show output missing %q:\n%s", want, out)
+			}
+		}
+
+		// add-waiter, then again: second registration is a reported no-op.
+		out, stderr, err = bdProxiedRunBuffers(t, bd, p.dir, "gate", "add-waiter", gateID, "shelley")
+		if err != nil {
+			t.Fatalf("gate add-waiter failed: %v\nstderr:\n%s", err, stderr)
+		}
+		if !strings.Contains(out, "Added waiter to gate "+gateID+": shelley") {
+			t.Errorf("expected added-waiter confirmation, got:\n%s", out)
+		}
+		out, stderr, err = bdProxiedRunBuffers(t, bd, p.dir, "gate", "add-waiter", gateID, "shelley")
+		if err != nil {
+			t.Fatalf("repeat gate add-waiter failed: %v\nstderr:\n%s", err, stderr)
+		}
+		if !strings.Contains(out, "Waiter already registered on gate "+gateID) {
+			t.Errorf("expected already-registered message, got:\n%s", out)
+		}
+
+		out, stderr, err = bdProxiedRunBuffers(t, bd, p.dir, "gate", "show", gateID)
+		if err != nil {
+			t.Fatalf("gate show after add-waiter failed: %v\nstderr:\n%s", err, stderr)
+		}
+		if !strings.Contains(out, "Waiters:") || !strings.Contains(out, "- shelley") {
+			t.Errorf("gate show should list the registered waiter, got:\n%s", out)
+		}
+
+		// gate list --all --json: the consumers read .id/.status/.description
+		// (containing "Reason: ") and .waiters, so pin the raw JSON keys.
+		out, stderr, err = bdProxiedRunBuffers(t, bd, p.dir, "gate", "list", "--all", "--json")
+		if err != nil {
+			t.Fatalf("gate list --all --json failed: %v\nstderr:\n%s", err, stderr)
+		}
+		var listed []map[string]any
+		s := strings.TrimSpace(out)
+		if start := strings.Index(s, "["); start < 0 {
+			t.Fatalf("no JSON array in gate list output:\n%s", out)
+		} else if err := json.Unmarshal([]byte(s[start:]), &listed); err != nil {
+			t.Fatalf("parse gate list JSON: %v\n%s", err, out)
+		}
+		var row map[string]any
+		for _, r := range listed {
+			if r["id"] == gateID {
+				row = r
+			}
+		}
+		if row == nil {
+			t.Fatalf("gate %s missing from gate list --all --json:\n%s", gateID, out)
+		}
+		if row["status"] != "open" {
+			t.Errorf("gate list .status = %v, want open", row["status"])
+		}
+		if desc, _ := row["description"].(string); !strings.Contains(desc, "Reason: Need design review") {
+			t.Errorf("gate list .description missing 'Reason: ' marker: %v", row["description"])
+		}
+		if waiters, ok := row["waiters"].([]any); !ok || len(waiters) != 1 || waiters[0] != "shelley" {
+			t.Errorf("gate list .waiters = %v, want [shelley]", row["waiters"])
+		}
+
+		// resolve: rc-only consumption, gate closes, target unblocks.
+		out, stderr, err = bdProxiedRunBuffers(t, bd, p.dir, "gate", "resolve", gateID, "--reason", "design approved")
+		if err != nil {
+			t.Fatalf("gate resolve failed: %v\nstderr:\n%s", err, stderr)
+		}
+		if !strings.Contains(out, "Gate resolved: "+gateID) || !strings.Contains(out, "Reason: design approved") {
+			t.Errorf("unexpected gate resolve output:\n%s", out)
+		}
+		db := openProxiedDB(t, p)
+		if got := readStatus(t, db, gateID); got != types.StatusClosed {
+			t.Errorf("resolved gate should be closed, got %q", got)
+		}
+		if ids := gateReadyIDs(t, bd, p); !ids[target.ID] {
+			t.Errorf("target %s should be ready again after resolve", target.ID)
+		}
+	})
+
+	// The wh-park shape: a bead gate names the awaited bead in --await-id, and
+	// --json create hands scripts the gate as an object.
+	t.Run("bead_gate_wh_park_shape", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "gbp")
+		parked := bdProxiedCreate(t, bd, p.dir, "Parked bead")
+		awaited := bdProxiedCreate(t, bd, p.dir, "Awaited bead")
+
+		out, stderr, err := bdProxiedRunBuffers(t, bd, p.dir,
+			"gate", "create", "--type=bead", "--blocks", parked.ID, "--await-id", awaited.ID, "--reason", "waiting on "+awaited.ID)
+		if err != nil {
+			t.Fatalf("bead gate create failed: %v\nstderr:\n%s", err, stderr)
+		}
+		gateID := parseCreatedGateID(t, out)
+
+		out, stderr, err = bdProxiedRunBuffers(t, bd, p.dir, "gate", "show", gateID)
+		if err != nil {
+			t.Fatalf("gate show failed: %v\nstderr:\n%s", err, stderr)
+		}
+		if !strings.Contains(out, "Await Type: bead") || !strings.Contains(out, "Await ID: "+awaited.ID) {
+			t.Errorf("gate show missing bead await markers:\n%s", out)
+		}
+
+		// The already-ported gate check consumes this gate: closing the awaited
+		// bead resolves it, proving create wired await_type/await_id for real.
+		bdProxiedClose(t, bd, p.dir, awaited.ID)
+		out, stderr, err = bdProxiedRunBuffers(t, bd, p.dir, "gate", "check", "--type", "bead")
+		if err != nil {
+			t.Fatalf("gate check failed: %v\nstderr:\n%s", err, stderr)
+		}
+		if !strings.Contains(out, "1 resolved") {
+			t.Errorf("expected the bead gate to resolve via gate check, got:\n%s", out)
+		}
+		db := openProxiedDB(t, p)
+		if got := readStatus(t, db, gateID); got != types.StatusClosed {
+			t.Errorf("bead gate should be closed after gate check, got %q", got)
+		}
+
+		// --json create for script consumers that prefer the object.
+		out, stderr, err = bdProxiedRunBuffers(t, bd, p.dir,
+			"gate", "create", "--type=human", "--blocks", parked.ID, "--json")
+		if err != nil {
+			t.Fatalf("gate create --json failed: %v\nstderr:\n%s", err, stderr)
+		}
+		var created map[string]any
+		s := strings.TrimSpace(out)
+		if start := strings.Index(s, "{"); start < 0 {
+			t.Fatalf("no JSON object in gate create --json output:\n%s", out)
+		} else if err := json.Unmarshal([]byte(s[start:]), &created); err != nil {
+			t.Fatalf("parse gate create JSON: %v\n%s", err, out)
+		}
+		if id, _ := created["id"].(string); id == "" {
+			t.Errorf("gate create --json must carry .id, got: %v", created)
+		}
+		if created["issue_type"] != "gate" {
+			t.Errorf("gate create --json .issue_type = %v, want gate", created["issue_type"])
+		}
+	})
+
+	// Fail-closed: every bad read or bad target exits nonzero with a
+	// distinguishable message; nothing prints a success shape.
+	t.Run("error_paths_fail_closed", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "gfe")
+		notGate := bdProxiedCreate(t, bd, p.dir, "Ordinary task")
+
+		cases := []struct {
+			name string
+			args []string
+			want string
+		}{
+			{"show_missing", []string{"gate", "show", "gfe-doesnotexist"}, "gate not found"},
+			{"show_non_gate", []string{"gate", "show", notGate.ID}, "is not a gate issue"},
+			{"resolve_missing", []string{"gate", "resolve", "gfe-doesnotexist"}, "gate not found"},
+			{"resolve_non_gate", []string{"gate", "resolve", notGate.ID}, "is not a gate issue"},
+			{"add_waiter_missing", []string{"gate", "add-waiter", "gfe-doesnotexist", "w"}, "gate not found"},
+			{"add_waiter_non_gate", []string{"gate", "add-waiter", notGate.ID, "w"}, "is not a gate issue"},
+			{"create_missing_target", []string{"gate", "create", "--blocks", "gfe-doesnotexist"}, "issue not found"},
+		}
+		for _, tc := range cases {
+			stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, tc.args...)
+			if err == nil {
+				t.Errorf("%s: expected nonzero exit, got success:\n%s", tc.name, stdout)
+				continue
+			}
+			if combined := stdout + stderr; !strings.Contains(combined, tc.want) {
+				t.Errorf("%s: expected %q in output, got:\n%s", tc.name, tc.want, combined)
+			}
+		}
+
+		if got := readStatus(t, openProxiedDB(t, p), notGate.ID); got == types.StatusClosed {
+			t.Error("gate resolve on a non-gate must not close it")
+		}
+	})
+}

--- a/cmd/bd/gate_proxied_server.go
+++ b/cmd/bd/gate_proxied_server.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"os"
@@ -196,6 +197,261 @@ func fireProxiedUpdateHook(ctx context.Context, after *types.Issue) error {
 	if err := runner.RunSync(hooks.EventUpdate, after); err != nil {
 		return fmt.Errorf("on_update hook: %w", err)
 	}
+	return nil
+}
+
+// gateProxiedNotFound reports whether an issue lookup failed because the row
+// does not exist, as opposed to the read itself failing. The distinction is
+// what keeps `bd gate show` fail-closed: "no gate" and "could not read" must
+// not collapse into one message.
+func gateProxiedNotFound(err error) bool {
+	return errors.Is(err, storage.ErrNotFound) || errors.Is(err, sql.ErrNoRows)
+}
+
+func runGateShowProxiedServer(_ *cobra.Command, ctx context.Context, args []string) error {
+	evt := metrics.NewCommandEvent("gate-show")
+	defer func() {
+		if c := metrics.Global(); c != nil {
+			c.CloseEventAndAdd(evt)
+		}
+	}()
+
+	gateID := args[0]
+
+	uw, err := proxiedOpenReadUOW(ctx)
+	if err != nil {
+		return err
+	}
+	defer uw.Close(ctx)
+
+	issue, err := uw.IssueUseCase().GetIssue(ctx, gateID)
+	if gateProxiedNotFound(err) {
+		return HandleErrorRespectJSON("gate not found: %s", gateID)
+	}
+	if err != nil {
+		// A failed read is not "no gate": it exits nonzero with its own
+		// message so a caller grepping the output cannot mistake an
+		// unreachable server for a missing gate.
+		return HandleErrorRespectJSON("reading gate %s: %v", gateID, err)
+	}
+
+	if issue.IssueType != "gate" {
+		return HandleErrorRespectJSON("%s is not a gate issue (type=%s)", gateID, issue.IssueType)
+	}
+
+	if jsonOutput {
+		return outputJSON(issue)
+	}
+
+	renderGateShow(issue)
+	return nil
+}
+
+type gateAddWaiterApply struct {
+	already bool
+	after   *types.Issue
+}
+
+func runGateAddWaiterProxiedServer(_ *cobra.Command, ctx context.Context, args []string) error {
+	CheckReadonly("gate add-waiter")
+
+	evt := metrics.NewCommandEvent("gate-add-waiter")
+	defer func() {
+		if c := metrics.Global(); c != nil {
+			c.CloseEventAndAdd(evt)
+		}
+	}()
+
+	gateID := args[0]
+	waiter := args[1]
+
+	if uowProvider == nil {
+		return HandleError("proxied-server UOW provider not initialized")
+	}
+
+	applied, err := uow.RunTxResult(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (gateAddWaiterApply, string, error) {
+		var out gateAddWaiterApply
+
+		issue, err := uw.IssueUseCase().GetIssue(ctx, gateID)
+		if gateProxiedNotFound(err) {
+			return out, "", fmt.Errorf("gate not found: %s", gateID)
+		}
+		if err != nil {
+			return out, "", fmt.Errorf("reading gate %s: %w", gateID, err)
+		}
+		if issue.IssueType != "gate" {
+			return out, "", fmt.Errorf("%s is not a gate issue (type=%s)", gateID, issue.IssueType)
+		}
+
+		for _, w := range issue.Waiters {
+			if w == waiter {
+				out.already = true
+				// Empty commit message: a registered waiter is a no-op, and a
+				// no-op writes no Dolt commit.
+				return out, "", nil
+			}
+		}
+
+		newWaiters := append(issue.Waiters, waiter)
+		if err := uw.IssueUseCase().UpdateIssue(ctx, gateID, map[string]any{"waiters": newWaiters}, actor); err != nil {
+			return out, "", fmt.Errorf("updating gate: %w", err)
+		}
+		if after, getErr := uw.IssueUseCase().GetIssue(ctx, gateID); getErr == nil {
+			out.after = after
+		}
+		return out, fmt.Sprintf("bd: gate add-waiter %s", gateID), nil
+	})
+	if err != nil {
+		return HandleError("%v", err)
+	}
+
+	if applied.already {
+		renderGateWaiterAlready(gateID)
+		return nil
+	}
+
+	if err := fireProxiedUpdateHook(ctx, applied.after); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: %s: %v\n", gateID, err)
+	}
+	commandDidWrite.Store(true)
+
+	renderGateWaiterAdded(gateID, waiter)
+	return nil
+}
+
+type gateCreateApply struct {
+	gate   *types.Issue
+	target *types.Issue
+}
+
+func runGateCreateProxiedServer(cmd *cobra.Command, ctx context.Context) error {
+	CheckReadonly("gate create")
+
+	evt := metrics.NewCommandEvent("gate-create")
+	defer func() {
+		if c := metrics.Global(); c != nil {
+			c.CloseEventAndAdd(evt)
+		}
+	}()
+
+	in, err := gatherGateCreateInput(cmd)
+	if err != nil {
+		return HandleErrorRespectJSON("%v", err)
+	}
+
+	if uowProvider == nil {
+		return HandleError("proxied-server UOW provider not initialized")
+	}
+
+	// One transaction, one Dolt commit for the whole invocation: the direct
+	// route's create + add-dependency + explicit store.Commit collapse into a
+	// single unit of work carrying the same commit message. Semantically
+	// equivalent, minus the window where the gate exists without its edge.
+	applied, err := uow.RunTxResult(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (gateCreateApply, string, error) {
+		var out gateCreateApply
+
+		target, err := uw.IssueUseCase().GetIssue(ctx, in.blocksID)
+		if err != nil {
+			// The direct route reports every target-lookup failure as
+			// not-found; keep that message for parity.
+			return out, "", fmt.Errorf("issue not found: %s", in.blocksID)
+		}
+
+		res, err := uw.IssueUseCase().CreateIssue(ctx, domain.CreateIssueParams{Issue: buildGateIssue(in, target.ID)}, actor)
+		if err != nil {
+			return out, "", fmt.Errorf("creating gate: %w", err)
+		}
+
+		dep := &types.Dependency{
+			IssueID:     target.ID,
+			DependsOnID: res.Issue.ID,
+			Type:        types.DepBlocks,
+		}
+		if err := uw.DependencyUseCase().AddDependency(ctx, dep, actor); err != nil {
+			return out, "", fmt.Errorf("adding blocking dependency: %w", err)
+		}
+
+		out.gate = res.Issue
+		out.target = target
+		return out, fmt.Sprintf("bd: create gate %s blocking %s", res.Issue.ID, target.ID), nil
+	})
+	if err != nil {
+		return HandleErrorRespectJSON("%v", err)
+	}
+
+	commandDidWrite.Store(true)
+
+	if jsonOutput {
+		return outputJSON(applied.gate)
+	}
+
+	renderGateCreated(applied.gate, applied.target, in)
+	return nil
+}
+
+type gateResolveApply struct {
+	before    *types.Issue
+	after     *types.Issue
+	oldStatus string
+}
+
+func runGateResolveProxiedServer(cmd *cobra.Command, ctx context.Context, args []string) error {
+	CheckReadonly("gate resolve")
+
+	evt := metrics.NewCommandEvent("gate-resolve")
+	defer func() {
+		if c := metrics.Global(); c != nil {
+			c.CloseEventAndAdd(evt)
+		}
+	}()
+
+	gateID := args[0]
+	reason, _ := cmd.Flags().GetString("reason")
+
+	if uowProvider == nil {
+		return HandleError("proxied-server UOW provider not initialized")
+	}
+
+	applied, err := uow.RunTxResult(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (gateResolveApply, string, error) {
+		var out gateResolveApply
+
+		issue, err := uw.IssueUseCase().GetIssue(ctx, gateID)
+		if gateProxiedNotFound(err) {
+			return out, "", fmt.Errorf("gate not found: %s", gateID)
+		}
+		if err != nil {
+			return out, "", fmt.Errorf("reading gate %s: %w", gateID, err)
+		}
+		if issue.IssueType != "gate" {
+			return out, "", fmt.Errorf("%s is not a gate issue (type=%s)", gateID, issue.IssueType)
+		}
+
+		res, err := uw.IssueUseCase().CloseIssue(ctx, gateID, domain.CloseIssueParams{Reason: reason}, actor)
+		if err != nil {
+			return out, "", fmt.Errorf("closing gate: %w", err)
+		}
+
+		out.before = issue
+		out.after = res.Issue
+		out.oldStatus = "open"
+		if issue.Status != "" {
+			out.oldStatus = string(issue.Status)
+		}
+		return out, fmt.Sprintf("bd: gate resolve %s", gateID), nil
+	})
+	if err != nil {
+		return HandleError("%v", err)
+	}
+
+	if applied.after != nil {
+		audit.LogFieldChange(applied.after.ID, "status", applied.oldStatus, "closed", actor, reason)
+	}
+	if err := fireProxiedCloseHooks(ctx, applied.before, applied.after); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: %s: %v\n", gateID, err)
+	}
+	commandDidWrite.Store(true)
+
+	renderGateResolved(gateID, reason)
 	return nil
 }
 

--- a/internal/storage/domain/db/issue.go
+++ b/internal/storage/domain/db/issue.go
@@ -833,6 +833,12 @@ func normalizeUpdateValue(key string, value any) any {
 		case []byte:
 			return string(v)
 		}
+	case "waiters":
+		// The column is TEXT holding a JSON array; the embedded path
+		// (issueops.updateIssueInTx) marshals unconditionally, and a raw
+		// []string would be refused by the SQL driver here.
+		waitersJSON, _ := json.Marshal(value)
+		return string(waitersJSON)
 	}
 	return value
 }

--- a/internal/storage/domain/db/normalize_update_value_test.go
+++ b/internal/storage/domain/db/normalize_update_value_test.go
@@ -1,0 +1,33 @@
+package db
+
+import (
+	"testing"
+	"time"
+)
+
+// TestNormalizeUpdateValueWaiters pins the waiters serialization: the column
+// is TEXT holding a JSON array, and the embedded path (issueops.updateIssueInTx)
+// marshals the value unconditionally. Before bd-v50ru this repository passed
+// the raw []string to the SQL driver, which refused it — so every waiters
+// update through the proxied backend (e.g. `bd gate add-waiter`) failed.
+func TestNormalizeUpdateValueWaiters(t *testing.T) {
+	got := normalizeUpdateValue("waiters", []string{"a", "b"})
+	if got != `["a","b"]` {
+		t.Errorf("waiters []string: got %#v, want %q", got, `["a","b"]`)
+	}
+	if got := normalizeUpdateValue("waiters", []string{}); got != `[]` {
+		t.Errorf("waiters empty slice: got %#v, want %q", got, `[]`)
+	}
+	if got := normalizeUpdateValue("waiters", nil); got != `null` {
+		t.Errorf("waiters nil: got %#v, want %q", got, `null`)
+	}
+
+	// Untouched keys pass through unchanged.
+	if got := normalizeUpdateValue("title", "hello"); got != "hello" {
+		t.Errorf("title passthrough: got %#v", got)
+	}
+	now := time.Now()
+	if got := normalizeUpdateValue("due_at", now); got != now.UTC() {
+		t.Errorf("due_at normalization: got %#v", got)
+	}
+}


### PR DESCRIPTION
## What

Ports the four remaining routable `bd gate` subcommands — **create, add-waiter, resolve, show** — to proxied-server mode, extending the conventions `gate check`/`gate list` already established in `cmd/bd/gate_proxied_server.go`. Refs **bd-v50ru**, program **bd-vxavz**.

`gate discover` deliberately keeps its proxied-mode refusal: it interleaves GitHub CLI queries with per-gate writes and incremental per-gate output, so it is not the pure store-routing this port covers. It can be ported later with the discovered-map pattern `gate check` uses if the need arises.

## How

- **gate create** — ONE `uow.RunTxResult` doing target lookup + `IssueUseCase().CreateIssue` + `DependencyUseCase().AddDependency`, under the same commit message the direct route writes (`bd: create gate <id> blocking <target>`). The direct route's create + add-dependency + explicit `store.Commit` collapse into **one Dolt commit per invocation** — semantically equivalent, minus the window where the gate exists without its blocking edge.
- **gate add-waiter** — one transaction; re-reads the gate in-tx, validates type, appends the waiter. An already-registered waiter returns an **empty commit message** (deliberate no-commit) and prints the classic "Waiter already registered" line. Fires the `on_update` hook post-commit.
- **gate resolve** — one transaction (existence + type check + `CloseIssue`), then `audit.LogFieldChange` + close hooks post-commit — exactly the shape `gate check`'s in-file closes already use.
- **gate show** — read-only UOW. Fail-closed: not-found exits nonzero with `gate not found: <id>`, while a failed **read** exits nonzero with a distinct `reading gate <id>: …` message, so an unreachable server can never be mistaken for "no gate".

**Output parity is structural, not copied:** the direct route's renderers and gate-create construction were extracted into shared helpers (`renderGateShow`, `renderGateCreated`, `renderGateResolved`, `renderGateWaiterAdded`/`Already`, `gatherGateCreateInput`, `buildGateIssue`) and both routes call the same code. The `Created gate <id>` line, the `gate show` markers, and `gate list --all --json`'s `.id/.status/.description/.waiters` are what the wyvern wheelhouse scripts parse; the new journey test pins all of them.

## The domain/db change (please scrutinize)

`internal/storage/domain/db/issue.go` — the new journey test caught a latent bug beyond cmd/bd routing: the proxied repository's `normalizeUpdateValue` never serialized the `waiters` field, so **any** waiters update through the proxied backend failed at the SQL driver:

```
Error: updating gate: db: Update ghj-v5l: sql: converting argument $1 type: unsupported type []string, a slice of string
```

`waiters` was already in `allowedUpdateFields`, and the embedded path (`issueops.updateIssueInTx`, update.go:429) has always JSON-marshaled it — the proxied repo just never grew the same arm. The fix mirrors the embedded path exactly (unconditional `json.Marshal` for the `waiters` key), placed after `DiscardNoopIssueUpdates` so the no-op comparison still sees the raw `[]string`. `normalize_update_value_test.go` pins the serialization.

## Tests

- `go build ./...`, `go vet ./cmd/bd/... ./internal/storage/domain/db/...`, `gofmt -l` — all clean, and the pre-commit `golangci-lint run --new-from-rev` reported **0 issues**.
- `go test ./cmd/bd -run 'Gate' -count=1` (embedded/unit) — **ok, 148.8s** (re-run after the domain/db fix).
- `BEADS_TEST_PROXIED_SERVER=1 go test ./cmd/bd -run 'TestProxiedServerGate' -count=1` (docker testcontainers) — **ok, 283.1s**: `TestProxiedServerGateCheck` (pre-existing, no regression) + new `TestProxiedServerGateLifecycle` (human-gate journey incl. ready-front block/unblock, wh-park bead-gate shape resolved by `gate check`, `--json` create, fail-closed error table). Its first run failed on the waiters serialization bug above — the fix is what made it green, i.e. the journey test earned its keep.
- `go test ./internal/storage/domain/... -count=1` — **all ok** (incl. the full dolt-backed `domain/db` suite, 366.9s).
- `TestProxiedServerGateLifecycle` added to `.github/scripts/proxied-cmd-test-shards.txt` shard 1 (the lightest shard by the generator's own cost metric; a full regeneration reshuffles all ~108 entries and drops the file's hand-written placement notes, so this follows the file's "newly-added tests" append path instead).
- A whole-tree `go test ./internal/storage/...` all-at-once run showed `internal/storage/dolt` and `internal/storage/uow` failing **only** with `failed to create Dolt store: failed to initialize schema: context deadline exceeded` / 10m suite timeouts — container-setup starvation from every dolt-backed package spinning containers concurrently on one laptop, in packages this diff does not touch. A follow-up isolated re-run is noted below in comments if anything differs.

## Deviations / notes for review

- No existing tests asserted the old "not supported in proxied-server mode" strings for these four subcommands — nothing to invert.
- `gate create --json` on the proxied route returns the server-hydrated created issue (timestamps etc. populated by the create result) rather than the client-built struct the direct route echoes; `.id`/`.issue_type` and friends are identical.
- Error-order nit: `--timeout` is now parsed before the `--blocks` target lookup on both routes (shared `gatherGateCreateInput`), so an invocation with **both** a bogus timeout and a missing target reports `invalid timeout` where the direct route used to report `issue not found` first.
- `gate show`'s read-failure message (`reading gate <id>: …`) is new on the proxied route only; the direct route folded every read error into `gate not found`. Fail-closed law says those must be distinguishable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018YmpYVCa5eN6JtG26dJLMs