### PR TITLE
fix(show): expose guarded-write revision in JSON

### DIFF
--- a/cmd/bd/protocol/corpus.go
+++ b/cmd/bd/protocol/corpus.go
@@ -181,16 +181,38 @@ var provenanceValueKeys = map[string]string{
 	"build":   "<BUILD>",
 }
 
+// revisionPlaceholder is the canonical stand-in for a guarded-write revision
+// (row_lock) token value.
+const revisionPlaceholder = "<REVISION>"
+
+// volatileValueKeys have a stable presence but a per-write-random value, so the
+// corpus pins that the field EXISTS (its wire shape) while replacing its value
+// with a placeholder — exactly as it does for timestamps. `bd show --json`
+// exposes the guarded-write revision (the row_lock optimistic-concurrency
+// token), which the engine rewrites to a fresh random value on every
+// lifecycle/ownership write; pinning its literal value would break both the
+// golden byte-comparison and the double-run determinism check. Same bare-key-
+// name scope caveat as the provenance transforms below: `revision` is currently
+// emitted only by `bd show --json`. If a future command ever emits a
+// deterministic field named `revision`, scope this to the show capture (thread
+// Capture.Name through generation) before relying on it.
+var volatileValueKeys = map[string]string{
+	"revision": revisionPlaceholder,
+}
+
 // CanonicalizeJSON normalizes a bd JSON blob so that two independent runs
 // produce byte-identical output:
 //
 //  1. Any string value that is an RFC3339/RFC3339Nano timestamp is replaced
 //     with "<TS>".
-//  2. Any array whose elements are all objects is stably sorted by the
+//  2. Any per-write-random token value (the guarded-write "revision" /
+//     row_lock, matched by key name) is replaced with "<REVISION>", pinning
+//     the field's presence without its nondeterministic value.
+//  3. Any array whose elements are all objects is stably sorted by the
 //     element's "id" field (falling back to the element's canonical-JSON
 //     form when "id" is absent or equal), so list/ready/sql ordering is
 //     deterministic regardless of storage iteration order.
-//  3. The result is re-marshaled with 2-space indentation and sorted keys
+//  4. The result is re-marshaled with 2-space indentation and sorted keys
 //     (Go's encoding/json sorts map keys), yielding a minimal, byte-stable
 //     diff.
 //
@@ -254,6 +276,16 @@ func canonValue(v any) any {
 					t[k] = ph
 					continue
 				}
+			}
+			// Replace per-write-random token values (the guarded-write revision /
+			// row_lock) with a placeholder: pin that bd show exposes a revision
+			// field, not its nondeterministic value. Unlike the provenance keys
+			// above this is unconditional — the value is a JSON number, not a
+			// string — but it stays a bare-key match, so keep the scope caveat in
+			// mind (see volatileValueKeys).
+			if ph, ok := volatileValueKeys[k]; ok {
+				t[k] = ph
+				continue
 			}
 			t[k] = canonValue(child)
 		}

--- a/cmd/bd/protocol/testdata/corpus/envelope/show.json
+++ b/cmd/bd/protocol/testdata/corpus/envelope/show.json
@@ -26,6 +26,7 @@
       "issue_type": "feature",
       "owner": "test@protocol.test",
       "priority": 1,
+      "revision": "<REVISION>",
       "status": "open",
       "title": "Corpus root issue",
       "updated_at": "<TS>"

--- a/cmd/bd/protocol/testdata/corpus/flat/show.json
+++ b/cmd/bd/protocol/testdata/corpus/flat/show.json
@@ -25,6 +25,7 @@
     "issue_type": "feature",
     "owner": "test@protocol.test",
     "priority": 1,
+    "revision": "<REVISION>",
     "status": "open",
     "title": "Corpus root issue",
     "updated_at": "<TS>"

