### PR TITLE
fix(proxy): stop doomed proxied starts from starving concurrent Shutdown of proxy.lock (bd-ill4f)

### DIFF
--- a/internal/storage/dbproxy/proxy/server.go
+++ b/internal/storage/dbproxy/proxy/server.go
@@ -114,9 +114,32 @@ func (p *proxyServer) ListenAndServe(parentCtx context.Context) error {
 		}
 		return fmt.Errorf("acquire %s: %w", LockFileName, err)
 	}
-	defer lock.Unlock()
+	// proxy.lock is held for the proxy's whole lifetime, but a doomed start
+	// must be able to release it early (before its backend teardown) without
+	// the deferred release double-unlocking. Only the main goroutine touches
+	// this.
+	lockHeld := true
+	releaseLock := func() {
+		if lockHeld {
+			lockHeld = false
+			lock.Unlock()
+		}
+	}
+	defer releaseLock()
 	if err := clearSpawnMarkerAfterLock(p.rootDir); err != nil {
 		return fmt.Errorf("clear proxy spawn marker: %w", err)
+	}
+
+	// Fast-abort: a concurrent `bd dolt stop` advances the stop epoch before
+	// waiting (briefly) for proxy.lock, so an epoch that moved between the
+	// spawning parent's read and this child taking the lock dooms this start.
+	// Abort before opening any listener or booting the backend: the stopper
+	// then observes a free lock within milliseconds instead of after a full
+	// doomed boot-and-teardown cycle.
+	if changed, err := stopEpochChanged(p.rootDir, p.stopEpoch); err != nil {
+		return fmt.Errorf("check proxy stop epoch after acquiring %s: %w", LockFileName, err)
+	} else if changed {
+		return fmt.Errorf("%w for %s: stop epoch advanced before startup", errStartInterrupted, p.rootDir)
 	}
 
 	logPath := filepath.Join(p.rootDir, LogFileName)
@@ -148,6 +171,54 @@ func (p *proxyServer) ListenAndServe(parentCtx context.Context) error {
 			cancel()
 		}
 	}()
+
+	// Watch the stop epoch across the whole startup window (listen, backend
+	// Start, readiness wait). A stop that begins mid-boot advances the epoch
+	// first and then waits only shutdownConfirmDeadline for proxy.lock, which
+	// this child holds throughout the boot; without a watcher the child would
+	// notice the doomed start only at the pre-publish fence, potentially tens
+	// of seconds later. Canceling ctx aborts the backend Start / ready wait
+	// within about one poll interval. Transient epoch read errors are ignored
+	// here; the pre-publish fence remains the authoritative check.
+	epochWatchCtx, epochWatchCancel := context.WithCancel(context.Background())
+	epochWatchDone := make(chan struct{})
+	go func() {
+		defer close(epochWatchDone)
+		ticker := time.NewTicker(openPollInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-epochWatchCtx.Done():
+				return
+			case <-ticker.C:
+				changed, err := stopEpochChanged(p.rootDir, p.stopEpoch)
+				if err != nil {
+					continue
+				}
+				if changed {
+					cancel()
+					return
+				}
+			}
+		}
+	}()
+	stopEpochWatch := func() {
+		epochWatchCancel()
+		<-epochWatchDone
+	}
+	defer stopEpochWatch()
+
+	// abortInterruptedStart tears down a doomed start whose stop epoch
+	// advanced mid-boot. The interrupting stop is polling proxy.lock under a
+	// budget (shutdownConfirmDeadline) far smaller than a backend stop can
+	// take, and nothing has been published, so release the lock BEFORE the
+	// backend teardown instead of starving the stopper into its timeout.
+	abortInterruptedStart := func() error {
+		p.stats.IncBackendStop()
+		releaseLock()
+		_ = stopBackendBounded(p.server)
+		return fmt.Errorf("%w for %s: stop epoch advanced during startup", errStartInterrupted, p.rootDir)
+	}
 
 	addr := fmt.Sprintf("127.0.0.1:%d", p.port)
 
