### PR TITLE
feat(recompute-blocked): port to proxied-server mode + cross-mode cascade parity suite (bd-04vav)

### DIFF
--- a/.github/scripts/proxied-cmd-test-shards.txt
+++ b/.github/scripts/proxied-cmd-test-shards.txt
@@ -134,6 +134,7 @@
 
 15 15 TestProxiedServerMolShow
 15 15 TestProxiedServerOrphans
+15 15 TestProxiedServerRecomputeBlocked
 15 15 TestProxiedServerShow2
 15 15 TestProxiedServerUnclaim
 15 15 TestProxiedServerUpdate3

--- a/.github/scripts/proxied-cmd-test-shards.txt
+++ b/.github/scripts/proxied-cmd-test-shards.txt
@@ -42,6 +42,7 @@
 15 3 TestProxiedServerUpdate2
 15 3 TestProxiedServerUpdateConcurrentMetadata
 
+15 4 TestProxiedServerCascadeParity
 15 4 TestProxiedServerClose2
 15 4 TestProxiedServerDeleteConcurrent
 15 4 TestProxiedServerDuplicates

--- a/cmd/bd/cascade_parity_proxied_integration_test.go
+++ b/cmd/bd/cascade_parity_proxied_integration_test.go
@@ -1,0 +1,262 @@
+//go:build cgo
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// cascadeRunner drives one storage mode. It is bdRunner plus the one read these
+// tests need — "does this id still exist?" — which must NOT fatal when the
+// answer is no, because that answer is the whole measurement.
+type cascadeRunner struct {
+	mode string
+	// run fatals on nonzero exit; use for setup steps that must succeed.
+	run func(t *testing.T, args ...string) string
+	// exists reports whether id resolves, with no opinion about it.
+	exists func(t *testing.T, id string) bool
+}
+
+func proxiedCascadeRunner(t *testing.T, bd string, p proxiedProject) cascadeRunner {
+	return cascadeRunner{
+		mode: "proxied",
+		run: func(t *testing.T, args ...string) string {
+			t.Helper()
+			stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, args...)
+			if err != nil {
+				t.Fatalf("proxied bd %s failed: %v\nstdout:\n%s\nstderr:\n%s",
+					strings.Join(args, " "), err, stdout, stderr)
+			}
+			return stdout
+		},
+		exists: func(t *testing.T, id string) bool {
+			t.Helper()
+			_, _, err := bdProxiedRunBuffers(t, bd, p.dir, "show", id)
+			return err == nil
+		},
+	}
+}
+
+func classicCascadeRunner(t *testing.T, bd, dir string) cascadeRunner {
+	return cascadeRunner{
+		mode: "classic",
+		run: func(t *testing.T, args ...string) string {
+			t.Helper()
+			return runClassic(t, bd, dir, args...)
+		},
+		exists: func(t *testing.T, id string) bool {
+			t.Helper()
+			_, err := bdRunWithFlockRetry(t, bd, dir, "show", id)
+			return err == nil
+		},
+	}
+}
+
+// gateDeliveryLedgerOutcome is what wh-gate-sweep's purge step is allowed to
+// leave behind: the gate gone, and NOTHING else.
+type gateDeliveryLedgerOutcome struct {
+	gateGone        bool
+	targetSurvives  bool
+	siblingSurvives bool
+}
+
+// runGateDeliveryLedger replays wh-gate-sweep's third step — `bd delete <gate>
+// --force` used as a delivery ledger (the gate row IS the record that the wake
+// has not been sent yet, so purging it is how the sweep becomes idempotent).
+//
+// The fixture is the shape that makes this dangerous: `bd gate create --blocks
+// <target>` records the edge as target DEPENDS-ON gate, so the gated bead is a
+// DEPENDENT of the row being deleted. A delete that cascades to dependents
+// therefore deletes the very bead the sweep just unblocked, plus anything
+// downstream of it — which is why the sibling below hangs off the target.
+func runGateDeliveryLedger(t *testing.T, r cascadeRunner) gateDeliveryLedgerOutcome {
+	t.Helper()
+
+	target := parseIssueJSON(t, []byte(r.run(t, "create", "--json", "Gated work")))
+	sibling := parseIssueJSON(t, []byte(r.run(t, "create", "--json", "Downstream of the gated work",
+		"--deps", "blocked-by:"+target.ID)))
+
+	gateOut := r.run(t, "gate", "create", "--type=human", "--blocks", target.ID,
+		"--reason", "Need design review")
+	gateID := parseCreatedGateID(t, gateOut)
+
+	r.run(t, "gate", "resolve", gateID, "--reason", "reviewed")
+	r.run(t, "delete", gateID, "--force")
+
+	return gateDeliveryLedgerOutcome{
+		gateGone:        !r.exists(t, gateID),
+		targetSurvives:  r.exists(t, target.ID),
+		siblingSurvives: r.exists(t, sibling.ID),
+	}
+}
+
+// wispDecayOutcome is the observable result of the wisp-decay pair the
+// wheelhouse runs to bound a flooding lane's trail: `bd close <wisp>` then
+// `bd purge --pattern <p> --force`.
+type wispDecayOutcome struct {
+	wispGone              bool
+	durableClosedSurvives bool
+	openWispSurvives      bool
+}
+
+// runWispDecay replays that pair. The two survivors are the load-bearing half:
+// purge is EPHEMERAL-only and CLOSED-only, so a durable closed bead and an open
+// wisp must both come through untouched. A purge that swept either would be
+// deleting durable work, or reclaiming a wisp a lane is still using.
+func runWispDecay(t *testing.T, r cascadeRunner) wispDecayOutcome {
+	t.Helper()
+
+	durable := parseIssueJSON(t, []byte(r.run(t, "create", "--json", "Durable closed bead")))
+	r.run(t, "close", durable.ID, "--reason", "done")
+
+	wisp := parseIssueJSON(t, []byte(r.run(t, "create", "--json", "Decaying heartbeat",
+		"--ephemeral", "--wisp-type", "heartbeat")))
+	openWisp := parseIssueJSON(t, []byte(r.run(t, "create", "--json", "Live heartbeat",
+		"--ephemeral", "--wisp-type", "heartbeat")))
+	r.run(t, "close", wisp.ID, "--reason", "decayed")
+
+	r.run(t, "purge", "--pattern", "*", "--force")
+
+	return wispDecayOutcome{
+		wispGone:              !r.exists(t, wisp.ID),
+		durableClosedSurvives: r.exists(t, durable.ID),
+		openWispSurvives:      r.exists(t, openWisp.ID),
+	}
+}
+
+// pruneSweepOutcome is the observable result of `bd prune --pattern '*'
+// --force`, the durable-plane sibling of the wisp purge.
+type pruneSweepOutcome struct {
+	closedGone         bool
+	openSurvives       bool
+	referencedSurvives bool
+}
+
+// runPruneSweep replays a durable prune. The referenced bead is the interesting
+// one: prune is reference-aware and must protect a closed bead an OPEN bead
+// still cites by id, which is a property no cascade rule can supply and which
+// therefore has to be checked separately in each mode.
+func runPruneSweep(t *testing.T, r cascadeRunner) pruneSweepOutcome {
+	t.Helper()
+
+	open := parseIssueJSON(t, []byte(r.run(t, "create", "--json", "Still open")))
+	closed := parseIssueJSON(t, []byte(r.run(t, "create", "--json", "Now closed")))
+	referenced := parseIssueJSON(t, []byte(r.run(t, "create", "--json", "Cited decision")))
+	r.run(t, "create", "--json", "Open citer", "--description", "per "+referenced.ID+" we decided X")
+	r.run(t, "close", closed.ID, referenced.ID, "--reason", "done")
+
+	r.run(t, "prune", "--pattern", "*", "--force")
+
+	return pruneSweepOutcome{
+		closedGone:         !r.exists(t, closed.ID),
+		openSurvives:       r.exists(t, open.ID),
+		referencedSurvives: r.exists(t, referenced.ID),
+	}
+}
+
+// TestProxiedServerCascadeParity is the delete/prune/purge half of bd-04vav:
+// proxied `bd delete` ALWAYS cascades (--cascade is refused outright), so the
+// question the wheelhouse needs answered is not "is there a flag" but "does the
+// cascade reach anything classic mode would have left alone" — on the two
+// shapes it actually runs: wh-gate-sweep's gate purge, and the wisp-decay
+// close+purge pair.
+//
+// Both scenarios are replayed against a classic embedded workspace and a
+// proxied one and the outcomes compared, so a divergence is reported as a
+// divergence rather than as one mode's test failing alone.
+func TestProxiedServerCascadeParity(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+
+	// KNOWN DIVERGENCE — DATA LOSS. Read this before changing anything below.
+	//
+	// Proxied `bd delete <gate> --force` deletes the bead the gate was gating,
+	// and everything downstream of THAT, because the proxied route passes
+	// Cascade:true unconditionally while classic cascades only under an explicit
+	// --cascade (which proxied refuses outright). On wh-gate-sweep's fixture the
+	// cascade is not a nuance: the sweep's third step is `bd delete <gate>
+	// --force`, and `bd gate create --blocks <target>` makes the gated bead a
+	// DEPENDENT of the gate, so on the proxied plane that step destroys the work
+	// it just unblocked. It is a cutover blocker for the shared-server
+	// constellation, not a wart.
+	//
+	// This subtest CHARACTERIZES the defect rather than asserting the fix: the
+	// classic half pins the behavior that is correct, and the proxied half pins
+	// exactly today's damage, so the suite stays honest and green while the
+	// divergence is open — and fails the moment the blast radius CHANGES, in
+	// either direction. Whoever fixes proxied delete's cascade flips
+	// wantProxied to match wantClassic and deletes this paragraph.
+	t.Run("gate_delivery_ledger", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "cgp")
+		proxied := runGateDeliveryLedger(t, proxiedCascadeRunner(t, bd, p))
+
+		classicDir, _, _ := bdInit(t, bd, "--prefix", "cgc")
+		classic := runGateDeliveryLedger(t, classicCascadeRunner(t, bd, classicDir))
+
+		wantClassic := gateDeliveryLedgerOutcome{
+			gateGone: true, targetSurvives: true, siblingSurvives: true,
+		}
+		if classic != wantClassic {
+			t.Errorf("classic gate delivery-ledger delete: got %#v, want %#v", classic, wantClassic)
+		}
+
+		wantProxied := gateDeliveryLedgerOutcome{
+			gateGone: true, targetSurvives: false, siblingSurvives: false,
+		}
+		if proxied != wantProxied {
+			t.Errorf("proxied gate delivery-ledger delete: got %#v, want %#v "+
+				"(the known unconditional-cascade divergence; if this now matches classic, "+
+				"the defect is fixed — make wantProxied equal wantClassic)", proxied, wantProxied)
+		}
+		if proxied != classic {
+			t.Logf("KNOWN DIVERGENCE (bd-04vav): proxied delete cascades where classic does not.\n"+
+				"  proxied: %#v\n  classic: %#v\n"+
+				"  wh-gate-sweep's `bd delete <gate> --force` would destroy the gated bead "+
+				"and its dependents on the proxied plane.", proxied, classic)
+		}
+	})
+
+	t.Run("wisp_decay", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "cwp")
+		proxied := runWispDecay(t, proxiedCascadeRunner(t, bd, p))
+
+		classicDir, _, _ := bdInit(t, bd, "--prefix", "cwc")
+		classic := runWispDecay(t, classicCascadeRunner(t, bd, classicDir))
+
+		if proxied != classic {
+			t.Errorf("wisp decay differs across modes:\n  proxied: %#v\n  classic: %#v",
+				proxied, classic)
+		}
+		if !proxied.wispGone {
+			t.Errorf("proxied: closed wisp survived purge --pattern '*' --force")
+		}
+		if !proxied.durableClosedSurvives {
+			t.Errorf("proxied: purge deleted a DURABLE closed bead — purge is ephemeral-only")
+		}
+		if !proxied.openWispSurvives {
+			t.Errorf("proxied: purge deleted an OPEN wisp — purge is closed-only")
+		}
+	})
+
+	t.Run("prune_sweep", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "cpp")
+		proxied := runPruneSweep(t, proxiedCascadeRunner(t, bd, p))
+
+		classicDir, _, _ := bdInit(t, bd, "--prefix", "cpc")
+		classic := runPruneSweep(t, classicCascadeRunner(t, bd, classicDir))
+
+		if proxied != classic {
+			t.Errorf("prune sweep differs across modes:\n  proxied: %#v\n  classic: %#v",
+				proxied, classic)
+		}
+		want := pruneSweepOutcome{closedGone: true, openSurvives: true, referencedSurvives: true}
+		if proxied != want {
+			t.Errorf("proxied prune sweep: got %#v, want %#v", proxied, want)
+		}
+	})
+}

