### PR TITLE
feat(import): port bd import to proxied-server mode (bd-o58fz)

### DIFF
--- a/cmd/bd/import.go
+++ b/cmd/bd/import.go
@@ -14,7 +14,7 @@ import (
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/metrics"
-	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/uow"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -117,9 +117,6 @@ func init() {
 }
 
 func runImport(cmd *cobra.Command, args []string) error {
-	if usesProxiedServer() {
-		return HandleErrorRespectJSON("import is not supported in proxied-server mode")
-	}
 	evt := metrics.NewCommandEvent("import")
 	defer func() {
 		if c := metrics.Global(); c != nil {
@@ -213,10 +210,27 @@ type importResultJSON struct {
 }
 
 func runImportFromReader(ctx context.Context, r io.Reader, source string) error {
+	issues, memories, err := parseImportRecords(r)
+	if err != nil {
+		return err
+	}
+
+	if usesProxiedServer() {
+		return runImportRecordsProxied(ctx, issues, memories, source)
+	}
+
 	if store == nil {
 		return fmt.Errorf("no database — run 'bd init' or 'bd bootstrap' first")
 	}
+	return runImportRecordsClassic(ctx, issues, memories, source)
+}
 
+// parseImportRecords scans one JSONL stream into issue rows and memory
+// records — the `bd import` / `bd import -` parse loop, shared by the classic
+// and proxied modes. Same record vocabulary as parseJSONLFile (the bootstrap
+// reader): the optional _schema header and tombstones are skipped, and the
+// legacy "wisp" boolean is honored as an alias for "ephemeral".
+func parseImportRecords(r io.Reader) ([]*types.Issue, []memoryRecord, error) {
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 0, 1024*1024), 64*1024*1024)
 
@@ -231,7 +245,7 @@ func runImportFromReader(ctx context.Context, r io.Reader, source string) error 
 
 		var peek map[string]json.RawMessage
 		if err := json.Unmarshal([]byte(line), &peek); err != nil {
-			return fmt.Errorf("failed to parse JSONL line: %w", err)
+			return nil, nil, fmt.Errorf("failed to parse JSONL line: %w", err)
 		}
 
 		// Skip the optional beads-jsonl header record (§J1.3). A canonical
@@ -251,7 +265,7 @@ func runImportFromReader(ctx context.Context, r io.Reader, source string) error 
 			if err := json.Unmarshal(rawType, &typeStr); err == nil && typeStr == "memory" {
 				var mem memoryRecord
 				if err := json.Unmarshal([]byte(line), &mem); err != nil {
-					return fmt.Errorf("failed to parse memory record: %w", err)
+					return nil, nil, fmt.Errorf("failed to parse memory record: %w", err)
 				}
 				if mem.Key != "" && mem.Value != "" {
 					memories = append(memories, mem)
@@ -262,7 +276,7 @@ func runImportFromReader(ctx context.Context, r io.Reader, source string) error 
 
 		var issue types.Issue
 		if err := json.Unmarshal([]byte(line), &issue); err != nil {
-			return fmt.Errorf("failed to parse issue from JSONL: %w", err)
+			return nil, nil, fmt.Errorf("failed to parse issue from JSONL: %w", err)
 		}
 		if issue.Status == "tombstone" {
 			continue
@@ -277,9 +291,16 @@ func runImportFromReader(ctx context.Context, r io.Reader, source string) error 
 		issues = append(issues, &issue)
 	}
 	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("failed to scan JSONL: %w", err)
+		return nil, nil, fmt.Errorf("failed to scan JSONL: %w", err)
 	}
+	return issues, memories, nil
+}
 
+// runImportRecordsClassic is the classic (embedded/direct store) import
+// pipeline over the parsed records: dedup, dry-run classification, memory
+// writes, the batch issue import, the final commit and the issue_prefix
+// reconciliation.
+func runImportRecordsClassic(ctx context.Context, issues []*types.Issue, memories []memoryRecord, source string) error {
 	// Dedup: skip issues whose title matches an existing open issue
 	dedupHits := 0
 	if importDedup && len(issues) > 0 {
@@ -300,33 +321,8 @@ func runImportFromReader(ctx context.Context, r io.Reader, source string) error 
 		if err != nil {
 			return fmt.Errorf("dry-run: %w", err)
 		}
-		result.Created = classification.Created
-		result.Updated = classification.Updated
-		result.Unchanged = classification.Unchanged
-		result.Skipped += classification.Skipped
-		result.IDs = append(result.IDs, classification.ImportedIDs...)
-		result.StaleSkippedIDs = classification.StaleSkippedIDs
-		result.UpdatedIssues = classification.UpdatedIssues
-		result.TieKeptLocalIDs = classification.TieKeptLocalIDs
-
-		if jsonOutput {
-			return outputJSON(result)
-		}
-		// The leading count is the sum of the breakdown that follows it
-		// (not len(issues)), which can be larger when rows were stale
-		// skipped — those are reported separately below instead of being
-		// folded into a total the breakdown then wouldn't add up to.
-		considered := result.Created + result.Updated + result.Unchanged
-		fmt.Fprintf(os.Stderr, "Would import %d issues (%d new, %d updated, %d unchanged) and %d memories from %s",
-			considered, result.Created, result.Updated, result.Unchanged, len(memories), source)
-		if dedupHits > 0 {
-			fmt.Fprintf(os.Stderr, " (%d duplicates skipped)", dedupHits)
-		}
-		if len(result.StaleSkippedIDs) > 0 {
-			fmt.Fprintf(os.Stderr, " (%d stale skipped)", len(result.StaleSkippedIDs))
-		}
-		fmt.Fprintln(os.Stderr)
-		return nil
+		applyImportDryRunClassification(&result, classification)
+		return renderImportDryRun(result, len(memories), source, dedupHits)
 	}
 
 	// Import memories
@@ -345,14 +341,7 @@ func runImportFromReader(ctx context.Context, r io.Reader, source string) error 
 		if err != nil {
 			return fmt.Errorf("import failed: %w", err)
 		}
-		result.Created = importResult.Created
-		result.Updated = importResult.Updated
-		result.Skipped += importResult.Skipped
-		result.SkippedDependencies = append(result.SkippedDependencies, importResult.SkippedDependencies...)
-		result.IDs = append(result.IDs, importResult.ImportedIDs...)
-		result.UpdatedIssues = append(result.UpdatedIssues, importResult.UpdatedIssues...)
-		result.TieKeptLocalIDs = append(result.TieKeptLocalIDs, importResult.TieKeptLocalIDs...)
-		result.StaleSkippedIDs = append(result.StaleSkippedIDs, importResult.StaleSkippedIDs...)
+		applyImportOutcome(&result, importResult)
 	}
 
 	if result.Created > 0 || result.Memories > 0 {
@@ -385,6 +374,62 @@ func runImportFromReader(ctx context.Context, r io.Reader, source string) error 
 		}
 	}
 
+	return renderImportOutcome(result, source, dedupHits)
+}
+
+// applyImportDryRunClassification folds a dry-run classification into the
+// command's JSON result, identically in both modes.
+func applyImportDryRunClassification(result *importResultJSON, classification *ImportResult) {
+	result.Created = classification.Created
+	result.Updated = classification.Updated
+	result.Unchanged = classification.Unchanged
+	result.Skipped += classification.Skipped
+	result.IDs = append(result.IDs, classification.ImportedIDs...)
+	result.StaleSkippedIDs = classification.StaleSkippedIDs
+	result.UpdatedIssues = classification.UpdatedIssues
+	result.TieKeptLocalIDs = classification.TieKeptLocalIDs
+}
+
+// applyImportOutcome folds a real import's outcome into the command's JSON
+// result, identically in both modes.
+func applyImportOutcome(result *importResultJSON, importResult *ImportResult) {
+	result.Created = importResult.Created
+	result.Updated = importResult.Updated
+	result.Skipped += importResult.Skipped
+	result.SkippedDependencies = append(result.SkippedDependencies, importResult.SkippedDependencies...)
+	result.IDs = append(result.IDs, importResult.ImportedIDs...)
+	result.UpdatedIssues = append(result.UpdatedIssues, importResult.UpdatedIssues...)
+	result.TieKeptLocalIDs = append(result.TieKeptLocalIDs, importResult.TieKeptLocalIDs...)
+	result.StaleSkippedIDs = append(result.StaleSkippedIDs, importResult.StaleSkippedIDs...)
+}
+
+// renderImportDryRun reports a dry run (JSON or stderr), identically in both
+// modes.
+func renderImportDryRun(result importResultJSON, memoriesCount int, source string, dedupHits int) error {
+	if jsonOutput {
+		return outputJSON(result)
+	}
+	// The leading count is the sum of the breakdown that follows it
+	// (not len(issues)), which can be larger when rows were stale
+	// skipped — those are reported separately below instead of being
+	// folded into a total the breakdown then wouldn't add up to.
+	considered := result.Created + result.Updated + result.Unchanged
+	//nolint:gosec // G705: stderr, not a browser context
+	fmt.Fprintf(os.Stderr, "Would import %d issues (%d new, %d updated, %d unchanged) and %d memories from %s",
+		considered, result.Created, result.Updated, result.Unchanged, memoriesCount, source)
+	if dedupHits > 0 {
+		fmt.Fprintf(os.Stderr, " (%d duplicates skipped)", dedupHits) //nolint:gosec // G705: stderr, not a browser context
+	}
+	if len(result.StaleSkippedIDs) > 0 {
+		fmt.Fprintf(os.Stderr, " (%d stale skipped)", len(result.StaleSkippedIDs))
+	}
+	fmt.Fprintln(os.Stderr)
+	return nil
+}
+
+// renderImportOutcome reports a completed import (JSON or stderr),
+// identically in both modes.
+func renderImportOutcome(result importResultJSON, source string, dedupHits int) error {
 	if jsonOutput {
 		return outputJSON(result)
 	}
@@ -417,8 +462,33 @@ func runImportFromReader(ctx context.Context, r io.Reader, source string) error 
 	return nil
 }
 
+// importTitleSearcher is the read seam the --dedup filter needs. It lives in
+// THIS file because naming types.IssueFilter is denied by default under
+// cmd/bd and import.go is the named exception for the bulk-movement family
+// (.golangci.yml, forbidigo): the classic storage.DoltStorage satisfies it
+// directly, and uowImportTitleSearcher adapts the proxied unit of work.
+type importTitleSearcher interface {
+	SearchIssues(ctx context.Context, query string, filter types.IssueFilter) ([]*types.Issue, error)
+}
+
+// uowImportTitleSearcher adapts a unit of work's issue use case to the
+// classic []*types.Issue search shape filterDuplicatesByTitle consumes. Both
+// stacks run the same issueops search underneath (issues merged with wisps),
+// so --dedup sees the same title universe in both modes.
+type uowImportTitleSearcher struct {
+	uw uow.UnitOfWork
+}
+
+func (s uowImportTitleSearcher) SearchIssues(ctx context.Context, query string, filter types.IssueFilter) ([]*types.Issue, error) {
+	page, err := s.uw.IssueUseCase().SearchIssues(ctx, query, filter)
+	if err != nil {
+		return nil, err
+	}
+	return page.Items, nil
+}
+
 // filterDuplicatesByTitle removes issues whose title matches an existing open issue.