@@ -186,10 +257,20 @@ func (p *proxyServer) ListenAndServe(parentCtx context.Context) error {
 
 	p.stats.IncBackendStart()
 	if err := p.server.Start(ctx); err != nil {
+		// Start failed with no backend left running (Start cleans up its own
+		// failure), so there is no teardown to move off the lock; classifying
+		// the epoch-watcher cancellation just keeps the child's exit reason
+		// precise for the spawning parent.
+		if changed, cerr := stopEpochChanged(p.rootDir, p.stopEpoch); cerr == nil && changed {
+			return fmt.Errorf("%w for %s: stop epoch advanced during backend start (%v)", errStartInterrupted, p.rootDir, err)
+		}
 		return fmt.Errorf("start database server: %w", err)
 	}
 
 	if err := waitForServerReady(ctx, p.server, serverReadyTimeout); err != nil {
+		if changed, cerr := stopEpochChanged(p.rootDir, p.stopEpoch); cerr == nil && changed {
+			return abortInterruptedStart()
+		}
 		p.stats.IncBackendStop()
 		_ = stopBackendBounded(p.server)
 		return fmt.Errorf("database server not ready: %w", err)
@@ -219,15 +300,17 @@ func (p *proxyServer) ListenAndServe(parentCtx context.Context) error {
 	// process took proxy.lock, so a `bd dolt stop` that began during a slow
 	// backend start has no record of this attempt. It did advance the stop
 	// epoch first, so re-check it here and abort instead of publishing a
-	// running proxy after that stop returned.
+	// running proxy after that stop returned. The startup epoch watcher is
+	// stopped (synchronously) first: past this fence a stop finds the
+	// published proxy.pid and stops the proxy through it, so a watcher
+	// cancellation must not race the publish.
+	stopEpochWatch()
 	if changed, err := stopEpochChanged(p.rootDir, p.stopEpoch); err != nil {
 		p.stats.IncBackendStop()
 		_ = stopBackendBounded(p.server)
 		return fmt.Errorf("re-check proxy stop epoch before publish: %w", err)
 	} else if changed {
-		p.stats.IncBackendStop()
-		_ = stopBackendBounded(p.server)
-		return fmt.Errorf("%w for %s: stop epoch advanced during startup", errStartInterrupted, p.rootDir)
+		return abortInterruptedStart()
 	}
 
 	if err := pidfile.Write(p.rootDir, PIDFileName, pidfile.PidFile{

--- a/internal/storage/dbproxy/proxy/server_epoch_internal_test.go
+++ b/internal/storage/dbproxy/proxy/server_epoch_internal_test.go
@@ -2,6 +2,8 @@ package proxy
 
 import (
 	"context"
+	"errors"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -10,6 +12,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/storage/dbproxy/pidfile"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/server"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/util"
 )
 
 // epochAdvancingServer simulates the F4 race deterministically: `bd dolt
@@ -64,4 +67,157 @@ func TestListenAndServe_StopEpochAdvanceDuringStartupAbortsPublish(t *testing.T)
 	counters := ts.Snapshot()
 	assert.Equal(t, int64(1), counters.StartCalls)
 	assert.Equal(t, int64(1), counters.StopCalls, "aborting the publish must still stop the backend")
+}
+
+// TestListenAndServe_StopEpochAdvancedBeforeStartupNeverBootsBackend asserts
+// the fast-abort: a stop epoch that advanced between the spawning parent's
+// read and the child taking proxy.lock aborts the start before any backend
+// boot, so the child holds proxy.lock for milliseconds, not a boot cycle.
+func TestListenAndServe_StopEpochAdvancedBeforeStartupNeverBootsBackend(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	baseline, err := readStopEpoch(root)
+	require.NoError(t, err)
+	require.NoError(t, advanceStopEpoch(root))
+
+	ts := server.New()
+	p := NewProxyServer(ProxyOpts{
+		RootDir:   root,
+		Port:      0,
+		Server:    ts,
+		StopEpoch: baseline,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	err = p.ListenAndServe(ctx)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errStartInterrupted)
+
+	pf, readErr := pidfile.Read(root, PIDFileName)
+	require.NoError(t, readErr)
+	assert.Nil(t, pf, "proxy.pid must not be published after a pre-startup stop")
+
+	counters := ts.Snapshot()
+	assert.Equal(t, int64(0), counters.StartCalls, "a pre-doomed start must never boot the backend")
+	assert.Equal(t, int64(0), counters.StopCalls)
+}
+
+// blockingStopServer holds Stop open until released, exposing the window in
+// which a doomed start is tearing its backend down.
+type blockingStopServer struct {
+	*epochAdvancingServer
+	stopEntered chan struct{}
+	stopRelease chan struct{}
+}
+
+func (s *blockingStopServer) Stop(ctx context.Context) error {
+	close(s.stopEntered)
+	<-s.stopRelease
+	return s.epochAdvancingServer.TestDatabaseServerImpl.Stop(ctx)
+}
+
+// TestListenAndServe_InterruptedStartReleasesProxyLockBeforeBackendStop pins
+// the bd-ill4f invariant directly: a start doomed by a concurrent stop must
+// release proxy.lock BEFORE its backend teardown, because the interrupting
+// Shutdown polls that lock under shutdownConfirmDeadline (5s) while a backend
+// stop may take far longer. Before the fix this deadlocked the stopper into
+// "timeout (5s) acquiring proxy.lock after inspecting pid 0".
+func TestListenAndServe_InterruptedStartReleasesProxyLockBeforeBackendStop(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	baseline, err := readStopEpoch(root)
+	require.NoError(t, err)
+
+	ts := server.New()
+	backend := &blockingStopServer{
+		epochAdvancingServer: &epochAdvancingServer{TestDatabaseServerImpl: ts, rootDir: root, t: t},
+		stopEntered:          make(chan struct{}),
+		stopRelease:          make(chan struct{}),
+	}
+
+	p := NewProxyServer(ProxyOpts{
+		RootDir:   root,
+		Port:      0,
+		Server:    backend,
+		StopEpoch: baseline,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- p.ListenAndServe(ctx) }()
+
+	select {
+	case <-backend.stopEntered:
+	case err := <-serveDone:
+		t.Fatalf("ListenAndServe returned before backend Stop was entered: %v", err)
+	case <-time.After(15 * time.Second):
+		t.Fatal("doomed start never reached backend Stop")
+	}
+
+	// The doomed backend teardown is now in flight; proxy.lock must already
+	// be free for the concurrent stopper.
+	lock, lockErr := util.TryLock(filepath.Join(root, LockFileName))
+	require.NoError(t, lockErr, "proxy.lock must be released before the doomed backend teardown, not after")
+	lock.Unlock()
+
+	close(backend.stopRelease)
+	select {
+	case err := <-serveDone:
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errStartInterrupted)
+	case <-time.After(15 * time.Second):
+		t.Fatal("ListenAndServe did not return after backend Stop was released")
+	}
+
+	pf, readErr := pidfile.Read(root, PIDFileName)
+	require.NoError(t, readErr)
+	assert.Nil(t, pf, "proxy.pid must not be published after the stop epoch advanced")
+	counters := ts.Snapshot()
+	assert.Equal(t, int64(1), counters.StopCalls, "aborting the publish must still stop the backend")
+}
+
+// TestListenAndServe_StopEpochAdvanceAbortsSlowReadyWait asserts the startup
+// epoch watcher: a stop that lands while the backend is booting (here: never
+// becoming ready) aborts the start within a poll interval or two instead of
+// riding out the full serverReadyTimeout with proxy.lock held.
+func TestListenAndServe_StopEpochAdvanceAbortsSlowReadyWait(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	baseline, err := readStopEpoch(root)
+	require.NoError(t, err)
+
+	ts := server.New()
+	ts.DialErr = errors.New("backend never becomes ready")
+	backend := &epochAdvancingServer{TestDatabaseServerImpl: ts, rootDir: root, t: t}
+
+	p := NewProxyServer(ProxyOpts{
+		RootDir:   root,
+		Port:      0,
+		Server:    backend,
+		StopEpoch: baseline,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	started := time.Now()
+	err = p.ListenAndServe(ctx)
+	elapsed := time.Since(started)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errStartInterrupted)
+	// Without the watcher the doomed start only notices the epoch after the
+	// full ready wait (serverReadyTimeout, 30s). The generous bound still
+	// proves the watcher fired; typical runtimes are a few hundred ms.
+	assert.Less(t, elapsed, 15*time.Second,
+		"doomed start must abort its ready wait via the epoch watcher, not ride out serverReadyTimeout")
+
+	pf, readErr := pidfile.Read(root, PIDFileName)
+	require.NoError(t, readErr)
+	assert.Nil(t, pf, "proxy.pid must not be published after the stop epoch advanced")
+	counters := ts.Snapshot()
+	assert.Equal(t, int64(1), counters.StopCalls, "aborting the ready wait must still stop the backend")
 }


### PR DESCRIPTION
Fixes the pinned flake in `TestManagedLocalProxiedStopStartInterleave` (bd-ill4f), where BOTH interleaved sides lost: the start returned `proxy startup interrupted by concurrent shutdown` and the stop returned `proxy.Shutdown partial: backend stopped; proxy left running: timeout (5s) acquiring proxy.lock after inspecting pid 0`, firing the test's both-failed branch.

## Root cause: asymmetric lock budgets

`Shutdown` advances the stop epoch FIRST (`internal/storage/dbproxy/proxy/shutdown.go:85`), dooming any in-flight start. But the proxy **child** acquires `proxy.lock` at the top of `ListenAndServe` (`server.go:110-117`, held for the proxy's whole lifetime) and then, before publishing anything, walks the entire boot under that lock: listener, control plane, backend `Start` (a real `dolt sql-server` boot — seconds), and a ready wait of up to `serverReadyTimeout` (30s). It only notices the advanced epoch at the pre-publish fence (`server.go:223-231`, `errStartInterrupted`) — and then stopped the backend (`stopBackendBounded`, dolt shutdown GC + process exit — seconds more) **while still holding `proxy.lock`**.

Meanwhile `stopAndAcquire` budgets only `shutdownConfirmDeadline` = 5s (`shutdown.go:18`) for that same lock, and since the child never published `proxy.pid`, `pf == nil` — producing the literal `timeout (5s) acquiring proxy.lock after inspecting pid 0` (`shutdown.go:346-357`). The spawn marker doesn't help: the child clears it the moment it takes the lock (`server.go:118`), so the stopper has no signal that a doomed start owns the lock.

(One correction to the original recon: the *parent* start side releases `proxy.lock` before exec'ing the child — `endpoint.go` `forkExecChild` releases pre-`cmd.Start` as part of the marker handoff. The long hold is entirely in the child.)

## Structural fix (directions (a) + (c); no budget inflation)

All child-side, in `ListenAndServe`:

1. **Fast-abort after lock acquisition** — the child re-checks the stop epoch immediately after taking `proxy.lock` and clearing the spawn marker, before opening any listener or booting the backend. A stop that raced the spawn handoff now sees a free lock within **milliseconds**.
2. **Startup epoch watcher** — a goroutine polls the stop epoch every `openPollInterval` (100ms) across the whole startup window and cancels the startup context on advance, so a stop landing mid-boot aborts the backend `Start`/ready wait within ~one poll interval instead of riding out a doomed 30s boot. The watcher is stopped *synchronously* before the pre-publish fence, so a watcher cancellation can never race the publish; the fence re-read remains the authoritative check.
3. **Early lock release on the doomed path** — an interrupted start releases `proxy.lock` BEFORE its backend teardown (`abortInterruptedStart`). Nothing was published, so the lock protects nothing further; the waiting stopper acquires it immediately, finds `pf == nil`, and finishes its proxy phase. The backend teardown then converges benignly with the stopper's own backend phase (kill of a verified, already-dying pid; `pidfile.Remove` is not-exist-tolerant; `proxy-child.lock` is released by the backend's exit).

## Why the flake shape is now impossible

The stop-side 5s lock budget now only has to cover the child's *epoch-noticing latency* (≤ ~100ms poll + a bounded SIGKILL-abort of the backend start), never a backend boot or teardown. Every doomed-start path releases `proxy.lock` before any multi-second work: pre-boot dooms exit in milliseconds (fast-abort), mid-boot dooms cancel the boot within a poll interval, and post-boot dooms drop the lock before stopping the backend. So `stopAndAcquire` can no longer time out against an unpublished child, which is the only way to reach `pid 0` in that message. The start side still reports `errStartInterrupted` (by design — that side losing is the test's accepted outcome); the stop side now always completes, so the both-failed branch cannot fire.

## Normal start/stop paths: unchanged

- A start with no concurrent stop: the watcher observes no epoch change and is stopped before publish; lock lifetime and publish sequence are identical.
- A stop of a published proxy: unchanged (`Shutdown` path untouched — zero edits to `shutdown.go`; no timeout was inflated).
- Startup failures without a stop (listen error, backend not ready, etc.): teardown still runs under the lock, exactly as before.

## New regression tests (`server_epoch_internal_test.go`)

- `TestListenAndServe_StopEpochAdvancedBeforeStartupNeverBootsBackend` — pre-doomed start aborts with **zero** backend `Start` calls.
- `TestListenAndServe_InterruptedStartReleasesProxyLockBeforeBackendStop` — pins the invariant directly: while the doomed backend teardown is blocked in `Stop`, `util.TryLock(proxy.lock)` **succeeds** from the test (this is exactly what the stopper needs; fails on the old code).
- `TestListenAndServe_StopEpochAdvanceAbortsSlowReadyWait` — a stop landing during a never-ready backend boot aborts via the watcher in well under `serverReadyTimeout` (fails on the old code, which rides out the full 30s ready wait).

The CI-enforced `TestManagedLocalProxiedStopStartInterleave` is untouched (still present, still listed by the `proxied-local-smoke.yml` `-test.list` gate).

## Verification

On darwin (source tree):
- `go build ./...` — exit 0
- `go vet ./internal/storage/dbproxy/... ./cmd/bd/` — exit 0
- `go test ./internal/storage/dbproxy/... -count=1` — all packages ok, exit 0
- `go test ./internal/storage/dbproxy/proxy/ ./internal/storage/dbproxy/server/ -count=5 -timeout 15m` — ok (36.5s / 32.1s), exit 0

In a `golang:1.26` linux/arm64 container mirroring `proxied-local-smoke.yml` (pinned dolt 2.2.2, `-tags gms_pure_go`, `BEADS_TEST_PROXIED_LOCAL=1 BEADS_TEST_SKIP=dolt BEADS_TEST_BD_BINARY=<prebuilt>`):
- `-test.run '^TestManagedLocalProxiedStopStartInterleave$' -test.count=10 -test.timeout 20m` — **10/10 PASS** (7.6-10.9s each), `ok github.com/steveyegge/beads/cmd/bd 86.203s`, exit 0 (the test was flaky at count=1 before)
- `-test.run '^TestManagedLocalProxied' -test.count=1` — full managed-local lifecycle lane (foreign-listener, reused-pid, legacy-record, orphan-backend, N-process convergence, interleave), all PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