--- a/cmd/bd/protocol/testdata/corpus/manifest.json
+++ b/cmd/bd/protocol/testdata/corpus/manifest.json
@@ -61,7 +61,7 @@
     },
     "envelope/show": {
       "cmd": "bd show corpus-root --json",
-      "sha256": "ed15174a85cf33ef810cce77906d15756e80c324f8d7c6cc98330efb7dc35a70"
+      "sha256": "52c3ac87e5cb992c15a9705d77bb07ac0ffd3892359bd78579b4214f7bfb9460"
     },
     "envelope/update": {
       "cmd": "bd update corpus-root --json --priority 0 --add-label corpus-label --set-metadata phase=2 --description \"updated corpus root\"",
@@ -129,7 +129,7 @@
     },
     "flat/show": {
       "cmd": "bd show corpus-root --json",
-      "sha256": "586fa1f5a1aef647185b857e182df6a35f1887e22c483c8ccb1b715b69abe506"
+      "sha256": "57977d893d55da712c4ab25b718bb48d2764cb40c2a15d1bbf312b7c58e6010b"
     },
     "flat/update": {
       "cmd": "bd update corpus-root --json --priority 0 --add-label corpus-label --set-metadata phase=2 --description \"updated corpus root\"",

--- a/cmd/bd/serve_reads_parity_integration_test.go
+++ b/cmd/bd/serve_reads_parity_integration_test.go
@@ -25,13 +25,25 @@ import (
 // The comparison is on DECODED JSON, so key order and whitespace do not enter
 // into it; what is compared is every key and every value of every item.
 
-// readsParityAllowlist is the complete set of documented differences between
-// the two surfaces' bodies. It is EMPTY, deliberately: both surfaces marshal
-// the same canonical Go structs (the wire schemas are x-go-type-pinned to
-// them), so there is nothing left for an item to differ by. An entry here is a
-// permanent, reviewed divergence — not a place to record a surprise.
+// readsParityAllowlist is the complete set of documented per-field differences
+// between the two surfaces' bodies. An entry here is a permanent, reviewed
+// divergence — not a place to record a surprise. Both surfaces otherwise
+// marshal the same canonical Go structs (the wire schemas are x-go-type-pinned
+// to them), so the field-level answer is identical except for the one entry
+// below.
 //
-// The three differences that DO exist are structural rather than per-field, so
+//   - `revision`: the guarded-write optimistic-concurrency token (the issues
+//     row_lock cell) is a CLI-only detail projection. `bd show --json` renames
+//     it to the storage-neutral `revision` for guarded clients
+//     (projectShowJSONDetails in show_unit_helpers.go); GET
+//     /v0/beads/issues/{id} serializes the raw IssueDetails, whose RowVersion
+//     is json:"-", so the field is absent over HTTP by design. The v0 HTTP
+//     object schema is apigen-frozen and the token is only meaningful to the
+//     CLI's guarded-write path, so this asymmetry is intentional, not drift. If
+//     the token is ever needed over HTTP, extend that surface and delete this
+//     entry.
+//
+// Three further differences exist but are structural rather than per-field, so
 // every comparison below states its terms explicitly instead of waving them
 // through here:
 //
@@ -49,7 +61,12 @@ import (
 //     TestListLimitPolicyIsResolvedBeforeTheRequest pins that policy branch by
 //     branch; every comparison here passes an EXPLICIT limit on both sides so
 //     it is comparing the operation and not that policy.
-var readsParityAllowlist = map[string]string{}
+var readsParityAllowlist = map[string]string{
+	"revision": "CLI-only guarded-write token: `bd show --json` projects the " +
+		"row_lock optimistic-concurrency cell as `revision` (projectShowJSONDetails); " +
+		"the apigen-frozen v0 HTTP object keeps RowVersion json:\"-\", so the " +
+		"field is absent over GET /v0/beads/issues/{id} by design.",
+}
 
 // getJSONArray fetches a page endpoint and returns its decoded items.
 func (sp *serveProcess) items(t *testing.T, path string) []map[string]any {

--- a/cmd/bd/show.go
+++ b/cmd/bd/show.go
@@ -169,7 +169,7 @@ var showCmd = &cobra.Command{
 					result.Close()
 					return HandleErrorRespectJSON("%v", derr)
 				}
-				allDetails = append(allDetails, details)
+				allDetails = append(allDetails, projectShowJSONDetails(details))
 				result.Close()
 				continue
 			}

--- a/cmd/bd/show_details_json_test.go
+++ b/cmd/bd/show_details_json_test.go
@@ -74,3 +74,30 @@ func TestProjectShowJSONDetailsExposesRevision(t *testing.T) {
 		}
 	}
 }
+
+// TestProjectShowJSONDetailsEmitsZeroRevision pins the legacy-zero wire
+// behavior: RowVersion == 0 is the migration-0054 backfill token, a legitimate
+// CAS value a guarded client must be able to read. The projection drops
+// omitempty so `revision` is always emitted, including 0 — an absent field must
+// never stand in for a legacy-zero row.
+func TestProjectShowJSONDetailsEmitsZeroRevision(t *testing.T) {
+	details := &types.IssueDetails{Issue: types.Issue{
+		ID:         "be-legacy-zero",
+		Title:      "Legacy un-mutated issue",
+		RowVersion: 0,
+	}}
+
+	data, err := json.Marshal(projectShowJSONDetails(details))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	js := string(data)
+	if !strings.Contains(js, `"revision":0`) {
+		t.Errorf("expected revision:0 to be emitted for a legacy-zero row, got: %s", js)
+	}
+	for _, forbidden := range []string{"row_version", "RowVersion", "row_lock"} {
+		if strings.Contains(js, forbidden) {
+			t.Errorf("show JSON leaked storage field %q: %s", forbidden, js)
+		}
+	}
+}

--- a/cmd/bd/show_details_json_test.go
+++ b/cmd/bd/show_details_json_test.go
@@ -52,3 +52,25 @@ func TestIssueDetailsCountOnlyJSON(t *testing.T) {
 		t.Errorf("expected no comments key in count-only output, got: %s", js)
 	}
 }
