### PR TITLE
Serve a registered backend from the store bd already opened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Dolt provider and either failed with a misleading Dolt error or connected to
   a defaulted host and served the wrong database.
 
+### Fixed
+
+- **`GET /v0/beads/context` and `bd context` no longer describe every
+  workspace as Dolt.** The shared identity projection hardcoded
+  `backend: dolt` and copied `dolt_mode` and `database` unconditionally — and
+  both of those default rather than fail, so a workspace on a registered
+  backend was reported as `backend="dolt"`, `dolt_mode="embedded"`,
+  `database="beads"`: a confident description of a topology it is not on, on
+  the one endpoint automation is told to trust for a server's identity. The
+  backend is now named as the store open resolves it, and the two Dolt-derived
+  values are reported only for the Dolt backend; a registered backend reports
+  the empty string for both, which is the only value `bd` can assert about a
+  backend it does not implement. No wire field is renamed, retyped or dropped
+  — both remain required strings, and the `v0` shape is unchanged.
+
+- **`bd --readonly serve` is refused instead of binding a server that cannot
+  do what it advertises.** The advertised capability set is a property of the
+  build and includes the issue-claim operation, so under strict readonly the
+  two database sources degraded differently and silently: a registered backend
+  bound on its read-only store and answered every claim with an opaque 500
+  while still advertising `issues.claim`, and a Dolt SQL-server workspace built
+  its own writable provider and let every claim land, so the flag bought
+  nothing. `bd serve` now refuses to start under `--readonly` (or `readonly` in
+  config), before it resolves the workspace, so the answer is the same on both.
+
 - **Public surface for out-of-tree storage backends** (bd-h3dib.2). The
   storage backend contract and its conformance suite are now importable by
   external Go modules — the conformance-gated external-backend path promised

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`bd serve` runs on a registered storage backend.** A downstream
+  distribution that registers a backend
+  (`github.com/steveyegge/beads/backend`.`Register`) could already use it from
+  every ordinary `bd` command — `bd list`, `bd create` and friends dispatch
+  the store open through the registry — but `bd serve` alone reimplemented a
+  creation path of its own, hard-wired to Dolt's SQL wire, and refused the
+  workspace before it got there. It now uses the store the root command
+  already opened, through the same registry dispatch: zero creation calls of
+  its own, so there is one creation path rather than two. The two issue roles
+  are taken from BENEATH the workspace's hook decorator, keeping the
+  documented "hooks do not fire" contract (`httpapi.Listen` refuses a
+  hook-firing role rather than trusting the caller), and the store's lifecycle
+  stays where it was — opened and closed by the root command, closed only
+  after the server has drained. The startup line names the source
+  (`db=roles`) and the backend (`mode="<name> (registered backend)"`).
+
+  The permanent refusal is unchanged and unweakened: an embedded-Dolt
+  workspace is still refused, because its commit protocol runs outside the SQL
+  transaction and this server's per-request atomicity would be a lie there.
+  The classification consults the registry before any Dolt-mode signal, which
+  is the order the store open already resolves them in — and which also fixes
+  a latent `CGO_ENABLED=0` bug where a registered workspace was handed to the
+  Dolt provider and either failed with a misleading Dolt error or connected to
+  a defaulted host and served the wrong database.
+
 - **Public surface for out-of-tree storage backends** (bd-h3dib.2). The
   storage backend contract and its conformance suite are now importable by
   external Go modules — the conformance-gated external-backend path promised

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Dolt provider and either failed with a misleading Dolt error or connected to
   a defaulted host and served the wrong database.
 
+### Changed
+
+- **BREAKING: `bd --readonly serve` is now refused instead of binding a server
+  that cannot do what it advertises.** On a Dolt SQL-server workspace this
+  previously bound a fully functional, fully writable server — the flag was a
+  silent no-op there — so anyone scripting `bd --readonly serve` as a "safe"
+  read server loses it on upgrade and should drop the flag. The advertised capability set is a property of the
+  build and includes the issue-claim operation, so under strict readonly the
+  two database sources degraded differently and silently: a registered backend
+  bound on its read-only store and answered every claim with an opaque 500
+  while still advertising `issues.claim`, and a Dolt SQL-server workspace built
+  its own writable provider and let every claim land, so the flag bought
+  nothing. `bd serve` now refuses to start under `--readonly` (or `readonly` in
+  config), before it resolves the workspace, so the answer is the same on both.
+
 ### Fixed
 
 - **`GET /v0/beads/context` and `bd context` no longer describe every
@@ -48,16 +63,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the empty string for both, which is the only value `bd` can assert about a
   backend it does not implement. No wire field is renamed, retyped or dropped
   — both remain required strings, and the `v0` shape is unchanged.
-
-- **`bd --readonly serve` is refused instead of binding a server that cannot
-  do what it advertises.** The advertised capability set is a property of the
-  build and includes the issue-claim operation, so under strict readonly the
-  two database sources degraded differently and silently: a registered backend
-  bound on its read-only store and answered every claim with an opaque 500
-  while still advertising `issues.claim`, and a Dolt SQL-server workspace built
-  its own writable provider and let every claim land, so the flag bought
-  nothing. `bd serve` now refuses to start under `--readonly` (or `readonly` in
-  config), before it resolves the workspace, so the answer is the same on both.
 
 - **Public surface for out-of-tree storage backends** (bd-h3dib.2). The
   storage backend contract and its conformance suite are now importable by

--- a/cmd/bd/context_cmd.go
+++ b/cmd/bd/context_cmd.go
@@ -66,11 +66,10 @@ Examples:
 		// proxied route gets from the provider, and hands it to the same
 		// view. That is what keeps `bd context` one answer across two routes,
 		// and what puts both of them on the projection GET /v0/beads/context
-		// serves.
-		snapshot := domain.ContextInfo{
-			Backend:   configfile.BackendDolt,
-			BdVersion: Version,
-		}
+		// serves. TestContextRoutesNameOneWorkspaceTheSameWay holds them to it;
+		// until it existed both routes carried their own `Backend: dolt` and
+		// agreed by telling the same lie.
+		snapshot := domain.ContextInfo{BdVersion: Version}
 
 		if selected := selectedNoDBBeadsDir(cmd); selected != "" {
 			prepareSelectedNoDBContext(selected)
@@ -105,25 +104,8 @@ Examples:
 			cfg = configfile.DefaultConfig()
 		}
 
-		snapshot.DoltMode = cfg.GetDoltMode()
-		snapshot.Database = cfg.GetDoltDatabase()
-		snapshot.ProjectID = cfg.ProjectID
-
-		if cfg.IsDoltServerMode() {
-			snapshot.ServerHost = cfg.GetDoltServerHost()
-			dsCfg := doltserver.DefaultConfig(rc.BeadsDir)
-			snapshot.ServerPort = dsCfg.Port
-		}
-		if cfg.IsDoltProxiedServerMode() {
-			p, err := resolveProxiedServerRootPath(rc.BeadsDir)
-			if err != nil {
-				return HandleError("resolve proxied server root: %v", err)
-			}
-			snapshot.ProxiedDir = p
-		}
-
-		if dataDir := cfg.GetDoltDataDir(); dataDir != "" {
-			snapshot.DataDir = dataDir
+		if err := applyContextBackend(&snapshot, rc.BeadsDir, cfg); err != nil {
+			return HandleError("%v", err)
 		}
 
 		snapshot.SyncRemote = resolveSyncRemoteFromDir(rc.BeadsDir)
@@ -135,6 +117,41 @@ Examples:
 		printContextText(info)
 		return nil
 	},
+}
+
+// applyContextBackend records the backend half of the direct route's snapshot,
+// off the config files it just read.
+//
+// It is a named function rather than a run of assignments inside the command so
+// that the claim above it — that both `bd context` routes assemble the SAME
+// snapshot — is something a test can drive rather than something a reader has
+// to check by eye. TestContextRoutesNameOneWorkspaceTheSameWay does exactly
+// that, comparing this against the contextinfo provider the proxied route and
+// GET /v0/beads/context both go through.
+//
+// The identity itself goes through domain.SetBackendIdentity, which is the one
+// policy both routes share: it is what stops a non-Dolt workspace from being
+// described as embedded Dolt on database "beads", which is what both routes did
+// while each held its own copy of `Backend: configfile.BackendDolt`.
+func applyContextBackend(snapshot *domain.ContextInfo, beadsDir string, cfg *configfile.Config) error {
+	snapshot.SetBackendIdentity(cfg.GetBackend(), cfg.GetDoltMode(), cfg.GetDoltDatabase())
+	snapshot.ProjectID = cfg.ProjectID
+
+	if cfg.IsDoltServerMode() {
+		snapshot.ServerHost = cfg.GetDoltServerHost()
+		snapshot.ServerPort = doltserver.DefaultConfig(beadsDir).Port
+	}
+	if cfg.IsDoltProxiedServerMode() {
+		p, err := resolveProxiedServerRootPath(beadsDir)
+		if err != nil {
+			return fmt.Errorf("resolve proxied server root: %w", err)
+		}
+		snapshot.ProxiedDir = p
+	}
+	if dataDir := cfg.GetDoltDataDir(); dataDir != "" {
+		snapshot.DataDir = dataDir
+	}
+	return nil
 }
 
 func printContextText(info ContextInfo) {

--- a/cmd/bd/context_cmd.go
+++ b/cmd/bd/context_cmd.go
@@ -179,8 +179,15 @@ func printContextText(info ContextInfo) {
 	// Backend
 	fmt.Println("Backend:")
 	fmt.Printf("  type:         %s\n", info.Backend)
-	fmt.Printf("  mode:         %s\n", info.DoltMode)
-	fmt.Printf("  database:     %s\n", info.Database)
+	// Dolt-only identity. A registered backend reports neither, and a bare
+	// "mode:" with nothing after it reads as a failure to determine rather than
+	// as not-applicable — so omit them, like every other optional field here.
+	if info.DoltMode != "" {
+		fmt.Printf("  mode:         %s\n", info.DoltMode)
+	}
+	if info.Database != "" {
+		fmt.Printf("  database:     %s\n", info.Database)
+	}
 	if info.ServerHost != "" {
 		fmt.Printf("  server:       %s:%d\n", info.ServerHost, info.ServerPort)
 	}

--- a/cmd/bd/context_identity_test.go
+++ b/cmd/bd/context_identity_test.go
@@ -112,6 +112,10 @@ func TestContextRoutesNameOneWorkspaceTheSameWay(t *testing.T) {
 	}
 }
 
+// NOT COVERED: this drives applyContextBackend, not contextCmd's RunE, so it
+// pins the shared projection rather than the command's own wiring. A change
+// that bypassed applyContextBackend inside RunE would not be caught here.
+//
 // directContextSnapshot assembles the snapshot `bd context`'s direct route
 // answers from, off the same config files the command reads.
 func directContextSnapshot(t *testing.T, beadsDir string) domain.ContextInfo {

--- a/cmd/bd/context_identity_test.go
+++ b/cmd/bd/context_identity_test.go
@@ -1,0 +1,137 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/beads"
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/backends"
+	"github.com/steveyegge/beads/internal/storage/contextinfo"
+	"github.com/steveyegge/beads/internal/storage/domain"
+)
+
+// TestContextRoutesNameOneWorkspaceTheSameWay.
+//
+// There are two routes to a workspace snapshot and they are not
+// interchangeable: `bd context` reads the config files itself, because it has
+// to answer in degraded states where no database opens, while the proxied route
+// and GET /v0/beads/context go through the contextinfo provider. Both hand the
+// result to domain.PublishedContext, which exists so that the identity an
+// automation client is given and the identity printed on the operator's
+// terminal beside it are the same values read the same way.
+//
+// Nothing tested that. Both routes carried their own `Backend:
+// configfile.BackendDolt`, so a workspace on a registered backend was described
+// as embedded Dolt on database "beads" by both — the same lie twice, which is
+// indistinguishable from agreement.
+func TestContextRoutesNameOneWorkspaceTheSameWay(t *testing.T) {
+	const registered = "context-identity-backend"
+	backends.Register(registered, backends.Backend{
+		Open: func(context.Context, string) (storage.DoltStorage, error) {
+			return nil, errors.ErrUnsupported
+		},
+		OpenReadOnly: func(context.Context, string) (storage.DoltStorage, error) {
+			return nil, errors.ErrUnsupported
+		},
+		WorkspaceIsBeadsDir: true,
+	})
+	t.Cleanup(func() { backends.Deregister(registered) })
+
+	for _, tc := range []struct {
+		name string
+		cfg  *configfile.Config
+		want domain.PublishedContextFields
+	}{
+		{
+			// The case that was wrong. This workspace configures no Dolt
+			// anything, and both Dolt values default rather than fail.
+			name: "a registered backend",
+			cfg:  &configfile.Config{Backend: registered, ProjectID: "proj-registered"},
+			want: domain.PublishedContextFields{Backend: registered, ProjectID: "proj-registered"},
+		},
+		{
+			name: "embedded dolt",
+			cfg: &configfile.Config{
+				Backend:   configfile.BackendDolt,
+				DoltMode:  configfile.DoltModeEmbedded,
+				ProjectID: "proj-dolt",
+			},
+			want: domain.PublishedContextFields{
+				Backend:   configfile.BackendDolt,
+				DoltMode:  configfile.DoltModeEmbedded,
+				Database:  configfile.DefaultDoltDatabase,
+				ProjectID: "proj-dolt",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			initGitRepoAt(t, dir)
+			beadsDir := filepath.Join(dir, ".beads")
+			if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+				t.Fatalf("mkdir .beads: %v", err)
+			}
+			if err := tc.cfg.Save(beadsDir); err != nil {
+				t.Fatalf("save metadata.json: %v", err)
+			}
+			t.Chdir(dir)
+			t.Setenv("BEADS_DIR", beadsDir)
+			beads.ResetCaches()
+			t.Cleanup(beads.ResetCaches)
+
+			provider, err := contextinfo.NewContextProvider(dir, Version).ContextUseCase().GetContextInfo(t.Context())
+			if err != nil {
+				t.Fatalf("provider route: %v", err)
+			}
+			direct := directContextSnapshot(t, beadsDir)
+
+			// The paths and the version come from the workspace either way and
+			// are not what this compares; the identity is.
+			want := tc.want
+			want.BdVersion, want.BeadsDir, want.RepoRoot = Version, provider.BeadsDir, provider.RepoRoot
+
+			for _, got := range []struct {
+				route  string
+				fields domain.PublishedContextFields
+			}{
+				{"the contextinfo provider (GET /v0/beads/context, bd context in proxied mode)", domain.PublishedContext(provider)},
+				{"the direct route (bd context)", domain.PublishedContext(direct)},
+			} {
+				if got.fields != want {
+					t.Errorf("%s published\n  %+v\nwant\n  %+v", got.route, got.fields, want)
+				}
+			}
+		})
+	}
+}
+
+// directContextSnapshot assembles the snapshot `bd context`'s direct route
+// answers from, off the same config files the command reads.
+func directContextSnapshot(t *testing.T, beadsDir string) domain.ContextInfo {
+	t.Helper()
+	rc, err := beads.GetRepoContext()
+	if err != nil {
+		t.Fatalf("repo context: %v", err)
+	}
+	cfg, err := configfile.Load(beadsDir)
+	if err != nil || cfg == nil {
+		t.Fatalf("load metadata.json: %v", err)
+	}
+
+	snapshot := domain.ContextInfo{
+		BdVersion: Version,
+		BeadsDir:  rc.BeadsDir,
+		RepoRoot:  rc.RepoRoot,
+	}
+	if err := applyContextBackend(&snapshot, rc.BeadsDir, cfg); err != nil {
+		t.Fatalf("applyContextBackend: %v", err)
+	}
+	return snapshot
+}