--- a/cmd/bd/recompute_blocked.go
+++ b/cmd/bd/recompute_blocked.go
@@ -23,8 +23,9 @@ trusts the flag, so stale values silently hide ready work or surface blocked
 work.
 
 This command runs the full recompute unconditionally and commits the result.
-It is idempotent: on a consistent database it changes nothing. Works in both
-embedded and server mode (unlike 'bd doctor', which is server-mode only).
+It is idempotent: on a consistent database it changes nothing. Works in every
+storage mode — embedded, server, and proxied-server (unlike 'bd doctor', which
+is server-mode only).
 
 Examples:
   bd recompute-blocked          # Repair stale is_blocked flags
@@ -32,9 +33,6 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if usesProxiedServer() {
-			return HandleErrorRespectJSON("recompute-blocked is not supported in proxied-server mode")
-		}
 		CheckReadonly("recompute-blocked")
 
 		evt := metrics.NewCommandEvent("recompute-blocked")
@@ -46,6 +44,10 @@ Examples:
 
 		ctx := rootCtx
 
+		if usesProxiedServer() {
+			return runRecomputeBlockedProxiedServer(ctx)
+		}
+
 		recomputer, ok := storage.UnwrapStore(store).(storage.BlockedRecomputer)
 		if !ok {
 			return HandleError("storage backend does not support is_blocked recompute")
@@ -54,17 +56,24 @@ Examples:
 		if err != nil {
 			return HandleError("recompute is_blocked: %v", err)
 		}
-
-		if jsonOutput {
-			return outputJSON(map[string]interface{}{"rows_corrected": changed})
-		}
-		if changed == 0 {
-			fmt.Println("is_blocked already consistent — nothing to recompute.")
-			return nil
-		}
-		fmt.Printf("Recomputed is_blocked: %d row(s) corrected.\n", changed)
-		return nil
+		return renderRecomputeBlocked(changed)
 	},
