### PR TITLE
feat(heartbeat): port bd heartbeat to proxied-server mode (bd-aq0ql)

### DIFF
--- a/.github/scripts/proxied-cmd-test-shards.txt
+++ b/.github/scripts/proxied-cmd-test-shards.txt
@@ -66,6 +66,7 @@
 15 7 TestProxiedServerClose
 15 7 TestProxiedServerCloseConcurrent
 15 7 TestProxiedServerExternalCreate
+15 7 TestProxiedServerHeartbeat
 15 7 TestProxiedServerMolStale
 15 7 TestProxiedServerReadyWisp
 15 7 TestProxiedServerReclaim

--- a/cmd/bd/heartbeat.go
+++ b/cmd/bd/heartbeat.go
@@ -36,9 +36,6 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if usesProxiedServer() {
-			return HandleErrorRespectJSON("heartbeat is not supported in proxied-server mode")
-		}
 		CheckReadonly("heartbeat")
 
 		evt := metrics.NewCommandEvent("heartbeat")
@@ -50,6 +47,10 @@ Examples:
 
 		ctx := rootCtx
 		id := args[0]
+
+		if usesProxiedServer() {
+			return runHeartbeatProxiedServer(ctx, id)
+		}
 
 		result, err := resolveAndGetIssueForMutation(ctx, store, id)
 		if err != nil {
@@ -80,16 +81,24 @@ Examples:
 
 		SetLastTouchedID(result.ResolvedID)
 
-		if jsonOutput {
-			return outputJSON(map[string]string{
-				"id":     result.ResolvedID,
-				"status": "heartbeat",
-				"owner":  actor,
-			})
-		}
-		fmt.Printf("%s Heartbeat %s (lease refreshed)\n", ui.RenderPass("✓"), formatFeedbackID(result.ResolvedID, result.Issue.Title))
-		return nil
+		return renderHeartbeatSuccess(result.ResolvedID, result.Issue.Title)
 	},