+
+func TestProjectShowJSONDetailsExposesRevision(t *testing.T) {
+	details := &types.IssueDetails{Issue: types.Issue{
+		ID:         "be-revision",
+		Title:      "Versioned issue",
+		RowVersion: 123456789,
+	}}
+
+	data, err := json.Marshal(projectShowJSONDetails(details))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	js := string(data)
+	if !strings.Contains(js, `"revision":123456789`) {
+		t.Errorf("expected revision token in show JSON, got: %s", js)
+	}
+	for _, forbidden := range []string{"row_version", "RowVersion", "row_lock"} {
+		if strings.Contains(js, forbidden) {
+			t.Errorf("show JSON leaked storage field %q: %s", forbidden, js)
+		}
+	}
+}

--- a/cmd/bd/show_embedded_test.go
+++ b/cmd/bd/show_embedded_test.go
@@ -129,6 +129,9 @@ func TestEmbeddedShow(t *testing.T) {
 		if m["description"] != "A description" {
 			t.Errorf("expected description, got %v", m["description"])
 		}
+		if revision, ok := m["revision"].(float64); !ok || revision == 0 {
+			t.Errorf("expected non-zero revision, got %v", m["revision"])
+		}
 	})
 
 	t.Run("show_json_includes_labels", func(t *testing.T) {

--- a/cmd/bd/show_proxied_integration_test.go
+++ b/cmd/bd/show_proxied_integration_test.go
@@ -122,6 +122,9 @@ func TestProxiedServerShow(t *testing.T) {
 		if m["priority"] != float64(1) {
 			t.Errorf("priority: got %v, want 1", m["priority"])
 		}
+		if revision, ok := m["revision"].(float64); !ok || revision == 0 {
+			t.Errorf("revision: got %v, want a non-zero opaque token", m["revision"])
+		}
 		if _, ok := m["created_at"]; !ok {
 			t.Errorf("missing created_at")
 		}

--- a/cmd/bd/show_proxied_server.go
+++ b/cmd/bd/show_proxied_server.go
@@ -468,7 +468,7 @@ func runShowProxiedDefault(ctx context.Context, uw uow.UnitOfWork, in *showProxi
 				return HandleErrorRespectJSON("%v", derr)
 			}
 			foundCount++
-			allDetails = append(allDetails, details)
+			allDetails = append(allDetails, projectShowJSONDetails(details))
 			continue
 		}
 

--- a/cmd/bd/show_unit_helpers.go
+++ b/cmd/bd/show_unit_helpers.go
@@ -14,9 +14,17 @@ import (
 // absent from generic Issue JSON and JSONL, while `bd show --json` exposes the
 // opaque token required by guarded clients under the storage-neutral name
 // `revision`.
+//
+// The field is emitted WITHOUT omitempty. 0 is a legitimate, comparable token:
+// a guarded write that expects 0 matches an un-mutated legacy migration-0054
+// row and fails any current (non-zero) row — correct CAS semantics. Omitting it
+// would leave a guarded client unable to read the 0 it must send on exactly the
+// legacy rows the token protects, and would make an absent field ambiguously
+// mean either "legacy-zero" or "no token". `revision` is therefore always
+// present, including 0.
 type showJSONIssueDetails struct {
 	*types.IssueDetails
-	Revision int64 `json:"revision,omitempty"`
+	Revision int64 `json:"revision"`
 }
 
 func projectShowJSONDetails(details *types.IssueDetails) showJSONIssueDetails {

--- a/cmd/bd/show_unit_helpers.go
+++ b/cmd/bd/show_unit_helpers.go
@@ -10,6 +10,19 @@ import (
 	"github.com/steveyegge/beads/internal/validation"
 )
 
+// showJSONIssueDetails is the CLI-only detail projection. RowVersion remains
+// absent from generic Issue JSON and JSONL, while `bd show --json` exposes the
+// opaque token required by guarded clients under the storage-neutral name
+// `revision`.
+type showJSONIssueDetails struct {
+	*types.IssueDetails
+	Revision int64 `json:"revision,omitempty"`
+}
+
+func projectShowJSONDetails(details *types.IssueDetails) showJSONIssueDetails {
+	return showJSONIssueDetails{IssueDetails: details, Revision: details.RowVersion}
+}
+
 // validateIssueUpdatable checks if an issue can be updated.
 // Uses the centralized validation package for consistency.
 func validateIssueUpdatable(id string, issue *types.Issue) error {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -66,15 +66,15 @@ type Issue struct {
 	// granting replica.
 	LeaseGrantedNode string `json:"lease_granted_node,omitempty"`
 
-	// ===== Concurrency (Go-only; never serialized) =====
+	// ===== Concurrency (generic Issue JSON/JSONL omits this field) =====
 	// RowVersion is an opaque optimistic-concurrency token for the library's own
 	// Go call sites: the issues/wisps row_lock cell, a random non-zero value the
 	// engine rewrites on every status/ownership-mutating write. It is
 	// EQUALITY-ONLY — compare it, never order or interpret it — and a change
 	// signals the row was mutated since you read it. It is json:"-" on purpose:
-	// row_lock is random per write, so serializing it would break stable bd
-	// --json goldens and bd export round-trips; a Go consumer reads
-	// issue.RowVersion directly instead.
+	// row_lock is random per write, so generic Issue serialization would break
+	// stable list/export round-trips. The detail-view DTO projects it explicitly
+	// as `revision` for guarded clients; Go consumers read RowVersion directly.
 	//
 	// Coverage is deliberately partial: it changes on claim/close/unclaim and the
 	// generic update path, but NOT on direct-UPDATE paths that rewrite text

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -945,13 +945,10 @@ func TestIssueLeaseJSONSerialization(t *testing.T) {
 	}
 }
 
-// TestRowVersionNeverSerialized locks in the Go-only decision for RowVersion:
-// it is a live Go field (library call sites build an optimistic-concurrency
-// token from it) but json:"-", so its random-per-write value never reaches any
-// bd --json surface or bd export. Serializing it would break stable protocol
-// goldens and export round-trips because the value is regenerated on every
-// write. The value must be absent from the bare Issue and from the two
-// embedding wrappers that back show/list/ready (IssueDetails, IssueWithCounts).
+// TestRowVersionNeverSerialized locks in the storage/interchange boundary:
+// RowVersion stays absent from generic Issue JSON and its embedding wrappers.
+// A CLI adapter may project it separately under a public wire name without
+// leaking the storage field into JSONL exports or the shared object model.
 func TestRowVersionNeverSerialized(t *testing.T) {
 	iss := Issue{ID: "test-1", Title: "Versioned", Status: StatusOpen, RowVersion: 123456789}
 

--- a/tests/regression/regression_test.go
+++ b/tests/regression/regression_test.go
@@ -513,6 +513,11 @@ var volatileFields = []string{
 	"last_activity", "closed_by_session",
 	"compaction_level", "original_size",
 	"content_hash",
+	// revision (row_lock) is the guarded-write optimistic-concurrency token that
+	// bd show --json began exposing (bd-bwa7n): a random value the engine
+	// rewrites on every write, and absent from the v0.49.6 baseline's show
+	// output entirely, so it is pure cross-version noise for this oracle.
+	"revision",
 }
 
 // showOnlyFields are present in bd show --json but were not in bd export.


### PR DESCRIPTION
## What

Expose the current non-zero row-version token as `revision` in the default `bd show <id> --json` response for both direct and proxied stores.

The projection is CLI-only. Generic `Issue` JSON, JSONL export, list/ready responses, and the HTTP object model remain unchanged.

## Why

Schema v59 hydrates `Issue.RowVersion`, but that field is intentionally `json:"-"`. The show command therefore discarded the token before subprocess clients could use revision-fenced close/update operations. A fresh issue had a non-zero durable `row_lock` while `bd show --json` omitted `revision` entirely.

This adapts the show-wire contract from #4682 to main's newer `RowVersion` design without reviving the broad serialization surface from that older branch. It unblocks Gas City lifecycle certification (`ga-f7v2ft.77` / `.79`).

## Verification

- RED before fix: embedded `show_json` returned `revision: <nil>`.
- Direct embedded `bd show --json`: green.
- Proxied-server `bd show --json`: green.
- `internal/types`, `internal/workapi`, and `internal/httpapi`: green.
- Focused pre-commit lint: 0 issues.

Closes bd-bwa7n.

_codex-unknown-model-unknown-reasoning on behalf of CI Bot_