-func filterDuplicatesByTitle(ctx context.Context, st storage.DoltStorage, issues []*types.Issue) ([]*types.Issue, int) {
+func filterDuplicatesByTitle(ctx context.Context, st importTitleSearcher, issues []*types.Issue) ([]*types.Issue, int) {
 	existing, err := st.SearchIssues(ctx, "", types.IssueFilter{})
 	if err != nil {
 		return issues, 0

--- a/cmd/bd/import.go
+++ b/cmd/bd/import.go
@@ -440,10 +440,10 @@ func renderImportOutcome(result importResultJSON, source string, dedupHits int) 
 	}
 	fmt.Fprintf(os.Stderr, " from %s", source)
 	if dedupHits > 0 {
-		fmt.Fprintf(os.Stderr, " (%d duplicates skipped)", dedupHits)
+		fmt.Fprintf(os.Stderr, " (%d duplicates skipped)", dedupHits) //nolint:gosec // G705: stderr, not a browser context
 	}
 	if staleSkipped := result.Skipped - dedupHits; staleSkipped > 0 {
-		fmt.Fprintf(os.Stderr, " (%d stale skipped; use --allow-stale to restore older rows)", staleSkipped)
+		fmt.Fprintf(os.Stderr, " (%d stale skipped; use --allow-stale to restore older rows)", staleSkipped) //nolint:gosec // G705: stderr, not a browser context
 	}
 	fmt.Fprintln(os.Stderr)
 	if len(result.UpdatedIssues) > 0 {

--- a/cmd/bd/import_proxied_integration_test.go
+++ b/cmd/bd/import_proxied_integration_test.go
@@ -1,0 +1,370 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// importFixtureJSONL builds an export-shaped JSONL stream: an optional
+// header line, issue rows marshalled from types.Issue (so the fixture cannot
+// drift from the parser's schema), a memory record and a tombstone row the
+// importer must skip.
+func importFixtureJSONL(t *testing.T, issues []*types.Issue, extraLines ...string) string {
+	t.Helper()
+	var b strings.Builder
+	b.WriteString(`{"_schema":"beads-jsonl/1","_sort":"stable-v1"}` + "\n")
+	for _, issue := range issues {
+		line, err := json.Marshal(issue)
+		if err != nil {
+			t.Fatalf("marshal fixture issue %s: %v", issue.ID, err)
+		}
+		b.Write(line)
+		b.WriteString("\n")
+	}
+	for _, line := range extraLines {
+		b.WriteString(line + "\n")
+	}
+	return b.String()
+}
+
+// bdProxiedImport runs `bd import <args>` and returns the stderr report
+// (import writes its human report to stderr), failing the test on error.
+func bdProxiedImport(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	fullArgs := append([]string{"import"}, args...)
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, dir, fullArgs...)
+	if err != nil {
+		t.Fatalf("bd import %s failed: %v\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), err, stdout, stderr)
+	}
+	return stderr
+}
+
+func bdProxiedImportWithInput(t *testing.T, bd, dir, input string, args ...string) (string, string, error) {
+	t.Helper()
+	fullArgs := append([]string{"import"}, args...)
+	cmd := exec.Command(bd, fullArgs...)
+	cmd.Dir = dir
+	cmd.Env = bdProxiedEnv(dir)
+	cmd.Stdin = strings.NewReader(input)
+	stdout, stderr, err := runCommandBuffers(t, cmd)
+	return stdout.String(), stderr.String(), err
+}
+
+func proxiedImportQueryInt(t *testing.T, db *sql.DB, query string, args ...any) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRowContext(context.Background(), query, args...).Scan(&n); err != nil {
+		t.Fatalf("query %q: %v", query, err)
+	}
+	return n
+}
+
+func proxiedImportQueryString(t *testing.T, db *sql.DB, query string, args ...any) string {
+	t.Helper()
+	var s string
+	if err := db.QueryRowContext(context.Background(), query, args...).Scan(&s); err != nil {
+		t.Fatalf("query %q: %v", query, err)
+	}
+	return s
+}
+
+func TestProxiedServerImport(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+
+	when := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+
+	// fixtureIssues returns the canonical three-row batch: one row carrying
+	// labels and a comment, one carrying a blocks edge onto the first, one
+	// plain row — enough shape to prove the aux data actually lands.
+	fixtureIssues := func(prefix string) []*types.Issue {
+		return []*types.Issue{
+			{
+				ID: prefix + "-r1", Title: "Round-trip one", Status: types.StatusOpen,
+				IssueType: types.TypeTask, Priority: 2,
+				Labels:    []string{"lane:test", "imported"},
+				Comments:  []*types.Comment{{ID: prefix + "-r1-c1", Author: "fixture", Text: "carried comment", CreatedAt: when}},
+				CreatedAt: when, UpdatedAt: when,
+			},
+			{
+				ID: prefix + "-r2", Title: "Round-trip two", Status: types.StatusOpen,
+				IssueType: types.TypeBug, Priority: 1,
+				Dependencies: []*types.Dependency{{IssueID: prefix + "-r2", DependsOnID: prefix + "-r1", Type: types.DepBlocks}},
+				CreatedAt:    when, UpdatedAt: when,
+			},
+			{
+				ID: prefix + "-r3", Title: "Round-trip three", Status: types.StatusClosed,
+				IssueType: types.TypeChore, Priority: 3, CloseReason: "done in fixture",
+				CreatedAt: when, UpdatedAt: when,
+			},
+		}
+	}
+
+	t.Run("roundtrip_one_commit_with_content", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "impa")
+		db := openProxiedDB(t, p)
+
+		fixture := importFixtureJSONL(t, fixtureIssues("impa"),
+			`{"_type":"memory","key":"import-probe","value":"remembered"}`,
+			`{"id":"impa-dead","title":"Tombstoned","status":"tombstone"}`,
+		)
+		path := filepath.Join(p.dir, "roundtrip.jsonl")
+		if err := os.WriteFile(path, []byte(fixture), 0o644); err != nil {
+			t.Fatalf("write fixture: %v", err)
+		}
+
+		head := proxiedDoltHead(t, db)
+		report := bdProxiedImport(t, bd, p.dir, path)
+		if !strings.Contains(report, "Imported 3 issues and 1 memories") {
+			t.Errorf("import report = %q, want 'Imported 3 issues and 1 memories'", report)
+		}
+
+		// ONE commit for the whole invocation: rows, aux data and the memory
+		// together. The proxied path has no PostRun auto-commit, so this is
+		// the Importer capability's single DOLT_COMMIT.
+		if n := proxiedDoltCommitCountSince(t, db, head); n != 1 {
+			t.Errorf("commits for one import = %d, want exactly 1", n)
+		}
+
+		// Direct content assertions — presence of the aux data, not just row
+		// counts or byte-equality.
+		if got := proxiedImportQueryInt(t, db, "SELECT COUNT(*) FROM issues WHERE id LIKE 'impa-r%'"); got != 3 {
+			t.Errorf("issue rows = %d, want 3", got)
+		}
+		if got := proxiedImportQueryInt(t, db, "SELECT COUNT(*) FROM labels WHERE issue_id = 'impa-r1'"); got != 2 {
+			t.Errorf("impa-r1 labels = %d, want 2", got)
+		}
+		if got := proxiedImportQueryString(t, db, "SELECT text FROM comments WHERE issue_id = 'impa-r1'"); got != "carried comment" {
+			t.Errorf("impa-r1 comment = %q, want the carried comment", got)
+		}
+		if got := proxiedImportQueryInt(t, db, "SELECT COUNT(*) FROM dependencies WHERE issue_id = 'impa-r2' AND depends_on_issue_id = 'impa-r1' AND type = 'blocks'"); got != 1 {
+			t.Errorf("impa-r2 blocks edge = %d, want 1", got)
+		}
+		if got := proxiedImportQueryString(t, db, "SELECT value FROM config WHERE `key` = 'kv.memory.import-probe'"); got != "remembered" {
+			t.Errorf("memory value = %q, want %q", got, "remembered")
+		}
+		if got := proxiedImportQueryInt(t, db, "SELECT COUNT(*) FROM issues WHERE id = 'impa-dead'"); got != 0 {
+			t.Errorf("tombstone row imported: %d rows, want 0", got)
+		}
+		if got := proxiedImportQueryString(t, db, "SELECT status FROM issues WHERE id = 'impa-r3'"); got != "closed" {
+			t.Errorf("impa-r3 status = %q, want closed", got)
+		}
+
+		// bd's own view agrees with the raw oracle.
+		shown := bdProxiedShow(t, bd, p.dir, "impa-r1")
+		if shown.Title != "Round-trip one" || shown.Priority != 2 {
+			t.Errorf("show impa-r1 = title %q priority %d, want the imported row", shown.Title, shown.Priority)
+		}
+
+		// Re-import of the identical snapshot converges: no duplicated aux
+		// data, and nothing new to commit.
+		headBeforeReimport := proxiedDoltHead(t, db)
+		_ = bdProxiedImport(t, bd, p.dir, path)
+		if got := proxiedImportQueryInt(t, db, "SELECT COUNT(*) FROM labels WHERE issue_id = 'impa-r1'"); got != 2 {
+			t.Errorf("labels after re-import = %d, want 2 (idempotent merge)", got)
+		}
+		if got := proxiedImportQueryInt(t, db, "SELECT COUNT(*) FROM comments WHERE issue_id = 'impa-r1'"); got != 1 {
+			t.Errorf("comments after re-import = %d, want 1 (idempotent merge)", got)
+		}
+		if n := proxiedDoltCommitCountSince(t, db, headBeforeReimport); n != 0 {
+			t.Errorf("re-import of an identical snapshot made %d commits, want 0 (working-set no-op)", n)
+		}
+	})
+
+	t.Run("stdin_dash_and_redirect_guard", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "impb")
+		db := openProxiedDB(t, p)
+
+		fixture := importFixtureJSONL(t, []*types.Issue{{
+			ID: "impb-s1", Title: "From stdin", Status: types.StatusOpen,
+			IssueType: types.TypeTask, Priority: 2, CreatedAt: when, UpdatedAt: when,
+		}})
+
+		// bd import - reads the piped stream.
+		_, stderr, err := bdProxiedImportWithInput(t, bd, p.dir, fixture, "-")
+		if err != nil {
+			t.Fatalf("bd import -: %v\n%s", err, stderr)
+		}
+		if !strings.Contains(stderr, "Imported 1 issues") {
+			t.Errorf("stdin import report = %q, want 'Imported 1 issues'", stderr)
+		}
+		if got := proxiedImportQueryInt(t, db, "SELECT COUNT(*) FROM issues WHERE id = 'impb-s1'"); got != 1 {
+			t.Errorf("stdin row = %d, want 1", got)
+		}
+
+		// Redirected stdin WITHOUT "-" must refuse rather than silently
+		// importing the default JSONL (bd-axluy).
+		_, stderr, err = bdProxiedImportWithInput(t, bd, p.dir, fixture)
+		if err == nil {
+			t.Fatal("bd import with redirected stdin and no \"-\" should refuse")
+		}
+		if !strings.Contains(stderr, "use 'bd import -'") {
+			t.Errorf("redirect-guard message = %q, want the bd-axluy hint", stderr)
+		}
+	})
+
+	t.Run("upsert_updates_and_stale_guard", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "impc")
+		db := openProxiedDB(t, p)
+
+		// Seed a live row through the ordinary create door.
+		created := bdProxiedCreate(t, bd, p.dir, "Live local row", "--type", "task", "--priority", "2")
+
+		// An older snapshot of that row is stale-skipped: local state wins.
+		old := when.Add(-30 * 24 * time.Hour)
+		staleFixture := importFixtureJSONL(t, []*types.Issue{{
+			ID: created.ID, Title: "Older snapshot title", Status: types.StatusOpen,
+			IssueType: types.TypeTask, Priority: 4, CreatedAt: old, UpdatedAt: old,
+		}})
+		stalePath := filepath.Join(p.dir, "stale.jsonl")
+		if err := os.WriteFile(stalePath, []byte(staleFixture), 0o644); err != nil {
+			t.Fatalf("write stale fixture: %v", err)
+		}
+		report := bdProxiedImport(t, bd, p.dir, stalePath)
+		if !strings.Contains(report, "stale skipped") {
+			t.Errorf("stale import report = %q, want a stale-skipped notice", report)
+		}
+		if got := proxiedImportQueryString(t, db, "SELECT title FROM issues WHERE id = ?", created.ID); got != "Live local row" {
+			t.Errorf("title after stale import = %q, want local row kept", got)
+		}
+
+		// --allow-stale deliberately restores the older snapshot.
+		_ = bdProxiedImport(t, bd, p.dir, "--allow-stale", stalePath)
+		if got := proxiedImportQueryString(t, db, "SELECT title FROM issues WHERE id = ?", created.ID); got != "Older snapshot title" {
+			t.Errorf("title after --allow-stale = %q, want the older snapshot restored", got)
+		}
+
+		// A strictly-newer row upserts and the report names the change.
+		newer := time.Now().UTC().Add(time.Hour).Truncate(time.Second)
+		newerFixture := importFixtureJSONL(t, []*types.Issue{{
+			ID: created.ID, Title: "Newer imported title", Status: types.StatusOpen,
+			IssueType: types.TypeTask, Priority: 1, CreatedAt: old, UpdatedAt: newer,
+		}})
+		newerPath := filepath.Join(p.dir, "newer.jsonl")
+		if err := os.WriteFile(newerPath, []byte(newerFixture), 0o644); err != nil {
+			t.Fatalf("write newer fixture: %v", err)
+		}
+		report = bdProxiedImport(t, bd, p.dir, newerPath)
+		if !strings.Contains(report, "Updated 1 existing issue(s)") {
+			t.Errorf("newer import report = %q, want the updated-issues summary", report)
+		}
+		if got := proxiedImportQueryString(t, db, "SELECT title FROM issues WHERE id = ?", created.ID); got != "Newer imported title" {
+			t.Errorf("title after newer import = %q, want the imported rewrite", got)
+		}
+	})
+
+	t.Run("dry_run_classifies_and_writes_nothing", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "impd")
+		db := openProxiedDB(t, p)
+
+		fixture := importFixtureJSONL(t, fixtureIssues("impd"),
+			`{"_type":"memory","key":"dry-probe","value":"never"}`,
+		)
+		path := filepath.Join(p.dir, "dry.jsonl")
+		if err := os.WriteFile(path, []byte(fixture), 0o644); err != nil {
+			t.Fatalf("write fixture: %v", err)
+		}
+
+		head := proxiedDoltHead(t, db)
+		stdout, _, err := bdProxiedRunBuffers(t, bd, p.dir, "import", "--dry-run", "--json", path)
+		if err != nil {
+			t.Fatalf("dry-run import: %v\n%s", err, stdout)
+		}
+		var report struct {
+			Created int  `json:"created"`
+			DryRun  bool `json:"dry_run"`
+		}
+		start := strings.Index(stdout, "{")
+		if start < 0 {
+			t.Fatalf("no JSON in dry-run output: %s", stdout)
+		}
+		if err := json.Unmarshal([]byte(stdout[start:]), &report); err != nil {
+			t.Fatalf("parse dry-run JSON: %v\n%s", err, stdout)
+		}
+		if !report.DryRun || report.Created != 3 {
+			t.Errorf("dry-run report = %+v, want dry_run=true created=3", report)
+		}
+		if n := proxiedDoltCommitCountSince(t, db, head); n != 0 {
+			t.Errorf("dry run made %d commits, want 0", n)
+		}
+		if got := proxiedImportQueryInt(t, db, "SELECT COUNT(*) FROM issues WHERE id LIKE 'impd-r%'"); got != 0 {
+			t.Errorf("dry run wrote %d rows, want 0", got)
+		}
+		if got := proxiedImportQueryInt(t, db, "SELECT COUNT(*) FROM config WHERE `key` = 'kv.memory.dry-probe'"); got != 0 {
+			t.Errorf("dry run wrote the memory, want none")
+		}
+	})
+
+	t.Run("dedup_skips_matching_open_title", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "impe")
+		db := openProxiedDB(t, p)
+
+		bdProxiedCreate(t, bd, p.dir, "Duplicate title", "--type", "task")
+
+		fixture := importFixtureJSONL(t, []*types.Issue{
+			{
+				ID: "impe-d1", Title: "Duplicate title", Status: types.StatusOpen,
+				IssueType: types.TypeTask, Priority: 2, CreatedAt: when, UpdatedAt: when,
+			},
+			{
+				ID: "impe-d2", Title: "Fresh title", Status: types.StatusOpen,
+				IssueType: types.TypeTask, Priority: 2, CreatedAt: when, UpdatedAt: when,
+			},
+		})
+		path := filepath.Join(p.dir, "dedup.jsonl")
+		if err := os.WriteFile(path, []byte(fixture), 0o644); err != nil {
+			t.Fatalf("write fixture: %v", err)
+		}
+		report := bdProxiedImport(t, bd, p.dir, "--dedup", path)
+		if !strings.Contains(report, "(1 duplicates skipped)") {
+			t.Errorf("dedup report = %q, want '(1 duplicates skipped)'", report)
+		}
+		if got := proxiedImportQueryInt(t, db, "SELECT COUNT(*) FROM issues WHERE id = 'impe-d1'"); got != 0 {
+			t.Errorf("duplicate-titled row imported, want skipped")
+		}
+		if got := proxiedImportQueryInt(t, db, "SELECT COUNT(*) FROM issues WHERE id = 'impe-d2'"); got != 1 {
+			t.Errorf("fresh-titled row missing, want imported")
+		}
+	})
+
+	t.Run("import_is_the_sanctioned_upsert_door", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "impf")
+		db := openProxiedDB(t, p)
+
+		created := bdProxiedCreate(t, bd, p.dir, "Occupied id", "--type", "task")
+
+		// Import IS the sanctioned upsert door: the occupied ID upserts.
+		newer := time.Now().UTC().Add(time.Hour).Truncate(time.Second)
+		fixture := importFixtureJSONL(t, []*types.Issue{{
+			ID: created.ID, Title: "Upserted through the door", Status: types.StatusOpen,
+			IssueType: types.TypeTask, Priority: 2, CreatedAt: when, UpdatedAt: newer,
+		}})
+		path := filepath.Join(p.dir, "door.jsonl")
+		if err := os.WriteFile(path, []byte(fixture), 0o644); err != nil {
+			t.Fatalf("write fixture: %v", err)
+		}
+		_ = bdProxiedImport(t, bd, p.dir, path)
+		if got := proxiedImportQueryString(t, db, "SELECT title FROM issues WHERE id = ?", created.ID); got != "Upserted through the door" {
+			t.Errorf("title after upsert = %q, want the imported rewrite", got)
+		}
+	})
+}