+}
+
+// renderHeartbeatSuccess prints the success shape both storage routes share —
+// the classic path and the proxied-server path (heartbeat_proxied_server.go)
+// call exactly this code, so the --json contract workers parse
+// ({"id","status":"heartbeat","owner"}) cannot drift between modes.
+func renderHeartbeatSuccess(id, title string) error {
+	if jsonOutput {
+		return outputJSON(map[string]string{
+			"id":     id,
+			"status": "heartbeat",
+			"owner":  actor,
+		})
+	}
+	fmt.Printf("%s Heartbeat %s (lease refreshed)\n", ui.RenderPass("✓"), formatFeedbackID(id, title))
+	return nil
 }
 
 func init() {

--- a/cmd/bd/heartbeat_proxied_integration_test.go
+++ b/cmd/bd/heartbeat_proxied_integration_test.go
@@ -1,0 +1,237 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestProxiedServerHeartbeat journeys bd heartbeat through the proxied-server
+// plane (bd-aq0ql). The worker contract is the exit code (workers call
+// heartbeat every ~90s and only check rc), the --json success shape is
+// {"id","status":"heartbeat","owner"}, and — the bd-lrgn1 invariant — a
+// heartbeat mints exactly ZERO Dolt commits: the lease write lands in the
+// dolt_ignored leases table via the SQL-only ephemeral commit, with the same
+// timestamps/format classic `bd reclaim` staleness semantics consume (the
+// SQL body is literally issueops.HeartbeatIssueInTx in both modes).
+func TestProxiedServerHeartbeat(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+	p := newSharedProxiedProject(t, bd, "hbt")
+
+	db := openProxiedDB(t, p)
+
+	leaseRow := func(t *testing.T, id string) (holder string, expires, heartbeat time.Time, ok bool) {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		err := db.QueryRowContext(ctx,
+			"SELECT holder, lease_expires_at, heartbeat_at FROM leases WHERE issue_id = ?", id,
+		).Scan(&holder, &expires, &heartbeat)
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", time.Time{}, time.Time{}, false
+		}
+		if err != nil {
+			t.Fatalf("read lease row for %s: %v", id, err)
+		}
+		return holder, expires, heartbeat, true
+	}
+
+	doltCommits := func(t *testing.T) int {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		var n int
+		if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM dolt_log").Scan(&n); err != nil {
+			t.Fatalf("count dolt_log: %v", err)
+		}
+		return n
+	}
+
+	backdateLease := func(t *testing.T, id string, by time.Duration) {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		past := time.Now().UTC().Add(-by)
+		res, err := db.ExecContext(ctx,
+			"UPDATE leases SET lease_expires_at = ?, heartbeat_at = ? WHERE issue_id = ?", past, past, id)
+		if err != nil {
+			t.Fatalf("backdate lease for %s: %v", id, err)
+		}
+		if n, _ := res.RowsAffected(); n == 0 {
+			t.Fatalf("no lease row to backdate for %s", id)
+		}
+	}
+
+	t.Run("refreshes_lease_zero_dolt_commits", func(t *testing.T) {
+		issue := bdProxiedCreate(t, bd, p.dir, "Heartbeat target", "--type", "task")
+		bdProxiedUpdate(t, bd, p.dir, issue.ID, "--claim", "--actor", "worker-7")
+		if holder, _, _, ok := leaseRow(t, issue.ID); !ok || holder != "worker-7" {
+			t.Fatalf("claim did not arm a worker-7 lease (ok=%v holder=%q)", ok, holder)
+		}
+
+		// Make the lease stale so the refresh is unambiguous, then rescue it.
+		backdateLease(t, issue.ID, time.Hour)
+		_, preExpires, preHeartbeat, _ := leaseRow(t, issue.ID)
+
+		commitsBefore := doltCommits(t)
+		out, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "--actor", "worker-7", "heartbeat", issue.ID)
+		if err != nil {
+			t.Fatalf("heartbeat: %v\nstdout:\n%s\nstderr:\n%s", err, out, stderr)
+		}
+		if !strings.Contains(out, "Heartbeat "+issue.ID) || !strings.Contains(out, "(lease refreshed)") {
+			t.Errorf("unexpected heartbeat output:\n%s", out)
+		}
+
+		// The bd-lrgn1 acceptance criterion, proxied edition: the lease
+		// advanced but dolt_log is byte-for-byte the same length — the write
+		// rode the SQL-only ephemeral commit, no Dolt commit, no history.
+		if commitsAfter := doltCommits(t); commitsAfter != commitsBefore {
+			t.Errorf("heartbeat minted Dolt commits: %d -> %d", commitsBefore, commitsAfter)
+		}
+		holder, expires, heartbeat, ok := leaseRow(t, issue.ID)
+		if !ok {
+			t.Fatal("lease row vanished after heartbeat")
+		}
+		if holder != "worker-7" {
+			t.Errorf("holder = %q, want worker-7 (heartbeat must not move the lease)", holder)
+		}
+		if !expires.After(preExpires) || !expires.After(time.Now().UTC()) {
+			t.Errorf("lease_expires_at not pushed into the future: pre=%v post=%v", preExpires, expires)
+		}
+		if !heartbeat.After(preHeartbeat) {
+			t.Errorf("heartbeat_at not advanced: pre=%v post=%v", preHeartbeat, heartbeat)
+		}
+
+		// Classic-staleness parity: the freshly-heartbeaten lease reads as
+		// live to the reclaim sweep (reclaim consumes the very timestamps
+		// heartbeat just wrote — same clock, same format).
+		rout, rerr := bdProxiedRun(t, bd, p.dir, "reclaim", "--older-than", "0s", "--json")
+		if rerr != nil {
+			t.Fatalf("reclaim: %v\n%s", rerr, rout)
+		}
+		if strings.Contains(string(rout), issue.ID) {
+			t.Errorf("reclaim reverted a just-heartbeaten lease:\n%s", rout)
+		}
+	})
+
+	t.Run("json_shape", func(t *testing.T) {
+		issue := bdProxiedCreate(t, bd, p.dir, "JSON heartbeat", "--type", "task")
+		bdProxiedUpdate(t, bd, p.dir, issue.ID, "--claim", "--actor", "worker-json")
+
+		out, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "--actor", "worker-json", "heartbeat", issue.ID, "--json")
+		if err != nil {
+			t.Fatalf("heartbeat --json: %v\nstdout:\n%s\nstderr:\n%s", err, out, stderr)
+		}
+		s := strings.TrimSpace(out)
+		start := strings.Index(s, "{")
+		if start < 0 {
+			t.Fatalf("no JSON object in heartbeat --json output:\n%s", out)
+		}
+		var got map[string]any
+		if err := json.Unmarshal([]byte(s[start:]), &got); err != nil {
+			t.Fatalf("parse heartbeat --json: %v\n%s", err, out)
+		}
+		// outputJSON envelopes every payload with schema_version (both modes);
+		// the heartbeat contract on top of it is exactly id/status/owner.
+		want := map[string]string{"id": issue.ID, "status": "heartbeat", "owner": "worker-json"}
+		for k, v := range want {
+			if got[k] != v {
+				t.Errorf("heartbeat --json .%s = %v, want %q", k, got[k], v)
+			}
+		}
+		delete(got, "schema_version")
+		if len(got) != len(want) {
+			t.Errorf("heartbeat --json shape drifted: got %v, want exactly keys id/status/owner", got)
+		}
+	})
+
+	t.Run("wrong_owner_refused", func(t *testing.T) {
+		issue := bdProxiedCreate(t, bd, p.dir, "Not your lease", "--type", "task")
+		bdProxiedUpdate(t, bd, p.dir, issue.ID, "--claim", "--actor", "worker-7")
+		_, preExpires, _, _ := leaseRow(t, issue.ID)
+
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "--actor", "intruder", "heartbeat", issue.ID)
+		if err == nil {
+			t.Fatalf("expected nonzero exit for wrong-owner heartbeat, got success:\n%s", stdout)
+		}
+		if combined := stdout + stderr; !strings.Contains(combined, "already claimed") {
+			t.Errorf("expected 'already claimed' classification, got:\n%s", combined)
+		}
+		if _, expires, _, ok := leaseRow(t, issue.ID); !ok || !expires.Equal(preExpires) {
+			t.Errorf("wrong-owner heartbeat must not touch the lease (ok=%v pre=%v post=%v)", ok, preExpires, expires)
+		}
+	})
+
+	t.Run("unclaimed_refused", func(t *testing.T) {
+		issue := bdProxiedCreate(t, bd, p.dir, "Never claimed", "--type", "task")
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "--actor", "worker-7", "heartbeat", issue.ID)
+		if err == nil {
+			t.Fatalf("expected nonzero exit heartbeating an unclaimed issue, got success:\n%s", stdout)
+		}
+		if combined := stdout + stderr; !strings.Contains(combined, "not claimable") {
+			t.Errorf("expected 'not claimable' classification, got:\n%s", combined)
+		}
+	})
+
+	t.Run("closed_refused", func(t *testing.T) {
+		issue := bdProxiedCreate(t, bd, p.dir, "Closed lease", "--type", "task")
+		bdProxiedUpdate(t, bd, p.dir, issue.ID, "--claim", "--actor", "worker-7")
+		if out, err := bdProxiedRun(t, bd, p.dir, "--actor", "worker-7", "close", issue.ID); err != nil {
+			t.Fatalf("close: %v\n%s", err, out)
+		}
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "--actor", "worker-7", "heartbeat", issue.ID)
+		if err == nil {
+			t.Fatalf("expected nonzero exit heartbeating a closed issue (worker must learn to stop), got:\n%s", stdout)
+		}
+		if combined := stdout + stderr; !strings.Contains(combined, "not claimable") {
+			t.Errorf("expected 'not claimable' classification, got:\n%s", combined)
+		}
+	})
+
+	t.Run("missing_refused", func(t *testing.T) {
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "heartbeat", "hbt-doesnotexist")
+		if err == nil {
+			t.Fatalf("expected nonzero exit for a missing id, got success:\n%s", stdout)
+		}
+		if combined := stdout + stderr; !strings.Contains(combined, "not found") {
+			t.Errorf("expected 'not found' error, got:\n%s", combined)
+		}
+	})
+
+	t.Run("rearms_hand_doled_claim", func(t *testing.T) {
+		// A claim hand-doled through a generic update never arms a lease
+		// (bd-9hpgf); the holder's first heartbeat opts into lease semantics.
+		// This is the INSERT path of the lease write, so it doubles as the
+		// zero-Dolt-commit proof for UpsertLeaseInTx under the ephemeral
+		// commit.
+		issue := bdProxiedCreate(t, bd, p.dir, "Hand-doled claim", "--type", "task")
+		bdProxiedUpdate(t, bd, p.dir, issue.ID, "--assignee", "hand-worker", "--status", "in_progress")
+		if _, _, _, ok := leaseRow(t, issue.ID); ok {
+			t.Fatal("generic update must not arm a lease")
+		}
+
+		commitsBefore := doltCommits(t)
+		out, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "--actor", "hand-worker", "heartbeat", issue.ID)
+		if err != nil {
+			t.Fatalf("re-arm heartbeat: %v\nstdout:\n%s\nstderr:\n%s", err, out, stderr)
+		}
+		if commitsAfter := doltCommits(t); commitsAfter != commitsBefore {
+			t.Errorf("re-arm heartbeat minted Dolt commits: %d -> %d", commitsBefore, commitsAfter)
+		}
+		holder, expires, _, ok := leaseRow(t, issue.ID)
+		if !ok || holder != "hand-worker" {
+			t.Fatalf("heartbeat should have armed a hand-worker lease (ok=%v holder=%q)", ok, holder)
+		}
+		if !expires.After(time.Now().UTC()) {
+			t.Errorf("re-armed lease_expires_at should be in the future, got %v", expires)
+		}
+	})
+}

