### PR TITLE
fix: bd show no longer deletes HTML-tag-shaped spans from description/notes

### DIFF
--- a/internal/uimd/markdown.go
+++ b/internal/uimd/markdown.go
@@ -59,10 +59,18 @@ func RenderMarkdown(markdown string) string {
 		return markdown
 	}
 
-	rendered, err := renderer.Render(markdown)
+	// Bead bodies are plain text, not HTML. Goldmark (glamour's parser) treats any
+	// "<" that looks like the start of an HTML tag as inline/block raw HTML, and
+	// glamour's renderer sanitizes those raw-HTML nodes down to nothing — silently
+	// deleting the tag-shaped span (and, for an unclosed tag, everything up to the
+	// next ">", across lines). Escape angle brackets before rendering so nothing
+	// is ever parsed as raw HTML, then unescape the entities glamour leaves intact
+	// in its plain-text output so the visible result matches the stored text.
+	rendered, err := renderer.Render(escapeAngleBrackets(markdown))
 	if err != nil {
 		return markdown
 	}
+	rendered = unescapeAngleBrackets(rendered)
 
 	if !useHyperlinks {
 		rendered = stripOSC8Hyperlinks(rendered)
@@ -73,6 +81,25 @@ func RenderMarkdown(markdown string) string {
 
 	return rendered
 }
+
+// escapeAngleBrackets replaces literal "<" and ">" with their HTML entity
+// equivalents so goldmark's inline/block HTML parsing never triggers on them.
+func escapeAngleBrackets(s string) string {
+	return angleEscaper.Replace(s)
+}
+
+// unescapeAngleBrackets reverses escapeAngleBrackets on rendered output.
+// Glamour's plain-text rendering path passes entities through unchanged, so
+// after rendering the escaped markdown, "&lt;"/"&gt;" in the output are the
+// original literal angle brackets, not markup that needs to stay escaped.
+func unescapeAngleBrackets(s string) string {
+	return angleUnescaper.Replace(s)
+}
+
+var (
+	angleEscaper   = strings.NewReplacer("<", "&lt;", ">", "&gt;")
+	angleUnescaper = strings.NewReplacer("&lt;", "<", "&gt;", ">")
+)
 
 // stripOSC8Hyperlinks removes only OSC 8 hyperlink open/close sequences.
 // Glamour emits OSC 8 whenever it renders links, but OSC 8 support is separate

--- a/internal/uimd/markdown_test.go
+++ b/internal/uimd/markdown_test.go
@@ -127,6 +127,64 @@ func TestRenderMarkdownReturnsRawMarkdownInAgentMode(t *testing.T) {
 	}
 }
 
