### PR TITLE
feat(swarm): port bd swarm status + validate to proxied-server mode (bd-gen49)

### DIFF
--- a/.github/scripts/proxied-cmd-test-shards.txt
+++ b/.github/scripts/proxied-cmd-test-shards.txt
@@ -92,6 +92,7 @@
 15 10 TestProxiedServerLabel
 15 10 TestProxiedServerList
 15 10 TestProxiedServerSQLDatabaseFlag
+15 10 TestProxiedServerSwarm
 15 10 TestProxiedServerUpdateWisp
 
 15 11 TestProxiedServerCompactHistory

--- a/cmd/bd/swarm.go
+++ b/cmd/bd/swarm.go
@@ -158,7 +158,7 @@ Examples:
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if usesProxiedServer() {
-			return HandleErrorRespectJSON("swarm validate is not supported in proxied-server mode")
+			return runSwarmValidateProxiedServer(cmd, rootCtx, args)
 		}
 		evt := metrics.NewCommandEvent("swarm-validate")
 		defer func() {
@@ -665,7 +665,7 @@ Examples:
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if usesProxiedServer() {
-			return HandleErrorRespectJSON("swarm status is not supported in proxied-server mode")
+			return runSwarmStatusProxiedServer(cmd, rootCtx, args)
 		}
 		evt := metrics.NewCommandEvent("swarm-status")
 		defer func() {

--- a/cmd/bd/swarm_proxied_integration_test.go
+++ b/cmd/bd/swarm_proxied_integration_test.go
@@ -1,0 +1,257 @@
+//go:build cgo
+
+package main
+
+import (
+	"encoding/json"
+	"os/exec"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// swarmModeRunner runs the same bd binary against one project in one mode
+// (classic embedded or proxied-server), so the cross-mode parity checks below
+// exercise identical commands against identical fixtures and diff the output.
+type swarmModeRunner struct {
+	name string
+	dir  string
+	env  func(dir string) []string
+}
+
+func (m swarmModeRunner) run(t *testing.T, bd string, args ...string) (string, string, error) {
+	t.Helper()
+	cmd := exec.Command(bd, args...)
+	cmd.Dir = m.dir
+	cmd.Env = m.env(m.dir)
+	stdout, stderr, err := runCommandBuffers(t, cmd)
+	return stdout.String(), stderr.String(), err
+}
+
+func (m swarmModeRunner) mustRun(t *testing.T, bd string, args ...string) string {
+	t.Helper()
+	stdout, stderr, err := m.run(t, bd, args...)
+	if err != nil {
+		t.Fatalf("[%s] bd %s failed: %v\nstdout:\n%s\nstderr:\n%s",
+			m.name, strings.Join(args, " "), err, stdout, stderr)
+	}
+	return stdout
+}
+
+func (m swarmModeRunner) mustFail(t *testing.T, bd string, args ...string) string {
+	t.Helper()
+	stdout, stderr, err := m.run(t, bd, args...)
+	if err == nil {
+		t.Fatalf("[%s] expected bd %s to fail, but it succeeded:\nstdout:\n%s\nstderr:\n%s",
+			m.name, strings.Join(args, " "), stdout, stderr)
+	}
+	return stdout + stderr
+}
+
+// buildSwarmParityFixture creates the same epic DAG in either mode, using
+// explicit IDs so the two modes' outputs are byte-comparable:
+//
+//	psw-epic1
+//	├─ psw-c1  closed
+//	├─ psw-c2  in_progress, assignee worker1
+//	├─ psw-c3  open, no blockers          (ready)
+//	└─ psw-c4  open, blocks-dep on psw-c3 (blocked)
+func buildSwarmParityFixture(t *testing.T, bd string, m swarmModeRunner) {
+	t.Helper()
+	// --id and --parent cannot be combined at create, so children get their
+	// parent-child edge via dep add.
+	m.mustRun(t, bd, "create", "Swarm port epic", "--type", "epic", "--id", "psw-epic1")
+	m.mustRun(t, bd, "create", "Child done", "--type", "task", "--id", "psw-c1")
+	m.mustRun(t, bd, "create", "Child active", "--type", "task", "--id", "psw-c2")
+	m.mustRun(t, bd, "create", "Child ready", "--type", "task", "--id", "psw-c3")
+	m.mustRun(t, bd, "create", "Child waiting", "--type", "task", "--id", "psw-c4")
+	for _, child := range []string{"psw-c1", "psw-c2", "psw-c3", "psw-c4"} {
+		m.mustRun(t, bd, "dep", "add", child, "psw-epic1", "--type", "parent-child")
+	}
+	m.mustRun(t, bd, "dep", "add", "psw-c4", "psw-c3")
+	m.mustRun(t, bd, "close", "psw-c1", "-r", "fixture: pre-closed child")
+	m.mustRun(t, bd, "update", "psw-c2", "--status", "in_progress", "--assignee", "worker1")
+}
+
+// buildSwarmCycleFixture creates a second epic whose two children form a
+// blocking cycle. `bd dep add` refuses to create the closing edge (the cycle
+// gate is upstream of both modes), so the reverse edge is planted with raw
+// SQL via `bd sql`. Proxied-only: classic embedded mode has no `bd sql`
+// ("not yet supported in embedded mode") and no other CLI door past the
+// cycle gate, so there is no classic run to diff against — the detector
+// itself (detectStructuralIssues) is the same shared code on both routes.
+func buildSwarmCycleFixture(t *testing.T, bd string, m swarmModeRunner) {
+	t.Helper()
+	m.mustRun(t, bd, "create", "Cycle epic", "--type", "epic", "--id", "psw-epic2")
+	m.mustRun(t, bd, "create", "Cycle A", "--type", "task", "--id", "psw-c5")
+	m.mustRun(t, bd, "create", "Cycle B", "--type", "task", "--id", "psw-c6")
+	for _, child := range []string{"psw-c5", "psw-c6"} {
+		m.mustRun(t, bd, "dep", "add", child, "psw-epic2", "--type", "parent-child")
+	}
+	m.mustRun(t, bd, "dep", "add", "psw-c5", "psw-c6")
+	m.mustRun(t, bd, "sql",
+		"INSERT INTO dependencies (id, issue_id, depends_on_issue_id, type, created_at, created_by, metadata) "+
+			"VALUES (UUID(), 'psw-c6', 'psw-c5', 'blocks', NOW(), 'tester', '{}')")
+}
+
+// parseSwarmJSON extracts the first JSON object from stdout.
+func parseSwarmJSON(t *testing.T, mode, out string) map[string]interface{} {
+	t.Helper()
+	s := strings.TrimSpace(out)
+	start := strings.IndexAny(s, "{")
+	if start < 0 {
+		t.Fatalf("[%s] no JSON object in swarm output: %s", mode, s)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(s[start:]), &m); err != nil {
+		t.Fatalf("[%s] parse swarm JSON: %v\n%s", mode, err, s)
+	}
+	return m
+}
+
+// stripSwarmStatusTimestamps blanks the closed_at field on every completed
+// entry in a parsed `swarm status --json` document. It is the only
+// wall-clock-dependent field, so the rest must match across modes exactly.
+func stripSwarmStatusTimestamps(t *testing.T, doc map[string]interface{}) {
+	t.Helper()
+	completed, ok := doc["completed"].([]interface{})
+	if !ok {
+		t.Fatalf("swarm status JSON has no completed array: %v", doc)
+	}
+	for _, entry := range completed {
+		if e, ok := entry.(map[string]interface{}); ok {
+			delete(e, "closed_at")
+		}
+	}
+}
+
+func TestProxiedServerSwarm(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+
+	// One journey: identical fixture in a proxied-server project and a classic
+	// embedded project (same binary), then every read compared across modes.
+	p := newSharedProxiedProject(t, bd, "psw")
+	classicDir, _, _ := bdInit(t, bd, "--prefix", "psw")
+
+	proxied := swarmModeRunner{name: "proxied", dir: p.dir, env: bdProxiedEnv}
+	classic := swarmModeRunner{name: "classic", dir: classicDir, env: bdEnv}
+	modes := []swarmModeRunner{proxied, classic}
+
+	for _, m := range modes {
+		buildSwarmParityFixture(t, bd, m)
+	}
+	buildSwarmCycleFixture(t, bd, proxied)
+
+	// Read-only invariant: neither swarm status nor swarm validate may write a
+	// Dolt commit. Capture HEAD before the reads and re-check at the end.
+	db := openProxiedDB(t, p)
+	headBefore := proxiedDoltHead(t, db)
+
+	t.Run("status_fields", func(t *testing.T) {
+		out := proxied.mustRun(t, bd, "swarm", "status", "psw-epic1")
+		for _, want := range []string{
+			"psw-c1",
+			"⟳ psw-c2 [worker1]",
+			"○ psw-c3",
+			"◌ psw-c4 (needs psw-c3)",
+			"Progress: 1/4 complete, 1/4 active (25%)",
+		} {
+			if !strings.Contains(out, want) {
+				t.Errorf("swarm status missing %q:\n%s", want, out)
+			}
+		}
+	})
+
+	t.Run("status_matches_classic", func(t *testing.T) {
+		proxiedOut := proxied.mustRun(t, bd, "swarm", "status", "psw-epic1")
+		classicOut := classic.mustRun(t, bd, "swarm", "status", "psw-epic1")
+		if proxiedOut != classicOut {
+			t.Errorf("swarm status output diverged from classic:\nproxied:\n%s\nclassic:\n%s", proxiedOut, classicOut)
+		}
+	})
+
+	t.Run("status_json_matches_classic", func(t *testing.T) {
+		proxiedDoc := parseSwarmJSON(t, "proxied", proxied.mustRun(t, bd, "swarm", "status", "psw-epic1", "--json"))
+		classicDoc := parseSwarmJSON(t, "classic", classic.mustRun(t, bd, "swarm", "status", "psw-epic1", "--json"))
+		// closed_at is the run's wall clock; everything else must be identical.
+		stripSwarmStatusTimestamps(t, proxiedDoc)
+		stripSwarmStatusTimestamps(t, classicDoc)
+		if !reflect.DeepEqual(proxiedDoc, classicDoc) {
+			t.Errorf("swarm status --json diverged from classic:\nproxied: %v\nclassic: %v", proxiedDoc, classicDoc)
+		}
+		if got := proxiedDoc["total_issues"]; got != float64(4) {
+			t.Errorf("total_issues = %v, want 4", got)
+		}
+		if got := proxiedDoc["blocked_count"]; got != float64(1) {
+			t.Errorf("blocked_count = %v, want 1", got)
+		}
+	})
+
+	t.Run("validate_clean_dag", func(t *testing.T) {
+		out := proxied.mustRun(t, bd, "swarm", "validate", "psw-epic1")
+		for _, want := range []string{
+			"psw-epic1",
+			"Total issues: 4 (1 closed)",
+			"Swarmable: YES",
+		} {
+			if !strings.Contains(out, want) {
+				t.Errorf("swarm validate missing %q:\n%s", want, out)
+			}
+		}
+	})
+
+	t.Run("validate_matches_classic", func(t *testing.T) {
+		proxiedOut := proxied.mustRun(t, bd, "swarm", "validate", "psw-epic1")
+		classicOut := classic.mustRun(t, bd, "swarm", "validate", "psw-epic1")
+		if proxiedOut != classicOut {
+			t.Errorf("swarm validate output diverged from classic:\nproxied:\n%s\nclassic:\n%s", proxiedOut, classicOut)
+		}
+	})
+
+	t.Run("validate_json_matches_classic", func(t *testing.T) {
+		proxiedDoc := parseSwarmJSON(t, "proxied", proxied.mustRun(t, bd, "swarm", "validate", "psw-epic1", "--json"))
+		classicDoc := parseSwarmJSON(t, "classic", classic.mustRun(t, bd, "swarm", "validate", "psw-epic1", "--json"))
+		if !reflect.DeepEqual(proxiedDoc, classicDoc) {
+			t.Errorf("swarm validate --json diverged from classic:\nproxied: %v\nclassic: %v", proxiedDoc, classicDoc)
+		}
+		if got := proxiedDoc["swarmable"]; got != true {
+			t.Errorf("swarmable = %v, want true", got)
+		}
+		if got := proxiedDoc["max_parallelism"]; got != float64(2) {
+			t.Errorf("max_parallelism = %v, want 2", got)
+		}
+	})
+
+	t.Run("validate_cycle_fails", func(t *testing.T) {
+		// The cycle path's member ordering is map-iteration-dependent, so
+		// this asserts the verdict, not the bytes: nonzero exit (classic's
+		// SilentExit on !Swarmable), the cycle error, and the NO verdict —
+		// all produced by the same shared code the classic route runs.
+		out := proxied.mustFail(t, bd, "swarm", "validate", "psw-epic2")
+		if !strings.Contains(out, "Dependency cycle detected") {
+			t.Errorf("expected cycle error, got:\n%s", out)
+		}
+		if !strings.Contains(out, "Swarmable: NO") {
+			t.Errorf("expected 'Swarmable: NO', got:\n%s", out)
+		}
+	})
+
+	t.Run("create_and_list_still_refused", func(t *testing.T) {
+		out := proxied.mustFail(t, bd, "swarm", "create", "psw-epic1")
+		if !strings.Contains(out, "swarm create is not supported in proxied-server mode") {
+			t.Errorf("expected swarm create refusal, got:\n%s", out)
+		}
+		out = proxied.mustFail(t, bd, "swarm", "list")
+		if !strings.Contains(out, "swarm list is not supported in proxied-server mode") {
+			t.Errorf("expected swarm list refusal, got:\n%s", out)
+		}
+	})
+
+	t.Run("reads_write_no_dolt_commit", func(t *testing.T) {
+		if headAfter := proxiedDoltHead(t, db); headAfter != headBefore {
+			t.Errorf("swarm status/validate advanced Dolt HEAD: before=%s after=%s", headBefore, headAfter)
+		}
+	})
+}

--- a/cmd/bd/swarm_proxied_server.go
+++ b/cmd/bd/swarm_proxied_server.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/steveyegge/beads/internal/metrics"
+	"github.com/steveyegge/beads/internal/storage/uow"
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/internal/utils"
+)
+
+// bd swarm status / validate in proxied-server mode (bd-gen49).
+//
+// Both commands are pure computed reads: the epic's child graph is loaded and
+// analyzed in memory, nothing is written, so the whole body runs inside one
+// read-only unit of work via uow.RunTxRead — no commit message, no Dolt
+// commit, no commandDidWrite. The shared traversal and rendering code
+// (analyzeEpicForSwarm, getSwarmStatus, renderSwarmAnalysis, renderSwarmStatus)
+// is exactly the classic route's; the only proxied-specific piece is
+// uowMolReader, the existing adapter that satisfies the SwarmStorage seam (and
+// utils.PartialIDResolverStore) over the UOW use-cases.
+//
+// swarm create and swarm list stay gated: no downstream consumer, and their
+// classic refusals in swarm.go are untouched.
+
+// runSwarmValidateProxiedServer ports `bd swarm validate` to proxied-server mode.
+func runSwarmValidateProxiedServer(cmd *cobra.Command, ctx context.Context, args []string) error {
+	evt := metrics.NewCommandEvent("swarm-validate")
+	defer func() {
+		if c := metrics.Global(); c != nil {
+			c.CloseEventAndAdd(evt)
+		}
+	}()
+
+	verbose, _ := cmd.Flags().GetBool("verbose")
+
+	if uowProvider == nil {
+		return HandleErrorRespectJSON("proxied-server UOW provider not initialized")
+	}
+
+	analysis, err := uow.RunTxRead(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (*SwarmAnalysis, error) {
+		r := uowMolReader{uw: uw}
+
+		epicID, err := utils.ResolvePartialID(ctx, r, args[0])
+		if err != nil {
+			return nil, fmt.Errorf("epic '%s' not found: %v", args[0], err)
+		}
+
+		epic, err := uw.IssueUseCase().GetIssue(ctx, epicID)
+		if gateProxiedNotFound(err) || (err == nil && epic == nil) {
+			// Classic reports a nil epic after a successful resolve this way;
+			// keep the message for parity.
+			return nil, fmt.Errorf("epic '%s' not found", epicID)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to get epic: %v", err)
+		}
+
+		if epic.IssueType != types.TypeEpic && epic.IssueType != "molecule" {
+			return nil, fmt.Errorf("'%s' is not an epic or molecule (type: %s)", epicID, epic.IssueType)
+		}
+
+		analysis, err := analyzeEpicForSwarm(ctx, r, epic)
+		if err != nil {
+			return nil, fmt.Errorf("failed to analyze epic: %v", err)
+		}
+		return analysis, nil
+	})
+	if err != nil {
+		return HandleErrorRespectJSON("%v", err)
+	}
+
+	if !verbose {
+		analysis.Issues = nil
+	}
+
+	if jsonOutput {
+		if jerr := outputJSON(analysis); jerr != nil {
+			return jerr
+		}
+		if !analysis.Swarmable {
+			return SilentExit()
+		}
+		return nil
+	}
+
+	renderSwarmAnalysis(analysis)
+
+	if !analysis.Swarmable {
+		return SilentExit()
+	}
+	return nil
+}
+
+// runSwarmStatusProxiedServer ports `bd swarm status` to proxied-server mode.
+func runSwarmStatusProxiedServer(_ *cobra.Command, ctx context.Context, args []string) error {
+	evt := metrics.NewCommandEvent("swarm-status")
+	defer func() {
+		if c := metrics.Global(); c != nil {
+			c.CloseEventAndAdd(evt)
+		}
+	}()
+
+	if uowProvider == nil {
+		return HandleErrorRespectJSON("proxied-server UOW provider not initialized")
+	}
+
+	status, err := uow.RunTxRead(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (*SwarmStatus, error) {
+		r := uowMolReader{uw: uw}
+
+		issueID, err := utils.ResolvePartialID(ctx, r, args[0])
+		if err != nil {
+			return nil, fmt.Errorf("issue '%s' not found: %v", args[0], err)
+		}
+
+		issue, err := uw.IssueUseCase().GetIssue(ctx, issueID)
+		if gateProxiedNotFound(err) || (err == nil && issue == nil) {
+			return nil, fmt.Errorf("issue '%s' not found", issueID)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to get issue: %v", err)
+		}
+
+		var epic *types.Issue
+
+		if issue.IssueType == "molecule" && issue.MolType == types.MolTypeSwarm {
+			deps, err := r.GetDependencyRecords(ctx, issue.ID)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get swarm dependencies: %v", err)
+			}
+			for _, dep := range deps {
+				if dep.Type == types.DepRelatesTo {
+					epic, err = uw.IssueUseCase().GetIssue(ctx, dep.DependsOnID)
+					if err != nil {
+						return nil, fmt.Errorf("failed to get linked epic: %v", err)
+					}
+					break
+				}
+			}
+			if epic == nil {
+				return nil, fmt.Errorf("swarm molecule '%s' has no linked epic", issueID)
+			}
+		} else if issue.IssueType == types.TypeEpic || issue.IssueType == "molecule" {
+			epic = issue
+		} else {
+			return nil, fmt.Errorf("'%s' is not an epic or swarm molecule (type: %s)", issueID, issue.IssueType)
+		}
+
+		status, err := getSwarmStatus(ctx, r, epic)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get swarm status: %v", err)
+		}
+		return status, nil
+	})
+	if err != nil {
+		return HandleErrorRespectJSON("%v", err)
+	}
+
+	if jsonOutput {
+		return outputJSON(status)
+	}
+
+	renderSwarmStatus(status)
+	return nil
+}


