### PR TITLE
fix(create): proxied create --id refuses occupied ids per R1 (bd-b8itp)

### DIFF
--- a/cmd/bd/create_proxied_integration_test.go
+++ b/cmd/bd/create_proxied_integration_test.go
@@ -5,8 +5,10 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -345,6 +347,51 @@ A new feature
 		}
 		if sourceRepo != "/path/to/repo" {
 			t.Errorf("source_repo: got %q, want %q", sourceRepo, "/path/to/repo")
+		}
+	})
+
+	// RULING R1 (TestParityCreateOnOccupiedIDRefuses): `bd create --id` on an
+	// occupied ID refuses with exit 1 and a fixed message, leaving the
+	// pre-existing row untouched. This is the proxied twin of the embedded
+	// parity pin — before the bd-b8itp fix the proxied route sent the
+	// domain-level upsert form and silently destroyed the existing issue
+	// while reporting "Created issue:".
+	t.Run("occupied_id_refuses", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "oc")
+		seeded := bdProxiedCreate(t, bd, p.dir, "Original title",
+			"--id", "oc-occ1", "-d", "original description", "-p", "0")
+		if seeded.ID != "oc-occ1" {
+			t.Fatalf("seed ID = %q, want oc-occ1", seeded.ID)
+		}
+
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "create", "Replacement title",
+			"--id", "oc-occ1", "-d", "replacement description", "-p", "4")
+		if err == nil {
+			t.Fatalf("bd create --id oc-occ1 should have refused the occupied ID\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+		}
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+			t.Errorf("exit = %v, want exit code 1", err)
+		}
+		const wantErr = "Error: oc-occ1 already exists; use bd update, or bd import for upsert semantics\n"
+		if stderr != wantErr {
+			t.Errorf("stderr = %q, want %q", stderr, wantErr)
+		}
+		if stdout != "" {
+			t.Errorf("stdout = %q, want empty on a refused create", stdout)
+		}
+
+		db := openProxiedDB(t, p)
+		var title, description string
+		var priority int
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT title, description, priority FROM issues WHERE id = ?", "oc-occ1").
+			Scan(&title, &description, &priority); err != nil {
+			t.Fatalf("query surviving row: %v", err)
+		}
+		if title != "Original title" || description != "original description" || priority != 0 {
+			t.Errorf("row after refused create = title=%q description=%q priority=%d, want the seeded values", title, description, priority)
 		}
 	})
 

--- a/cmd/bd/create_proxied_server.go
+++ b/cmd/bd/create_proxied_server.go
@@ -145,6 +145,14 @@ func runCreateProxiedSingle(_ *cobra.Command, ctx context.Context, in createInpu
 			// this can't drift from parseDepSpec's normalization rules.
 			DiscoveredFromParent: discoveredFromParentSpec(deps),
 			ForcePrefix:          in.force,
+			// RULING R1: `bd create` is create-only — an occupied --id must
+			// refuse, never silently upsert the existing row. This routes the
+			// insert through the domain's strict form (EnsureIssueIDAvailableInTx
+			// + InsertIssueStrictInTx, which still stamps a fresh row_lock)
+			// instead of the upsert-by-default insertIssueRow, matching the uow
+			// facade's createParams. Batch/upsert callers (bd import) keep the
+			// upsert form.
+			CreateOnly: true,
 		}
 
 		var result domain.CreateIssueResult
@@ -161,6 +169,12 @@ func runCreateProxiedSingle(_ *cobra.Command, ctx context.Context, in createInpu
 		return result.Issue, fmt.Sprintf("bd: create %s", result.Issue.ID), nil
 	})
 	if err != nil {
+		// RULING R1: an occupied --id is a refusal, not a silent full-row
+		// upsert reported as success. Same message and exit code as the
+		// embedded path (cmd/bd/create.go).
+		if errors.Is(err, storage.ErrAlreadyExists) && in.explicitID != "" {
+			return HandleErrorRespectJSON("%s already exists; use bd update, or bd import for upsert semantics", in.explicitID)
+		}
 		return HandleError("%v", err)
 	}
 


### PR DESCRIPTION
## Bug (bd-b8itp, program bd-vxavz)

Proxied-server `bd create --id <occupied>` silently upserted the existing row (full-row `ON DUPLICATE KEY UPDATE`) and reported `Created issue:` — violating RULING R1 (`bd create` is create-only; `bd import` is the sanctioned upsert door). Classic mode refuses correctly; the parity pin (`TestParityCreateOnOccupiedIDRefuses`) only covered the embedded env.

**Reproduce-first:** the new proxied subtest was written and run against the unpatched tree first — the second `create --id oc-occ1` succeeded with `✓ Created issue: oc-occ1 — Replacement title` (the silent clobber), then passes with the fix.

## Fix

One param + one error mapping in `runCreateProxiedSingle` (cmd/bd/create_proxied_server.go):

- `CreateOnly: true` in `domain.CreateIssueParams` — routes the insert through the domain's strict form (`EnsureIssueIDAvailableInTx` + `InsertIssueStrictInTx`, which stamps a fresh `row_lock` exactly like the upsert form). This is the identical convention the uow facade already uses (`createParams`, internal/storage/uow/issue_operations.go).
- `storage.ErrAlreadyExists` + explicit `--id` → the same refusal message/exit code as the embedded path (byte-identical to cmd/bd/create.go): `Error: <id> already exists; use bd update, or bd import for upsert semantics`, exit 1.

The upsert SQL (`insertIssueRow`) is untouched — batch/upsert callers (embedded import stack, other proxied verbs `quick`/`gate`/`state`/`todo`/`mol_port`) keep upserting. Duplicate-key errors classify as `backoff.Permanent` (only serialization errors 1213/1205/40001/40P01 retry), so the refusal surfaces immediately.

## Tests

- New pin: `TestProxiedServerCreate2/occupied_id_refuses` (create_proxied_integration_test.go) — exit 1, exact stderr, empty stdout, and the seeded row asserted intact via direct DB read. `TestProxiedServerCreate2` is already in the shard manifest (15 5) — no manifest change.
- Proxied create family green; import upsert proof green (`TestEmbeddedImport/upsert_existing`, `TestImportFromLocalJSONL`); `go build`/`go vet`/`gofmt` clean.
- 6 `TestParity*` fails in the dev env are ambient (missing `git config beads.role` polluting exact-stderr asserts) — **FAIL-set identical on an unpatched-baseline A/B** (name-only diff empty), the bd-vb2u0 pattern.

## Reviewer notes

- Behavior note: with `CreateOnly` set, domain create re-validates the explicit-ID prefix against the server DB's raw `issue_prefix`/`allowed_prefixes` (no YAML overlay) — matching serve-mode facade behavior, which has always validated this way. A shared-server workspace whose YAML prefix diverges from the DB prefix could now hit `ErrPrefixMismatch` where it previously (wrongly) upserted; `--force` bypasses. Flagged for a beadable note if that shape exists in the wild.
- Markdown-batch and graph proxied create paths deliberately untouched (markdown takes no explicit IDs; graph has its own in-tx collision preflight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)