--- a/cmd/bd/import_proxied_server.go
+++ b/cmd/bd/import_proxied_server.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/storage/uow"
+	"github.com/steveyegge/beads/internal/types"
+	publicops "github.com/steveyegge/beads/issueops"
+)
+
+// proxiedImporter hands back the guarded bulk-import surface for the
+// proxied-server provider, through the provider's OWN capability accessor —
+// the same two-step proxiedIssueReader and proxiedBatchCloser perform, and
+// for the same reason: the accessor is where each layer is added, so a
+// command that reached for the constructor would get an unlayered importer.
+func proxiedImporter() (publicops.Importer, error) {
+	if uowProvider == nil {
+		return nil, errors.New("proxied-server UOW provider not initialized")
+	}
+	src, ok := uowProvider.(uow.ImporterSource)
+	if !ok {
+		return nil, fmt.Errorf("proxied-server provider %T does not offer the import surface", uowProvider)
+	}
+	return src.Importer()
+}
+
+// runImportRecordsProxied is the proxied-server import pipeline over the
+// parsed records. It mirrors runImportRecordsClassic stage for stage — dedup,
+// dry-run classification, stale pre-filter, batch write, issue_prefix
+// reconciliation — through the SAME classification and reporting code, with
+// two deliberate structural differences:
+//
+//   - ONE COMMIT PER INVOCATION. The classic path chunks a large import into
+//     bounded transactions (a SQLite write-lock fairness measure) and commits
+//     the issue_prefix sync separately; the proxied path has no PostRun
+//     auto-commit and the whole import — rows, memories, prefix sync — lands
+//     in ONE unit of work with ONE history entry, the Importer capability's
+//     contract.
+//
+//   - The stale guard keeps its classic two-half shape: the pre-filter runs in
+//     its own read (reporting StaleSkippedIDs and keeping stale rows' aux data
+//     out of the batch), and RejectStaleUpserts re-checks updated_at inside
+//     the write transaction, closing the same race the classic path closes.
+func runImportRecordsProxied(ctx context.Context, issues []*types.Issue, memories []memoryRecord, source string) error {
+	if uowProvider == nil {
+		return fmt.Errorf("proxied-server UOW provider not initialized")
+	}
+
+	// Dedup: skip issues whose title matches an existing open issue.
+	dedupHits := 0
+	if importDedup && len(issues) > 0 {
+		type dedupOutcome struct {
+			kept []*types.Issue
+			hits int
+		}
+		out, err := uow.RunTxRead(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (dedupOutcome, error) {
+			kept, hits := filterDuplicatesByTitle(ctx, uowImportTitleSearcher{uw: uw}, issues)
+			return dedupOutcome{kept: kept, hits: hits}, nil
+		})
+		if err != nil {
+			return err
+		}
+		issues = out.kept
+		dedupHits = out.hits
+	}
+
+	result := importResultJSON{
+		Source:    source,
+		DedupHits: dedupHits,
+		DryRun:    importDryRun,
+	}
+
+	if importDryRun {
+		result.Memories = len(memories)
+		result.Skipped = dedupHits
+
+		classification, err := uow.RunTxRead(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (*ImportResult, error) {
+			return classifyDryRunImport(ctx, uw.IssueUseCase(), issues, importAllowStale)
+		})
+		if err != nil {
+			return fmt.Errorf("dry-run: %w", err)
+		}
+		applyImportDryRunClassification(&result, classification)
+		return renderImportDryRun(result, len(memories), source, dedupHits)
+	}
+
+	// Pre-filter half of the stale guard (bd-pkim8): report rows already
+	// known stale and keep their labels/comments/dependencies out of the
+	// batch entirely. A local update racing between this read and the batch
+	// write is caught by RejectStaleUpserts inside the write transaction.
+	var staleSkippedIDs []string
+	var changePlan importChangePlan
+	if !importAllowStale && len(issues) > 0 {
+		type staleOutcome struct {
+			filtered []*types.Issue
+			skipped  []string
+			plan     importChangePlan
+		}
+		out, err := uow.RunTxRead(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (staleOutcome, error) {
+			filtered, skipped, plan, err := filterStaleImportIssues(ctx, uw.IssueUseCase(), issues)
+			if err != nil {
+				return staleOutcome{}, err
+			}
+			return staleOutcome{filtered: filtered, skipped: skipped, plan: plan}, nil
+		})
+		if err != nil {
+			return err
+		}
+		issues = out.filtered
+		staleSkippedIDs = out.skipped
+		changePlan = out.plan
+	}
+
+	memoryEntries := make([]publicops.ImportMemory, 0, len(memories))
+	for _, mem := range memories {
+		memoryEntries = append(memoryEntries, publicops.ImportMemory{
+			Key:   kvPrefix + memoryPrefix + mem.Key,
+			Value: mem.Value,
+		})
+	}
+
+	importer, err := proxiedImporter()
+	if err != nil {
+		return err
+	}
+
+	// THE BATCH: rows, memories and the issue_prefix reconciliation in one
+	// transaction, one history entry. The prefix sync runs even when the
+	// batch is otherwise empty, exactly as the classic path's post-commit
+	// sync does (be-llaf; config.yaml is authoritative, not a rename).
+	batch, err := importer.ImportBatch(ctx, publicops.ImportBatchRequest{
+		Actor:                getActorWithGit(),
+		Issues:               issues,
+		Memories:             memoryEntries,
+		AllowStale:           importAllowStale,
+		SkipPrefixValidation: true,
+		SyncIssuePrefix:      config.GetString("issue-prefix"),
+		Source:               filepath.Base(source),
+	})
+	if err != nil {
+		return fmt.Errorf("import failed: %w", err)
+	}
+	result.Memories = batch.MemoriesImported
+
+	if len(issues) > 0 {
+		staleRejectedSet := make(map[string]struct{}, len(batch.StaleRejectedIDs))
+		for _, id := range batch.StaleRejectedIDs {
+			staleRejectedSet[id] = struct{}{}
+		}
+		skippedDependencies := make([]string, 0, len(batch.SkippedDependencies))
+		for _, dep := range batch.SkippedDependencies {
+			skippedDependencies = append(skippedDependencies, fmt.Sprintf("%s -> %s: %s", dep.IssueID, dep.DependsOnID, dep.Reason))
+		}
+		applyImportOutcome(&result, assembleImportResult(issues, staleSkippedIDs, changePlan, staleRejectedSet, skippedDependencies))
+	} else {
+		result.Skipped += len(staleSkippedIDs)
+		result.StaleSkippedIDs = append(result.StaleSkippedIDs, staleSkippedIDs...)
+	}
+
+	return renderImportOutcome(result, source, dedupHits)
+}