### PR DESCRIPTION
## What (bd-gen49, program bd-vxavz)

`bd swarm status` and `bd swarm validate` — pure computed reads (epic progress; ready fronts + cycle detection) — stop refusing proxied-server mode. Whole body runs inside one `uow.RunTxRead` (no commit message, no dolt commit, no `commandDidWrite`), with the **existing** `uowMolReader` adapter satisfying the `SwarmStorage` seam and `utils.PartialIDResolverStore` — no new adapter needed; all traversal/rendering code (`analyzeEpicForSwarm`, `getSwarmStatus`, renderers) is shared with classic unchanged. `swarm create`/`swarm list` stay gated with their existing refusals (no downstream consumer).

## Tests

`TestProxiedServerSwarm` (9 subtests, 31.9s PASS; sharded 15/10 per the manifest's recorded hash-fallback convention): builds an identical explicit-ID epic DAG in a proxied project AND a classic embedded project, then asserts:
- `swarm status` + `swarm validate` human output **byte-for-byte** across modes; `--json` deep-equal (only `closed_at` wall-clock stripped)
- planted-cycle validate failure (proxied-only plant via `bd sql`; classic embedded has no door to plant a cycle — detector is the same shared function; documented in test)
- create/list still refused with the exact existing messages
- reads advance no dolt HEAD

Embedded swarm families green (17 subtests + ready-fronts + closed-open-cycle, 49.6s). `go build`/`go vet`/`gofmt` clean. No ambient reds encountered.

## Reviewer notes (self-flagged)

- Error-path mapping where classic's `store.GetIssue` nil handling collapses onto `gateProxiedNotFound(err) || (err == nil && epic == nil)` — reachable only if the row vanishes between resolve and fetch.
- `uowMolReader.GetDependents` includes wisp-plane dependents — verified parity with classic (`issueops.GetDependentsWithMetadataInTx` reads both `dependencies` and `wisp_dependencies` on both routes), not drift.
- The `swarm status <molecule-id>` branch is ported for parity but end-to-end untestable in proxied mode while `swarm create` stays gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JtAkNTf8DGzP1AF3FMuGmm