+// TestRenderMarkdownPreservesAngleBracketSpans is the regression guard for
+// ra-peoy7: RenderMarkdown must never delete tag-shaped "<...>" spans from
+// body text (goldmark parses them as raw HTML, and glamour's ANSI renderer
+// sanitizes those nodes down to nothing). Multi-line unclosed tags are the
+// worst case — the deletion used to swallow every line up to the next ">".
+func TestRenderMarkdownPreservesAngleBracketSpans(t *testing.T) {
+	withMarkdownEnv(t, map[string]string{
+		"NO_COLOR":        "1",
+		"TERM":            "dumb",
+		"CLICOLOR_FORCE":  "",
+		"FORCE_HYPERLINK": "",
+		"BD_AGENT_MODE":   "",
+		"CLAUDE_CODE":     "",
+	})
+
+	t.Run("intra-line tag-shaped and comparison-operator spans", func(t *testing.T) {
+		input := "LINE1: run foo <PLACEHOLDER> bar\n" +
+			"LINE2: literal a<b and c>d\n" +
+			"LINE3: html-ish <em>text</em> tail\n"
+		out := RenderMarkdown(input)
+		for _, want := range []string{
+			"LINE1: run foo <PLACEHOLDER> bar",
+			"LINE2: literal a<b and c>d",
+			"LINE3: html-ish <em>text</em> tail",
+		} {
+			if !strings.Contains(out, want) {
+				t.Fatalf("expected rendered output to contain %q, got %q", want, out)
+			}
+		}
+	})
+
+	t.Run("unclosed tag-shaped token does not eat following lines", func(t *testing.T) {
+		input := "P: start <unclosed\n" +
+			"Q: middle line one\n" +
+			"R: middle line two\n" +
+			"S: end > tail\n"
+		out := RenderMarkdown(input)
+		for _, want := range []string{
+			"P: start <unclosed",
+			"Q: middle line one",
+			"R: middle line two",
+			"S: end > tail",
+		} {
+			if !strings.Contains(out, want) {
+				t.Fatalf("expected rendered output to contain %q, got %q", want, out)
+			}
+		}
+	})
+
+	t.Run("non-tag-shaped angle brackets stay intact (control)", func(t *testing.T) {
+		input := "E1: <_foo> and <123> and < b > survive already"
+		out := RenderMarkdown(input)
+		if !strings.Contains(out, "<_foo>") || !strings.Contains(out, "<123>") {
+			t.Fatalf("expected already-preserved spans to remain intact, got %q", out)
+		}
+	})
+}
+
 func withMarkdownEnv(t *testing.T, values map[string]string) {
 	t.Helper()
 


### PR DESCRIPTION
### What breaks

Goldmark (glamour's markdown parser, used by `bd show` to render
description/notes bodies) parses any `<...>`-shaped text as raw HTML,
and glamour's ANSI renderer sanitizes those nodes down to nothing —
silently dropping the span. For an unclosed tag-shaped token, this can
eat everything up to the next `>` in the document.

This isn't a cosmetic issue: any bead body containing something that
merely *looks* like an HTML tag — a shell redirect, a generic type
parameter, a comparison chain, a `<name>` placeholder — silently loses
that text (or more) every time `bd show` renders it. There is no
warning; the field is just shorter than what was written.

### Reproduction

```
$ bd create "tag-span repro" -d 'before <script> after, and unclosed <foo bar'
$ bd show <id>
DESCRIPTION

  before  after, and unclosed <foo bar
```

The `<script>` span is gone entirely — compare the stored value (visible
via `bd show <id> --json`, which is untouched) against the rendered
output.

### The fix

Escape angle brackets before handing body text to glamour, and unescape
them in the rendered output, so `bd show` never eats plain text that
merely looks like a tag. Scoped to `internal/uimd/markdown.go`
(`RenderMarkdown`), the single call site shared by every `bd show` body
path (`show.go`, `show_display.go`, `show_proxied_server.go`,
`show_children.go`); JSON output and title rendering are untouched.

### Verification

On top of current `upstream/main` (`d801ec43d`):

```
go build ./...                                        # clean
go vet ./internal/uimd/...                              # clean
go test ./internal/uimd/... -run TestRenderMarkdownPreservesAngleBracketSpans -v
```

All 3 subtests pass (intra-line tag-shaped + comparison-operator spans,
unclosed-tag-shaped token, and a non-tag-shaped-angle-brackets control).

Behavioral proof (the deciding fact — not just the unit test), built
both an unpatched (`upstream/main`) and patched `bd` binary and compared
`bd show` output for the same stored bead against a real store:

```
$ bd create "tag-span repro" -d 'before <script> after, and unclosed <foo bar'
zz-k7h

$ ./bd-unpatched show zz-k7h
DESCRIPTION
  before  after, and unclosed <foo bar

$ ./bd-patched show zz-k7h
DESCRIPTION
  before <script> after, and unclosed <foo bar
```

Unpatched drops `<script>` outright; patched preserves it byte-for-byte
alongside the untouched unclosed `<foo bar` token later in the same
line. `bd show <id> --json` (unaffected by either binary) confirms the
stored value always contained the full text — this is a *rendering*
bug, not a storage bug, which is exactly why the city's working
convention has been "read specs from `bd show --json`, never the
rendered view" for anything that might contain a tag-shaped span. This
fix retires the need for that convention.

### Note on scope: only one of two patches in the source bead

The originating bead (city-internal; not referenced here since upstream
can't resolve it) bundled this fix with a second, unrelated one:
validating `--waits-for-gate` before the write and rejecting it without
`--waits-for`. That second defect is already fixed and merged upstream
as PR #4918 (`fix(create): reject --waits-for-gate when --waits-for is
absent; add regression tests`), which additionally closes two related
gaps (batch-route rejection, child-ID-not-burned-on-rejected-create)
beyond what the preserved patch here covered. This PR carries only the
tag-span rendering fix.