+}
+
+// renderRecomputeBlocked writes the command's whole result, and is shared by
+// every mode so the text and the JSON shape downstream callers read cannot
+// drift between them. wh-bridge-sync only reads the exit code, but a human
+// repairing a stale graph reads these two lines.
+func renderRecomputeBlocked(changed int) error {
+	if jsonOutput {
+		return outputJSON(map[string]interface{}{"rows_corrected": changed})
+	}
+	if changed == 0 {
+		fmt.Println("is_blocked already consistent — nothing to recompute.")
+		return nil
+	}
+	fmt.Printf("Recomputed is_blocked: %d row(s) corrected.\n", changed)
+	return nil
 }
 
 func init() {

--- a/cmd/bd/recompute_blocked_proxied_integration_test.go
+++ b/cmd/bd/recompute_blocked_proxied_integration_test.go
@@ -1,0 +1,237 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// bdRunner runs `bd <args>` in one storage mode's workspace and returns stdout,
+// fataling on a nonzero exit. It is what lets the corrupt-then-repair scenario
+// below be written ONCE and replayed against classic and proxied, which is the
+// only way a parity claim about them can be checked rather than asserted.
+type bdRunner struct {
+	mode string
+	run  func(t *testing.T, args ...string) string
+	// setIsBlocked commits a wrong is_blocked value for id. The MECHANISM is
+	// necessarily mode-specific (classic embedded refuses `bd sql`), which is
+	// fine and in fact the point: what parity is claimed about is the repair's
+	// behavior on an equivalently corrupted database, not how it got corrupted.
+	setIsBlocked func(t *testing.T, id string, value int)
+}
+
+// blockedRepairObservation is everything the scenario can observe about
+// `bd recompute-blocked` through the CLI: both rendered branches and the count.
+// Every field must match across modes.
+type blockedRepairObservation struct {
+	repairText string
+	repairRows int
+	noopText   string
+}
+
+// runBlockedRepairScenario commits a database whose is_blocked column disagrees
+// with its own dependency graph, then repairs it — the exact shape the command
+// exists for (a stale flag left behind by a merge whose scoped recompute never
+// ran, bd-6dnrw.37), not a dirty working set.
+//
+// Both modes COMMIT their corruption (see bdRunner.setIsBlocked), so the graph
+// tables are clean when the repair's dirty-graph guard looks at them and the
+// scenario exercises the repair rather than the guard.
+func runBlockedRepairScenario(t *testing.T, r bdRunner) blockedRepairObservation {
+	t.Helper()
+
+	blocker := parseIssueJSON(t, []byte(r.run(t, "create", "--json", "Blocker")))
+	blocked := parseIssueJSON(t, []byte(r.run(t, "create", "--json", "Blocked", "--deps", "blocked-by:"+blocker.ID)))
+	free := parseIssueJSON(t, []byte(r.run(t, "create", "--json", "Unblocked")))
+
+	// Corrupt in BOTH directions, so the repair has to mark and unmark. A
+	// one-sided fixture passes a repair that only ever sets the flag one way.
+	r.setIsBlocked(t, blocked.ID, 0)
+	r.setIsBlocked(t, free.ID, 1)
+
+	obs := blockedRepairObservation{}
+	obs.repairText = strings.TrimSpace(r.run(t, "recompute-blocked"))
+
+	r.setIsBlocked(t, blocked.ID, 0)
+	obs.repairRows = recomputeRowsCorrected(t, r.run(t, "recompute-blocked", "--json"))
+
+	// Idempotency is the property wh-bridge-sync's 3x retry rides on.
+	obs.noopText = strings.TrimSpace(r.run(t, "recompute-blocked"))
+	return obs
+}
+
+func recomputeRowsCorrected(t *testing.T, out string) int {
+	t.Helper()
+	start := strings.Index(out, "{")
+	if start < 0 {
+		t.Fatalf("no JSON object in recompute-blocked output:\n%s", out)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out[start:]), &payload); err != nil {
+		t.Fatalf("parse recompute-blocked JSON: %v\nraw: %s", err, out[start:])
+	}
+	n, ok := payload["rows_corrected"].(float64)
+	if !ok {
+		t.Fatalf("rows_corrected missing or not a number in %v", payload)
+	}
+	return int(n)
+}
+
+func proxiedBDRunner(t *testing.T, bd string, p proxiedProject) bdRunner {
+	run := func(t *testing.T, args ...string) string {
+		t.Helper()
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, args...)
+		if err != nil {
+			t.Fatalf("proxied bd %s failed: %v\nstdout:\n%s\nstderr:\n%s",
+				strings.Join(args, " "), err, stdout, stderr)
+		}
+		return stdout
+	}
+	return bdRunner{
+		mode: "proxied",
+		run:  run,
+		// `bd sql` COMMITS in proxied mode, so the graph tables are clean when
+		// the repair's dirty-graph guard looks at them.
+		setIsBlocked: func(t *testing.T, id string, value int) {
+			t.Helper()
+			run(t, "sql", "UPDATE issues SET is_blocked = "+strconv.Itoa(value)+" WHERE id = '"+id+"'")
+		},
+	}
+}
+
+// classicBDRunner drives an embedded-mode workspace. Its corruption goes
+// through the dolt CLI because embedded mode refuses `bd sql` outright, and it
+// COMMITS the corruption for the same reason the proxied side does: the repair
+// under test refuses a dirty graph, so a fixture that left one would be testing
+// the guard instead of the repair.
+func classicBDRunner(t *testing.T, bd, beadsDir, prefix, doltBin string) bdRunner {
+	dbDir := filepath.Join(beadsDir, "embeddeddolt", prefix)
+	dir := filepath.Dir(beadsDir)
+	return bdRunner{
+		mode: "classic",
+		run: func(t *testing.T, args ...string) string {
+			t.Helper()
+			return runClassic(t, bd, dir, args...)
+		},
+		setIsBlocked: func(t *testing.T, id string, value int) {
+			t.Helper()
+			runDolt(t, doltBin, dbDir, "sql", "-q",
+				"UPDATE issues SET is_blocked = "+strconv.Itoa(value)+" WHERE id = '"+id+"'")
+			runDolt(t, doltBin, dbDir, "add", "issues")
+			runDolt(t, doltBin, dbDir, "commit", "-m", "test: corrupt is_blocked",
+				"--author", "Parity Test <parity@example.com>")
+		},
+	}
+}
+
+// TestProxiedServerRecomputeBlocked covers the proxied-server port of
+// `bd recompute-blocked` (bd-04vav).
+//
+// The downstream consumer is wh-bridge-sync, which runs this after a
+// cross-machine merge under a timeout cap and retries up to three times on the
+// strength of the command being IDEMPOTENT and its exit code being HONEST. Both
+// of those are asserted here directly, alongside the repair itself, the
+// mode-independent commit it lands, and the dirty-graph refusal that had to
+// survive the port — a repair that committed flags derived from someone else's
+// uncommitted dependency edits would be worse than no repair at all.
+func TestProxiedServerRecomputeBlocked(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+
+	t.Run("cross_mode_parity", func(t *testing.T) {
+		t.Parallel()
+		doltBin, err := exec.LookPath("dolt")
+		if err != nil {
+			t.Skip("dolt binary not on PATH: the classic half of the oracle cannot corrupt its fixture")
+		}
+		p := newSharedProxiedProject(t, bd, "rbp")
+		proxied := runBlockedRepairScenario(t, proxiedBDRunner(t, bd, p))
+
+		_, classicBeads, _ := bdInit(t, bd, "--prefix", "rbc")
+		classic := runBlockedRepairScenario(t, classicBDRunner(t, bd, classicBeads, "rbc", doltBin))
+
+		if proxied != classic {
+			t.Errorf("recompute-blocked differs across modes:\n  proxied: %#v\n  classic: %#v",
+				proxied, classic)
+		}
+		// Pin the shared values too, so a symmetric regression in both modes
+		// (the failure an equality-only oracle is blind to) still fails.
+		if proxied.repairRows != 1 {
+			t.Errorf("rows_corrected: got %d, want 1", proxied.repairRows)
+		}
+		if !strings.Contains(proxied.repairText, "Recomputed is_blocked: 2 row(s) corrected") {
+			t.Errorf("repair line: got %q", proxied.repairText)
+		}
+		if !strings.Contains(proxied.noopText, "is_blocked already consistent") {
+			t.Errorf("no-op line: got %q", proxied.noopText)
+		}
+	})
+
+	t.Run("commits_only_when_it_repairs", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "rbc2")
+		run := proxiedBDRunner(t, bd, p)
+		blocker := parseIssueJSON(t, []byte(run.run(t, "create", "--json", "Blocker")))
+		blocked := parseIssueJSON(t, []byte(run.run(t, "create", "--json", "Blocked",
+			"--deps", "blocked-by:"+blocker.ID)))
+
+		db := openProxiedDB(t, p)
+		if !readIsBlocked(t, db, blocked.ID) {
+			t.Fatalf("fixture: %s should start blocked", blocked.ID)
+		}
+
+		// A no-op repair must mint NO commit: the bridge runs this on every tick
+		// that owes a recompute, and a commit per tick is history every clone
+		// then has to pull.
+		before := readDoltHead(t, db)
+		run.run(t, "recompute-blocked")
+		if got := readDoltLogCountSince(t, db, before); got != 0 {
+			t.Errorf("no-op recompute created %d dolt commit(s), want 0", got)
+		}
+
+		run.run(t, "sql", "UPDATE issues SET is_blocked = 0 WHERE id = '"+blocked.ID+"'")
+		before = readDoltHead(t, db)
+		run.run(t, "recompute-blocked")
+		if got := readDoltLogCountSince(t, db, before); got != 1 {
+			t.Errorf("repair created %d dolt commit(s), want exactly 1", got)
+		}
+		if msg := readDoltLogTopMessage(t, db); msg != "bd: recompute is_blocked (full)" {
+			t.Errorf("repair commit message: got %q, want the mode-independent message", msg)
+		}
+		if !readIsBlocked(t, db, blocked.ID) {
+			t.Errorf("%s: is_blocked still 0 after repair", blocked.ID)
+		}
+	})
+
+	t.Run("refuses_dirty_graph", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "rbd")
+		blocker := bdProxiedCreate(t, bd, p.dir, "Blocker")
+		bdProxiedCreate(t, bd, p.dir, "Blocked", "--deps", "blocked-by:"+blocker.ID)
+
+		// Dirty `issues` OUTSIDE bd, so nothing commits it: a direct write on
+		// the server's own connection is the hand-resolved-merge state the guard
+		// exists for.
+		db := openProxiedDB(t, p)
+		if _, err := db.ExecContext(context.Background(),
+			"UPDATE issues SET title = 'dirtied' WHERE id = ?", blocker.ID); err != nil {
+			t.Fatalf("dirty the working set: %v", err)
+		}
+
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "recompute-blocked")
+		if err == nil {
+			t.Fatalf("recompute-blocked must refuse a dirty graph; it succeeded:\nstdout:\n%s\nstderr:\n%s",
+				stdout, stderr)
+		}
+		if !strings.Contains(stdout+stderr, "needs a clean working set") {
+			t.Errorf("expected the dirty-graph refusal, got:\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+		}
+	})
+}