--- a/cmd/bd/serve.go
+++ b/cmd/bd/serve.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -11,8 +12,10 @@ import (
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/httpapi"
 	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/backends"
 	"github.com/steveyegge/beads/internal/storage/contextinfo"
 	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/issueops"
 )
 
 // serveCmdName is the command name, shared with the root command's post-run
@@ -85,20 +88,27 @@ WHAT THIS DOES NOT DO
 }
 
 func init() {
-	serveCmd.Flags().StringVar(&serveAddr, "addr", "127.0.0.1:0",
-		"Address to bind as IP:PORT; the host must be a numeric IP literal, and port 0 takes an ephemeral port")
-	serveCmd.Flags().BoolVar(&serveAllowNonLoopback, "allow-non-loopback", false,
-		"Permit a bind beyond loopback. bd serve has no authentication: every peer that can reach the address gets full read and claim access")
+	registerServeFlags(serveCmd)
 	rootCmd.AddCommand(serveCmd)
+}
+
+// registerServeFlags declares bd serve's own flags.
+//
+// It is a named function rather than a block in init so a test that runs the
+// command in-process can put the flag set back the way it found it: cobra
+// merges every inherited persistent flag into a command's own FlagSet the first
+// time it parses one, and that mutation outlives the run.
+func registerServeFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&serveAddr, "addr", "127.0.0.1:0",
+		"Address to bind as IP:PORT; the host must be a numeric IP literal, and port 0 takes an ephemeral port")
+	cmd.Flags().BoolVar(&serveAllowNonLoopback, "allow-non-loopback", false,
+		"Permit a bind beyond loopback. bd serve has no authentication: every peer that can reach the address gets full read and claim access")
 }
 
 func runServe() error {
 	// Flag validation first: it depends on nothing about the workspace, so the
 	// refusal for a bad --addr is the same in every mode.
 	if _, err := httpapi.ValidateBindAddr(serveAddr, serveAllowNonLoopback); err != nil {
-		return HandleError("%v", err)
-	}
-	if err := serveModeGate(); err != nil {
 		return HandleError("%v", err)
 	}
 
@@ -111,15 +121,58 @@ func runServe() error {
 		return HandleError("cannot resolve workspace context: %v", err)
 	}
 
+	// The classification reads the workspace's own configuration, so it runs
+	// after the context resolves rather than before it. A directory with no
+	// workspace at all therefore reports that it has none, instead of reporting
+	// the embedded refusal for a workspace nobody found.
+	db, err := serveDatabaseSource(info.BeadsDir)
+	if err != nil {
+		return HandleError("%v", err)
+	}
+
+	if serveAllowNonLoopback {
+		fmt.Fprintf(os.Stderr,
+			"bd serve: WARNING: --allow-non-loopback binds %s beyond loopback. "+
+				"This API has no authentication and no TLS: any peer that can reach it can read every issue and claim work as any actor.\n",
+			serveAddr)
+	}
+
+	if db.source == serveSourceStore {
+		// Nothing to create. PersistentPreRunE already opened this workspace
+		// through the same backends.Lookup dispatch every ordinary bd command
+		// opens it with, so the store bd list and bd create answer from is the
+		// store sitting in front of this server — one creation path, which is
+		// the whole point of this arm. Opening a second handle here would
+		// double the pools and self-conflict with any backend that takes an
+		// exclusive workspace lock.
+		//
+		// Closing it is the root command's business too: PersistentPostRunE
+		// runs after this function returns, which is after the server has
+		// fully drained, so no request can reach a closed store. runServe must
+		// not close it.
+		reader, claimer, err := serveIssueRoles(store)
+		if err != nil {
+			return HandleError("bd serve: %v", err)
+		}
+		return serveListen(httpapi.Config{
+			Addr:             serveAddr,
+			AllowNonLoopback: serveAllowNonLoopback,
+			Reader:           reader,
+			Claimer:          claimer,
+			Workspace:        info,
+			SchemaVersion:    JSONSchemaVersion,
+			Mode:             serveResolvedMode(info, db),
+		})
+	}
+
 	provider := uowProvider
 	if provider == nil {
 		// Server, external-server and shared-server workspaces: PersistentPreRunE
 		// builds a DoltStore for those and no unit-of-work provider, so serve
 		// builds its own from the same connection settings the store used.
 		//
-		// That store stays open for the life of the process and serve never
-		// touches it. Opening and closing it is the root command's business, not
-		// a single command's, but it is not free either: its pool holds an idle
+		// On this arm that store stays open for the life of the process and
+		// serve never touches it. It is not free either: its pool holds an idle
 		// connection or two against the very server this process is about to
 		// pool twenty more on. Worth knowing when sizing a shared Dolt server's
 		// max_connections.
@@ -132,6 +185,10 @@ func runServe() error {
 		// which knows nothing about --global. Report the database the provider
 		// actually opened, or the handshake names one database while every
 		// operation answers from another.
+		//
+		// The store source needs no such override: backend.Open consumes the
+		// same metadata.json GetContextInfo just read, so the handshake and the
+		// operations share one source of truth by construction.
 		info.Database = topology.database
 		p, err := newSQLServerUOWProvider(rootCtx, info.BeadsDir, topology)
 		if err != nil {
@@ -149,74 +206,158 @@ func runServe() error {
 		provider = p
 	}
 
-	if serveAllowNonLoopback {
-		fmt.Fprintf(os.Stderr,
-			"bd serve: WARNING: --allow-non-loopback binds %s beyond loopback. "+
-				"This API has no authentication and no TLS: any peer that can reach it can read every issue and claim work as any actor.\n",
-			serveAddr)
-	}
-
-	srv, err := httpapi.Listen(httpapi.Config{
+	return serveListen(httpapi.Config{
 		Addr:             serveAddr,
 		AllowNonLoopback: serveAllowNonLoopback,
 		Provider:         provider,
 		Workspace:        info,
 		SchemaVersion:    JSONSchemaVersion,
-		Mode:             serveResolvedMode(info),
+		Mode:             serveResolvedMode(info, db),
 	})
+}
+
+// serveListen binds and runs. It is where the two database sources converge:
+// everything past the source is the same server.
+//
+// Graceful shutdown rides the signal context the root command already sets up
+// (SIGINT/SIGTERM/SIGHUP). A proxied provider is closed where every proxied
+// command closes it, in PersistentPostRunE — which in proxied mode does nothing
+// else; the provider serve built for a server-mode workspace is closed by
+// runServe's own defer, and a registered backend's store by the same
+// PersistentPostRunE that opened it. None of those paths runs the auto-commit,
+// export or push maintenance: proxied mode never had it, and serve is excluded
+// from it by name (runsPostCommandMaintenance, cmd/bd/main.go).
+func serveListen(cfg httpapi.Config) error {
+	srv, err := httpapi.Listen(cfg)
 	if err != nil {
 		return HandleError("%v", err)
 	}
-
-	// Graceful shutdown rides the signal context the root command already sets
-	// up (SIGINT/SIGTERM/SIGHUP). A proxied provider is closed where every
-	// proxied command closes it, in PersistentPostRunE — which in proxied mode
-	// does nothing else; the provider serve built for a server-mode workspace is
-	// closed by the defer above. Neither path runs the auto-commit, export or
-	// push maintenance: proxied mode never had it, and server mode is excluded
-	// from it by name (runsPostCommandMaintenance, cmd/bd/main.go).
 	return srv.Serve(rootCtx)
 }
 
-// serveModeGate refuses the one workspace mode bd serve cannot answer for.
+// serveSource names which of httpapi.Config's two database sources a workspace
+// is served from.
+type serveSource int
+
+const (
+	// serveSourceProvider is the unit-of-work provider: one unit of work per
+	// request, timed into that request's uow_ms and drawn from a pool bd serve
+	// bounds itself. Every Dolt SQL-server topology takes it.
+	serveSourceProvider serveSource = iota
+	// serveSourceStore is the two issue roles, taken off the store the root
+	// command already opened. A registered backend's facade is a store rather
+	// than a unit-of-work provider, so this is the source it has.
+	serveSourceStore
+)
+
+// String names the source. It exists so a failed comparison prints "store" or
+// "provider" rather than an integer.
+func (s serveSource) String() string {
+	if s == serveSourceStore {
+		return "store"
+	}
+	return "provider"
+}
+
+// serveDatabase is the resolved answer to the one question bd serve asks about
+// a workspace before it binds anything: where does this server read and claim
+// from.
+type serveDatabase struct {
+	// source is which of httpapi.Config's two database sources to build.
+	source serveSource
+	// backend is the registered backend's name on the store source, and empty
+	// on the provider source.
+	backend string
+}
+
+// serveDatabaseSource classifies the workspace. It is both the mode gate and
+// the wiring decision, in one function, so the two can never disagree about one
+// workspace.
 //
-// Embedded is permanent, and the message is written to promise nothing: its
-// commit protocol runs outside the SQL transaction on a separate connection, so
-// the per-request atomicity this server's contract states would be a lie there.
-// That is a property of the backend rather than of what has been built so far,
-// which is also why no unit-of-work provider for it exists or will.
+// THE REGISTRY IS CONSULTED FIRST, and that ordering is not a preference.
+// PersistentPreRunE dispatches the store open on backends.Lookup before
+// anything looks at Dolt mode, so a registered workspace opens its registered
+// store even with BEADS_DOLT_SHARED_SERVER=1 exported. Resolving it the other
+// way here would build a Dolt unit-of-work provider over a non-Dolt store and
+// answer HTTP from a different database than the CLI reaches in the same
+// directory. Registry-first is also what closes the !cgo corner, where
+// isEmbeddedMode is a constant false and a registered workspace would otherwise
+// be handed to the Dolt provider and fail with a misleading Dolt error — or
+// connect to a defaulted host and serve the wrong database.
 //
-// THIS IS THE ENFORCEMENT POINT, and it is now the only one. It used to be
-// redundant: httpapi.Listen took a unit-of-work provider or nothing, so deleting
-// this gate would still have left an embedded-backed server unbuildable.
-// httpapi.Config now also accepts the two issue roles as a database source and
-// the embedded store publishes both accessors, so it is buildable — and nothing
-// downstream will catch a bypass here, because internal/httpapi cannot see the
-// backend behind a role. That is also why runServe builds a provider and never
-// hands Listen roles, which TestServeBuildsOnlyAProviderBackedServer pins.
-//
-// Every mode that does have a SQL server behind it is served: proxied (managed
-// or external), and — since bd-emv — server, external-server and shared-server,
-// which build their provider in runServe.
+// EMBEDDED DOLT IS PERMANENT, and this is the only place that refusal lives.
+// Its commit protocol runs outside the SQL transaction on a separate
+// connection, so the per-request atomicity this server's contract states would
+// be a lie there. That is a property of the backend rather than of what has
+// been built so far, which is also why no unit-of-work provider for it exists
+// or will. Nothing downstream will catch a bypass: internal/httpapi cannot see
+// the backend behind a role, and every store publishes both role accessors
+// whatever it is. TestServeNamesOneDatabaseSourcePerServerItBuilds pins that
+// the roles are only ever reached through here.
+func serveDatabaseSource(beadsDir string) (serveDatabase, error) {
+	cfg, err := configfile.Load(beadsDir)
+	if err != nil {
+		// Never classify past an unreadable metadata.json. The classification's
+		// default is the embedded refusal, so falling back would refuse a
+		// workspace whose real backend nobody managed to read.
+		return serveDatabase{}, fmt.Errorf("load %s: %w", configfile.ConfigPath(beadsDir), err)
+	}
+	if backend := normalizeLoadedConfig(cfg).GetBackend(); backends.Registered(backend) {
+		return serveDatabase{source: serveSourceStore, backend: backend}, nil
+	}
+	if isEmbeddedMode() {
+		return serveDatabase{}, errServeEmbedded()
+	}
+	return serveDatabase{source: serveSourceProvider}, nil
+}
+
+// errServeEmbedded is the PERMANENT refusal. The message says what the
+// workspace is and what serve needs, and promises nothing further: the reason
+// is the embedded backend's commit protocol (see serveDatabaseSource), which no
+// amount of provider or role plumbing changes.
 //
 // The mode belongs in the message, not in ErrUnsupported.Backend: that field is
 // documented as a BACKEND name and is the embryo of the pluggable-backend error
 // taxonomy, so putting a topology string in it would hand every downstream
 // errors.As a mixed backend/mode vocabulary.
-func serveModeGate() error {
-	if isEmbeddedMode() {
-		return errServeEmbedded()
-	}
-	return nil
-}
-
-// errServeEmbedded is the PERMANENT refusal. The message says what the
-// workspace is and what serve needs, and promises nothing further: the reason
-// is the embedded backend's commit protocol (see serveModeGate), which no
-// amount of provider or role plumbing changes.
 func errServeEmbedded() error {
 	return fmt.Errorf("%w: bd serve requires a Dolt SQL server; this workspace uses embedded Dolt",
 		&storage.ErrUnsupported{Op: "serve", Backend: "embedded-dolt"})
+}
+
+// serveIssueRoles takes the two issue roles this server answers from off the
+// store the root command already opened.
+//
+// ONE PEEL, and never storage.UnwrapStore. bd's chain is
+// HookFiringStore -> InstrumentedStorage -> raw, and every decorator publishes
+// its own roles — that is what the accessors are for — so store.IssueClaimer()
+// returns a claimer that runs the workspace's on_update script for every claim
+// it lands. This server documents that hooks do not fire, so the hook layer has
+// to come off; the telemetry layer beneath it must not, or every request this
+// process serves goes unspanned and untimed. httpapi.Listen refuses a
+// hook-firing role rather than trusting this comment, so getting it wrong is a
+// startup error rather than a silent subprocess per claim.
+//
+// The assertion is conditional because a BD_NO_HOOKS=1 workspace has no hook
+// layer to peel.
+func serveIssueRoles(src storage.DoltStorage) (issueops.Reader, issueops.Claimer, error) {
+	if src == nil {
+		// Two nil roles would reach Listen as "no database source" — true, and
+		// useless. Name the condition that actually happened.
+		return nil, nil, errors.New("no store is open for this workspace")
+	}
+	if hooked, ok := src.(*storage.HookFiringStore); ok {
+		src = hooked.Unwrap()
+	}
+	reader, err := src.IssueReader()
+	if err != nil {
+		return nil, nil, fmt.Errorf("issue reader: %w", err)
+	}
+	claimer, err := src.IssueClaimer()
+	if err != nil {
+		return nil, nil, fmt.Errorf("issue claimer: %w", err)
+	}
+	return reader, claimer, nil
 }
 
 // serveResolvedMode labels the topology for the startup log line. Cosmetic —
@@ -224,7 +365,18 @@ func errServeEmbedded() error {
 // naming: an external dolt sql-server shares its max_connections budget with
 // every other bd process pointed at it, and this server's pool is a claim on
 // that budget.
-func serveResolvedMode(info domain.ContextInfo) string {
+//
+// A registered backend is named instead of being given a Dolt mode.
+// info.DoltMode carries one for every workspace, registered ones included:
+// GetContextInfo projects the Dolt fields unconditionally and hardcodes Backend
+// to "dolt" (internal/storage/domain/context.go). That is a pre-existing gap
+// shared with `bd context`, and its fix belongs in that shared projection so
+// CLI and API stay one identity — but repeating it in this label would be this
+// command's own choice to do so.
+func serveResolvedMode(info domain.ContextInfo, db serveDatabase) string {
+	if db.source == serveSourceStore {
+		return db.backend + " (registered backend)"
+	}
 	if !usesProxiedServer() {
 		// Server, external-server and shared-server: serve fronts the running
 		// dolt sql-server rather than starting one, so from this process the

--- a/cmd/bd/serve.go
+++ b/cmd/bd/serve.go
@@ -80,7 +80,13 @@ WHAT THIS DOES NOT DO
 
   An actor on an HTTP request is caller-asserted provenance for the audit trail,
   not authenticated identity — the same thing it has always been on the CLI,
-  where any local process can pass any --actor.`,
+  where any local process can pass any --actor.
+
+  It does not run under --readonly, and refuses to start rather than binding.
+  Every server it binds publishes the issue-claim operation, and the capability
+  set it advertises is a property of the build rather than of the flags on the
+  process that started it — so a read-only server would advertise a write it
+  could never land.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runServe()
@@ -110,6 +116,9 @@ func runServe() error {
 	// refusal for a bad --addr is the same in every mode.
 	if _, err := httpapi.ValidateBindAddr(serveAddr, serveAllowNonLoopback); err != nil {
 		return HandleError("%v", err)
+	}
+	if readonlyMode {
+		return HandleError("%v", errServeReadonly())
 	}
 
 	cwd, err := os.Getwd()
@@ -311,6 +320,43 @@ func serveDatabaseSource(beadsDir string) (serveDatabase, error) {
 	return serveDatabase{source: serveSourceProvider}, nil
 }
 
+// errServeReadonly refuses `bd --readonly serve`.
+//
+// AHEAD OF THE WORKSPACE, deliberately: every server this command builds
+// publishes the same operation set, claim included, so the answer cannot depend
+// on which database source the workspace resolves to. Putting it here is also
+// what makes it one answer rather than two — the two sources degraded
+// differently, and both silently.
+//
+//   - On the STORE source the root command opens the workspace through
+//     backend.OpenReadOnly and serve takes its claimer off that store. The
+//     server bound, GET /v0/beads/context went on advertising `issues.claim`
+//     (the capability set is derived from the route table and knows nothing
+//     about a CLI flag), and every claim answered 500 with the issue left open.
+//   - On the PROVIDER source serve builds its own unit-of-work provider from
+//     the workspace's connection settings, which carries no read-only posture,
+//     so `--readonly` bought the operator nothing and every claim landed.
+//     (Proxied mode never got here: the root pre-run already refuses strict
+//     readonly for it.)
+//
+// REFUSING RATHER THAN NARROWING THE SURFACE. Dropping `issues.claim` from a
+// read-only server's advertised capabilities would be a wire change — that list
+// is the documented pre-flight a client checks — and it would make one
+// operation's presence depend on a flag on the process that happened to start
+// the server, which no client can discover before connecting. bd already
+// answers this question the same way one layer down, where a backend that
+// cannot guarantee mutation-free access is turned away rather than opened
+// anyway (backendSupportsStrictReadonly, cmd/bd/main.go).
+//
+// The value is read from the global rather than a flag lookup because
+// `readonly` is also a config key, and PersistentPreRunE has already folded
+// both into readonlyMode by the time any RunE runs.
+func errServeReadonly() error {
+	return errors.New("bd serve is unavailable under strict readonly (--readonly, or readonly in config): " +
+		"every server it binds publishes the issue-claim operation, and refusing to start is the only honest " +
+		"answer — a server that advertised a claim it could never land would be worse than no server")
+}
+
 // errServeEmbedded is the PERMANENT refusal. The message says what the
 // workspace is and what serve needs, and promises nothing further: the reason
 // is the embedded backend's commit protocol (see serveDatabaseSource), which no
@@ -366,13 +412,11 @@ func serveIssueRoles(src storage.DoltStorage) (issueops.Reader, issueops.Claimer
 // every other bd process pointed at it, and this server's pool is a claim on
 // that budget.
 //
-// A registered backend is named instead of being given a Dolt mode.
-// info.DoltMode carries one for every workspace, registered ones included:
-// GetContextInfo projects the Dolt fields unconditionally and hardcodes Backend
-// to "dolt" (internal/storage/domain/context.go). That is a pre-existing gap
-// shared with `bd context`, and its fix belongs in that shared projection so
-// CLI and API stay one identity — but repeating it in this label would be this
-// command's own choice to do so.
+// A registered backend is named instead of being given a Dolt mode, which it
+// no longer has: GetContextInfo projects the Dolt-derived identity only for the
+// Dolt backend (internal/storage/domain/context.go), so info.DoltMode is empty
+// here and " (external dolt)" would read as a bare parenthetical about a
+// topology this workspace is not on.
 func serveResolvedMode(info domain.ContextInfo, db serveDatabase) string {
 	if db.source == serveSourceStore {
 		return db.backend + " (registered backend)"

--- a/cmd/bd/serve_inprocess_test.go
+++ b/cmd/bd/serve_inprocess_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"bufio"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+)
+
+// Shared plumbing for the tests that run `bd serve` IN-PROCESS.
+//
+// In-process is not a convenience here: a registered backend is init-time Go
+// wiring and OSS registers none, so a spawned `bd` has nothing to register and
+// could not reach that arm at all. What that costs is a bound server and a set
+// of package globals inside the test binary every other test shares, which is
+// what the snapshot-and-restore below exists for.
+//
+// None of it is cgo-specific, so it lives outside the embedded-Dolt end-to-end
+// file that first needed it.
+
+// restoreServeGlobals snapshots the package state one in-process serve run can
+// touch and puts it back afterwards, so a registered backend and a bound server
+// cannot leak into the tests sharing this binary.
+//
+// The flag set is part of that state and the least obvious part of it: cobra
+// merges every inherited persistent flag into serveCmd's own FlagSet the first
+// time it parses one, so a run through rootCmd.Execute leaves `bd serve`
+// carrying --json, --db and the rest of the root's surface. That is what
+// TestServeFlags reads. ResetFlags plus the command's own registration function
+// is the un-merge cobra does not offer.
+func restoreServeGlobals(t *testing.T) {
+	t.Helper()
+	origStore, origDBPath := store, dbPath
+	origServer, origProxied := serverMode, proxiedServerMode
+	origAddr, origNonLoopback := serveAddr, serveAllowNonLoopback
+	origCtx, origCancel := rootCtx, rootCancel
+	origCmdCtx, origUseGlobals := cmdCtx, testModeUseGlobals
+	t.Cleanup(func() {
+		if store != nil && store != origStore {
+			store.Close()
+		}
+		serveCmd.ResetFlags()
+		registerServeFlags(serveCmd) // rebinds serveAddr/serveAllowNonLoopback to the defaults
+		store, dbPath = origStore, origDBPath
+		serverMode, proxiedServerMode = origServer, origProxied
+		serveAddr, serveAllowNonLoopback = origAddr, origNonLoopback
+		rootCtx, rootCancel = origCtx, origCancel
+		cmdCtx, testModeUseGlobals = origCmdCtx, origUseGlobals
+		rootCmd.SetArgs(nil)
+	})
+}
+
+// resetRootPersistentFlags puts every root persistent flag back to the default
+// it was declared with, and clears its Changed bit, for the duration of one
+// test.
+//
+// A test binary that runs the root command in-process inherits whatever the
+// thousands of tests before it left in those flags and their bound globals —
+// and `Changed` is what several PersistentPreRunE branches dispatch on, not the
+// value. A stale `--db`/`--database` alone makes the pre-run refuse with
+// "--database ... is only supported in proxied-server mode" before the command
+// under test ever runs. Reset before, restore after, so this test neither reads
+// nor writes that shared state.
+func resetRootPersistentFlags(t *testing.T) {
+	t.Helper()
+	type flagState struct {
+		value   string
+		changed bool
+	}
+	before := map[string]flagState{}
+	rootCmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
+		before[f.Name] = flagState{value: f.Value.String(), changed: f.Changed}
+		if err := f.Value.Set(f.DefValue); err != nil {
+			t.Fatalf("reset --%s to its default %q: %v", f.Name, f.DefValue, err)
+		}
+		f.Changed = false
+	})
+	t.Cleanup(func() {
+		rootCmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
+			state, ok := before[f.Name]
+			if !ok {
+				return
+			}
+			_ = f.Value.Set(state.value)
+			f.Changed = state.changed
+		})
+	})
+}
+
+// captureStdoutLines redirects os.Stdout and streams its lines. bd serve prints
+// the address it bound — the only way to discover an ephemeral port — to
+// stdout, and the server is running by the time it does.
+func captureStdoutLines(t *testing.T) (<-chan string, func()) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+
+	lines := make(chan string, 64)
+	go func() {
+		defer close(lines)
+		scanner := bufio.NewScanner(r)
+		for scanner.Scan() {
+			lines <- scanner.Text()
+		}
+	}()
+
+	var stopped bool
+	stop := func() {
+		if stopped {
+			return
+		}
+		stopped = true
+		os.Stdout = orig
+		_ = w.Close()
+	}
+	t.Cleanup(func() {
+		stop()
+		_ = r.Close()
+	})
+	return lines, stop
+}
+
+// waitForBoundAddress reads the address `bd serve` printed on stdout, which is
+// the only way to discover the port under the ephemeral default. The server is
+// already accepting by the time that line is written.
+//
+// done carries the run's result so a serve that failed before binding is
+// reported as its own error rather than as a two-minute timeout.
+func waitForBoundAddress(t *testing.T, lines <-chan string, done <-chan error) string {
+	t.Helper()
+	deadline := time.After(2 * time.Minute)
+	for {
+		select {
+		case line, ok := <-lines:
+			if !ok {
+				t.Fatalf("bd serve exited before it bound: %v", <-done)
+			}
+			const prefix = "bd serve: listening on http://"
+			if addr, found := strings.CutPrefix(strings.TrimSpace(line), prefix); found {
+				return addr
+			}
+		case <-deadline:
+			t.Fatal("bd serve did not print a bound address")
+		}
+	}
+}

--- a/cmd/bd/serve_registered_backend_test.go
+++ b/cmd/bd/serve_registered_backend_test.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"io"
@@ -11,11 +10,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/spf13/pflag"
-
+	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/backends"
@@ -56,11 +55,22 @@ func TestServeAnswersFromARegisteredBackendStore(t *testing.T) {
 	hookMarker := filepath.Join(dir, "on_update.ran")
 	plantOnUpdateHook(t, beadsDir, hookMarker)
 
+	// Every store this process opens for the registered name is counted, and
+	// the count is an assertion at the end: bd serve creates NOTHING on this
+	// arm, so the root command's one open has to be the only one in the
+	// process. A serve that opened a handle of its own would leak it — nothing
+	// closes it — and double the backend's pools against a workspace some
+	// backends hold an exclusive lock on. Counting here catches it wherever it
+	// is spelled, because every store factory in cmd/bd dispatches through this
+	// same registry (newDoltStoreFromConfig, newReadOnlyStoreFromConfig).
+	var opens atomic.Int64
 	backends.Register(name, backends.Backend{
 		Open: func(ctx context.Context, beadsDir string) (storage.DoltStorage, error) {
+			opens.Add(1)
 			return embeddeddolt.Open(ctx, beadsDir, serveRegisteredDatabase, "main")
 		},
 		OpenReadOnly: func(ctx context.Context, beadsDir string) (storage.DoltStorage, error) {
+			opens.Add(1)
 			return embeddeddolt.OpenReadOnly(ctx, beadsDir, serveRegisteredDatabase, "main")
 		},
 		WorkspaceIsBeadsDir: true,
@@ -77,6 +87,31 @@ func TestServeAnswersFromARegisteredBackendStore(t *testing.T) {
 		body := getJSON(t, base+"/v0/beads/context")
 		if body["schema_version"] == nil {
 			t.Errorf("GET /v0/beads/context returned no schema_version: %v", body)
+		}
+	})
+
+	// GET /v0/beads/context is the one endpoint automation is told to trust for
+	// this server's identity, and it was reporting backend="dolt",
+	// dolt_mode="embedded", database="beads" here — a full, confident
+	// description of the exact topology bd serve REFUSES to serve, while the
+	// startup line beside it named the registered backend correctly.
+	//
+	// database is empty even though this workspace's metadata.json carries
+	// dolt_database and the store behind the registered name really does open
+	// it: bd does not implement this backend, its Open reads whatever it wants
+	// out of the workspace, and a value bd cannot verify is the same lie made
+	// quieter. Empty is what bd can assert. Both fields stay required strings —
+	// the wire shape is unchanged.
+	t.Run("the handshake names the registered backend", func(t *testing.T) {
+		body := getJSON(t, base+"/v0/beads/context")
+		if body["backend"] != name {
+			t.Errorf("backend = %v, want %q: the handshake names a backend this server is not on", body["backend"], name)
+		}
+		if body["dolt_mode"] != "" {
+			t.Errorf("dolt_mode = %v, want empty: a registered backend has no Dolt mode", body["dolt_mode"])
+		}
+		if body["database"] != "" {
+			t.Errorf("database = %v, want empty: bd cannot know which database a registered backend opened", body["database"])
 		}
 	})
 
@@ -114,6 +149,13 @@ func TestServeAnswersFromARegisteredBackendStore(t *testing.T) {
 	rootCancel()
 	if err := <-done; err != nil {
 		t.Fatalf("bd serve returned %v, want a clean shutdown", err)
+	}
+
+	// One open for the whole process, and it is the root command's. Serving
+	// from the store bd already opened is the entire point of this arm; a
+	// second handle here would be an unclosed leak with no owner.
+	if n := opens.Load(); n != 1 {
+		t.Errorf("the registered backend was opened %d times, want 1: bd serve created a store of its own", n)
 	}
 
 	// The root command owns the store's whole lifecycle: PersistentPostRunE
@@ -281,127 +323,7 @@ func startServeInProcess(t *testing.T, dir, beadsDir string) (string, <-chan err
 		done <- err
 	}()
 
-	deadline := time.After(2 * time.Minute)
-	for {
-		select {
-		case line, ok := <-lines:
-			if !ok {
-				t.Fatalf("bd serve exited before it bound: %v", <-done)
-			}
-			const prefix = "bd serve: listening on http://"
-			if addr, found := strings.CutPrefix(strings.TrimSpace(line), prefix); found {
-				return addr, done
-			}
-		case <-deadline:
-			t.Fatal("bd serve did not print a bound address")
-		}
-	}
-}
-
-// restoreServeGlobals snapshots the package state one in-process serve run can
-// touch and puts it back afterwards, so a registered backend and a bound server
-// cannot leak into the tests sharing this binary.
-//
-// The flag set is part of that state and the least obvious part of it: cobra
-// merges every inherited persistent flag into serveCmd's own FlagSet the first
-// time it parses one, so a run through rootCmd.Execute leaves `bd serve`
-// carrying --json, --db and the rest of the root's surface. That is what
-// TestServeFlags reads. ResetFlags plus the command's own registration function
-// is the un-merge cobra does not offer.
-func restoreServeGlobals(t *testing.T) {
-	t.Helper()
-	origStore, origDBPath := store, dbPath
-	origServer, origProxied := serverMode, proxiedServerMode
-	origAddr, origNonLoopback := serveAddr, serveAllowNonLoopback
-	origCtx, origCancel := rootCtx, rootCancel
-	origCmdCtx, origUseGlobals := cmdCtx, testModeUseGlobals
-	t.Cleanup(func() {
-		if store != nil && store != origStore {
-			store.Close()
-		}
-		serveCmd.ResetFlags()
-		registerServeFlags(serveCmd) // rebinds serveAddr/serveAllowNonLoopback to the defaults
-		store, dbPath = origStore, origDBPath
-		serverMode, proxiedServerMode = origServer, origProxied
-		serveAddr, serveAllowNonLoopback = origAddr, origNonLoopback
-		rootCtx, rootCancel = origCtx, origCancel
-		cmdCtx, testModeUseGlobals = origCmdCtx, origUseGlobals
-		rootCmd.SetArgs(nil)
-	})
-}
-
-// resetRootPersistentFlags puts every root persistent flag back to the default
-// it was declared with, and clears its Changed bit, for the duration of one
-// test.
-//
-// A test binary that runs the root command in-process inherits whatever the
-// thousands of tests before it left in those flags and their bound globals —
-// and `Changed` is what several PersistentPreRunE branches dispatch on, not the
-// value. A stale `--db`/`--database` alone makes the pre-run refuse with
-// "--database ... is only supported in proxied-server mode" before the command
-// under test ever runs. Reset before, restore after, so this test neither reads
-// nor writes that shared state.
-func resetRootPersistentFlags(t *testing.T) {
-	t.Helper()
-	type flagState struct {
-		value   string
-		changed bool
-	}
-	before := map[string]flagState{}
-	rootCmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
-		before[f.Name] = flagState{value: f.Value.String(), changed: f.Changed}
-		if err := f.Value.Set(f.DefValue); err != nil {
-			t.Fatalf("reset --%s to its default %q: %v", f.Name, f.DefValue, err)
-		}
-		f.Changed = false
-	})
-	t.Cleanup(func() {
-		rootCmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
-			state, ok := before[f.Name]
-			if !ok {
-				return
-			}
-			_ = f.Value.Set(state.value)
-			f.Changed = state.changed
-		})
-	})
-}
-
-// captureStdoutLines redirects os.Stdout and streams its lines. bd serve prints
-// the address it bound — the only way to discover an ephemeral port — to
-// stdout, and the server is running by the time it does.
-func captureStdoutLines(t *testing.T) (<-chan string, func()) {
-	t.Helper()
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("os.Pipe: %v", err)
-	}
-	orig := os.Stdout
-	os.Stdout = w
-
-	lines := make(chan string, 64)
-	go func() {
-		defer close(lines)
-		scanner := bufio.NewScanner(r)
-		for scanner.Scan() {
-			lines <- scanner.Text()
-		}
-	}()
-
-	var stopped bool
-	stop := func() {
-		if stopped {
-			return
-		}
-		stopped = true
-		os.Stdout = orig
-		_ = w.Close()
-	}
-	t.Cleanup(func() {
-		stop()
-		_ = r.Close()
-	})
-	return lines, stop
+	return waitForBoundAddress(t, lines, done), done
 }
 
 // getJSON issues a GET and decodes a JSON object body, failing on anything else.
@@ -430,4 +352,117 @@ func mustMarshal(t *testing.T, v any) []byte {
 		t.Fatalf("marshal: %v", err)
 	}
 	return out
+}
+
+// TestServeRefusesStrictReadonlyOnARegisteredBackend drives the strict-readonly
+// refusal in the workspace where it was measured, and where the alternative was
+// worst.
+//
+// Under `--readonly` the root command opens this workspace through
+// backend.OpenReadOnly, and serve takes its claimer off that store. The server
+// bound anyway, kept advertising `issues.claim` on GET /v0/beads/context — the
+// capability set comes off the route table and cannot see a CLI flag — and
+// answered every claim with an opaque 500, leaving the issue open and
+// unassigned. That is a server lying about what it can do, which is worse than
+// no server.
+//
+// The workspace here would serve: the same registration and the same store
+// answer reads over HTTP when the flag is absent
+// (TestServeAnswersFromTheStoreTheRootCommandOpened). What stops it is the
+// refusal, not a workspace that could not have answered anyway.
+// serveRefusalBudget is how long a refusal is given to be a refusal. Only a
+// failing run ever waits it out.
+const serveRefusalBudget = 30 * time.Second
+
+func TestServeRefusesStrictReadonlyOnARegisteredBackend(t *testing.T) {
+	const name = "serve-readonly-registered"
+	backends.Register(name, backends.Backend{
+		// Open is required by the registry and never reached: strict readonly
+		// is what sends the root command down OpenReadOnly, and that is the
+		// posture under test.
+		Open: func(context.Context, string) (storage.DoltStorage, error) {
+			return &serveIdentityStore{id: "read-write"}, nil
+		},
+		OpenReadOnly: func(context.Context, string) (storage.DoltStorage, error) {
+			return &serveIdentityStore{id: "read-only"}, nil
+		},
+		WorkspaceIsBeadsDir: true,
+	})
+	t.Cleanup(func() { backends.Deregister(name) })
+
+	dir := t.TempDir()
+	initGitRepoAt(t, dir)
+	beadsDir := filepath.Join(dir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	if err := (&configfile.Config{Backend: name}).Save(beadsDir); err != nil {
+		t.Fatalf("save metadata.json: %v", err)
+	}
+
+	useStorageModeGlobals(t)
+	restoreServeGlobals(t)
+	t.Chdir(dir)
+	t.Setenv("BEADS_DIR", beadsDir)
+	beads.ResetCaches()
+	t.Cleanup(beads.ResetCaches)
+
+	origReadonly := readonlyMode
+	readonlyMode = true
+	t.Cleanup(func() { readonlyMode = origReadonly })
+
+	// What PersistentPreRunE leaves behind under --readonly: the read-only open
+	// of this workspace, which is the store serve would have taken a claimer
+	// off.
+	backend, ok := backends.Lookup(name)
+	if !ok {
+		t.Fatalf("backend %q is not registered", name)
+	}
+	opened, err := backend.OpenReadOnly(t.Context(), beadsDir)
+	if err != nil {
+		t.Fatalf("read-only open: %v", err)
+	}
+	store = opened
+
+	serveAddr, serveAllowNonLoopback = "127.0.0.1:0", false
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	setRootContext(ctx, cancel)
+
+	// runServe is run on its own goroutine and bounded, because the failure
+	// this test is here to catch does not return: a serve that binds blocks
+	// until the root context is canceled, and an unbounded wait would turn the
+	// regression into a package-wide timeout instead of one named failure.
+	lines, stopCapture := captureStdoutLines(t)
+	var (
+		runErr error
+		bound  bool
+	)
+	done := make(chan error, 1)
+	stderr := captureBootstrapStderr(t, func() {
+		go func() { done <- runServe() }()
+		select {
+		case runErr = <-done:
+		case <-time.After(serveRefusalBudget):
+			bound = true
+			cancel()
+			runErr = <-done
+		}
+	})
+	stopCapture()
+
+	if bound {
+		t.Fatalf("bd --readonly serve bound a server over a read-only store and had to be stopped\nstderr:\n%s", stderr)
+	}
+	if runErr == nil {
+		t.Fatalf("bd --readonly serve returned no error\nstderr:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "--readonly") {
+		t.Errorf("the refusal does not name the flag that caused it: %q", stderr)
+	}
+	for line := range lines {
+		if strings.Contains(line, "listening on") {
+			t.Errorf("bd serve bound before refusing: %q", line)
+		}
+	}
 }

--- a/cmd/bd/serve_registered_backend_test.go
+++ b/cmd/bd/serve_registered_backend_test.go
@@ -1,0 +1,433 @@
+//go:build cgo
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/backends"
+	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// The registered-backend serve path end to end, in-process.
+//
+// In-process because it has to be: registration is init-time Go wiring and OSS
+// registers no alternate backend, so a spawned `bd` — the shape every other
+// serve integration test takes — has nothing to register and could not
+// reproduce this case at all. bd bootstrap's registered-backend test reaches
+// the same conclusion for the same reason.
+//
+// The store behind the registered NAME is a real embedded Dolt store. Embedded
+// Dolt is refused as a WORKSPACE (serveDatabaseSource), and that refusal is
+// about its commit protocol in production, not about wiring: behind a
+// registered name it is a real store with real SQL, real claim arbitration and
+// the real decorator chain, which is exactly the double this path needs.
+
+const serveRegisteredDatabase = "beads"
+
+func TestServeAnswersFromARegisteredBackendStore(t *testing.T) {
+	const name = "serve-registered-e2e"
+
+	dir := t.TempDir()
+	initGitRepoAt(t, dir)
+	beadsDir := filepath.Join(dir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	seedID := seedRegisteredBackendWorkspace(t, beadsDir)
+
+	// A hook the workspace would fire on a CLI claim. `bd serve` documents that
+	// it does not, and this marker is the only evidence that survives the
+	// subprocess either way.
+	hookMarker := filepath.Join(dir, "on_update.ran")
+	plantOnUpdateHook(t, beadsDir, hookMarker)
+
+	backends.Register(name, backends.Backend{
+		Open: func(ctx context.Context, beadsDir string) (storage.DoltStorage, error) {
+			return embeddeddolt.Open(ctx, beadsDir, serveRegisteredDatabase, "main")
+		},
+		OpenReadOnly: func(ctx context.Context, beadsDir string) (storage.DoltStorage, error) {
+			return embeddeddolt.OpenReadOnly(ctx, beadsDir, serveRegisteredDatabase, "main")
+		},
+		WorkspaceIsBeadsDir: true,
+	})
+	t.Cleanup(func() { backends.Deregister(name) })
+	if err := (&configfile.Config{Backend: name, DoltDatabase: serveRegisteredDatabase}).Save(beadsDir); err != nil {
+		t.Fatalf("save metadata.json: %v", err)
+	}
+
+	addr, done := startServeInProcess(t, dir, beadsDir)
+
+	base := "http://" + addr
+	t.Run("the handshake answers", func(t *testing.T) {
+		body := getJSON(t, base+"/v0/beads/context")
+		if body["schema_version"] == nil {
+			t.Errorf("GET /v0/beads/context returned no schema_version: %v", body)
+		}
+	})
+
+	t.Run("reads come from the registered store", func(t *testing.T) {
+		body := getJSON(t, base+"/v0/beads/ready?limit=5")
+		if !strings.Contains(string(mustMarshal(t, body)), seedID) {
+			t.Errorf("GET /v0/beads/ready does not carry the seeded issue %q: %v", seedID, body)
+		}
+	})
+
+	t.Run("a claim lands in the registered store", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodPost, base+"/v0/beads/issues/"+seedID+":claim",
+			strings.NewReader(`{"actor":"serve-e2e"}`))
+		if err != nil {
+			t.Fatalf("build claim request: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("claim: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			payload, _ := io.ReadAll(resp.Body)
+			t.Fatalf("claim status = %d, want 200: %s", resp.StatusCode, payload)
+		}
+	})
+
+	// Stop the server the way an operator does. The root command's signal
+	// context is what serve rides, so canceling it here exercises the real
+	// shutdown path including PersistentPostRunE.
+	if rootCancel == nil {
+		t.Fatal("the root command published no cancel function; nothing here stopped the server")
+	}
+	rootCancel()
+	if err := <-done; err != nil {
+		t.Fatalf("bd serve returned %v, want a clean shutdown", err)
+	}
+
+	// The root command owns the store's whole lifecycle: PersistentPostRunE
+	// closed it after the server drained. A store still open would still hold
+	// the embedded workspace's exclusive lock, so this reopen is the assertion.
+	if store != nil {
+		t.Error("PersistentPostRunE left the registered backend's store open")
+	}
+	reopened, err := embeddeddolt.Open(t.Context(), beadsDir, serveRegisteredDatabase, "main")
+	if err != nil {
+		t.Fatalf("reopen the workspace after shutdown: %v", err)
+	}
+	defer reopened.Close()
+
+	claimed, err := reopened.GetIssue(t.Context(), seedID)
+	if err != nil {
+		t.Fatalf("read the claimed issue back: %v", err)
+	}
+	if claimed.Status != types.StatusInProgress {
+		t.Errorf("status = %q, want %q: the HTTP claim did not land in the registered store", claimed.Status, types.StatusInProgress)
+	}
+	if claimed.Assignee != "serve-e2e" {
+		t.Errorf("assignee = %q, want serve-e2e", claimed.Assignee)
+	}
+
+	// The contract this server publishes: a CLI claim runs on_update, an HTTP
+	// claim does not. Only the peel beneath the hook decorator makes that true.
+	if _, err := os.Stat(hookMarker); err == nil {
+		t.Error("an HTTP claim ran this workspace's on_update hook; bd serve documents that hooks do not fire")
+	} else if !os.IsNotExist(err) {
+		t.Errorf("stat hook marker: %v", err)
+	}
+}
+
+// TestServeRefusesAnEmbeddedWorkspaceEndToEnd drives the permanent refusal
+// through runServe rather than through serveDatabaseSource alone.
+//
+// The unit test proves the classification; this proves the wiring honors it. An
+// edit that dropped the switch and always handed Listen the roles would pass
+// the unit test and fail here, which is the regression the source-level pin and
+// this test bracket from opposite sides.
+func TestServeRefusesAnEmbeddedWorkspaceEndToEnd(t *testing.T) {
+	useStorageModeGlobals(t)
+	if !isEmbeddedMode() {
+		t.Skip("this build cannot open an embedded workspace")
+	}
+
+	dir := t.TempDir()
+	initGitRepoAt(t, dir)
+	beadsDir := filepath.Join(dir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	if err := (&configfile.Config{Backend: configfile.BackendDolt}).Save(beadsDir); err != nil {
+		t.Fatalf("save metadata.json: %v", err)
+	}
+
+	restoreServeGlobals(t)
+	// No store, deliberately: the refusal must come from the classification and
+	// not from a role extraction that found nothing to take roles off.
+	store = nil
+	serveAddr = "127.0.0.1:0"
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	setRootContext(ctx, cancel)
+	t.Chdir(dir)
+	t.Setenv("BEADS_DIR", beadsDir)
+
+	// runServe surfaces the refusal through HandleError, which writes the
+	// message to stderr and returns an opaque exit error, so the message is
+	// only observable here.
+	var err error
+	stderr := captureBootstrapStderr(t, func() { err = runServe() })
+	if err == nil {
+		t.Fatalf("bd serve bound a server over an embedded Dolt workspace\nstderr:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "embedded Dolt") {
+		t.Errorf("runServe refused with %q; want the embedded refusal", stderr)
+	}
+	// Not "no store is open": a refusal from the role extraction would mean the
+	// classification had already been bypassed.
+	if strings.Contains(stderr, "no store is open") {
+		t.Error("runServe reached the role extraction on an embedded workspace; the classification was bypassed")
+	}
+}
+
+// seedRegisteredBackendWorkspace creates the embedded Dolt database the
+// registered backend will open and puts one claimable issue in it. The store is
+// closed before returning: it holds the workspace's exclusive lock, and the
+// server is about to want it.
+func seedRegisteredBackendWorkspace(t *testing.T, beadsDir string) string {
+	t.Helper()
+	seed, err := embeddeddolt.Open(t.Context(), beadsDir, serveRegisteredDatabase, "main")
+	if err != nil {
+		t.Fatalf("open the embedded store behind the registered backend: %v", err)
+	}
+	defer func() {
+		if err := seed.Close(); err != nil {
+			t.Fatalf("close the seed store: %v", err)
+		}
+	}()
+
+	if err := seed.SetConfig(t.Context(), "issue_prefix", "srv"); err != nil {
+		t.Fatalf("set issue prefix: %v", err)
+	}
+	const id = "srv-1"
+	now := time.Now().UTC()
+	issue := &types.Issue{
+		ID:        id,
+		Title:     "Claimable over HTTP",
+		IssueType: types.TypeTask,
+		Status:    types.StatusOpen,
+		Priority:  2,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := seed.CreateIssue(t.Context(), issue, "seed"); err != nil {
+		t.Fatalf("seed an issue: %v", err)
+	}
+	return id
+}
+
+// plantOnUpdateHook writes an on_update hook that touches marker. A CLI claim
+// in this workspace runs it; an HTTP claim must not.
+func plantOnUpdateHook(t *testing.T, beadsDir, marker string) {
+	t.Helper()
+	hooksDir := filepath.Join(beadsDir, "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatalf("mkdir hooks: %v", err)
+	}
+	script := "#!/bin/sh\ntouch " + marker + "\n"
+	if err := os.WriteFile(filepath.Join(hooksDir, "on_update"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write on_update hook: %v", err)
+	}
+}
+
+// startServeInProcess runs `bd serve` on the shared cobra command in a
+// goroutine and returns the address it bound plus a channel carrying the run's
+// result. The whole root command runs, so PersistentPreRunE is what opens the
+// registered backend's store — the point being that serve consumes the store bd
+// already creates rather than creating one of its own.
+func startServeInProcess(t *testing.T, dir, beadsDir string) (string, <-chan error) {
+	t.Helper()
+	restoreServeGlobals(t)
+	resetRootPersistentFlags(t)
+	store = nil
+	serverMode, proxiedServerMode = false, false
+
+	t.Chdir(dir)
+	t.Setenv("HOME", dir)
+	t.Setenv("BEADS_DIR", beadsDir)
+	t.Setenv("BEADS_DOLT_AUTO_START", "0")
+	t.Setenv("BEADS_NO_DAEMON", "1")
+	t.Setenv("BEADS_SKIP_IDENTITY_CHECK", "1")
+	t.Setenv("BD_NON_INTERACTIVE", "1")
+	t.Setenv("BD_DISABLE_METRICS", "1")
+	t.Setenv("BD_DISABLE_EVENT_FLUSH", "1")
+
+	lines, stopCapture := captureStdoutLines(t)
+	done := make(chan error, 1)
+	go func() {
+		rootCmd.SetArgs([]string{"serve", "--addr", "127.0.0.1:0"})
+		err := rootCmd.Execute()
+		stopCapture()
+		done <- err
+	}()
+
+	deadline := time.After(2 * time.Minute)
+	for {
+		select {
+		case line, ok := <-lines:
+			if !ok {
+				t.Fatalf("bd serve exited before it bound: %v", <-done)
+			}
+			const prefix = "bd serve: listening on http://"
+			if addr, found := strings.CutPrefix(strings.TrimSpace(line), prefix); found {
+				return addr, done
+			}
+		case <-deadline:
+			t.Fatal("bd serve did not print a bound address")
+		}
+	}
+}
+
+// restoreServeGlobals snapshots the package state one in-process serve run can
+// touch and puts it back afterwards, so a registered backend and a bound server
+// cannot leak into the tests sharing this binary.
+//
+// The flag set is part of that state and the least obvious part of it: cobra
+// merges every inherited persistent flag into serveCmd's own FlagSet the first
+// time it parses one, so a run through rootCmd.Execute leaves `bd serve`
+// carrying --json, --db and the rest of the root's surface. That is what
+// TestServeFlags reads. ResetFlags plus the command's own registration function
+// is the un-merge cobra does not offer.
+func restoreServeGlobals(t *testing.T) {
+	t.Helper()
+	origStore, origDBPath := store, dbPath
+	origServer, origProxied := serverMode, proxiedServerMode
+	origAddr, origNonLoopback := serveAddr, serveAllowNonLoopback
+	origCtx, origCancel := rootCtx, rootCancel
+	origCmdCtx, origUseGlobals := cmdCtx, testModeUseGlobals
+	t.Cleanup(func() {
+		if store != nil && store != origStore {
+			store.Close()
+		}
+		serveCmd.ResetFlags()
+		registerServeFlags(serveCmd) // rebinds serveAddr/serveAllowNonLoopback to the defaults
+		store, dbPath = origStore, origDBPath
+		serverMode, proxiedServerMode = origServer, origProxied
+		serveAddr, serveAllowNonLoopback = origAddr, origNonLoopback
+		rootCtx, rootCancel = origCtx, origCancel
+		cmdCtx, testModeUseGlobals = origCmdCtx, origUseGlobals
+		rootCmd.SetArgs(nil)
+	})
+}
+
+// resetRootPersistentFlags puts every root persistent flag back to the default
+// it was declared with, and clears its Changed bit, for the duration of one
+// test.
+//
+// A test binary that runs the root command in-process inherits whatever the
+// thousands of tests before it left in those flags and their bound globals —
+// and `Changed` is what several PersistentPreRunE branches dispatch on, not the
+// value. A stale `--db`/`--database` alone makes the pre-run refuse with
+// "--database ... is only supported in proxied-server mode" before the command
+// under test ever runs. Reset before, restore after, so this test neither reads
+// nor writes that shared state.
+func resetRootPersistentFlags(t *testing.T) {
+	t.Helper()
+	type flagState struct {
+		value   string
+		changed bool
+	}
+	before := map[string]flagState{}
+	rootCmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
+		before[f.Name] = flagState{value: f.Value.String(), changed: f.Changed}
+		if err := f.Value.Set(f.DefValue); err != nil {
+			t.Fatalf("reset --%s to its default %q: %v", f.Name, f.DefValue, err)
+		}
+		f.Changed = false
+	})
+	t.Cleanup(func() {
+		rootCmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
+			state, ok := before[f.Name]
+			if !ok {
+				return
+			}
+			_ = f.Value.Set(state.value)
+			f.Changed = state.changed
+		})
+	})
+}
+
+// captureStdoutLines redirects os.Stdout and streams its lines. bd serve prints
+// the address it bound — the only way to discover an ephemeral port — to
+// stdout, and the server is running by the time it does.
+func captureStdoutLines(t *testing.T) (<-chan string, func()) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+
+	lines := make(chan string, 64)
+	go func() {
+		defer close(lines)
+		scanner := bufio.NewScanner(r)
+		for scanner.Scan() {
+			lines <- scanner.Text()
+		}
+	}()
+
+	var stopped bool
+	stop := func() {
+		if stopped {
+			return
+		}
+		stopped = true
+		os.Stdout = orig
+		_ = w.Close()
+	}
+	t.Cleanup(func() {
+		stop()
+		_ = r.Close()
+	})
+	return lines, stop
+}
+
+// getJSON issues a GET and decodes a JSON object body, failing on anything else.
+func getJSON(t *testing.T, url string) map[string]any {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("GET %s status = %d, want 200: %s", url, resp.StatusCode, payload)
+	}
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode %s: %v", url, err)
+	}
+	return body
+}
+
+func mustMarshal(t *testing.T, v any) []byte {
+	t.Helper()
+	out, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return out
+}

--- a/cmd/bd/serve_source_test.go
+++ b/cmd/bd/serve_source_test.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/hooks"
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/issueops"
+)
+
+// TestServeDatabaseSourceClassifiesTheWorkspace drives the one decision point
+// bd serve has about where it reads and claims from.
+//
+// The registered arm is the whole point: the store the root command opened for
+// a registered backend is opened through the same registry dispatch every
+// ordinary bd command uses, so a workspace fully usable from the CLI must be
+// servable too. The embedded arm is the permanent refusal, and it is here so
+// that widening the classification cannot quietly narrow the refusal.
+func TestServeDatabaseSourceClassifiesTheWorkspace(t *testing.T) {
+	t.Run("a registered backend is served from its store", func(t *testing.T) {
+		const name = "serve-registry"
+		registerContractBackend(t, name)
+		useStorageModeGlobals(t)
+		beadsDir := writeContractBackendConfig(t, name)
+
+		db, err := serveDatabaseSource(beadsDir)
+		if err != nil {
+			t.Fatalf("serveDatabaseSource() = %v, want the store source", err)
+		}
+		if db.source != serveSourceStore {
+			t.Errorf("source = %v, want serveSourceStore", db.source)
+		}
+		if db.backend != name {
+			t.Errorf("backend = %q, want %q", db.backend, name)
+		}
+	})
+
+	// The registry outranks every dolt-mode signal, because that is the order
+	// the store open already resolves them in: PersistentPreRunE dispatches on
+	// backends.Lookup before anything looks at shared-server mode, so a
+	// registered workspace with BEADS_DOLT_SHARED_SERVER=1 exported still opens
+	// the registered store. Resolving it the other way here would build a Dolt
+	// provider over a non-Dolt store and serve a different database than the
+	// CLI in the same workspace reaches.
+	t.Run("the registry outranks a shared-server environment", func(t *testing.T) {
+		const name = "serve-registry-shared"
+		registerContractBackend(t, name)
+		useStorageModeGlobals(t)
+		t.Setenv("BEADS_DOLT_SHARED_SERVER", "1")
+		beadsDir := writeContractBackendConfig(t, name)
+
+		db, err := serveDatabaseSource(beadsDir)
+		if err != nil {
+			t.Fatalf("serveDatabaseSource() = %v, want the store source", err)
+		}
+		if db.source != serveSourceStore {
+			t.Errorf("source = %v, want serveSourceStore: the store open gives the registry precedence here", db.source)
+		}
+	})
+
+	t.Run("an unloadable metadata.json is named, not classified", func(t *testing.T) {
+		useStorageModeGlobals(t)
+		beadsDir := t.TempDir()
+		writeBrokenBeadsConfig(t, beadsDir)
+
+		db, err := serveDatabaseSource(beadsDir)
+		if err == nil {
+			t.Fatalf("serveDatabaseSource() = %v, nil; want the load failure rather than a classification", db)
+		}
+		if !strings.Contains(err.Error(), configfile.ConfigPath(beadsDir)) {
+			t.Errorf("error does not name the file it could not read: %v", err)
+		}
+	})
+}
+
+// TestServeIssueRolesComeFromBeneathTheHookDecorator.
+//
+// bd serve documents that hooks do not fire, and a store's accessors hand out
+// its decorators by design — `store.IssueClaimer()` on bd's own chain returns a
+// claimer that runs the workspace's on_update script for every claim it lands.
+// httpapi.Listen refuses exactly that value (storage.RoleFiresHooks), so this is
+// the difference between a server that boots and one that does not.
+func TestServeIssueRolesComeFromBeneathTheHookDecorator(t *testing.T) {
+	// Two layers beneath the hooks, because peeling ONE is the requirement and
+	// peeling all of them (storage.UnwrapStore) is the mistake that looks
+	// identical on a single-layer chain. The middle store stands in for the
+	// telemetry layer bd wires there, which is an Unwrapper too.
+	inner := &serveRolesStore{reader: &serveStubReader{}, claimer: &serveStubClaimer{}}
+	middle := &serveRolesStore{reader: &serveStubReader{}, claimer: &serveStubClaimer{}, inner: inner}
+	chained := wireStorageDecorators(middle, hooks.NewRunner(t.TempDir()), false)
+
+	if _, ok := chained.(*storage.HookFiringStore); !ok {
+		t.Fatalf("wireStorageDecorators produced %T, not a hook-firing store; this test proves nothing", chained)
+	}
+	fromTheStore, err := chained.IssueClaimer()
+	if err != nil {
+		t.Fatalf("IssueClaimer: %v", err)
+	}
+	if !storage.RoleFiresHooks(fromTheStore) {
+		t.Fatal("the store's own accessor no longer returns a hook-firing claimer; this test proves nothing")
+	}
+
+	reader, claimer, err := serveIssueRoles(chained)
+	if err != nil {
+		t.Fatalf("serveIssueRoles: %v", err)
+	}
+	// The same predicate httpapi.Listen refuses on, so a regression here is a
+	// server that refuses to boot rather than one that runs hooks silently.
+	if storage.RoleFiresHooks(claimer) {
+		t.Error("bd serve would run this workspace's hooks on every HTTP claim")
+	}
+	if claimer != issueops.Claimer(middle.claimer) {
+		t.Errorf("claimer came from %p, want the layer directly beneath the hooks (%p)", claimer, middle.claimer)
+	}
+	if reader != issueops.Reader(middle.reader) {
+		t.Errorf("reader came from %p, want the layer directly beneath the hooks (%p)", reader, middle.reader)
+	}
+
+	t.Run("a workspace with hooks disabled has no layer to peel", func(t *testing.T) {
+		// BD_NO_HOOKS=1 wires no hook decorator at all, so the roles are the
+		// store's own and the peel must be conditional.
+		bare := wireStorageDecorators(middle, hooks.NewRunner(t.TempDir()), true)
+		reader, claimer, err := serveIssueRoles(bare)
+		if err != nil {
+			t.Fatalf("serveIssueRoles: %v", err)
+		}
+		if claimer != issueops.Claimer(middle.claimer) || reader != issueops.Reader(middle.reader) {
+			t.Error("serveIssueRoles peeled a layer that was not there")
+		}
+	})
+
+	t.Run("no open store is an error, not a nil source", func(t *testing.T) {
+		// httpapi.Listen refuses a half-set pair, but a nil store reaching it
+		// as two nil roles would report "no database source" — true, and
+		// useless. Name the real condition here.
+		if _, _, err := serveIssueRoles(nil); err == nil {
+			t.Fatal("serveIssueRoles(nil) = nil error; want a refusal naming the missing store")
+		}
+	})
+}
+
+// TestServeResolvedModeNamesTheRegisteredBackend. The startup label is
+// cosmetic, but "embedded (external dolt)" for a registered backend is two
+// wrong statements about the topology an operator is trying to identify.
+func TestServeResolvedModeNamesTheRegisteredBackend(t *testing.T) {
+	// A registered workspace has no dolt mode, and this is the field that
+	// carries one — see the ContextInfo gap noted on serveResolvedMode.
+	info := domain.ContextInfo{DoltMode: configfile.DoltModeEmbedded}
+
+	got := serveResolvedMode(info, serveDatabase{source: serveSourceStore, backend: "acme"})
+	if got != "acme (registered backend)" {
+		t.Errorf("mode = %q, want %q", got, "acme (registered backend)")
+	}
+	if strings.Contains(got, configfile.DoltModeEmbedded) || strings.Contains(got, "dolt") {
+		t.Errorf("mode reports a Dolt topology for a registered backend: %q", got)
+	}
+}
+
+// writeBrokenBeadsConfig plants a metadata.json that configfile.Load cannot
+// parse, which is the one input serveDatabaseSource must refuse rather than
+// classify: falling back to a default here would serve the embedded default
+// for a workspace whose real backend is unknown.
+func writeBrokenBeadsConfig(t *testing.T, beadsDir string) {
+	t.Helper()
+	if err := os.WriteFile(configfile.ConfigPath(beadsDir), []byte("{ not json"), 0o600); err != nil {
+		t.Fatalf("write broken metadata.json: %v", err)
+	}
+}
+
+// serveRolesStore is the smallest DoltStorage the role extraction can be
+// pointed at: it publishes its own roles and unwraps to an inner store with
+// different ones, so a peel of the wrong depth lands on identifiably wrong
+// values. The embedded DoltStorage is nil because nothing here reaches past
+// the three methods below.
+type serveRolesStore struct {
+	storage.DoltStorage
+	reader  *serveStubReader
+	claimer *serveStubClaimer
+	inner   storage.DoltStorage
+}
+
+func (s *serveRolesStore) IssueReader() (issueops.Reader, error)   { return s.reader, nil }
+func (s *serveRolesStore) IssueClaimer() (issueops.Claimer, error) { return s.claimer, nil }
+func (s *serveRolesStore) Unwrap() storage.DoltStorage             { return s.inner }
+
+type serveStubReader struct{}
+
+func (*serveStubReader) Ready(context.Context, issueops.ReadyRequest) (issueops.IssuePage, error) {
+	return issueops.IssuePage{}, errors.ErrUnsupported
+}
+
+func (*serveStubReader) List(context.Context, issueops.ListRequest) (issueops.IssuePage, error) {
+	return issueops.IssuePage{}, errors.ErrUnsupported
+}
+
+func (*serveStubReader) Get(context.Context, issueops.GetRequest) (*issueops.IssueDetails, error) {
+	return nil, errors.ErrUnsupported
+}
+
+type serveStubClaimer struct{}
+
+func (*serveStubClaimer) Claim(context.Context, issueops.ClaimRequest) (issueops.ClaimResult, error) {
+	return issueops.ClaimResult{}, errors.ErrUnsupported
+}

--- a/cmd/bd/serve_store_identity_test.go
+++ b/cmd/bd/serve_store_identity_test.go
@@ -1,0 +1,201 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/beads"
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/backends"
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/issueops"
+)
+
+// TestServeAnswersFromTheStoreTheRootCommandOpened pins the one property this
+// whole arm exists for, and pins it as a property rather than as a shape.
+//
+// "Serve answers from the store bd already opened" and "serve opens a second
+// store of its own" produce identical output on every other assertion available:
+// the same reads, the same claims, the same handshake, the same clean shutdown.
+// The difference is a leaked handle with no owner, doubled pools, and — on a
+// backend that takes an exclusive workspace lock — a second open that fights the
+// first. Replacing `store` in runServe with a store opened here, which compiles,
+// used to pass everything.
+//
+// So WHICH store answered has to be readable off the wire. Every open through
+// this registry hands back a store whose reader answers with one issue named
+// after that open: the first is "store-1", a second would be "store-2". The
+// response body says which one the server is on, and no amount of wiring can
+// forge it.
+func TestServeAnswersFromTheStoreTheRootCommandOpened(t *testing.T) {
+	const name = "serve-store-identity"
+
+	var opens atomic.Int64
+	open := func(context.Context, string) (storage.DoltStorage, error) {
+		return &serveIdentityStore{id: fmt.Sprintf("store-%d", opens.Add(1))}, nil
+	}
+	backends.Register(name, backends.Backend{
+		Open:                open,
+		OpenReadOnly:        open,
+		WorkspaceIsBeadsDir: true,
+	})
+	t.Cleanup(func() { backends.Deregister(name) })
+
+	dir := t.TempDir()
+	initGitRepoAt(t, dir)
+	beadsDir := filepath.Join(dir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	if err := (&configfile.Config{Backend: name}).Save(beadsDir); err != nil {
+		t.Fatalf("save metadata.json: %v", err)
+	}
+
+	useStorageModeGlobals(t)
+	restoreServeGlobals(t)
+	t.Chdir(dir)
+	t.Setenv("BEADS_DIR", beadsDir)
+	// The workspace snapshot is resolved once per process and cached, so a test
+	// that chdirs into its own workspace has to clear it going in and coming
+	// out.
+	beads.ResetCaches()
+	t.Cleanup(beads.ResetCaches)
+
+	// Stand in for PersistentPreRunE, which opens the workspace through exactly
+	// this dispatch and leaves it in `store`. This is the store bd already
+	// opened, and it is store-1.
+	opened, err := openRegisteredStoreForTest(t, name, beadsDir)
+	if err != nil {
+		t.Fatalf("open the registered backend: %v", err)
+	}
+	store = opened
+
+	serveAddr, serveAllowNonLoopback = "127.0.0.1:0", false
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	setRootContext(ctx, cancel)
+
+	lines, stopCapture := captureStdoutLines(t)
+	done := make(chan error, 1)
+	go func() {
+		err := runServe()
+		stopCapture()
+		done <- err
+	}()
+	addr := waitForBoundAddress(t, lines, done)
+
+	body := getBody(t, "http://"+addr+"/v0/beads/ready?limit=5")
+	if !strings.Contains(body, opened.id) {
+		t.Errorf("GET /v0/beads/ready answered from a store other than the one bd opened (%s):\n%s", opened.id, body)
+	}
+	// Named separately, because the two failures are different bugs: the body
+	// above says the server is on the wrong store, and this says a store was
+	// created that nobody will ever close.
+	if n := opens.Load(); n != 1 {
+		t.Errorf("the registered backend was opened %d times, want 1: bd serve created a store of its own", n)
+	}
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("runServe returned %v, want a clean shutdown", err)
+	}
+}
+
+// openRegisteredStoreForTest opens the workspace the way PersistentPreRunE
+// does: through the registry, by name, with no knowledge of what is behind it.
+func openRegisteredStoreForTest(t *testing.T, name, beadsDir string) (*serveIdentityStore, error) {
+	t.Helper()
+	backend, ok := backends.Lookup(name)
+	if !ok {
+		t.Fatalf("backend %q is not registered", name)
+	}
+	opened, err := backend.Open(t.Context(), beadsDir)
+	if err != nil {
+		return nil, err
+	}
+	identified, ok := opened.(*serveIdentityStore)
+	if !ok {
+		t.Fatalf("the registry returned %T, not the identified store this test reads by name", opened)
+	}
+	return identified, nil
+}
+
+// getBody issues a GET and returns the raw body, failing on anything but a 200.
+func getBody(t *testing.T, url string) string {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	payload, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read %s: %v", url, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s status = %d, want 200: %s", url, resp.StatusCode, payload)
+	}
+	return string(payload)
+}
+
+// serveIdentityStore is a store that says which store it is. Its reader answers
+// every ready query with a single issue whose ID is the store's own, so the
+// identity of the value the server was wired to is a substring of the response
+// rather than something a test has to reach inside the server to inspect.
+//
+// The embedded DoltStorage is nil: nothing on this path calls anything else, and
+// a nil-panic naming the method would be a truer failure than a stub that
+// answered.
+type serveIdentityStore struct {
+	storage.DoltStorage
+	id string
+}
+
+func (s *serveIdentityStore) IssueReader() (issueops.Reader, error) {
+	return serveIdentityReader{id: s.id}, nil
+}
+
+func (s *serveIdentityStore) IssueClaimer() (issueops.Claimer, error) {
+	return serveIdentityClaimer{}, nil
+}
+
+// Close is the one lifecycle method that is reached: the test harness closes a
+// store it finds left behind. There is nothing to release.
+func (s *serveIdentityStore) Close() error { return nil }
+
+type serveIdentityReader struct{ id string }
+
+func (r serveIdentityReader) Ready(context.Context, issueops.ReadyRequest) (issueops.IssuePage, error) {
+	return issueops.IssuePage{
+		Items: []*issueops.IssueWithCounts{{Issue: &types.Issue{
+			ID:     r.id,
+			Title:  "answered by " + r.id,
+			Status: types.StatusOpen,
+		}}},
+	}, nil
+}
+
+func (serveIdentityReader) List(context.Context, issueops.ListRequest) (issueops.IssuePage, error) {
+	return issueops.IssuePage{}, errors.ErrUnsupported
+}
+
+func (serveIdentityReader) Get(context.Context, issueops.GetRequest) (*issueops.IssueDetails, error) {
+	return nil, errors.ErrUnsupported
+}
+
+type serveIdentityClaimer struct{}
+
+func (serveIdentityClaimer) Claim(context.Context, issueops.ClaimRequest) (issueops.ClaimResult, error) {
+	return issueops.ClaimResult{}, errors.ErrUnsupported
+}

--- a/cmd/bd/serve_test.go
+++ b/cmd/bd/serve_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"go/ast"
 	"go/parser"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/spf13/pflag"
 
+	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/httpapi"
 	"github.com/steveyegge/beads/internal/storage"
@@ -362,4 +364,92 @@ func packageDir(t *testing.T) string {
 		t.Fatal("cannot resolve this test's source path")
 	}
 	return filepath.Dir(file)
+}
+
+// TestServeRefusesStrictReadonly.
+//
+// `bd --readonly serve` is a contradiction, and until it was refused it
+// resolved differently on each of the two database sources — badly on both.
+//
+// On the STORE source the root command opens the workspace through
+// backend.OpenReadOnly and serve takes its claimer off that store, so the
+// server bound, GET /v0/beads/context went on advertising `issues.claim` (the
+// capability set is derived from the route table and knows nothing about a CLI
+// flag), and every claim came back 500 with the issue left open and unassigned.
+// A server that advertises a write it will always fail is worse than no server.
+//
+// On the PROVIDER source it was the other silent answer: serve builds its own
+// unit-of-work provider from the workspace's connection settings, which has no
+// read-only posture at all, so `--readonly` bought the operator nothing and
+// every claim landed. (Proxied mode never got that far — the root pre-run
+// already refuses strict readonly for it.)
+//
+// Refusing is the same policy bd already applies one layer down, where a
+// backend that cannot guarantee mutation-free access is turned away rather than
+// opened anyway. It is also the only answer that is the same on both sources.
+//
+// The gate is ahead of the workspace, which this pins by refusing in a
+// directory that has no workspace at all: no topology can reach past it.
+func TestServeRefusesStrictReadonly(t *testing.T) {
+	// Refused in a directory with NO workspace, which is how the ordering is
+	// pinned: the gate cannot be sitting behind a topology if there is no
+	// topology to resolve. That is what makes one test cover both sources.
+	// TestServeRefusesStrictReadonlyOnARegisteredBackend drives the same
+	// refusal in a workspace that would otherwise have served.
+	t.Run("before any workspace is resolved", func(t *testing.T) {
+		stderr, err := runServeUnderReadonly(t, t.TempDir())
+		if err == nil {
+			t.Fatalf("bd --readonly serve bound a server\nstderr:\n%s", stderr)
+		}
+		if !strings.Contains(stderr, "--readonly") {
+			t.Errorf("the refusal does not name the flag that caused it: %q", stderr)
+		}
+		if strings.Contains(stderr, "cannot resolve workspace context") {
+			t.Errorf("the readonly refusal runs after the workspace is resolved: %q", stderr)
+		}
+	})
+
+	t.Run("the capability set stays honest", func(t *testing.T) {
+		// The other way to settle this would have been to drop issues.claim
+		// from what a read-only server advertises. That is a wire change —
+		// `capabilities` is the documented pre-flight a client checks — and it
+		// would make one operation's presence depend on a CLI flag, which no
+		// client can discover before connecting. Refusing the process instead
+		// leaves the published surface a property of the build.
+		if !slices.Contains(httpapi.Capabilities(), "issues.claim") {
+			t.Error("issues.claim left the advertised capability set; bd serve refuses --readonly " +
+				"precisely so that set never has to vary")
+		}
+	})
+}
+
+// runServeUnderReadonly runs bd serve with strict readonly set, in dir, and
+// returns what it wrote to stderr. The refusal reaches the operator through
+// HandleError, which writes the message to stderr and returns an opaque exit
+// error, so the message is only observable here.
+func runServeUnderReadonly(t *testing.T, dir string) (string, error) {
+	t.Helper()
+	useStorageModeGlobals(t)
+	restoreServeGlobals(t)
+
+	origReadonly := readonlyMode
+	readonlyMode = true
+	t.Cleanup(func() { readonlyMode = origReadonly })
+
+	store = nil
+	serveAddr, serveAllowNonLoopback = "127.0.0.1:0", false
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	setRootContext(ctx, cancel)
+	t.Chdir(dir)
+	// The workspace snapshot is resolved once per process and cached, so
+	// without this a directory with no workspace would still resolve to
+	// whichever one an earlier test in this binary left behind — and "no
+	// workspace" is the whole premise of the ordering assertion above.
+	beads.ResetCaches()
+	t.Cleanup(beads.ResetCaches)
+
+	var err error
+	stderr := captureBootstrapStderr(t, func() { err = runServe() })
+	return stderr, err
 }

--- a/cmd/bd/serve_test.go
+++ b/cmd/bd/serve_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/spf13/pflag"
 
+	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/httpapi"
 	"github.com/steveyegge/beads/internal/storage"
 )
@@ -159,9 +160,14 @@ func TestServeRefusalsPromiseNothing(t *testing.T) {
 		} {
 			t.Run(tc.name, func(t *testing.T) {
 				useStorageModeGlobals(t)
+				beadsDir := writeContractBackendConfig(t, configfile.BackendDolt)
 				tc.apply(t)
-				if err := serveModeGate(); err != nil {
-					t.Fatalf("serveModeGate() = %v, want nil: this mode has a SQL server and bd serve builds a provider for it", err)
+				db, err := serveDatabaseSource(beadsDir)
+				if err != nil {
+					t.Fatalf("serveDatabaseSource() = %v, want nil: this mode has a SQL server and bd serve builds a provider for it", err)
+				}
+				if db.source != serveSourceProvider {
+					t.Errorf("source = %v, want serveSourceProvider", db.source)
 				}
 			})
 		}
@@ -174,10 +180,11 @@ func TestServeRefusalsPromiseNothing(t *testing.T) {
 			// is a constant false there, so there is no case to make.
 			t.Skip("this build cannot open an embedded workspace")
 		}
-		err := serveModeGate()
+		beadsDir := writeContractBackendConfig(t, configfile.BackendDolt)
+		_, err := serveDatabaseSource(beadsDir)
 		var unsupported *storage.ErrUnsupported
 		if !errors.As(err, &unsupported) {
-			t.Fatalf("serveModeGate() = %v, want the typed embedded refusal", err)
+			t.Fatalf("serveDatabaseSource() = %v, want the typed embedded refusal", err)
 		}
 		if unsupported.Backend != "embedded-dolt" {
 			t.Errorf("Backend = %q, want embedded-dolt", unsupported.Backend)
@@ -201,23 +208,29 @@ func useStorageModeGlobals(t *testing.T) {
 	})
 }
 
-// TestServeBuildsOnlyAProviderBackedServer is the source-level half of the
-// embedded refusal, and it exists because the other half stopped being
-// structural.
+// TestServeNamesOneDatabaseSourcePerServerItBuilds is the source-level half of
+// the embedded refusal. It replaces TestServeBuildsOnlyAProviderBackedServer,
+// which pinned a world in which bd built provider-backed servers only.
 //
-// httpapi.Listen once took a unit-of-work provider or nothing, and there is no
-// provider for the embedded backend, so an embedded-backed server could not be
-// built even with serveModeGate deleted. httpapi.Config now also accepts the
-// two issue roles as a database source, and the embedded store publishes both
-// accessors — so the shortest edit from here to a server whose per-request
-// atomicity claim is false is handing Listen the roles off the store the root
-// command already opened. internal/httpapi will not catch it: a role is an
-// interface, and nothing about one says which backend is behind it.
+// That world ended for a reason and not by accident: the registered-backend arm
+// exists precisely so a store bd already opened can be served. But the property
+// the old test protected did not end with it — internal/httpapi still cannot
+// tell an embedded-backed role from any other, so the shortest edit from here to
+// a server whose per-request atomicity claim is false is still handing Listen
+// the roles off whatever store happens to be open.
 //
-// So the claim this pins is narrow and checkable: bd names exactly one database
-// source, and it is the provider serveModeGate has already vouched for. An edit
-// that reaches for the roles instead fails here and has to read that gate.
-func TestServeBuildsOnlyAProviderBackedServer(t *testing.T) {
+// So this pins what is left, and it is narrow and checkable:
+//
+//   - every httpapi.Config bd builds names exactly ONE COMPLETE database
+//     source — Provider alone, or Reader and Claimer together. A half-set pair
+//     binds, answers every read, and nil-dereferences on the first claim;
+//     Listen refuses it, and so does this, one layer earlier;
+//   - both arms exist, so the test cannot pass because one was deleted;
+//   - a roles-bearing Config is built only inside a function that consults
+//     serveDatabaseSource and names serveSourceStore. That is the gate holding
+//     the embedded refusal, so an edit that reaches for the roles anywhere else
+//     fails here and has to go read it.
+func TestServeNamesOneDatabaseSourcePerServerItBuilds(t *testing.T) {
 	dir := packageDir(t)
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -225,7 +238,7 @@ func TestServeBuildsOnlyAProviderBackedServer(t *testing.T) {
 	}
 
 	fset := token.NewFileSet()
-	configs, provided := 0, 0
+	var providerBacked, rolesBacked int
 	for _, entry := range entries {
 		name := entry.Name()
 		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
@@ -235,50 +248,107 @@ func TestServeBuildsOnlyAProviderBackedServer(t *testing.T) {
 		if err != nil {
 			t.Fatalf("parse %s: %v", name, err)
 		}
-		ast.Inspect(file, func(n ast.Node) bool {
-			lit, ok := n.(*ast.CompositeLit)
+
+		// Attribute every literal to its enclosing function. A literal outside
+		// one is not reachable through the gate by construction, so the
+		// whole-file count below refuses to let it hide.
+		attributed := 0
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
 			if !ok {
-				return true
+				continue
 			}
-			sel, ok := lit.Type.(*ast.SelectorExpr)
-			if !ok || sel.Sel.Name != "Config" {
-				return true
-			}
-			if pkg, ok := sel.X.(*ast.Ident); !ok || pkg.Name != "httpapi" {
-				return true
-			}
-			configs++
-			for _, elt := range lit.Elts {
-				kv, ok := elt.(*ast.KeyValueExpr)
-				if !ok {
-					continue
+			for _, lit := range httpapiConfigLiterals(fn) {
+				attributed++
+				keys := configLiteralKeys(lit)
+				provider := keys["Provider"]
+				reader, claimer := keys["Reader"], keys["Claimer"]
+
+				switch {
+				case provider && (reader || claimer):
+					t.Errorf("%s: this httpapi.Config names two database sources; pass exactly one",
+						fset.Position(lit.Pos()))
+				case reader != claimer:
+					t.Errorf("%s: this httpapi.Config sets one issue role without the other; a reader without a "+
+						"claimer binds, answers every read, and fails the first claim on a live server",
+						fset.Position(lit.Pos()))
+				case provider:
+					providerBacked++
+				case reader && claimer:
+					rolesBacked++
+					if !functionMentions(fn, "serveDatabaseSource") || !functionMentions(fn, "serveSourceStore") {
+						t.Errorf("%s: %s builds a roles-backed httpapi.Config without consulting serveDatabaseSource. "+
+							"That gate is where the permanent embedded-Dolt refusal lives, and internal/httpapi "+
+							"cannot tell an embedded-backed role from any other — read it before changing this",
+							fset.Position(lit.Pos()), fn.Name.Name)
+					}
+				default:
+					t.Errorf("%s: this httpapi.Config names no database source", fset.Position(lit.Pos()))
 				}
-				key, ok := kv.Key.(*ast.Ident)
-				if !ok {
-					continue
-				}
-				switch key.Name {
-				case "Reader", "Claimer":
-					t.Errorf("%s: bd serve sets httpapi.Config.%s. The roles source bypasses the unit-of-work "+
-						"provider serveModeGate vouched for, and internal/httpapi cannot tell an embedded-backed "+
-						"role from any other — read serveModeGate before changing this",
-						fset.Position(kv.Pos()), key.Name)
-				case "Provider":
-					provided++
-				}
 			}
-			return true
-		})
+		}
+		if total := len(httpapiConfigLiterals(file)); total != attributed {
+			t.Errorf("%s: %d of %d httpapi.Config literals are outside any function; such a literal cannot be "+
+				"reached through serveDatabaseSource", name, total-attributed, total)
+		}
 	}
 
-	// Both counts, so the test cannot pass because the literal moved, was
-	// renamed, or stopped naming a source at all.
-	if configs == 0 {
-		t.Fatal("no httpapi.Config literal in cmd/bd: this test no longer looks at the code that builds the server")
+	// Both arms, so the test cannot pass because one was deleted, renamed, or
+	// stopped naming a source at all.
+	if providerBacked == 0 {
+		t.Error("no provider-backed httpapi.Config in cmd/bd: the dolt SQL-server workspaces are no longer served")
 	}
-	if provided != configs {
-		t.Errorf("%d of %d httpapi.Config literals set Provider; every server bd builds is provider-backed", provided, configs)
+	if rolesBacked == 0 {
+		t.Error("no roles-backed httpapi.Config in cmd/bd: a registered backend is no longer served from its store")
 	}
+}
+
+// httpapiConfigLiterals returns every `httpapi.Config{...}` composite literal
+// under n.
+func httpapiConfigLiterals(n ast.Node) []*ast.CompositeLit {
+	var out []*ast.CompositeLit
+	ast.Inspect(n, func(n ast.Node) bool {
+		lit, ok := n.(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		sel, ok := lit.Type.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Config" {
+			return true
+		}
+		if pkg, ok := sel.X.(*ast.Ident); ok && pkg.Name == "httpapi" {
+			out = append(out, lit)
+		}
+		return true
+	})
+	return out
+}
+
+// configLiteralKeys is the set of field names a keyed composite literal sets.
+func configLiteralKeys(lit *ast.CompositeLit) map[string]bool {
+	keys := make(map[string]bool, len(lit.Elts))
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		if key, ok := kv.Key.(*ast.Ident); ok {
+			keys[key.Name] = true
+		}
+	}
+	return keys
+}
+
+// functionMentions reports whether fn's body names the given identifier.
+func functionMentions(fn *ast.FuncDecl, name string) bool {
+	found := false
+	ast.Inspect(fn, func(n ast.Node) bool {
+		if ident, ok := n.(*ast.Ident); ok && ident.Name == name {
+			found = true
+		}
+		return !found
+	})
+	return found
 }
 
 // packageDir is this test file's own directory, resolved from the compiled-in

--- a/engdocs/SERVE_RUNBOOK.md
+++ b/engdocs/SERVE_RUNBOOK.md
@@ -254,6 +254,7 @@ gives the shape, the `request_error` line gives the cause.
 | Message | Cause |
 |---|---|
 | `bd serve requires a Dolt SQL server; this workspace uses embedded Dolt` | Permanent. The embedded backend commits outside the SQL transaction on a separate connection, so this server's per-request atomicity would be a lie there. Refused by `serveDatabaseSource`, which is the only thing refusing it — see "Workspace modes" in the design doc. |
+| `bd serve is unavailable under strict readonly` | `--readonly`, or `readonly` in config. Every server this command binds publishes the issue-claim operation and the advertised capability set is a property of the build, not of the flags on the process that started it — so the alternatives were a server advertising a claim it always fails (the store source, where the read-only open reaches the claimer) or a `--readonly` that quietly bought nothing (the provider source, which builds its own writable connection). Drop the flag to serve. |
 | `host must be a numeric IP literal, not a name — use 127.0.0.1 rather than localhost` | `--addr` was given a DNS name. |
 | `binds beyond loopback; bd serve has no authentication, so this requires --allow-non-loopback` | A non-loopback `--addr` without the flag. |
 | `address already in use` | The fixed-port mutual exclusion working as intended: a second server is already on that port. |

--- a/engdocs/SERVE_RUNBOOK.md
+++ b/engdocs/SERVE_RUNBOOK.md
@@ -155,6 +155,14 @@ knob. If it does not, `bd serve` says so at startup with
 `event=pool_limits_unavailable` and runs with an **unbounded** pool rather than
 silently pretending. Check for that line before trusting the arithmetic above.
 
+None of this arithmetic applies to a registered backend, which is served from
+the store the root command opened rather than from a unit-of-work provider
+(`db=roles` on the startup line, against `db=provider` for every Dolt topology).
+The pool belongs to that backend, `bd serve` neither owns it nor can reach it,
+and no `pool_limits_unavailable` line is emitted — a missing capability would be
+reported for a provider that was never asked for. Size that pool wherever the
+backend is configured.
+
 `maxConns = 64` bounds *accepted TCP connections*, which is a client-side limit
 and not part of the database budget. It exists because the semaphore does not
 bound connections: Go spawns a goroutine per connection, and one parked on a
@@ -245,7 +253,7 @@ gives the shape, the `request_error` line gives the cause.
 
 | Message | Cause |
 |---|---|
-| `bd serve requires a Dolt SQL server; this workspace uses embedded Dolt` | Permanent. The embedded backend commits outside the SQL transaction on a separate connection, so this server's per-request atomicity would be a lie there. Refused by `serveModeGate`, which is the only thing refusing it — see "Workspace modes" in the design doc. |
+| `bd serve requires a Dolt SQL server; this workspace uses embedded Dolt` | Permanent. The embedded backend commits outside the SQL transaction on a separate connection, so this server's per-request atomicity would be a lie there. Refused by `serveDatabaseSource`, which is the only thing refusing it — see "Workspace modes" in the design doc. |
 | `host must be a numeric IP literal, not a name — use 127.0.0.1 rather than localhost` | `--addr` was given a DNS name. |
 | `binds beyond loopback; bd serve has no authentication, so this requires --allow-non-loopback` | A non-loopback `--addr` without the flag. |
 | `address already in use` | The fixed-port mutual exclusion working as intended: a second server is already on that port. |

--- a/engdocs/design/bd-serve-v0.md
+++ b/engdocs/design/bd-serve-v0.md
@@ -364,3 +364,74 @@ the store open already resolves them in that order: a registered workspace opens
 its registered store even with `BEADS_DOLT_SHARED_SERVER=1` exported. Resolving
 it the other way would build a Dolt provider over a non-Dolt store and answer
 HTTP from a different database than the CLI reaches in the same directory.
+
+That "one store" claim is pinned as a property rather than as a shape.
+`TestServeAnswersFromTheStoreTheRootCommandOpened` wires the registered
+backend so every open hands back a store whose reader answers with one issue
+named after that open, and reads the name back off `GET /v0/beads/ready`: a
+serve that opened a handle of its own answers as `store-2`. The end-to-end test
+counts opens through the registry and requires exactly one for the whole
+process. Both are needed — the count catches the leak, the name catches the
+substitution — because a second handle is otherwise invisible: same reads, same
+claims, same handshake, same clean shutdown.
+
+**THE IDENTITY HANDSHAKE IS BACKEND-AWARE.** `GET /v0/beads/context` reported
+`backend="dolt"`, `dolt_mode="embedded"`, `database="beads"` for a registered
+workspace — a full description of the exact topology this command refuses to
+serve, on the one endpoint automation is told to trust for a server's identity,
+while the startup line beside it named the registered backend correctly. The
+cause was in the shared projection: `GetContextInfo` hardcoded the backend to
+`dolt` and copied the Dolt fields unconditionally, and both of those DEFAULT
+rather than fail (an absent dolt_mode reads "embedded", an absent dolt_database
+reads "beads").
+
+The fix is in that projection (`domain.ContextInfo.SetBackendIdentity`), not in
+`bd serve`, and the placement is the point: `bd context`, `bd context --json`
+and this endpoint all read their workspace identity through
+`domain.PublishedContext`, which exists so the three cannot name one workspace
+differently. Correcting the value in `runServe` would have made the HTTP
+handshake truthful and left the CLI printing `backend: dolt` in the same
+directory — reintroducing exactly the drift that projection prevents. It also
+put the gate beside the one already there: `IsDoltServerMode` and
+`IsDoltProxiedServerMode` are false for any non-Dolt backend, so the bind
+endpoint and proxied root were already withheld; `dolt_mode` and `database` were
+the two with no such guard.
+
+There were TWO copies of the hardcode, which is why one policy function rather
+than one edit: the contextinfo use case, and `bd context`'s direct route, which
+reads the config files itself so it can answer in degraded states where no
+database opens. Both carried their own `Backend: configfile.BackendDolt`, so
+they agreed by telling the same lie — indistinguishable, until now, from
+agreeing. `TestContextRoutesNameOneWorkspaceTheSameWay` compares what the two
+routes publish for one workspace, which is the claim the shared projection has
+always made and nothing had tested.
+
+A registered backend reports the EMPTY string for both, and that is the only
+value `bd` can assert. The backend's `Open` reads whatever it wants out of the
+workspace; `bd` does not implement it and cannot know which logical database it
+settled on, so any non-empty guess is the same lie made quieter. Both stay
+required strings on the wire — no field is renamed, retyped or dropped, and the
+`v0` shape is unchanged.
+
+**STRICT READONLY IS REFUSED.** `bd --readonly serve` does not bind, on either
+source, and the gate runs before the workspace is resolved so that the answer
+cannot depend on the topology. Every server this command builds publishes the
+same operation set, claim included.
+
+It had degraded differently and silently on each source. On the store source
+the root command opens through `backend.OpenReadOnly` and serve took its claimer
+off that store, so the server bound, kept advertising `issues.claim`, and
+answered every claim with an opaque 500, leaving the issue open and unassigned.
+On the provider source serve builds its own unit-of-work provider from the
+workspace's connection settings, which carries no read-only posture, so
+`--readonly` bought nothing and every claim landed. (Proxied mode never reached
+either: the root pre-run already refuses strict readonly for it.)
+
+The alternative — dropping `issues.claim` from a read-only server's advertised
+capabilities — was rejected as a wire change: `capabilities` is the documented
+pre-flight a client checks before calling, and making one operation's presence
+depend on a flag on the process that started the server gives a client something
+it cannot discover before connecting. Refusing keeps the published surface a
+property of the build, and matches how `bd` already answers this question one
+layer down, where a backend that cannot guarantee mutation-free access is turned
+away rather than opened anyway.

--- a/engdocs/design/bd-serve-v0.md
+++ b/engdocs/design/bd-serve-v0.md
@@ -311,13 +311,18 @@ construction and no longer is. `httpapi.Listen` once took a unit-of-work
 provider or nothing at all, so an embedded-backed server was not *constructible*
 — the absence of a provider was itself the refusal. `httpapi.Config` now also
 takes the two issue roles as a database source, and the embedded store publishes
-both accessors, so one is. The gate is `serveModeGate` in `cmd/bd/serve.go`: it
-runs before serve resolves anything else about the workspace, and
-`TestServeRefusalsPromiseNothing` pins both that it refuses and that its message
-promises nothing. `bd serve` also builds provider-backed servers and only those,
-which `TestServeBuildsOnlyAProviderBackedServer` pins against the source of
-`cmd/bd` — so a change that routed serve through store roles fails a test rather
-than quietly reaching the embedded backend by a path this gate never sees.
+both accessors, so one is. The gate is `serveDatabaseSource` in
+`cmd/bd/serve.go`, which classifies the workspace and refuses; it is both the
+gate and the wiring decision, in one function, so the two cannot disagree about
+one workspace. `TestServeRefusalsPromiseNothing` pins both that it refuses and
+that its message promises nothing, and
+`TestServeRefusesAnEmbeddedWorkspaceEndToEnd` drives the refusal through
+`runServe`. `TestServeNamesOneDatabaseSourcePerServerItBuilds` pins against the
+source of `cmd/bd` that every server `bd` builds names exactly one complete
+database source and that a roles-backed one is only ever built where that
+classification is consulted — so a change that reached for store roles anywhere
+else fails a test rather than quietly reaching the embedded backend by a path
+this gate never sees.
 
 **NOT ENFORCED.** `internal/httpapi` does not refuse an embedded-backed server
 and cannot. A role is an interface, and no inspection of one reveals the commit
@@ -334,3 +339,28 @@ external), and server, external-server and shared-server. In the latter three
 the root command has already opened a `DoltStore` that serve never uses; serve
 builds its own unit-of-work provider from the same connection settings. That
 idle store matters only for the connection budget — see the runbook.
+
+**A REGISTERED BACKEND IS SERVED FROM THE STORE THE ROOT COMMAND OPENED.** A
+downstream distribution registers a backend (`internal/storage/backends`) whose
+facade is a store rather than a unit-of-work provider, and
+`PersistentPreRunE` already opens it through the same `backends.Lookup` dispatch
+every ordinary `bd` command opens it with. So serve creates nothing on this arm:
+it takes `Config.Reader` and `Config.Claimer` off that store and hands them to
+`Listen`. A second handle would double the pools and self-conflict with any
+backend holding an exclusive workspace lock, and one creation path is the point.
+`PersistentPostRunE` closes the store, after `runServe` returns and therefore
+after the server has drained.
+
+The roles come from BENEATH the hook decorator
+(`(*storage.HookFiringStore).Unwrap`, one layer, never `storage.UnwrapStore` —
+the telemetry layer below it must survive). A store's accessors hand out its
+decorators by design, so the obvious `store.IssueClaimer()` returns a claimer
+that runs the workspace's `on_update` script for every claim it lands, which is
+exactly what this server documents it does not do. `Listen` refuses a
+hook-firing role rather than trusting that anyone read this paragraph.
+
+The classification consults the registry BEFORE any Dolt-mode signal, because
+the store open already resolves them in that order: a registered workspace opens
+its registered store even with `BEADS_DOLT_SHARED_SERVER=1` exported. Resolving
+it the other way would build a Dolt provider over a non-Dolt store and answer
+HTTP from a different database than the CLI reaches in the same directory.

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -156,7 +156,8 @@ type Config struct {
 	// be a self-declaration by the same caller-supplied code being checked.
 	// Embedded Dolt is the backend that does not qualify (its commit runs
 	// outside the SQL transaction on a separate connection) and it is refused
-	// where the workspace is actually known: serveModeGate in cmd/bd/serve.go.
+	// where the workspace is actually known: serveDatabaseSource in
+	// cmd/bd/serve.go.
 	//
 	// Unlike the provider path these are built ONCE, before Listen, rather than
 	// per request. The provider path rebuilds its roles per request for exactly

--- a/internal/storage/domain/context.go
+++ b/internal/storage/domain/context.go
@@ -24,6 +24,12 @@ type RepoPaths struct {
 }
 
 type BackendConfig struct {
+	// Backend is the resolved storage backend name, spelled the way the store
+	// open resolves it (configfile.GetBackend): "dolt" for the Dolt family
+	// including the legacy empty value, and a registered backend's own name
+	// otherwise. It is what tells GetContextInfo whether the Dolt-derived
+	// members beside it describe this workspace at all.
+	Backend             string
 	DoltMode            string
 	Database            string
 	ProjectID           string
@@ -100,6 +106,42 @@ func PublishedContext(info ContextInfo) PublishedContextFields {
 	}
 }
 
+// SetBackendIdentity records which backend a workspace is on, and the
+// Dolt-derived identity ONLY when that backend is Dolt.
+//
+// It is a method rather than three assignments because there are two routes to
+// a snapshot — this package's use case, and `bd context`'s direct route, which
+// reads the config files itself so it can answer in degraded states where no
+// database opens — and one policy they both call is what keeps them from naming
+// one workspace two ways.
+//
+// The gate is load-bearing, not defensive, because both Dolt values DEFAULT
+// rather than fail: configfile reads an absent dolt_mode as "embedded" and an
+// absent dolt_database as "beads". So a workspace on a registered backend,
+// which configures neither, was described in confident detail as embedded Dolt
+// on database "beads" — on `bd context`, on `bd context --json`, and on GET
+// /v0/beads/context, which is the one endpoint automation is told to trust for
+// a server's identity.
+//
+// A non-Dolt backend reports the EMPTY string for both, and that is the only
+// value bd can assert. A registered backend's Open reads whatever it wants out
+// of the workspace; bd does not implement it and cannot know which logical
+// database it settled on, so any non-empty guess would be the same lie made
+// quieter. Both remain required strings on the wire — the shape is unchanged,
+// only the claim is dropped.
+//
+// The rest of the Dolt projection is gated already, one layer down:
+// IsDoltServerMode and IsDoltProxiedServerMode are false for any backend that
+// is not Dolt, so the bind endpoint and the proxied root were never published
+// for one. These two were the members with no such guard.
+func (info *ContextInfo) SetBackendIdentity(backend, doltMode, database string) {
+	info.Backend = backend
+	info.DoltMode, info.Database = "", ""
+	if backend == configfile.BackendDolt {
+		info.DoltMode, info.Database = doltMode, database
+	}
+}
+
 type ContextUseCase interface {
 	GetContextInfo(ctx context.Context) (ContextInfo, error)
 }
@@ -137,13 +179,11 @@ func (u *contextUseCaseImpl) GetContextInfo(ctx context.Context) (ContextInfo, e
 		CWDRepoRoot:  paths.CWDRepoRoot,
 		IsRedirected: paths.IsRedirected,
 		IsWorktree:   paths.IsWorktree,
-		Backend:      configfile.BackendDolt,
-		DoltMode:     backend.DoltMode,
-		Database:     backend.Database,
 		ProjectID:    backend.ProjectID,
 		DataDir:      backend.DataDir,
 		BdVersion:    u.version,
 	}
+	info.SetBackendIdentity(backend.Backend, backend.DoltMode, backend.Database)
 
 	if hasRole {
 		info.Role = role

--- a/internal/storage/domain/context_test.go
+++ b/internal/storage/domain/context_test.go
@@ -64,6 +64,7 @@ func TestContextUseCase_Embedded(t *testing.T) {
 		role:   "contributor",
 		roleOK: true,
 		backend: BackendConfig{
+			Backend:   configfile.BackendDolt,
 			DoltMode:  configfile.DoltModeEmbedded,
 			Database:  "beads",
 			ProjectID: "proj-1",
@@ -109,9 +110,81 @@ func TestContextUseCase_Embedded(t *testing.T) {
 	}
 }
 
+// TestSetBackendIdentityIsTotal. The method decides all three members every
+// time it is called rather than only the ones it has a value for, so a snapshot
+// that already carried a Dolt mode cannot come out of it describing two
+// backends at once. Both routes to a snapshot call it, and only this makes the
+// result independent of what either had already filled in.
+func TestSetBackendIdentityIsTotal(t *testing.T) {
+	info := ContextInfo{
+		Backend:  configfile.BackendDolt,
+		DoltMode: configfile.DoltModeServer,
+		Database: "left_over",
+	}
+
+	info.SetBackendIdentity("acme", configfile.DoltModeEmbedded, configfile.DefaultDoltDatabase)
+
+	if info.Backend != "acme" || info.DoltMode != "" || info.Database != "" {
+		t.Errorf("Backend/DoltMode/Database = %q/%q/%q, want acme//: a non-Dolt backend kept a Dolt identity",
+			info.Backend, info.DoltMode, info.Database)
+	}
+
+	info.SetBackendIdentity(configfile.BackendDolt, configfile.DoltModeServer, "beads")
+	if info.DoltMode != configfile.DoltModeServer || info.Database != "beads" {
+		t.Errorf("DoltMode/Database = %q/%q, want server/beads", info.DoltMode, info.Database)
+	}
+}
+
+// TestContextUseCase_RegisteredBackendGetsNoDoltIdentity.
+//
+// Every context surface answers from this projection — `bd context`, `bd
+// context --json`, and GET /v0/beads/context — so a workspace on a registered
+// backend that is described here as embedded Dolt is described that way on all
+// three. It is not a cosmetic mislabel: the HTTP handshake is the one endpoint
+// automation is told to trust for a server's identity, and it was reporting the
+// exact topology `bd serve` refuses to serve.
+//
+// The three Dolt-derived values all default rather than fail — an absent
+// dolt_mode reads "embedded", an absent dolt_database reads "beads" — so a
+// registered workspace that configures none of them was described in full
+// detail, entirely wrongly.
+func TestContextUseCase_RegisteredBackendGetsNoDoltIdentity(t *testing.T) {
+	repo := &fakeContextRepo{
+		backend: BackendConfig{
+			// What configfile.Load defaults to for a workspace that
+			// configures no Dolt anything. The whole point is that these
+			// values describe Dolt and this workspace is not on it.
+			Backend:   "acme",
+			DoltMode:  configfile.DoltModeEmbedded,
+			Database:  configfile.DefaultDoltDatabase,
+			ProjectID: "proj-1",
+		},
+	}
+
+	info, err := NewContextUseCase(repo, "v0").GetContextInfo(context.Background())
+	if err != nil {
+		t.Fatalf("GetContextInfo: %v", err)
+	}
+	if info.Backend != "acme" {
+		t.Errorf("Backend = %q, want acme: the projection named a backend this workspace is not on", info.Backend)
+	}
+	if info.DoltMode != "" {
+		t.Errorf("DoltMode = %q, want empty: a registered backend has no Dolt mode, and bd cannot invent one", info.DoltMode)
+	}
+	if info.Database != "" {
+		t.Errorf("Database = %q, want empty: %q is the Dolt default, not a name this backend answers from",
+			info.Database, configfile.DefaultDoltDatabase)
+	}
+	// Everything that is not Dolt-derived still describes the workspace.
+	if info.ProjectID != "proj-1" {
+		t.Errorf("ProjectID = %q, want proj-1", info.ProjectID)
+	}
+}
+
 func TestContextUseCase_ServerMode(t *testing.T) {
 	repo := &fakeContextRepo{
 		backend: BackendConfig{
+			Backend:      configfile.BackendDolt,
 			DoltMode:     configfile.DoltModeServer,
 			ServerHost:   "db.example.com",
 			IsServerMode: true,
@@ -140,6 +213,7 @@ func TestContextUseCase_ServerMode(t *testing.T) {
 func TestContextUseCase_ProxiedServerMode(t *testing.T) {
 	repo := &fakeContextRepo{
 		backend: BackendConfig{
+			Backend:             configfile.BackendDolt,
 			DoltMode:            configfile.DoltModeProxiedServer,
 			IsProxiedServerMode: true,
 		},

--- a/internal/storage/domain/fs/context.go
+++ b/internal/storage/domain/fs/context.go
@@ -55,6 +55,7 @@ func (r *contextRepositoryImpl) BackendConfig(ctx context.Context) (domain.Backe
 		cfg = configfile.DefaultConfig()
 	}
 	return domain.BackendConfig{
+		Backend:             cfg.GetBackend(),
 		DoltMode:            cfg.GetDoltMode(),
 		Database:            cfg.GetDoltDatabase(),
 		ProjectID:           cfg.ProjectID,

--- a/internal/storage/domain/fs/context_test.go
+++ b/internal/storage/domain/fs/context_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/git"
+	"github.com/steveyegge/beads/internal/storage/backendnames"
 	"github.com/steveyegge/beads/internal/storage/domain"
 )
 
@@ -53,11 +54,33 @@ func TestContextRepository_BackendConfig(t *testing.T) {
 
 		got, err := repo.BackendConfig(context.Background())
 		require.NoError(t, err)
+		require.Equal(t, configfile.BackendDolt, got.Backend)
 		require.Equal(t, configfile.DoltModeEmbedded, got.DoltMode)
 		require.Equal(t, configfile.DefaultDoltDatabase, got.Database)
 		require.Empty(t, got.ProjectID)
 		require.False(t, got.IsServerMode)
 		require.False(t, got.IsProxiedServerMode)
+	})
+
+	// The backend NAME is what tells the projection above whether the Dolt
+	// fields beside it describe this workspace at all. Reading it here, from
+	// the same config the store open dispatches on, is what keeps the answer
+	// one source of truth rather than a second opinion.
+	t.Run("RegisteredBackendIsNamed", func(t *testing.T) {
+		// backendnames is the set configfile.GetBackend classifies against —
+		// the backends registry writes it on Register — so this is the same
+		// question the store open asks, without dragging the typed registry
+		// and its storage dependency into a config-reading test.
+		const name = "acme-context"
+		backendnames.Add(name)
+		t.Cleanup(func() { backendnames.Remove(name) })
+
+		_, beadsDir, repo := newContextRepoForTest(t)
+		writeMetadata(t, beadsDir, &configfile.Config{Backend: name})
+
+		got, err := repo.BackendConfig(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, name, got.Backend)
 	})
 
 	t.Run("EmbeddedWithExplicitValues", func(t *testing.T) {


### PR DESCRIPTION
`bd serve` had its own creation path. Every ordinary command opens its store through the registry —
`cmd/bd/store_factory.go` and the root pre-run both dispatch on `backends.Lookup(cfg.GetBackend())` —
but `runServe` ignored that and built a Dolt/MySQL-wire unit-of-work provider
(`resolveServerModeUOWTopology` + `newSQLServerUOWProvider`). So a registered backend was fully usable
from the CLI and unservable, for no reason other than serve having reimplemented store creation.

## The fix is to delete a path, not add one

Serve now calls **no** factory at all. By the time `runServe` starts, the store is already open in the
global, created by the root command's `PersistentPreRunE` through the same registry arm every command
uses — `serve` is not in `noDbCommands`, carries no `bd:skip_store`, and is not read-only. Serve takes
the issue roles off that store (peeling exactly the hook layer via `(*storage.HookFiringStore).Unwrap`,
which keeps telemetry) and hands them to `httpapi.Config`'s role fields. Calling a factory here would
open a **second** handle in the same process: double pools, and self-conflict for any backend holding
an exclusive workspace lock.

The Dolt modes are untouched. Proxied, server, external-server and shared-server keep their unit-of-work
provider, because it supplies real `uow_ms` and pool limits that the store path cannot. The decision
lives in one function rather than scattered across the call site and the mode label.

## A latent bug this closes

In `!cgo` builds `isEmbeddedMode()` is hard-false, so today's gate **already admits** a registered-backend
workspace — and `runServe` then resolves *Dolt* connection settings for it, either failing with a
misleading Dolt error or connecting to a defaulted host and serving the wrong database. Putting the
registry check before the dolt-mode branch closes that in both build modes, with the same
registry-wins-first precedence the store factories use.

The embedded-Dolt refusal is unchanged and still permanent — its message and typed
`ErrUnsupported{Backend: "embedded-dolt"}` are untouched.

## Three things review caught, all measured rather than argued

**The handshake lied.** `GET /v0/beads/context` is the one endpoint automation is told to trust for a
server's identity, and on the new arm it reported `backend="dolt"`, `dolt_mode="embedded"`,
`database="beads"` — the exact topology serve refuses to build — while the startup line on the same
process correctly named the backend. There turned out to be **two** copies of the hardcode, the domain
use case and `bd context`'s own route, so they agreed by telling the same lie; fixing one would have
left the CLI lying. Both now go through one `SetBackendIdentity`. A registered backend reports its name
and leaves `dolt_mode`/`database` empty — the only value bd can honestly assert, since the backend's
`Open` reads the workspace itself. No field renamed, retyped or dropped; zero spec diff.

**The core property was untested.** Swapping the roles source for a freshly opened second store compiled
and passed the entire suite, leaking an unclosed handle. Now pinned two ways: a registered backend whose
every `Open` returns a store naming *that* open, so `GET /v0/beads/ready` reveals which store answered;
and a count requiring exactly one registry open per process.

**`bd --readonly serve` bound a lying server.** It advertised `issues.claim` and answered 500 on every
claim. Checking the provider arm first showed the flag was already a silent no-op there — the server
built its own writable provider and every claim landed — so this is pre-existing, inherited in a worse
shape. `bd serve` now refuses under strict readonly on both sources, before the workspace is resolved.
Narrowing the advertised capability set was rejected: capabilities are the documented pre-flight a
client checks, and making an operation's presence depend on a flag on the server's process gives clients
something they cannot discover before connecting.

**This is a BREAKING change** on Dolt SQL-server workspaces, where `bd --readonly serve` previously bound
a fully functional writable server. It is under `### Changed` in CHANGELOG, not `### Fixed`.

## Verification

    cmd/bd            40 FAIL on main, 40 on this branch — identical BY NAME
    internal/httpapi  identical, exit 0
    internal/storage/uow  identical (run alone; it contends with cmd/bd otherwise)
    build x3 modes, vet, gofmt, golangci-lint vs the real merge base   all clean
    zero diff under internal/httpapi/spec/, internal/httpapi/apigen/, docs/reference/schema/

Every guard was mutation-checked with mutants that compile, and independently re-verified by standing up
a real server and curling it rather than by reading the diff.

One coverage limit stated rather than implied: the context parity test pins the shared projection, not
`contextCmd`'s own wiring — recorded as a NOT COVERED note in the test. And upstream has no registered
backend, so this arm's live coverage comes from a fake registered backend in tests; the Dolt server /
shared-server arms are covered by unit tests only, since no live harness for them exists here.

Agent-Signature: claude-opus-5