--- a/cmd/bd/heartbeat_proxied_server.go
+++ b/cmd/bd/heartbeat_proxied_server.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/uow"
+	"github.com/steveyegge/beads/internal/workapi"
+)
+
+// heartbeatProxiedOutcome carries what the render layer needs out of the
+// transaction: the fully-resolved ID and the title for the feedback line.
+type heartbeatProxiedOutcome struct {
+	id    string
+	title string
+}
+
+// runHeartbeatProxiedServer routes bd heartbeat through the proxied-server
+// plane. The lease write is EPHEMERAL (the dolt_ignored leases table,
+// bd-lrgn1): the transaction commits via uow.RunTxEphemeral's SQL-only form,
+// so a heartbeat mints exactly ZERO Dolt commits per invocation — the same
+// commit discipline as the classic DoltStore.HeartbeatIssue, and deliberately
+// nothing here sets commandDidWrite or creates a Dolt commit. The exit code
+// is the worker contract (workers call this every ~90s and only check rc):
+// 0 = lease refreshed; nonzero = the lease is gone (wrong owner, not
+// in_progress, closed, reclaimed) and the worker should stop.
+func runHeartbeatProxiedServer(ctx context.Context, id string) error {
+	if uowProvider == nil {
+		return HandleErrorRespectJSON("proxied-server UOW provider not initialized")
+	}
+
+	res, err := uow.RunTxEphemeral(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (heartbeatProxiedOutcome, error) {
+		issue, _, rerr := workapi.GetIssueOrWisp(ctx, workapi.NewUOWDetailSource(uw), id)
+		if errors.Is(rerr, storage.ErrNotFound) {
+			return heartbeatProxiedOutcome{}, fmt.Errorf("issue %s not found", id)
+		}
+		if rerr != nil {
+			return heartbeatProxiedOutcome{}, fmt.Errorf("resolving %s: %w", id, rerr)
+		}
+		// Wisps resolve here too and are refused below: the repo verb
+		// classifies them ErrNotClaimable ("is ephemeral"), same as classic.
+		if herr := uw.IssueUseCase().Heartbeat(ctx, issue.ID, actor); herr != nil {
+			return heartbeatProxiedOutcome{}, fmt.Errorf("heartbeat %s: %w", issue.ID, herr)
+		}
+		return heartbeatProxiedOutcome{id: issue.ID, title: issue.Title}, nil
+	})
+	if err != nil {
+		return HandleErrorRespectJSON("%v", err)
+	}
+
+	SetLastTouchedID(res.id)
+	return renderHeartbeatSuccess(res.id, res.title)
+}