--- a/cmd/bd/recompute_blocked_proxied_server.go
+++ b/cmd/bd/recompute_blocked_proxied_server.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/steveyegge/beads/internal/storage/versioncontrolops"
+)
+
+// runRecomputeBlockedProxiedServer routes bd recompute-blocked through the
+// proxied-server plane (bd-04vav).
+//
+// The repair itself is not reimplemented here: the guard, the fixpoint
+// recompute, the staging set and the commit message all come from
+// versioncontrolops.RecomputeAllBlockedOnConn, the same code the embedded and
+// server stores run, so the two modes cannot compute different flags or land
+// different history. What is mode-specific is only how the connection is got.
+//
+// It runs on a PINNED non-transactional connection rather than through
+// uow.RunTx*, for two reasons the other proxied ports do not have:
+//
+//   - The repair's post-commit DOLT_ADD/DOLT_COMMIT are stored procedures,
+//     which Dolt refuses inside an explicit transaction — the same reason every
+//     other versioncontrolops entry point takes a conn.
+//   - The uow commit path stages with DOLT_COMMIT('-Am', …). This repair must
+//     stage `issues` ALONE: it derives a flag from the graph and has no business
+//     sweeping an unrelated dirty working set into its commit, which is exactly
+//     what the dirty-graph guard exists to prevent on the read side.
+//
+// The exit code is the whole downstream contract (wh-bridge-sync runs this under
+// a timeout cap, treats rc 124 as "still running server-side", and retries up to
+// 3 times because the operation is idempotent): success is 0, and every failure
+// — an unreachable server, a dirty graph, a killed query — is a nonzero HandleError.
+// Nothing here invents a green.
+func runRecomputeBlockedProxiedServer(ctx context.Context) error {
+	var changed int64
+	if err := runProxiedNonTx(ctx, func(ctx context.Context, conn *sql.Conn) error {
+		var rerr error
+		changed, rerr = versioncontrolops.RecomputeAllBlockedOnConn(ctx, conn, "")
+		return rerr
+	}); err != nil {
+		// runProxiedNonTx reports its own provider failures and returns an
+		// already-rendered exit; re-wrapping would print a second Error line.
+		if _, reported := exitCodeFromError(err); reported {
+			return err
+		}
+		return HandleError("recompute is_blocked: %v", err)
+	}
+	return renderRecomputeBlocked(int(changed))
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -3919,16 +3920,11 @@ func (s *DoltStore) RecomputeAllBlocked(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("begin is_blocked recompute: %w", err)
 	}
-	// Refuse to derive and commit is_blocked from a dirty graph: the recompute
-	// reads the current working set and stages only `issues`, so pre-existing
-	// dirty issue/dependency edits would otherwise be swept into — or silently
-	// inform — the repair commit (bd-6dnrw.37). Checked inside this tx so it
-	// sees the same working set the recompute will read.
-	if err := issueops.GuardBlockedRecomputeWorkingSet(ctx, tx); err != nil {
-		_ = tx.Rollback()
-		return 0, err
-	}
-	changed, err := issueops.RecomputeAllIsBlockedInTx(ctx, tx)
+	// One shared body across every mode (guard a dirty graph, then recompute):
+	// the guard refuses to derive and commit is_blocked from uncommitted
+	// issue/dependency edits, and it runs inside THIS tx so it sees exactly the
+	// working set the recompute reads (bd-6dnrw.37).
+	changed, err := versioncontrolops.GuardedRecomputeAllBlockedInTx(ctx, tx)
 	if err != nil {
 		_ = tx.Rollback()
 		return 0, err
@@ -3939,11 +3935,25 @@ func (s *DoltStore) RecomputeAllBlocked(ctx context.Context) (int, error) {
 	if changed > 0 {
 		// Stage only issues — the synced table is_blocked lives on (wisps are
 		// dolt_ignore'd) — so an unrelated dirty working set is not swept in.
-		if err := s.doltAddAndCommit(ctx, []string{"issues"}, "bd: recompute is_blocked (full)"); err != nil {
+		if err := s.doltAddAndCommit(ctx, blockedRecomputeStagedTableList(),
+			versioncontrolops.BlockedRecomputeCommitMsg); err != nil {
 			return int(changed), err
 		}
 	}
 	return int(changed), nil
+}
+
+// blockedRecomputeStagedTableList is versioncontrolops.BlockedRecomputeStagedTables
+// in the ordered form doltAddAndCommit takes, so the staging set of the repair
+// commit is defined in exactly one place for every mode.
+func blockedRecomputeStagedTableList() []string {
+	staged := versioncontrolops.BlockedRecomputeStagedTables()
+	tables := make([]string, 0, len(staged))
+	for table := range staged {
+		tables = append(tables, table)
+	}
+	sort.Strings(tables)
+	return tables
 }
 
 // recomputeBlockedTx runs the post-merge is_blocked recompute in its own

--- a/internal/storage/embeddeddolt/version_control.go
+++ b/internal/storage/embeddeddolt/version_control.go
@@ -340,14 +340,12 @@ func (s *EmbeddedDoltStore) RecomputeBlockedAfterMerge(ctx context.Context, from
 func (s *EmbeddedDoltStore) RecomputeAllBlocked(ctx context.Context) (int, error) {
 	var changed int64
 	if err := s.withConn(ctx, true, func(tx *sql.Tx) error {
-		// Refuse to derive and commit is_blocked from a dirty graph (see
-		// DoltStore.RecomputeAllBlocked); checked inside the recompute tx so it
-		// sees the same working set the recompute will read (bd-6dnrw.37).
-		if e := issueops.GuardBlockedRecomputeWorkingSet(ctx, tx); e != nil {
-			return e
-		}
+		// One shared body across every mode: refuse to derive and commit
+		// is_blocked from a dirty graph (see DoltStore.RecomputeAllBlocked),
+		// checked inside the recompute tx so it sees the same working set the
+		// recompute will read (bd-6dnrw.37).
 		var e error
-		changed, e = issueops.RecomputeAllIsBlockedInTx(ctx, tx)
+		changed, e = versioncontrolops.GuardedRecomputeAllBlockedInTx(ctx, tx)
 		return e
 	}); err != nil {
 		return 0, err
@@ -357,7 +355,8 @@ func (s *EmbeddedDoltStore) RecomputeAllBlocked(ctx context.Context) (int, error
 		// recompute, so an unrelated dirty working set is not swept in.
 		if err := s.withMutatingDBConn(ctx, func(db versioncontrolops.DBConn) error {
 			return versioncontrolops.StageAndCommit(ctx, db,
-				map[string]bool{"issues": true}, "bd: recompute is_blocked (full)", commitAuthor)
+				versioncontrolops.BlockedRecomputeStagedTables(),
+				versioncontrolops.BlockedRecomputeCommitMsg, commitAuthor)
 		}); err != nil {
 			return int(changed), err
 		}

--- a/internal/storage/versioncontrolops/blocked_recompute.go
+++ b/internal/storage/versioncontrolops/blocked_recompute.go
@@ -1,0 +1,89 @@
+package versioncontrolops
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/steveyegge/beads/internal/storage/issueops"
+)
+
+// BlockedRecomputeCommitMsg is the Dolt commit message the FULL is_blocked
+// repair lands under. Every storage mode commits the repair under this exact
+// message, so a reader of dolt_log cannot tell which mode ran it — which is the
+// point: the repair is mode-independent (bd-6dnrw.37) and its history entry
+// must be too.
+const BlockedRecomputeCommitMsg = "bd: recompute is_blocked (full)"
+
+// BlockedRecomputeStagedTables is the exact staging set of the repair commit.
+//
+// ONLY `issues`. is_blocked lives on issues and wisps, but the wisp tables are
+// dolt_ignore'd and can never be staged, and staging anything wider would sweep
+// an unrelated dirty working set into a commit whose whole content is supposed
+// to be a derived flag. A fresh map per call because StageAndCommit's parameter
+// is a mutable set.
+func BlockedRecomputeStagedTables() map[string]bool {
+	return map[string]bool{"issues": true}
+}
+
+// GuardedRecomputeAllBlockedInTx is the entire in-transaction body of the full
+// is_blocked repair, shared verbatim by every mode's wrapper: refuse a dirty
+// graph, then recompute every issue and wisp, returning the number of rows
+// corrected.
+//
+// The guard runs as the FIRST statement inside the caller's transaction on
+// purpose — it must observe exactly the working set the recompute will read, or
+// it is guarding a different database than the one being repaired.
+//
+// Idempotent: a consistent database corrects nothing and returns 0.
+func GuardedRecomputeAllBlockedInTx(ctx context.Context, tx issueops.DBTX) (int64, error) {
+	if err := issueops.GuardBlockedRecomputeWorkingSet(ctx, tx); err != nil {
+		return 0, err
+	}
+	return issueops.RecomputeAllIsBlockedInTx(ctx, tx)
+}
+
+// BlockedRecomputeConn is a connection the whole repair can run on end to end:
+// it can open the repair's own SQL transaction, and it can issue the
+// DOLT_ADD/DOLT_COMMIT that must follow that transaction's commit (Dolt's
+// stored procedures cannot run inside an explicit transaction). Both *sql.DB
+// and *sql.Conn satisfy it.
+type BlockedRecomputeConn interface {
+	DBConn
+	BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)
+}
+
+// RecomputeAllBlockedOnConn runs the whole full is_blocked repair on conn and
+// returns the number of rows it corrected: guard + recompute inside one
+// transaction, then — only when something actually changed — stage `issues`
+// alone and commit under BlockedRecomputeCommitMsg.
+//
+// author may be empty, which omits --author and lets the server attribute the
+// commit to the connected session. That is the right default for the
+// proxied-server plane, whose every other commit (uow.Tx.Commit) is likewise
+// unauthored; a store that has a configured committer identity passes it.
+//
+// The returned count is meaningful even alongside a non-nil error from the
+// staging step: the rows WERE corrected in the working set, only the history
+// entry failed, and a caller that reported 0 there would be lying about the
+// database it is looking at.
+func RecomputeAllBlockedOnConn(ctx context.Context, conn BlockedRecomputeConn, author string) (int64, error) {
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("begin is_blocked recompute: %w", err)
+	}
+	changed, err := GuardedRecomputeAllBlockedInTx(ctx, tx)
+	if err != nil {
+		_ = tx.Rollback()
+		return 0, err
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("commit is_blocked recompute: %w", err)
+	}
+	if changed > 0 {
+		if err := StageAndCommit(ctx, conn, BlockedRecomputeStagedTables(), BlockedRecomputeCommitMsg, author); err != nil {
+			return changed, err
+		}
+	}
+	return changed, nil
+}

--- a/internal/storage/versioncontrolops/commit.go
+++ b/internal/storage/versioncontrolops/commit.go
@@ -38,6 +38,12 @@ func (t *DirtyTableTracker) DirtyTables() map[string]bool {
 //
 // If commitMsg is empty, no commit is created. "Nothing to commit" errors
 // are treated as benign (e.g., all writes were to dolt-ignored tables).
+//
+// An empty author omits --author entirely, leaving attribution to the connected
+// session. That is not a fallback for a missing identity but the proxied-server
+// plane's normal discipline: its every other commit (uow.Tx.Commit) is
+// unauthored, and passing an empty --author would be a malformed commit rather
+// than an unattributed one.
 func StageAndCommit(ctx context.Context, conn DBConn, dirtyTables map[string]bool, commitMsg, author string) error {
 	if commitMsg == "" || len(dirtyTables) == 0 {
 		return nil
@@ -49,7 +55,12 @@ func StageAndCommit(ctx context.Context, conn DBConn, dirtyTables map[string]boo
 		}
 	}
 
-	_, err := conn.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)", commitMsg, author)
+	var err error
+	if author == "" {
+		_, err = conn.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?)", commitMsg)
+	} else {
+		_, err = conn.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)", commitMsg, author)
+	}
 	if err != nil && !issueops.IsNothingToCommitError(err) {
 		return fmt.Errorf("dolt commit: %w", err)
 	}


### PR DESCRIPTION
Proxied parity F7 (bd-04vav, epic bd-vxavz): port `bd recompute-blocked` to proxied-server mode, plus a cross-mode cascade parity test suite for delete/prune/purge.

## Port
- The in-tx repair body (dirty-graph guard + fixpoint recompute) is hoisted to `internal/storage/versioncontrolops/blocked_recompute.go`; classic dolt, embedded, and proxied modes all call the ONE implementation — parity by construction. Staging set and commit message are likewise single-sourced (`BlockedRecomputeStagedTables` / `BlockedRecomputeCommitMsg`).
- Proxied route runs on a pinned non-tx conn (same as compact/gc): DOLT_ADD/DOLT_COMMIT stored procs refuse explicit tx, and the uow `-Am` commit path would over-stage — this repair must stage `issues` alone.
- `StageAndCommit` gains the empty-author form (omit `--author` entirely; matches the proxied plane's uow.Tx.Commit discipline).
- `CheckReadonly` now precedes the mode branch. Admin cleanup stays gated (descoped per recon on the bead — no wheelhouse call sites).

## Cascade parity suite + data-loss finding
New `cmd/bd/cascade_parity_proxied_integration_test.go`: gate-sweep delete, wisp close+purge, reference-aware prune, each asserted identical classic vs proxied.

⚠ **Measured divergence, filed as bd-paurh (P1, blocks bd-vxavz cutover):** proxied `bd delete <id> --force` forces `Cascade:true` — it deletes the gated TARGET and downstream where classic preserves them. `wh-gate-sweep:218` would destroy the beads it just unblocked. A characterization subtest pins today's blast radius and fails in either direction on change, so the fix PR must flip the pin deliberately.

## Residuals (on the bead, 8/5 executor report)
- `doctor/fix/blocked.go` still hardcodes its own staging set (drift risk).
- `RecomputeAllBlockedOnConn` is single-caller; classic DoltStore could adopt if DrainCall→ExecContext is deemed safe (transaction.go:167 precedent).
- Classic half of the cascade oracle needs the dolt binary (`bd sql` not in embedded).

## Verification
- Targeted suites green pre- and post-rebase onto 50763fcba (`TestProxiedServerRecomputeBlocked`, `TestProxiedServerCascadeParity`, 45s, count=1).
- Shard manifest updated (15/4 + 15/15).
- Ambient env reds verified FAIL-set-identical vs baseline (bd-7xtsq / bd-pppsh).

Review: lion (comment-review per current convention). Beads: bd-04vav; finding bd-paurh.