--- a/cmd/bd/import_shared.go
+++ b/cmd/bd/import_shared.go
@@ -105,6 +105,14 @@ type ImportChange struct {
 	Changes string `json:"changes,omitempty"`
 }
 
+// importIssueLookup is the read seam the import pre-filters and dry-run
+// classifiers need. The classic storage.DoltStorage satisfies it, and so does
+// the proxied unit of work's domain.IssueUseCase, so both modes classify
+// incoming rows against local state with the same code.
+type importIssueLookup interface {
+	GetIssuesByIDs(ctx context.Context, ids []string) ([]*types.Issue, error)
+}
+
 // importIssuesCore imports issues into the Dolt store.
 // This is a bridge function that delegates to the Dolt store's batch creation.
 func importIssuesCore(ctx context.Context, _ string, store storage.DoltStorage, issues []*types.Issue, opts ImportOptions) (*ImportResult, error) {
@@ -170,6 +178,15 @@ func importIssuesCore(ctx context.Context, _ string, store storage.DoltStorage, 
 		return nil, err
 	}
 
+	return assembleImportResult(issues, staleSkippedIDs, changePlan, staleRejectedSet, skippedDependencies), nil
+}
+
+// assembleImportResult folds the batch write's in-transaction outcomes (stale
+// rejections, skipped dependencies) into the pre-filter's classification,
+// producing the report both the classic and the proxied import return. Kept
+// as ONE function so the two modes cannot drift on how a stale-rejected row
+// is attributed.
+func assembleImportResult(issues []*types.Issue, staleSkippedIDs []string, changePlan importChangePlan, staleRejectedSet map[string]struct{}, skippedDependencies []string) *ImportResult {
 	importedIDs := make([]string, 0, len(issues))
 	for _, issue := range issues {
 		if _, rejected := staleRejectedSet[issue.ID]; rejected {
@@ -198,7 +215,7 @@ func importIssuesCore(ctx context.Context, _ string, store storage.DoltStorage, 
 		SkippedDependencies: skippedDependencies,
 		UpdatedIssues:       updatedIssues,
 		TieKeptLocalIDs:     changePlan.TieKeptLocal,
-	}, nil
+	}
 }
 
 // importIssuesChunked writes a large import in bounded transactions of
@@ -655,7 +672,7 @@ type importChangePlan struct {
 	NewCount int
 }
 
-func filterStaleImportIssues(ctx context.Context, store storage.DoltStorage, issues []*types.Issue) ([]*types.Issue, []string, importChangePlan, error) {
+func filterStaleImportIssues(ctx context.Context, store importIssueLookup, issues []*types.Issue) ([]*types.Issue, []string, importChangePlan, error) {
 	var plan importChangePlan
 	ids := make([]string, 0, len(issues))
 	seen := make(map[string]struct{}, len(issues))
@@ -775,7 +792,7 @@ func filterStaleImportIssues(ctx context.Context, store storage.DoltStorage, iss
 // --allow-stale write) imports every row regardless of timestamp ordering,
 // so no row is ever stale-skipped or tie-kept — existence is the only
 // question.
-func classifyImportIssuesExistence(ctx context.Context, store storage.DoltStorage, issues []*types.Issue) (importChangePlan, error) {
+func classifyImportIssuesExistence(ctx context.Context, store importIssueLookup, issues []*types.Issue) (importChangePlan, error) {
 	var plan importChangePlan
 	ids := make([]string, 0, len(issues))
 	seen := make(map[string]struct{}, len(issues))
@@ -831,7 +848,7 @@ func classifyImportIssuesExistence(ctx context.Context, store storage.DoltStorag
 // classifyDryRunImport runs the same id lookup as a real import, without
 // writing anything, so --dry-run can report create/update/skip counts
 // instead of treating every row as a create (GH#4901).
-func classifyDryRunImport(ctx context.Context, store storage.DoltStorage, issues []*types.Issue, allowStale bool) (*ImportResult, error) {
+func classifyDryRunImport(ctx context.Context, store importIssueLookup, issues []*types.Issue, allowStale bool) (*ImportResult, error) {
 	if len(issues) == 0 {
 		return &ImportResult{}, nil
 	}

--- a/cmd/bd/import_shared.go
+++ b/cmd/bd/import_shared.go
@@ -432,7 +432,7 @@ func wireDeferredImportDeps(ctx context.Context, store storage.DoltStorage, defe
 		if err := store.CreateIssuesWithFullOptions(ctx, depRows[start:end], actor, depOpts); err != nil {
 			return fmt.Errorf("import dependency pass chunk %d/%d failed (all %d issue rows are committed; re-run the import to resume — it converges): %w", chunk, depChunks, rowTotal, err)
 		}
-		fmt.Fprintf(importProgress, "bd import: deferred dependencies wired for %d/%d issues\n", end, depTotal)
+		fmt.Fprintf(importProgress, "bd import: deferred dependencies wired for %d/%d issues\n", end, depTotal) //nolint:gosec // G705: stderr, not a browser context
 	}
 	return nil
 }

--- a/cmd/bd/import_shared.go
+++ b/cmd/bd/import_shared.go
@@ -389,7 +389,7 @@ func writeImportRowChunks(ctx context.Context, store storage.DoltStorage, ordere
 		if err := store.CreateIssuesWithFullOptions(ctx, ordered[start:end], actor, rowOpts); err != nil {
 			return fmt.Errorf("import chunk %d/%d failed, %d issues already committed (committed rows are durable; re-run the import to resume — it converges): %w", chunk, chunks, start, err)
 		}
-		fmt.Fprintf(importProgress, "bd import: %d/%d issues committed\n", end, total)
+		fmt.Fprintf(importProgress, "bd import: %d/%d issues committed\n", end, total) //nolint:gosec // G705: stderr, not a browser context
 	}
 	return nil
 }

--- a/internal/storage/issueops/create.go
+++ b/internal/storage/issueops/create.go
@@ -25,7 +25,7 @@ type BatchContext struct {
 }
 
 // NewBatchContext reads config from the database and returns a BatchContext.
-func NewBatchContext(ctx context.Context, tx *sql.Tx, opts storage.BatchCreateOptions) (*BatchContext, error) {
+func NewBatchContext(ctx context.Context, tx DBTX, opts storage.BatchCreateOptions) (*BatchContext, error) {
 	customStatuses, err := GetCustomStatusesTx(ctx, tx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get custom statuses: %w", err)
@@ -50,7 +50,7 @@ func NewBatchContext(ctx context.Context, tx *sql.Tx, opts storage.BatchCreateOp
 	}, nil
 }
 
-func CreateIssueInTx(ctx context.Context, tx *sql.Tx, bc *BatchContext, issue *types.Issue, actor string) error {
+func CreateIssueInTx(ctx context.Context, tx DBTX, bc *BatchContext, issue *types.Issue, actor string) error {
 	_, err := CreateIssueInTxWithResult(ctx, tx, bc, issue, actor)
 	return err
 }
@@ -92,7 +92,7 @@ func mergeChangedTables(dst map[string]bool, src map[string]bool) map[string]boo
 	return dst
 }
 
-func CreateIssueInTxWithResult(ctx context.Context, tx *sql.Tx, bc *BatchContext, issue *types.Issue, actor string) (CreateIssueResult, error) {
+func CreateIssueInTxWithResult(ctx context.Context, tx DBTX, bc *BatchContext, issue *types.Issue, actor string) (CreateIssueResult, error) {
 	var result CreateIssueResult
 	if err := PrepareIssueForInsert(issue, bc.CustomStatuses, bc.CustomTypes); err != nil {
 		return result, err
@@ -167,7 +167,7 @@ func CreateIssueInTxWithResult(ctx context.Context, tx *sql.Tx, bc *BatchContext
 	return result, nil
 }
 
-func assignCreateIssueIDInTx(ctx context.Context, tx *sql.Tx, bc *BatchContext, issue *types.Issue, actor string) error {
+func assignCreateIssueIDInTx(ctx context.Context, tx DBTX, bc *BatchContext, issue *types.Issue, actor string) error {
 	if issue.ID == "" {
 		issueTable, _ := TableRouting(issue)
 		prefix := bc.ConfigPrefix
@@ -214,14 +214,14 @@ func (r *CreateIssuesResult) merge(changed map[string]bool) {
 	r.ChangedTables = mergeChangedTables(r.ChangedTables, changed)
 }
 
-func CreateIssuesInTx(ctx context.Context, tx *sql.Tx, issues []*types.Issue, actor string, opts storage.BatchCreateOptions) error {
+func CreateIssuesInTx(ctx context.Context, tx DBTX, issues []*types.Issue, actor string, opts storage.BatchCreateOptions) error {
 	_, err := CreateIssuesInTxWithResult(ctx, tx, issues, actor, opts)
 	return err
 }
 
 // CreateIssuesInTxWithResult creates issues and reports tables whose writes are
 // only knowable after SQL reconciliation, such as child counter advances.
-func CreateIssuesInTxWithResult(ctx context.Context, tx *sql.Tx, issues []*types.Issue, actor string, opts storage.BatchCreateOptions) (CreateIssuesResult, error) {
+func CreateIssuesInTxWithResult(ctx context.Context, tx DBTX, issues []*types.Issue, actor string, opts storage.BatchCreateOptions) (CreateIssuesResult, error) {
 	filteredIssues, err := filterCreateIssuesMixedBucketDependencies(issues, opts)
 	if err != nil {
 		return CreateIssuesResult{}, err
@@ -416,7 +416,7 @@ func filterCreateIssuesMixedBucketDependencies(issues []*types.Issue, opts stora
 	return issues, nil
 }
 
-func createBlockedRecomputeIDs(ctx context.Context, tx *sql.Tx, issues []*types.Issue, dependencies []persistedDependency) ([]string, []string, error) {
+func createBlockedRecomputeIDs(ctx context.Context, tx DBTX, issues []*types.Issue, dependencies []persistedDependency) ([]string, []string, error) {
 	issueSeen := make(map[string]bool, len(issues))
 	wispSeen := make(map[string]bool, len(issues))
 	issueIDs := make([]string, 0, len(issues))
@@ -551,7 +551,7 @@ func AllWisps(issues []*types.Issue) bool {
 // Returns (skip=true, nil) if the issue should be skipped.
 //
 //nolint:gosec // G201: table is a hardcoded constant
-func CheckOrphan(ctx context.Context, tx *sql.Tx, issue *types.Issue, issueTable string, handling storage.OrphanHandling) (skip bool, err error) {
+func CheckOrphan(ctx context.Context, tx DBTX, issue *types.Issue, issueTable string, handling storage.OrphanHandling) (skip bool, err error) {
 	if issue.ID == "" {
 		return false, nil
 	}
@@ -595,7 +595,7 @@ func CheckOrphan(ctx context.Context, tx *sql.Tx, issue *types.Issue, issueTable
 // tolerant via GH#4163).
 //
 //nolint:gosec // G201: siblingTable is one of two hardcoded constants
-func checkCrossTableIDCollision(ctx context.Context, tx *sql.Tx, id, issueTable string, opts storage.BatchCreateOptions) (skip bool, err error) {
+func checkCrossTableIDCollision(ctx context.Context, tx DBTX, id, issueTable string, opts storage.BatchCreateOptions) (skip bool, err error) {
 	if id == "" {
 		return false, nil
 	}
@@ -696,7 +696,7 @@ func InsertIssueStrictInTx(ctx context.Context, tx DBTX, table string, issue *ty
 	return nil
 }
 
-func PersistLabels(ctx context.Context, tx *sql.Tx, issue *types.Issue, actor, eventTable string) (CreateIssueResult, error) {
+func PersistLabels(ctx context.Context, tx DBTX, issue *types.Issue, actor, eventTable string) (CreateIssueResult, error) {
 	var result CreateIssueResult
 	if len(issue.Labels) == 0 {
 		return result, nil
@@ -749,7 +749,7 @@ func PersistLabels(ctx context.Context, tx *sql.Tx, issue *types.Issue, actor, e
 	return result, nil
 }
 
-func PersistComments(ctx context.Context, tx *sql.Tx, issue *types.Issue) (CreateIssueResult, error) {
+func PersistComments(ctx context.Context, tx DBTX, issue *types.Issue) (CreateIssueResult, error) {
 	var result CreateIssueResult
 	if len(issue.Comments) == 0 {
 		return result, nil
@@ -812,16 +812,16 @@ func PersistComments(ctx context.Context, tx *sql.Tx, issue *types.Issue) (Creat
 	return result, nil
 }
 
-func PersistDependencies(ctx context.Context, tx *sql.Tx, issues []*types.Issue, actor string) error {
+func PersistDependencies(ctx context.Context, tx DBTX, issues []*types.Issue, actor string) error {
 	_, err := PersistDependenciesWithResult(ctx, tx, issues, actor)
 	return err
 }
 
-func PersistDependenciesWithResult(ctx context.Context, tx *sql.Tx, issues []*types.Issue, actor string) (CreateIssueResult, error) {
+func PersistDependenciesWithResult(ctx context.Context, tx DBTX, issues []*types.Issue, actor string) (CreateIssueResult, error) {
 	return PersistDependenciesWithOptionsResult(ctx, tx, issues, actor, storage.BatchCreateOptions{})
 }
 
-func PersistDependenciesWithOptionsResult(ctx context.Context, tx *sql.Tx, issues []*types.Issue, actor string, opts storage.BatchCreateOptions) (CreateIssueResult, error) {
+func PersistDependenciesWithOptionsResult(ctx context.Context, tx DBTX, issues []*types.Issue, actor string, opts storage.BatchCreateOptions) (CreateIssueResult, error) {
 	var result CreateIssueResult
 	type pendingDependency struct {
 		dep      *types.Dependency
@@ -963,7 +963,7 @@ func recordSkippedDependencyEdge(opts storage.BatchCreateOptions, issueID, depen
 	opts.OnSkippedDependency(issueID, dependsOnID, reason)
 }
 
-func ReconcileChildCounters(ctx context.Context, tx *sql.Tx, issues []*types.Issue) (map[string]bool, error) {
+func ReconcileChildCounters(ctx context.Context, tx DBTX, issues []*types.Issue) (map[string]bool, error) {
 	type bucket struct {
 		maxChild int
 		isWisp   bool

--- a/internal/storage/issueops/dependencies.go
+++ b/internal/storage/issueops/dependencies.go
@@ -89,7 +89,7 @@ func IsExternalDepTarget(sourceID, targetID string) bool {
 // an override for callers that already know the answer from a cached prefix
 // set; leaving it false is safe, because IsExternalDepTarget re-derives the
 // same comparison from the edge itself.
-func ClassifyDepTarget(ctx context.Context, tx *sql.Tx, dep *types.Dependency, isCrossPrefix bool) DepTargetKind {
+func ClassifyDepTarget(ctx context.Context, tx DBTX, dep *types.Dependency, isCrossPrefix bool) DepTargetKind {
 	if isCrossPrefix || IsExternalDepTarget(dep.IssueID, dep.DependsOnID) {
 		return DepTargetExternal
 	}

--- a/internal/storage/issueops/helpers.go
+++ b/internal/storage/issueops/helpers.go
@@ -164,7 +164,7 @@ func RecordEventInTable(ctx context.Context, tx DBTX, table, issueID string, eve
 // in the specified table. Supports counter mode for non-ephemeral issues.
 //
 //nolint:gosec // G201: table is a hardcoded constant
-func GenerateIssueIDInTable(ctx context.Context, tx *sql.Tx, table, prefix string, issue *types.Issue, actor string) (string, error) {
+func GenerateIssueIDInTable(ctx context.Context, tx DBTX, table, prefix string, issue *types.Issue, actor string) (string, error) {
 	// Counter mode only applies to the issues table (not wisps).
 	if table == "issues" {
 		counterMode, err := IsCounterModeTx(ctx, tx)
@@ -207,7 +207,7 @@ func GenerateIssueIDInTable(ctx context.Context, tx *sql.Tx, table, prefix strin
 }
 
 // IsCounterModeTx checks whether issue_id_mode=counter is configured.
-func IsCounterModeTx(ctx context.Context, tx *sql.Tx) (bool, error) {
+func IsCounterModeTx(ctx context.Context, tx DBTX) (bool, error) {
 	var idMode string
 	err := tx.QueryRowContext(ctx, "SELECT value FROM config WHERE `key` = ?", "issue_id_mode").Scan(&idMode)
 	if err != nil && err != sql.ErrNoRows {
@@ -217,7 +217,7 @@ func IsCounterModeTx(ctx context.Context, tx *sql.Tx) (bool, error) {
 }
 
 // NextCounterIDTx atomically increments and returns the next sequential issue ID.
-func NextCounterIDTx(ctx context.Context, tx *sql.Tx, prefix string) (string, error) {
+func NextCounterIDTx(ctx context.Context, tx DBTX, prefix string) (string, error) {
 	res, err := tx.ExecContext(ctx, "UPDATE issue_counter SET last_id = last_id + 1 WHERE prefix = ?", prefix)
 	if err != nil {
 		return "", fmt.Errorf("failed to increment issue counter for prefix %q: %w", prefix, err)
@@ -258,7 +258,7 @@ func NextCounterIDTx(ctx context.Context, tx *sql.Tx, prefix string) (string, er
 
 // SeedCounterFromExistingIssuesTx scans existing issues to find the highest numeric suffix
 // for the given prefix, then seeds the issue_counter table if no row exists yet.
-func SeedCounterFromExistingIssuesTx(ctx context.Context, tx *sql.Tx, prefix string) error {
+func SeedCounterFromExistingIssuesTx(ctx context.Context, tx DBTX, prefix string) error {
 	var existing int
 	err := tx.QueryRowContext(ctx, "SELECT last_id FROM issue_counter WHERE prefix = ?", prefix).Scan(&existing)
 	if err == nil {
@@ -306,7 +306,7 @@ func SeedCounterFromExistingIssuesTx(ctx context.Context, tx *sql.Tx, prefix str
 // GetAdaptiveIDLengthTx returns the appropriate hash length based on database size.
 //
 //nolint:gosec // G201: table is a hardcoded constant
-func GetAdaptiveIDLengthTx(ctx context.Context, tx *sql.Tx, table, prefix string) (int, error) {
+func GetAdaptiveIDLengthTx(ctx context.Context, tx DBTX, table, prefix string) (int, error) {
 	var count int
 	err := tx.QueryRowContext(ctx, fmt.Sprintf(`
 		SELECT COUNT(*)
@@ -339,7 +339,7 @@ func DefaultAdaptiveConfig() AdaptiveIDConfig {
 }
 
 // GetAdaptiveConfigTx reads adaptive ID config from the database.
-func GetAdaptiveConfigTx(ctx context.Context, tx *sql.Tx) AdaptiveIDConfig {
+func GetAdaptiveConfigTx(ctx context.Context, tx DBTX) AdaptiveIDConfig {
 	cfg := DefaultAdaptiveConfig()
 
 	var probStr string
@@ -385,7 +385,7 @@ func ComputeAdaptiveLength(numIssues int, cfg AdaptiveIDConfig) int {
 }
 
 // GetCustomStatusesTx reads custom statuses from config within a transaction.
-func GetCustomStatusesTx(ctx context.Context, tx *sql.Tx) ([]string, error) {
+func GetCustomStatusesTx(ctx context.Context, tx DBTX) ([]string, error) {
 	detailed, err := ResolveCustomStatusesDetailedInTx(ctx, tx)
 	if err != nil {
 		return nil, err
@@ -528,7 +528,7 @@ func IsDoltNothingToCommit(err error) bool {
 }
 
 // ReadConfigPrefix reads and normalizes issue_prefix from the config table.
-func ReadConfigPrefix(ctx context.Context, tx *sql.Tx) (string, error) {
+func ReadConfigPrefix(ctx context.Context, tx DBTX) (string, error) {
 	var configPrefix string
 	err := tx.QueryRowContext(ctx, "SELECT value FROM config WHERE `key` = ?", "issue_prefix").Scan(&configPrefix)
 	if err == sql.ErrNoRows || configPrefix == "" {

--- a/internal/storage/uow/importer.go
+++ b/internal/storage/uow/importer.go
@@ -3,7 +3,6 @@ package uow
 import (
 	"context"
 	"fmt"
-	"sort"
 
 	"github.com/steveyegge/beads/internal/storage"
 	storageissueops "github.com/steveyegge/beads/internal/storage/issueops"
@@ -92,18 +91,11 @@ func (o *importer) ImportBatch(ctx context.Context, request publicops.ImportBatc
 			result.Created = len(request.Issues) - len(staleRejected)
 		}
 
-		if len(request.Memories) > 0 {
-			keys := make([]string, 0, len(request.Memories))
-			for key := range request.Memories {
-				keys = append(keys, key)
+		for _, memory := range request.Memories {
+			if err := uw.ConfigUseCase().SetConfig(ctx, memory.Key, memory.Value); err != nil {
+				return publicops.ImportBatchResult{}, "", fmt.Errorf("import memory %q: %w", memory.Key, err)
 			}
-			sort.Strings(keys)
-			for _, key := range keys {
-				if err := uw.ConfigUseCase().SetConfig(ctx, key, request.Memories[key]); err != nil {
-					return publicops.ImportBatchResult{}, "", fmt.Errorf("import memory %q: %w", key, err)
-				}
-			}
-			result.MemoriesImported = len(request.Memories)
+			result.MemoriesImported++
 		}
 
 		// config.yaml is authoritative for issue_prefix on the import flow

--- a/internal/storage/uow/importer.go
+++ b/internal/storage/uow/importer.go
@@ -1,0 +1,156 @@
+package uow
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/steveyegge/beads/internal/storage"
+	storageissueops "github.com/steveyegge/beads/internal/storage/issueops"
+	publicops "github.com/steveyegge/beads/issueops"
+)
+
+// ImporterSource is the capability accessor a unit-of-work provider offers
+// for the import role, the sibling of BatchCloserSource and IssueReaderSource.
+type ImporterSource interface {
+	Importer() (publicops.Importer, error)
+}
+
+// Importer returns the guarded bulk-import surface for this provider.
+func (p *doltSQLProvider) Importer() (publicops.Importer, error) {
+	return NewImporter(p)
+}
+
+// NewImporter constructs a public importer backed by provider.
+func NewImporter(provider UnitOfWorkProvider) (publicops.Importer, error) {
+	if isNilUnitOfWorkProvider(provider) {
+		return nil, fmt.Errorf("new importer: unit-of-work provider must not be nil")
+	}
+	return &importer{provider: provider}, nil
+}
+
+// importer lands one whole import batch through one unit of work.
+type importer struct {
+	provider UnitOfWorkProvider
+}
+
+var _ publicops.Importer = (*importer)(nil)
+
+// ImportBatch writes the whole batch in ONE unit of work and commits it as
+// ONE history entry: the issue rows through the SAME batch-upsert engine the
+// classic stores run (internal/storage/issueops.CreateIssuesInTxWithResult —
+// conditional row upsert, idempotent label/comment/dependency merge, child
+// counters, blocked recompute), the memory records, and the optional
+// issue_prefix reconciliation. A request-level failure rolls all of it back.
+//
+// The engine's callbacks land in the result instead of being exposed on the
+// request: RunTxResult retries the whole attempt on a serialization failure,
+// and result state declared inside the attempt cannot leak between retries
+// the way a caller's callback accumulator would.
+func (o *importer) ImportBatch(ctx context.Context, request publicops.ImportBatchRequest) (publicops.ImportBatchResult, error) {
+	if request.Actor == "" {
+		return publicops.ImportBatchResult{}, fmt.Errorf("import batch: actor must not be empty")
+	}
+	return RunTxResult(ctx, o.provider, func(ctx context.Context, uw UnitOfWork) (publicops.ImportBatchResult, string, error) {
+		var result publicops.ImportBatchResult
+
+		if len(request.Issues) > 0 {
+			runner, err := importStatementRunner(uw)
+			if err != nil {
+				return publicops.ImportBatchResult{}, "", err
+			}
+			staleRejected := make(map[string]struct{})
+			skippedSeen := make(map[string]struct{})
+			opts := storage.BatchCreateOptions{
+				OrphanHandling:                 storage.OrphanAllow,
+				SkipPrefixValidation:           request.SkipPrefixValidation,
+				RejectStaleUpserts:             !request.AllowStale,
+				SkipDependencyValidationErrors: true,
+				OnSkippedDependency: func(issueID, dependsOnID, reason string) {
+					key := issueID + "\x00" + dependsOnID + "\x00" + reason
+					if _, ok := skippedSeen[key]; ok {
+						return
+					}
+					skippedSeen[key] = struct{}{}
+					result.SkippedDependencies = append(result.SkippedDependencies, publicops.SkippedDependency{
+						IssueID:     issueID,
+						DependsOnID: dependsOnID,
+						Reason:      reason,
+					})
+				},
+				OnStaleRejected: func(issueID string) {
+					if _, ok := staleRejected[issueID]; ok {
+						return
+					}
+					staleRejected[issueID] = struct{}{}
+					result.StaleRejectedIDs = append(result.StaleRejectedIDs, issueID)
+				},
+			}
+			if _, err := storageissueops.CreateIssuesInTxWithResult(ctx, runner, request.Issues, request.Actor, opts); err != nil {
+				return publicops.ImportBatchResult{}, "", err
+			}
+			result.Created = len(request.Issues) - len(staleRejected)
+		}
+
+		if len(request.Memories) > 0 {
+			keys := make([]string, 0, len(request.Memories))
+			for key := range request.Memories {
+				keys = append(keys, key)
+			}
+			sort.Strings(keys)
+			for _, key := range keys {
+				if err := uw.ConfigUseCase().SetConfig(ctx, key, request.Memories[key]); err != nil {
+					return publicops.ImportBatchResult{}, "", fmt.Errorf("import memory %q: %w", key, err)
+				}
+			}
+			result.MemoriesImported = len(request.Memories)
+		}
+
+		// config.yaml is authoritative for issue_prefix on the import flow
+		// (be-llaf); a read or write failure here degrades to "not synced"
+		// rather than failing the batch, matching the classic path.
+		if request.SyncIssuePrefix != "" {
+			stored, _ := uw.ConfigUseCase().GetConfig(ctx, "issue_prefix")
+			if stored != request.SyncIssuePrefix {
+				if err := uw.ConfigUseCase().SetConfig(ctx, "issue_prefix", request.SyncIssuePrefix); err == nil {
+					result.PrefixSynced = true
+				}
+			}
+		}
+
+		return result, importBatchCommitMessage(request, result), nil
+	})
+}
+
+// importBatchCommitMessage names what LANDED, in the exact shape the classic
+// `bd import` has always committed. A batch that landed no issue rows and no
+// memories but did reconcile the prefix commits under the sync message the
+// classic path used for its separate config commit; a batch that landed
+// nothing at all returns "" and commits nothing.
+func importBatchCommitMessage(request publicops.ImportBatchRequest, result publicops.ImportBatchResult) string {
+	if result.Created > 0 || result.MemoriesImported > 0 {
+		msg := fmt.Sprintf("bd import: %d issues", result.Created)
+		if result.MemoriesImported > 0 {
+			msg += fmt.Sprintf(", %d memories", result.MemoriesImported)
+		}
+		return msg + fmt.Sprintf(" from %s", request.Source)
+	}
+	if result.PrefixSynced {
+		return "bd import: sync issue_prefix from config.yaml"
+	}
+	return ""
+}
+
+// importStatementRunner exposes the unit of work's statement runner to the
+// batch-upsert engine. The import role is deliberately NOT a use-case loop:
+// upsert semantics, aux-data merge, child counters and the blocked recompute
+// already live in internal/storage/issueops behind the DBTX seam, and the
+// domain/db Runner satisfies that seam, so the proxied path runs the SAME
+// code the classic stores run instead of mirroring it in parallel SQL.
+func importStatementRunner(uw UnitOfWork) (storageissueops.DBTX, error) {
+	b, ok := uw.(*baseUOW)
+	if !ok {
+		return nil, fmt.Errorf("uow: importer: %T does not expose a statement runner", uw)
+	}
+	return b.tx.Runner(), nil
+}

--- a/internal/storage/uow/importer_uow_test.go
+++ b/internal/storage/uow/importer_uow_test.go
@@ -1,0 +1,218 @@
+package uow
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+	publicops "github.com/steveyegge/beads/issueops"
+)
+
+// TestImporterUOW pins the Importer role's contract on the unit-of-work
+// backend: one ImportBatch call is one transaction and one history entry —
+// rows with their aux data, memories, and the issue_prefix reconciliation
+// together — and the in-transaction stale guard reports what it kept.
+//
+// ONE PROVIDER FOR THE WHOLE SUITE (it boots a real Dolt sql-server) and NO
+// t.Parallel: dolt_log is database-global here, so a parallel subtest would
+// move another subtest's history delta.
+func TestImporterUOW(t *testing.T) {
+	ctx := context.Background()
+	provider := newUOWRoleFixtureProvider(t, ctx, "imp")
+	kit := newUOWRoleFixtureKit(provider, "imp")
+
+	source, ok := provider.(ImporterSource)
+	if !ok {
+		t.Fatalf("provider %T does not offer the Importer accessor", provider)
+	}
+	imp, err := source.Importer()
+	if err != nil {
+		t.Fatalf("Importer(): %v", err)
+	}
+
+	countHistory := func(t *testing.T) int {
+		t.Helper()
+		n, err := kit.CountHistory(ctx)
+		if err != nil {
+			t.Fatalf("CountHistory: %v", err)
+		}
+		return n
+	}
+	queryInt := func(t *testing.T, query string, args ...any) int {
+		t.Helper()
+		var n int
+		if err := kit.QueryScalar(ctx, query, args, &n); err != nil {
+			t.Fatalf("QueryScalar %q: %v", query, err)
+		}
+		return n
+	}
+	queryString := func(t *testing.T, query string, args ...any) string {
+		t.Helper()
+		var s string
+		if err := kit.QueryScalar(ctx, query, args, &s); err != nil {
+			t.Fatalf("QueryScalar %q: %v", query, err)
+		}
+		return s
+	}
+
+	t.Run("OneBatchIsOneHistoryEntryWithAuxDataAndMemories", func(t *testing.T) {
+		before := countHistory(t)
+		when := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+		result, err := imp.ImportBatch(ctx, publicops.ImportBatchRequest{
+			Actor: "importer-test",
+			Issues: []*types.Issue{
+				{
+					ID: "imp-one", Title: "Imported one", Status: types.StatusOpen,
+					IssueType: types.TypeTask, Priority: 2,
+					Labels:    []string{"lane:test", "imported"},
+					Comments:  []*types.Comment{{ID: "imp-one-c1", Author: "importer-test", Text: "carried comment", CreatedAt: when}},
+					CreatedAt: when, UpdatedAt: when,
+				},
+				{
+					ID: "imp-two", Title: "Imported two", Status: types.StatusOpen,
+					IssueType: types.TypeBug, Priority: 1,
+					Dependencies: []*types.Dependency{{IssueID: "imp-two", DependsOnID: "imp-one", Type: types.DepBlocks}},
+					CreatedAt:    when, UpdatedAt: when,
+				},
+			},
+			Memories: []publicops.ImportMemory{{Key: "kv.memory.importer-probe", Value: "remembered"}},
+			Source:   "importer_uow_test.jsonl",
+		})
+		if err != nil {
+			t.Fatalf("ImportBatch: %v", err)
+		}
+		if result.Created != 2 {
+			t.Errorf("Created = %d, want 2", result.Created)
+		}
+		if result.MemoriesImported != 1 {
+			t.Errorf("MemoriesImported = %d, want 1", result.MemoriesImported)
+		}
+		if len(result.StaleRejectedIDs) != 0 {
+			t.Errorf("StaleRejectedIDs = %v, want none", result.StaleRejectedIDs)
+		}
+
+		if after := countHistory(t); after != before+1 {
+			t.Errorf("history entries = %d, want %d (ONE commit for the whole batch)", after, before+1)
+		}
+		// Direct content assertions, not just row counts: the aux data must
+		// actually be present on the imported rows.
+		if got := queryInt(t, "SELECT COUNT(*) FROM issues WHERE id IN ('imp-one','imp-two')"); got != 2 {
+			t.Errorf("issue rows = %d, want 2", got)
+		}
+		if got := queryInt(t, "SELECT COUNT(*) FROM labels WHERE issue_id = 'imp-one'"); got != 2 {
+			t.Errorf("imp-one labels = %d, want 2", got)
+		}
+		if got := queryInt(t, "SELECT COUNT(*) FROM comments WHERE issue_id = 'imp-one'"); got != 1 {
+			t.Errorf("imp-one comments = %d, want 1", got)
+		}
+		if got := queryInt(t, "SELECT COUNT(*) FROM dependencies WHERE issue_id = 'imp-two' AND depends_on_issue_id = 'imp-one' AND type = 'blocks'"); got != 1 {
+			t.Errorf("imp-two blocks edge = %d, want 1", got)
+		}
+		if got := queryString(t, "SELECT value FROM config WHERE `key` = 'kv.memory.importer-probe'"); got != "remembered" {
+			t.Errorf("memory value = %q, want %q", got, "remembered")
+		}
+		if msg := queryString(t, "SELECT message FROM dolt_log ORDER BY date DESC, commit_hash LIMIT 1"); !strings.Contains(msg, "bd import: 2 issues, 1 memories from importer_uow_test.jsonl") {
+			t.Errorf("history message = %q, want the bd import message", msg)
+		}
+	})
+
+	t.Run("ReimportConvergesWithoutDuplicatingAuxData", func(t *testing.T) {
+		when := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+		row := func() *types.Issue {
+			return &types.Issue{
+				ID: "imp-one", Title: "Imported one", Status: types.StatusOpen,
+				IssueType: types.TypeTask, Priority: 2,
+				Labels:    []string{"lane:test", "imported"},
+				Comments:  []*types.Comment{{ID: "imp-one-c1", Author: "importer-test", Text: "carried comment", CreatedAt: when}},
+				CreatedAt: when, UpdatedAt: when,
+			}
+		}
+		if _, err := imp.ImportBatch(ctx, publicops.ImportBatchRequest{
+			Actor: "importer-test", Issues: []*types.Issue{row()}, Source: "again.jsonl",
+		}); err != nil {
+			t.Fatalf("re-import: %v", err)
+		}
+		if got := queryInt(t, "SELECT COUNT(*) FROM labels WHERE issue_id = 'imp-one'"); got != 2 {
+			t.Errorf("labels after re-import = %d, want 2 (idempotent merge)", got)
+		}
+		if got := queryInt(t, "SELECT COUNT(*) FROM comments WHERE issue_id = 'imp-one'"); got != 1 {
+			t.Errorf("comments after re-import = %d, want 1 (idempotent merge)", got)
+		}
+	})
+
+	t.Run("StaleGuardRejectsInsideTheTransactionUnlessAllowed", func(t *testing.T) {
+		old := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+		staleRow := func() *types.Issue {
+			return &types.Issue{
+				ID: "imp-one", Title: "Stale snapshot title", Status: types.StatusOpen,
+				IssueType: types.TypeTask, Priority: 3,
+				CreatedAt: old, UpdatedAt: old,
+			}
+		}
+		result, err := imp.ImportBatch(ctx, publicops.ImportBatchRequest{
+			Actor: "importer-test", Issues: []*types.Issue{staleRow()}, Source: "stale.jsonl",
+		})
+		if err != nil {
+			t.Fatalf("stale import: %v", err)
+		}
+		if len(result.StaleRejectedIDs) != 1 || result.StaleRejectedIDs[0] != "imp-one" {
+			t.Fatalf("StaleRejectedIDs = %v, want [imp-one]", result.StaleRejectedIDs)
+		}
+		if result.Created != 0 {
+			t.Errorf("Created = %d, want 0 (the only row was rejected)", result.Created)
+		}
+		if got := queryString(t, "SELECT title FROM issues WHERE id = 'imp-one'"); got != "Imported one" {
+			t.Errorf("title after stale import = %q, want local row kept", got)
+		}
+
+		if _, err := imp.ImportBatch(ctx, publicops.ImportBatchRequest{
+			Actor: "importer-test", Issues: []*types.Issue{staleRow()}, AllowStale: true, Source: "stale.jsonl",
+		}); err != nil {
+			t.Fatalf("allow-stale import: %v", err)
+		}
+		if got := queryString(t, "SELECT title FROM issues WHERE id = 'imp-one'"); got != "Stale snapshot title" {
+			t.Errorf("title after --allow-stale = %q, want the older snapshot restored", got)
+		}
+	})
+
+	t.Run("EmptyBatchCommitsNothing", func(t *testing.T) {
+		before := countHistory(t)
+		result, err := imp.ImportBatch(ctx, publicops.ImportBatchRequest{Actor: "importer-test", Source: "empty.jsonl"})
+		if err != nil {
+			t.Fatalf("empty ImportBatch: %v", err)
+		}
+		if result.Created != 0 || result.MemoriesImported != 0 || result.PrefixSynced {
+			t.Errorf("empty batch result = %+v, want zero outcome", result)
+		}
+		if after := countHistory(t); after != before {
+			t.Errorf("history entries moved %d -> %d on an empty batch", before, after)
+		}
+	})
+
+	t.Run("PrefixSyncAloneCommitsUnderTheSyncMessage", func(t *testing.T) {
+		result, err := imp.ImportBatch(ctx, publicops.ImportBatchRequest{
+			Actor: "importer-test", SyncIssuePrefix: "impx", Source: "prefix.jsonl",
+		})
+		if err != nil {
+			t.Fatalf("prefix-sync ImportBatch: %v", err)
+		}
+		if !result.PrefixSynced {
+			t.Fatalf("PrefixSynced = false, want true")
+		}
+		if got := queryString(t, "SELECT value FROM config WHERE `key` = 'issue_prefix'"); got != "impx" {
+			t.Errorf("issue_prefix = %q, want %q", got, "impx")
+		}
+		// Restore for any later subtest.
+		if err := kit.SetConfig(ctx, "issue_prefix", "imp"); err != nil {
+			t.Fatalf("restore issue_prefix: %v", err)
+		}
+	})
+
+	t.Run("EmptyActorIsRefused", func(t *testing.T) {
+		if _, err := imp.ImportBatch(ctx, publicops.ImportBatchRequest{Source: "noactor.jsonl"}); err == nil {
+			t.Fatal("ImportBatch with empty actor should be refused")
+		}
+	})
+}

--- a/issueops/importer.go
+++ b/issueops/importer.go
@@ -15,9 +15,11 @@ type ImportBatchRequest struct {
 	// conditionally rewritten (see AllowStale), and labels, comments and
 	// dependencies merge idempotently.
 	Issues []*Issue
-	// Memories maps full config keys (the caller applies its kv prefixes) to
-	// values, imported alongside the issues in the same transaction.
-	Memories map[string]string
+	// Memories are the memory records, in file order, imported alongside the
+	// issues in the same transaction. Keys are full config keys (the caller
+	// applies its kv prefixes); a duplicated key writes twice and the later
+	// record wins, which is the classic import's sequential behavior.
+	Memories []ImportMemory
 	// AllowStale imports rows even when their updated_at is older than the
 	// stored issue's. When false, the engine's conditional upsert rejects the
 	// stale row inside the transaction and reports it in StaleRejectedIDs —
@@ -36,6 +38,12 @@ type ImportBatchRequest struct {
 	// Source names where the rows came from (a file basename or "stdin") and
 	// appears in the history entry's message.
 	Source string
+}
+
+// ImportMemory is one memory record ('bd remember') carried by an import.
+type ImportMemory struct {
+	Key   string
+	Value string
 }
 
 // SkippedDependency reports one dependency edge the import dropped rather

--- a/issueops/importer.go
+++ b/issueops/importer.go
@@ -1,0 +1,73 @@
+package issueops
+
+import "context"
+
+// ImportBatchRequest is one whole `bd import` invocation's write: every issue
+// row that survived the caller's pre-filters, every memory record, and the
+// optional issue_prefix reconciliation, landed in ONE transaction and ONE
+// history entry. The request is the transaction: there is no handle to hold
+// open, and a request-level failure rolls the whole import back.
+type ImportBatchRequest struct {
+	// Actor is recorded as the creator/mutator on every row the batch writes.
+	Actor string
+	// Issues are the parsed import rows, in file order. Row semantics are the
+	// import's standing upsert contract: a new ID inserts, an existing ID is
+	// conditionally rewritten (see AllowStale), and labels, comments and
+	// dependencies merge idempotently.
+	Issues []*Issue
+	// Memories maps full config keys (the caller applies its kv prefixes) to
+	// values, imported alongside the issues in the same transaction.
+	Memories map[string]string
+	// AllowStale imports rows even when their updated_at is older than the
+	// stored issue's. When false, the engine's conditional upsert rejects the
+	// stale row inside the transaction and reports it in StaleRejectedIDs —
+	// the in-transaction half of the import's two-half stale guard.
+	AllowStale bool
+	// SkipPrefixValidation admits rows whose ID prefix differs from the
+	// workspace's configured issue prefix, which is what an explicit
+	// `bd import` has always done.
+	SkipPrefixValidation bool
+	// SyncIssuePrefix, when non-empty, is the caller's authoritative issue
+	// prefix (config.yaml); if it differs from the stored issue_prefix the
+	// batch rewrites the stored value in the same transaction. Existing issue
+	// IDs are intentionally left unchanged: this is the import/migration
+	// reconciliation, not a rename.
+	SyncIssuePrefix string
+	// Source names where the rows came from (a file basename or "stdin") and
+	// appears in the history entry's message.
+	Source string
+}
+
+// SkippedDependency reports one dependency edge the import dropped rather
+// than failing the batch: its target is missing, invalid, or would form a
+// disallowed edge.
+type SkippedDependency struct {
+	IssueID     string
+	DependsOnID string
+	Reason      string
+}
+
+// ImportBatchResult reports what one import batch landed.
+type ImportBatchResult struct {
+	// Created counts the rows the batch wrote — inserts and rewrites alike —
+	// excluding stale-rejected rows.
+	Created int
+	// MemoriesImported counts the memory records written.
+	MemoriesImported int
+	// StaleRejectedIDs lists rows the in-transaction stale guard rejected: a
+	// locally-newer row kept every stored column. Deduplicated by ID.
+	StaleRejectedIDs []string
+	// SkippedDependencies lists the edges dropped by the batch, deduplicated.
+	SkippedDependencies []SkippedDependency
+	// PrefixSynced reports that the stored issue_prefix was rewritten to
+	// SyncIssuePrefix.
+	PrefixSynced bool
+}
+
+// Importer lands one whole import batch in one transaction with one history
+// entry. It is the sanctioned bulk-upsert door: Create refuses an occupied
+// ID, and this role is where re-importing an exported snapshot converges
+// instead of colliding.
+type Importer interface {
+	ImportBatch(ctx context.Context, request ImportBatchRequest) (ImportBatchResult, error)
+}


### PR DESCRIPTION
Ports `bd import` to proxied-server mode (bd-o58fz), removing the refusal at cmd/bd/import.go:120-122. Continues the DBTX foundation commit ad4065cf6.

## Approach

**One engine, two transports.** The predecessor commit widened `internal/storage/issueops.CreateIssuesInTxWithResult` and its transitive closure (batch context, ID generation, orphan check, conditional upsert, label/comment/dependency persistence, child counters, blocked recompute) from `*sql.Tx` to the existing `DBTX` interface. The domain/db `Runner` satisfies that seam, so the proxied import runs the SAME batch-upsert code the classic stores run — no parallel SQL mirror. The domain stubs (`domain.BatchCreateOptions`/`Issue`/`ImportResult`, config.go:72-78) stay untouched and unused; the port routes around them via DBTX.

Three layers:

1. **`issueops.Importer`** (public capability, `issueops/importer.go`): `ImportBatch(ctx, ImportBatchRequest) (ImportBatchResult, error)` — one whole invocation's write (issue rows, memories, optional issue_prefix reconciliation) in ONE unit of work with ONE history entry.
2. **uow implementation** (`internal/storage/uow/importer.go`): `ImporterSource` accessor on `doltSQLProvider` (BatchCloserSource pattern), `RunTxResult` body calling `CreateIssuesInTxWithResult` against the tx runner. Engine callbacks are folded into the result *inside the attempt*, so serialization-retry re-runs cannot double-count.
3. **CLI** (`cmd/bd/import_proxied_server.go` + refactor): the parse loop, `--dedup` filter, dry-run classification, stale pre-filter, result assembly and reporting are now shared seam-based code (`importIssueLookup` = `GetIssuesByIDs`, satisfied by both `storage.DoltStorage` and the UOW's `domain.IssueUseCase`; `importTitleSearcher` for dedup, with the `types.IssueFilter`-naming seam kept inside import.go, the forbidigo-exempt file). Both modes classify and report through the same functions; `assembleImportResult` is one function so stale-rejection attribution cannot drift.

## Classic option → proxied mapping

| Classic (`storage.BatchCreateOptions` built in import_shared.go) | Proxied (`ImportBatchRequest` → uow impl) |
|---|---|
| `OrphanHandling: OrphanAllow` | fixed `OrphanAllow` in the importer impl (import policy, one place) |
| `SkipPrefixValidation: opts.SkipPrefixValidation` | `request.SkipPrefixValidation` (explicit `bd import` passes true, same as classic) |
| `RejectStaleUpserts: !opts.AllowStale` | `!request.AllowStale` — same in-transaction half of the two-half stale guard |
| `ConflictSkip: opts.ConflictSkip` | never set: explicit `bd import` keeps UPSERT semantics (classic explicit import also never sets it; the GH#3955 auto-import fallback that uses it remains classic-only) |
| `SkipDependencyValidationErrors: true` | fixed true, same |
| `OnSkippedDependency` callback → formatted strings, deduped | collected as `[]SkippedDependency` in the RESULT (deduped per attempt); CLI formats `"%s -> %s: %s"` identically |
| `OnStaleRejected` callback → `staleRejectedSet` | collected as `StaleRejectedIDs` in the RESULT; CLI rebuilds the set and feeds the same `assembleImportResult` |

## One commit per invocation

No PostRun auto-commit in proxied mode; exactly one `RunTxResult` with a non-empty commit message per invocation. Consequences (deliberate divergences from classic, all doctrine-driven):

- **No chunking.** Classic chunks >250-row imports into bounded transactions (a SQLite write-lock fairness measure) with per-chunk progress. Proxied lands any size in one transaction/one `DOLT_COMMIT('-Am')` — chunking's rationale does not apply to the dolt server, and the one-commit doctrine forbids it. Dependency ordering/deferral machinery is unnecessary in the single-transaction shape (the engine handles all edges inline, exactly like classic's small-import path).
- **Prefix sync rides the same commit.** Classic commits the be-llaf issue_prefix sync separately via `CommitWithConfig` (its `store.Commit` skips the config table, GH#2455); `DOLT_COMMIT('-Am')` has no such split, so rows + memories + prefix sync are one history entry. A prefix-sync-only invocation commits under the classic sync message `"bd import: sync issue_prefix from config.yaml"`.
- Commit message otherwise byte-identical to classic: `bd import: N issues[, M memories] from <basename>`; a nothing-landed batch commits nothing ("nothing to commit" absorbed by RunTxResult, same as an identical-snapshot re-import).

The **stale guard keeps its classic two-half shape**: pre-filter in its own read (reports StaleSkippedIDs, keeps stale rows' aux data out of the batch), `RejectStaleUpserts` re-checks `updated_at` inside the write transaction, closing the same pre-filter→write race classic closes.

Memories are an ordered `[]ImportMemory` (file order, duplicates preserved, later record wins) — exact classic parity for both the sequential SetConfig behavior and the reported/committed memory count.

## CLI contract preserved

stdin `-` semantics (incl. the bd-axluy redirected-stdin-without-dash refusal, which runs before mode dispatch), `-i <file>`, bare `bd import` default-path resolution, `--dry-run`/`--json`/`--dedup`/`--allow-stale`, upsert/merge semantics (import stays the sanctioned upsert door), memories, and the exact human report (shared render functions, so the two modes cannot drift).

## Round-trip oracle (direct content assertions, not byte-equality)

`TestProxiedServerImport` (cmd/bd, gated on `BEADS_TEST_PROXIED_SERVER=1`, shared-container harness, parallel subtests each with their own project) asserts **presence of content** via raw-SQL oracles on the proxied DB plus `bd show`:

- round-trip: 3 rows landed; `labels` rows for the labeled issue = 2; comment **text** read back; `blocks` edge (issue_id, depends_on_issue_id, type) present; memory **value** in `config`; tombstone row NOT imported; closed row's status; `bd show` agrees with the raw oracle; **exactly 1 dolt commit** for the whole invocation (`DOLT_LOG` count since pre-import HEAD), and an identical re-import makes **0** commits with no duplicated labels/comments.
- stdin `-` + redirect guard; stale skip keeps the local title, `--allow-stale` restores the older snapshot, a newer row rewrites and reports `Updated 1 existing issue(s)`; `--dry-run --json` classifies (created=3) with 0 commits and 0 rows/memories written; `--dedup` skips the title-matched row only; occupied-ID upsert through import.

`TestImporterUOW` (internal/storage/uow, real dolt sql-server via the role-fixture harness) pins the capability itself: one batch = one history entry with label/comment/dependency/memory content assertions and the exact commit message; idempotent re-import; in-transaction stale rejection + `--allow-stale`; empty batch commits nothing; prefix-sync-only commits under the sync message; empty actor refused.

## Scope notes

- **Plane routing on import is unchanged classic behavior**: rows route via the same `TableRouting` (Ephemeral/NoHistory flags) the classic import uses — JSONL rows carry no table membership, so there is no new flag-based plane *classification* introduced here (re: the export-review note on PR #5351; a promoted no-history wisp re-imported from JSONL routes the same way in both modes).
- **Observed while testing, out of scope, flagged on the bead**: proxied `bd create --id <occupied>` reports success (`✓ Created issue:`) instead of the R1 refusal `TestParityCreateOnOccupiedIDRefuses` pins on the embedded path — that parity env is embedded-only. Not touched by this diff (create path unmodified).
- `bd export` remains refused in proxied mode (the export half is bd-v50ru, separate worktree/PR), so the journey test builds export-shaped fixtures by marshalling `types.Issue` rather than round-tripping through proxied `bd export`.
- The manifest for proxied-test-shard.sh deliberately gains no line: new `TestProxiedServer*` funcs hash-distribute automatically, and a manifest line naming a nonexistent/duplicate test fails CI.

## Verification (exit codes are the real shell exit codes)

- `go build ./...` — exit 0
- `go vet ./cmd/bd/ ./internal/... ./issueops/` — exit 0
- `BEADS_TEST_PROXIED_SERVER=1 go test ./cmd/bd/ -run 'TestImport|TestProxiedServerImport' -count=1 -timeout 25m` — **ok, exit 0, 28s** (classic TestImport* suite also re-run green after the refactor: 13.8s standalone)
- `go test ./internal/storage/... ./issueops/ -run 'Batch|Import' -count=1` — **all ok, exit 0, 33s** (incl. `TestImporterUOW` in the 27.9s uow package run, and the DBTX-widened engine under dolt/embeddeddolt/issueops)
- gosec/lint pre-commit hook: 0 issues on every commit; `gofmt -l` clean; no `types.IssueFilter`/`WorkFilter` naming outside the forbidigo-exempt import.go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