--- a/internal/storage/domain/db/issue.go
+++ b/internal/storage/domain/db/issue.go
@@ -1110,6 +1110,25 @@ func (r *issueSQLRepositoryImpl) UnclaimIssue(ctx context.Context, id, actor str
 	return nil
 }
 
+// HeartbeatIssue refreshes the lease on an issue actor holds in_progress,
+// mirroring DoltStore.HeartbeatIssue: wisps are ephemeral and never leased,
+// and the SQL work is the classic issueops.HeartbeatIssueInTx — same clock
+// (time.Now().UTC()), same TTL resolution (issueops.LeaseTTL), and the same
+// only-current-owner classification (storage.ErrAlreadyClaimed /
+// ErrNotClaimable) — so classic `bd reclaim` staleness semantics see proxied
+// heartbeats identically. Deliberately NO Dolt commit: the leases table is
+// dolt_ignored (bd-lrgn1), and the cmd layer commits this transaction with
+// uow.RunTxEphemeral (plain SQL COMMIT, nothing in dolt_log).
+func (r *issueSQLRepositoryImpl) HeartbeatIssue(ctx context.Context, id, actor string) error {
+	if issueops.IsActiveWispInTx(ctx, r.runner, id) {
+		return fmt.Errorf("db: IssueSQLRepository.HeartbeatIssue: %w: %s is ephemeral", storage.ErrNotClaimable, id)
+	}
+	if err := issueops.HeartbeatIssueInTx(ctx, r.runner, id, actor); err != nil {
+		return fmt.Errorf("db: IssueSQLRepository.HeartbeatIssue: %w", err)
+	}
+	return nil
+}
+
 func (r *issueSQLRepositoryImpl) ReclaimExpiredLeases(ctx context.Context, olderThan time.Duration, filter types.ReclaimFilter, actor string) ([]types.ReclaimedLease, error) {
 	cutoff := time.Now().UTC().Add(-olderThan)
 	out, err := issueops.ReclaimExpiredLeasesInTx(ctx, r.runner, cutoff, filter, actor)

--- a/internal/storage/domain/issue.go
+++ b/internal/storage/domain/issue.go
@@ -75,6 +75,7 @@ type IssueSQLRepository interface {
 	GetStaleIssues(ctx context.Context, filter types.StaleFilter) ([]*types.Issue, error)
 	GetEpicsEligibleForClosure(ctx context.Context) ([]*types.EpicStatus, error)
 	UnclaimIssue(ctx context.Context, id, actor string, force bool) error
+	HeartbeatIssue(ctx context.Context, id, actor string) error
 	ReclaimExpiredLeases(ctx context.Context, olderThan time.Duration, filter types.ReclaimFilter, actor string) ([]types.ReclaimedLease, error)
 }
 
@@ -282,6 +283,7 @@ type IssueUseCase interface {
 	GetStaleIssues(ctx context.Context, filter types.StaleFilter) ([]*types.Issue, error)
 	GetEpicsEligibleForClosure(ctx context.Context) ([]*types.EpicStatus, error)
 	Unclaim(ctx context.Context, id, actor string, force bool) error
+	Heartbeat(ctx context.Context, id, actor string) error
 	ReclaimExpiredLeases(ctx context.Context, olderThan time.Duration, filter types.ReclaimFilter, actor string) ([]types.ReclaimedLease, error)
 
 	CreateIssue(ctx context.Context, params CreateIssueParams, actor string) (CreateIssueResult, error)
@@ -1796,6 +1798,20 @@ func (u *issueUseCaseImpl) Unclaim(ctx context.Context, id, actor string, force 
 	}
 	if err := u.issueRepo.UnclaimIssue(ctx, id, actor, force); err != nil {
 		return fmt.Errorf("Unclaim: %w", err)
+	}
+	return nil
+}
+
+// Heartbeat refreshes the lease on an issue actor holds in_progress. The
+// write touches ONLY the ephemeral leases table (bd-lrgn1), so the caller
+// must run it under uow.RunTxEphemeral's no-Dolt-commit form — a heartbeat
+// mints no Dolt commit and no history in any mode (bd-aq0ql).
+func (u *issueUseCaseImpl) Heartbeat(ctx context.Context, id, actor string) error {
+	if id == "" {
+		return fmt.Errorf("Heartbeat: id must not be empty")
+	}
+	if err := u.issueRepo.HeartbeatIssue(ctx, id, actor); err != nil {
+		return fmt.Errorf("Heartbeat: %w", err)
 	}
 	return nil
 }

--- a/internal/storage/uow/doltserver_tx.go
+++ b/internal/storage/uow/doltserver_tx.go
@@ -24,7 +24,18 @@ func (t *doltServerTx) Commit(ctx context.Context, message string) error {
 	if t.done {
 		return errors.New("uow: commit: already done")
 	}
-	_, err := t.conn.ExecContext(ctx, "CALL DOLT_COMMIT('-Am', ?);", message)
+	// An empty message selects the EPHEMERAL commit form (bd-aq0ql): a plain
+	// SQL COMMIT persists the transaction's writes into the working set
+	// without minting a Dolt commit or history. This exists for work that
+	// touches ONLY dolt_ignored state — today the leases table (bd-lrgn1),
+	// whose heartbeats must never create commits — and is only reachable via
+	// uow.RunTxEphemeral: RunTx/RunTxResult treat an empty commitMsg as
+	// "nothing to commit" and never call Commit at all.
+	stmt, args := "CALL DOLT_COMMIT('-Am', ?);", []interface{}{message}
+	if message == "" {
+		stmt, args = "COMMIT;", nil
+	}
+	_, err := t.conn.ExecContext(ctx, stmt, args...)
 	if err == nil {
 		t.done = true
 		t.releaseConn()

--- a/internal/storage/uow/tx.go
+++ b/internal/storage/uow/tx.go
@@ -127,6 +127,58 @@ func RunTxResultWithin[T any](ctx context.Context, p UnitOfWorkProvider, maxElap
 	return result, err
 }
 
+// RunTxEphemeral is RunTxResult for work whose writes touch ONLY ephemeral
+// (dolt_ignored) state — today the leases table, whose writes must mint no
+// Dolt commit and no history (bd-lrgn1; ported to proxied mode by bd-aq0ql).
+// On success the attempt is committed with the SQL-only form (Tx.Commit with
+// an empty message ⇒ plain COMMIT, no DOLT_COMMIT), which persists the
+// working set but records nothing in dolt_log — the proxied analog of the
+// classic DoltStore.withRetryTx commit discipline that HeartbeatIssue relies
+// on. A serialization loser (heartbeat and reclaim/close contend on the same
+// lease row by design) is replayed against a fresh unit of work, exactly like
+// RunTxResult.
+//
+// Do NOT use this for work that writes versioned tables: those writes would
+// persist while silently bypassing Dolt history. Every versioned write goes
+// through RunTx/RunTxResult with a real commit message.
+func RunTxEphemeral[T any](ctx context.Context, p UnitOfWorkProvider, work TxReadFunc[T]) (T, error) {
+	var result T
+	bo := backoff.NewExponentialBackOff()
+	bo.InitialInterval = txRetryInitialInterval
+	bo.MaxElapsedTime = DefaultTxRetryMaxElapsed
+
+	err := backoff.Retry(func() error {
+		uw, err := p.NewUOW(ctx)
+		if err != nil {
+			if isSerializationError(err) {
+				return err
+			}
+			return backoff.Permanent(err)
+		}
+		defer closeAttempt(ctx, uw)
+
+		r, err := work(ctx, uw)
+		if err != nil {
+			if isSerializationError(err) {
+				return err
+			}
+			return backoff.Permanent(err)
+		}
+
+		if err := uw.Commit(ctx, ""); err != nil {
+			if isSerializationError(err) {
+				return err
+			}
+			return backoff.Permanent(err)
+		}
+
+		result = r
+		return nil
+	}, backoff.WithContext(bo, ctx))
+
+	return result, err
+}
+
 func RunTxRead[T any](ctx context.Context, p UnitOfWorkProvider, work TxReadFunc[T]) (T, error) {
 	var zero T
 	uw, err := p.NewUOW(ctx)


### PR DESCRIPTION
## What (bd-aq0ql, program bd-vxavz)

`bd heartbeat` stops refusing proxied-server mode and routes through the UOW plane, preserving the two properties that define heartbeat:

**1. ZERO Dolt commits per invocation (bd-lrgn1).** The recon's assumed shape (empty commitMsg on `RunTx*`) turned out to ROLL BACK the transaction — `RunTxResultWithin` skips `Commit` entirely on `commitMsg == ""` — which would silently lose the lease write. So the port adds the explicit ephemeral form:
- `uow.RunTxEphemeral` — same backoff/serialization-replay loop as `RunTxResult`, but commits with `uw.Commit(ctx, "")`.
- `doltServerTx.Commit` with an empty message now issues plain `COMMIT;` instead of `CALL DOLT_COMMIT('-Am', ?)` — persists the working set (the dolt_ignored leases table), mints nothing in dolt_log. This branch is unreachable from `RunTx`/`RunTxResult` (verified: they skip Commit on empty msg; the only other live uow Commit caller, update's stage-recorder decorator, forwards through `RunTxResultWithin` and inherits the same guard).

**2. Timestamp/classification parity with classic.** The new repo verb `IssueSQLRepository.HeartbeatIssue` (+ `IssueUseCase.Heartbeat`) delegates to the identical classic body `issueops.HeartbeatIssueInTx` — same clock (`time.Now().UTC()`), same TTL resolution, same only-current-owner classification (`ErrAlreadyClaimed`/`ErrNotClaimable`), same lease re-arm, same wisp refusal — so classic `bd reclaim` staleness semantics see proxied heartbeats identically.

Success output (text + the `{"id","status":"heartbeat","owner"}` --json shape workers parse) is extracted into shared `renderHeartbeatSuccess` so the two routes cannot drift. Exit code remains the worker contract (rc 0 = refreshed, nonzero = lease gone, stop). `--actor` override works in both modes. Deliberately nothing sets `commandDidWrite`.

## Tests

- `TestProxiedServerHeartbeat` journey (7 subtests, sharded 15/7 beside Reclaim): stale-lease rescue with `lease_expires_at`/`heartbeat_at` advanced AND `dolt_log` count unchanged; reclaim ignoring a just-heartbeaten lease (cross-verb parity); --json shape; wrong-owner / unclaimed / closed / missing refusals; lease re-arm INSERT path also under the zero-dolt-commit assertion.
- uow + domain + issueops + embeddeddolt/dolt lease families green; proxied Unclaim/Reclaim/GateLifecycle/KV spot-checks green (the Commit/RunTx surfaces touched). `go build`/`go vet`/`gofmt` clean.
- One ambient flake noted: `TestReclaimRevertsExpiredOnly` (classic dolt pkg, untouched by this diff; sleep-based 1s-TTL test) failed once under parallel load, passed solo and on family rerun — pre-existing timing sensitivity.

## Divergences from classic

None behavioral. Failure-message stderr gains the domain-layer wrapping prefixes every other proxied port carries; sentinels and exit codes identical.

## Reviewer scrutiny points (self-flagged)

- `doltServerTx.Commit("")` overload: guard comment covers it; confirm no future caller passes "" expecting a dolt commit.
- `RunTxEphemeral` has no `IsNothingToCommitError` tolerance (plain COMMIT can't produce it); serialization-retry mirrors `RunTxResultWithin` exactly.
- Plain `COMMIT` on a dolt sql-server does a working-set merge and can itself throw serialization errors — handled by the retry loop; wrong-owner subtest confirms a refused heartbeat leaves the lease byte-identical.
- `CheckReadonly` now applies to proxied heartbeat (previously unreachable) — matches the unclaim/gate ports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)