### PR TITLE
feat(unclaim,batch): port --if-assignee CAS and bd batch to proxied-server mode (bd-tb0yi)

### DIFF
--- a/.github/scripts/proxied-cmd-test-shards.txt
+++ b/.github/scripts/proxied-cmd-test-shards.txt
@@ -47,6 +47,7 @@
 15 4 TestProxiedServerDuplicates
 15 4 TestProxiedServerMolBond
 15 4 TestProxiedServerQuery
+15 4 TestProxiedServerUnclaimIfAssigneeParity
 15 4 TestProxiedServerWispCreate
 
 15 5 TestProxiedServerCreate2

--- a/.github/scripts/proxied-cmd-test-shards.txt
+++ b/.github/scripts/proxied-cmd-test-shards.txt
@@ -84,6 +84,7 @@
 15 8 TestProxiedServerServeClaim
 15 8 TestProxiedServerServeReadParity
 
+15 9 TestProxiedServerBatchParity
 15 9 TestProxiedServerDep2
 15 9 TestProxiedServerGraph
 15 9 TestProxiedServerMolProgress

--- a/cmd/bd/batch.go
+++ b/cmd/bd/batch.go
@@ -86,9 +86,6 @@ normal 'bd' subcommands for interactive/read operations.`,
 	SilenceUsage:  true,
 	SilenceErrors: false,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if usesProxiedServer() {
-			return HandleErrorRespectJSON("batch is not supported in proxied-server mode")
-		}
 		CheckReadonly("batch")
 
 		evt := metrics.NewCommandEvent("batch")
@@ -98,7 +95,8 @@ normal 'bd' subcommands for interactive/read operations.`,
 			}
 		}()
 
-		if store == nil {
+		proxied := usesProxiedServer()
+		if !proxied && store == nil {
 			return fmt.Errorf("no database connection available (%s)", diagHint())
 		}
 
@@ -167,17 +165,26 @@ normal 'bd' subcommands for interactive/read operations.`,
 			ctx = context.Background()
 		}
 
-		results := make([]batchOpResult, 0, len(ops))
-		err = transact(ctx, store, commitMsg, func(tx storage.Transaction) error {
-			for _, op := range ops {
-				res, rerr := runBatchOp(ctx, tx, op)
-				if rerr != nil {
-					return fmt.Errorf("line %d (%s): %w", op.line, op.raw, rerr)
+		// One transaction, one commit message, whole-batch rollback on the first
+		// failing line — the contract is the same on both backends; only the
+		// transaction primitive differs (uow.RunTx there, transact here), and
+		// both wrap a per-op dispatch that shares this file's parser.
+		var results []batchOpResult
+		if proxied {
+			results, err = runBatchProxiedServer(ctx, ops, commitMsg)
+		} else {
+			results = make([]batchOpResult, 0, len(ops))
+			err = transact(ctx, store, commitMsg, func(tx storage.Transaction) error {
+				for _, op := range ops {
+					res, rerr := runBatchOp(ctx, tx, op)
+					if rerr != nil {
+						return fmt.Errorf("line %d (%s): %w", op.line, op.raw, rerr)
+					}
+					results = append(results, res)
 				}
-				results = append(results, res)
-			}
-			return nil
-		})
+				return nil
+			})
+		}
 		if err != nil {
 			if jsonOutput {
 				if jerr := outputJSONError(err, "batch_error"); jerr != nil {

--- a/cmd/bd/batch_parity_test.go
+++ b/cmd/bd/batch_parity_test.go
@@ -1,0 +1,340 @@
+//go:build cgo
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// batchParityOutcome is everything a `bd batch` caller can observe, recorded
+// once per backend: exit codes, the summary and per-line report, and the state
+// the batch left in the database. Ids never appear — the two workspaces mint
+// their own — so rows are named by role and edges are counted.
+type batchParityOutcome struct {
+	// --dry-run parses and echoes without executing.
+	dryCode        int
+	dryEchoedLines int
+	dryTail        string
+	dryTouchedA    bool
+
+	// Empty input is a no-op success.
+	emptyCode int
+	emptyTail string
+
+	// The committed batch.
+	commitCode    int
+	commitSummary string
+	commitOps     []string
+	aStatus       types.Status
+	aPriority     int
+	bStatus       types.Status
+	cDeps         int
+	createdFound  bool
+
+	// A failing line rolls the WHOLE batch back.
+	rollbackCode      int
+	rollbackNamesLine bool
+	rollbackAPriority int
+	rollbackCReopened bool
+
+	// Grammar errors are refused before any write.
+	badGrammarCode      int
+	badGrammarNamesLine bool
+	badGrammarBStatus   types.Status
+
+	// dep remove closes the loop on the edge the batch added.
+	removeCode int
+	cDepsAfter int
+}
+
+// TestProxiedServerBatchParity is the cross-mode oracle for `bd batch` ported
+// to proxied-server mode.
+//
+// `bd batch` exists because a shell loop of N `bd` invocations is N
+// transactions and N Dolt commits; the command's whole value is that it is ONE
+// of each, all-or-nothing. So the interesting assertions are not "the ops
+// happened" but the transactional ones: a failing line at the END must undo the
+// successful lines BEFORE it, and a grammar error must be refused before
+// anything is written at all. Both are checked here on both backends, along
+// with the dry-run, empty-input and per-line report contracts that scripts
+// parse.
+//
+// TWO KNOWN DIVERGENCES are deliberately outside this oracle, both named at
+// their site (see the rollback step below and batch_proxied_server.go's dep
+// cases): an out-of-range `priority=` is written by the classic batch and
+// refused by the proxied one, and a batched `dep add`/`dep remove` records a
+// dependency history event here and not there. Neither changes the rows the
+// batch lands, and both are classic-batch inconsistencies with the CLI verbs
+// rather than something the port introduced.
+func TestProxiedServerBatchParity(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+
+	envs := newCrossModeEnvs(t, bd, "bpc", "bpp")
+	outcomes := make(map[string]batchParityOutcome, len(envs))
+
+	for _, env := range envs {
+		var got batchParityOutcome
+
+		a := env.create(t, "Batch A")
+		b := env.create(t, "Batch B")
+		c := env.create(t, "Batch C")
+
+		// Comments and blank lines are ignored; the four real lines cover every
+		// verb in the grammar except dep remove (exercised at the end).
+		script := fmt.Sprintf(""+
+			"# a comment line\n"+
+			"\n"+
+			"update %s status=in_progress priority=1\n"+
+			"close %s done via batch\n"+
+			"dep add %s %s blocks\n"+
+			"create task 2 \"Batch created issue\"\n", a, b, c, a)
+
+		// 1. --dry-run: parse and echo, execute nothing.
+		stdout, _, code := env.runStdin(t, script, "batch", "--dry-run")
+		got.dryCode = code
+		got.dryEchoedLines = strings.Count(stdout, "line ")
+		got.dryTail = lastNonEmptyLine(stdout)
+		got.dryTouchedA = env.show(t, a).Status != types.StatusOpen
+
+		// 2. Empty input is a no-op success, matching `bd list ... | bd batch`
+		// on an empty list.
+		stdout, _, code = env.runStdin(t, "", "batch")
+		got.emptyCode = code
+		got.emptyTail = lastNonEmptyLine(stdout)
+
+		// 3. The real batch.
+		stdout, stderr, code := env.runStdin(t, script, "batch")
+		got.commitCode = code
+		if code != 0 {
+			t.Fatalf("[%s] batch failed with exit %d\nstdout:\n%s\nstderr:\n%s", env.mode, code, stdout, stderr)
+		}
+		got.commitSummary = firstLineWithPrefix(stdout, "batch: ")
+		got.commitOps = batchReportOps(stdout)
+
+		rowA := env.show(t, a)
+		got.aStatus, got.aPriority = rowA.Status, rowA.Priority
+		got.bStatus = env.show(t, b).Status
+		got.cDeps = len(env.depList(t, c))
+		got.createdFound = env.hasIssueTitled(t, "Batch created issue")
+
+		// 4. A failing line rolls back the successful lines before it. The
+		// first line here would otherwise be a visible write (priority 3 on A,
+		// which the batch above set to 1) and the second reopens C; both must
+		// be gone after the third line fails on a non-existent id.
+		//
+		// KNOWN PRE-EXISTING DIVERGENCE, deliberately not exercised here: an
+		// OUT-OF-RANGE priority (`priority=5`) is written by the classic batch
+		// and refused by the proxied one, because the domain update funnel
+		// validates the range and issueops' transaction path does not. `bd
+		// update --priority 5` rejects it on both paths — only the batch
+		// grammar reaches the unvalidated seam — so this is a hole in classic
+		// batch rather than something the port introduced. Closing it is its
+		// own change; using an in-range value here keeps this case about
+		// rollback.
+		badID := "zz-nope-999"
+		rollback := fmt.Sprintf(""+
+			"update %s priority=3\n"+
+			"update %s status=in_progress\n"+
+			"close %s\n", a, c, badID)
+		stdout, stderr, code = env.runStdin(t, rollback, "batch")
+		got.rollbackCode = code
+		got.rollbackNamesLine = strings.Contains(stdout+stderr, "line 3")
+		got.rollbackAPriority = env.show(t, a).Priority
+		got.rollbackCReopened = env.show(t, c).Status != types.StatusOpen
+
+		// 5. A grammar error is refused by the shared parser BEFORE either
+		// backend is reached, so nothing is written even though line 1 is valid.
+		bad := fmt.Sprintf("close %s\nfrobnicate %s\n", b, b)
+		stdout, stderr, code = env.runStdin(t, bad, "batch")
+		got.badGrammarCode = code
+		got.badGrammarNamesLine = strings.Contains(stdout+stderr, "line 2")
+		got.badGrammarBStatus = env.show(t, b).Status
+
+		// 6. dep remove takes the edge back out.
+		stdout, stderr, code = env.runStdin(t, fmt.Sprintf("dep remove %s %s\n", c, a), "batch")
+		got.removeCode = code
+		if code != 0 {
+			t.Fatalf("[%s] batch dep remove failed with exit %d\nstdout:\n%s\nstderr:\n%s", env.mode, code, stdout, stderr)
+		}
+		got.cDepsAfter = len(env.depList(t, c))
+
+		outcomes[env.mode] = got
+
+		// Per-mode absolute expectations: parity with a shared bug is still a bug.
+		if got.dryCode != 0 || got.dryEchoedLines != 4 {
+			t.Errorf("[%s] dry-run: exit=%d echoed=%d, want 0/4", env.mode, got.dryCode, got.dryEchoedLines)
+		}
+		if got.dryTouchedA {
+			t.Errorf("[%s] dry-run executed the batch", env.mode)
+		}
+		if got.emptyCode != 0 || !strings.Contains(got.emptyTail, "0 operations") {
+			t.Errorf("[%s] empty input: exit=%d tail=%q, want 0 / a 0-operations no-op", env.mode, got.emptyCode, got.emptyTail)
+		}
+		if !strings.Contains(got.commitSummary, "4 operations committed") {
+			t.Errorf("[%s] commit summary = %q, want a 4-operations commit", env.mode, got.commitSummary)
+		}
+		if want := "update,close,dep.add,create"; strings.Join(got.commitOps, ",") != want {
+			t.Errorf("[%s] per-line report ops = %v, want %s", env.mode, got.commitOps, want)
+		}
+		if got.aStatus != types.StatusInProgress || got.aPriority != 1 {
+			t.Errorf("[%s] batch update: status=%q priority=%d, want in_progress/1", env.mode, got.aStatus, got.aPriority)
+		}
+		if got.bStatus != types.StatusClosed {
+			t.Errorf("[%s] batch close: status=%q, want closed", env.mode, got.bStatus)
+		}
+		if got.cDeps != 1 {
+			t.Errorf("[%s] batch dep add: %d edges on C, want 1", env.mode, got.cDeps)
+		}
+		if !got.createdFound {
+			t.Errorf("[%s] batch create: the created issue is missing", env.mode)
+		}
+		if got.rollbackCode == 0 {
+			t.Errorf("[%s] a failing batch line must exit non-zero", env.mode)
+		}
+		if got.rollbackAPriority != 1 {
+			t.Errorf("[%s] rollback did not undo the earlier line: priority=%d, want 1", env.mode, got.rollbackAPriority)
+		}
+		if got.rollbackCReopened {
+			t.Errorf("[%s] rollback did not undo the status line on C", env.mode)
+		}
+		if got.badGrammarCode == 0 || !got.badGrammarNamesLine {
+			t.Errorf("[%s] grammar error: exit=%d namesLine=%v, want non-zero and 'line 2'",
+				env.mode, got.badGrammarCode, got.badGrammarNamesLine)
+		}
+		if got.badGrammarBStatus != types.StatusClosed {
+			// B was already closed by the committed batch; a re-close from a
+			// script that never ran must not have changed anything either way.
+			t.Errorf("[%s] grammar error wrote something: B status=%q", env.mode, got.badGrammarBStatus)
+		}
+		if got.cDepsAfter != 0 {
+			t.Errorf("[%s] batch dep remove: %d edges left on C, want 0", env.mode, got.cDepsAfter)
+		}
+	}
+
+	assertBatchParity(t, outcomes["classic"], outcomes["proxied"])
+}
+
+func assertBatchParity(t *testing.T, classic, proxied batchParityOutcome) {
+	t.Helper()
+	type field struct {
+		name             string
+		classic, proxied any
+	}
+	fields := []field{
+		{"dry-run exit code", classic.dryCode, proxied.dryCode},
+		{"dry-run echoed lines", classic.dryEchoedLines, proxied.dryEchoedLines},
+		{"dry-run tail", classic.dryTail, proxied.dryTail},
+		{"dry-run executed anything", classic.dryTouchedA, proxied.dryTouchedA},
+		{"empty-input exit code", classic.emptyCode, proxied.emptyCode},
+		{"empty-input tail", classic.emptyTail, proxied.emptyTail},
+		{"commit exit code", classic.commitCode, proxied.commitCode},
+		{"commit summary", classic.commitSummary, proxied.commitSummary},
+		{"commit per-line ops", strings.Join(classic.commitOps, ","), strings.Join(proxied.commitOps, ",")},
+		{"A status", classic.aStatus, proxied.aStatus},
+		{"A priority", classic.aPriority, proxied.aPriority},
+		{"B status", classic.bStatus, proxied.bStatus},
+		{"C dependency count", classic.cDeps, proxied.cDeps},
+		{"created issue present", classic.createdFound, proxied.createdFound},
+		{"rollback exit code", classic.rollbackCode, proxied.rollbackCode},
+		{"rollback names failing line", classic.rollbackNamesLine, proxied.rollbackNamesLine},
+		{"A priority after rollback", classic.rollbackAPriority, proxied.rollbackAPriority},
+		{"C reopened after rollback", classic.rollbackCReopened, proxied.rollbackCReopened},
+		{"grammar-error exit code", classic.badGrammarCode, proxied.badGrammarCode},
+		{"grammar-error names line", classic.badGrammarNamesLine, proxied.badGrammarNamesLine},
+		{"B status after grammar error", classic.badGrammarBStatus, proxied.badGrammarBStatus},
+		{"dep-remove exit code", classic.removeCode, proxied.removeCode},
+		{"C dependency count after remove", classic.cDepsAfter, proxied.cDepsAfter},
+	}
+	for _, f := range fields {
+		if f.classic != f.proxied {
+			t.Errorf("cross-mode divergence on %s: classic=%v proxied=%v", f.name, f.classic, f.proxied)
+		}
+	}
+}
+
+// depList reads the dependency records of one issue as a flat array, the shape
+// `bd dep list --json` documents.
+func (e crossModeEnv) depList(t *testing.T, id string) []map[string]any {
+	t.Helper()
+	out := e.mustRun(t, "dep", "list", id, "--json")
+	trimmed := strings.TrimSpace(out)
+	if trimmed == "" || trimmed == "null" {
+		return nil
+	}
+	start := strings.Index(out, "[")
+	if start < 0 {
+		t.Fatalf("[%s] no JSON array in dep list output:\n%s", e.mode, out)
+	}
+	var records []map[string]any
+	if err := json.Unmarshal([]byte(out[start:]), &records); err != nil {
+		t.Fatalf("[%s] parse dep list JSON: %v\n%s", e.mode, err, out[start:])
+	}
+	return records
+}
+
+// hasIssueTitled reports whether any issue in the workspace carries title.
+func (e crossModeEnv) hasIssueTitled(t *testing.T, title string) bool {
+	t.Helper()
+	out := e.mustRun(t, "list", "--all", "--json")
+	start := strings.Index(out, "[")
+	if start < 0 {
+		return false
+	}
+	var rows []struct {
+		Title string `json:"title"`
+	}
+	if err := json.Unmarshal([]byte(out[start:]), &rows); err != nil {
+		t.Fatalf("[%s] parse list JSON: %v\n%s", e.mode, err, out[start:])
+	}
+	for _, row := range rows {
+		if row.Title == title {
+			return true
+		}
+	}
+	return false
+}
+
+// batchReportOps pulls the op names out of the per-line report `bd batch`
+// prints after a successful commit ("  line 3: update bd-x").
+func batchReportOps(stdout string) []string {
+	var ops []string
+	for _, line := range strings.Split(stdout, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "line ") {
+			continue
+		}
+		_, rest, ok := strings.Cut(trimmed, ": ")
+		if !ok {
+			continue
+		}
+		op, _, _ := strings.Cut(rest, " ")
+		ops = append(ops, op)
+	}
+	return ops
+}
+
+func firstLineWithPrefix(s, prefix string) string {
+	for _, line := range strings.Split(s, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), prefix) {
+			return strings.TrimSpace(line)
+		}
+	}
+	return ""
+}
+
+func lastNonEmptyLine(s string) string {
+	lines := strings.Split(s, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if trimmed := strings.TrimSpace(lines[i]); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/cmd/bd/batch_proxied_server.go
+++ b/cmd/bd/batch_proxied_server.go
@@ -1,0 +1,231 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/storage/uow"
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/internal/workapi"
+)
+
+// runBatchProxiedServer executes an already-parsed batch script in ONE
+// proxied-server unit of work.
+//
+// The two modes divide exactly where the command's contract does. Parsing,
+// validation, the dry-run echo, the empty-input no-op, the default commit
+// message and every byte of output stay in batch.go and are shared: a batch
+// script means the same thing whichever backend runs it, and a script rejected
+// by the parser is rejected before either backend is reached. What is per-mode
+// is the transaction primitive and the verbs the ops dispatch against —
+// storage.Transaction there, the unit of work's use cases here.
+//
+// uow.RunTx is the analog of the classic `transact`: one transaction, one
+// DOLT_COMMIT carrying the caller's message, and rollback of the WHOLE batch on
+// the first failing line (the line is named in the error exactly as the classic
+// path names it). RunTx additionally redoes the entire batch in a fresh unit of
+// work when Dolt reports a serialization failure — the batch is re-executed
+// against the winner's committed rows, never re-committed on a session the
+// server already rolled back.
+//
+// NOT RunTxEphemeral: a batch writes versioned tables, and the ephemeral form
+// commits without a Dolt commit (its whole point for the leases table), which
+// would persist these writes while silently bypassing Dolt history.
+func runBatchProxiedServer(ctx context.Context, ops []batchOp, commitMsg string) ([]batchOpResult, error) {
+	if uowProvider == nil {
+		return nil, HandleErrorRespectJSON("proxied-server UOW provider not initialized")
+	}
+	return uow.RunTxResult(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) ([]batchOpResult, string, error) {
+		// Built per attempt, not per call: a retried batch must report the
+		// results of the attempt that actually committed.
+		results := make([]batchOpResult, 0, len(ops))
+		for _, op := range ops {
+			res, rerr := runBatchOpUOW(ctx, uw, op)
+			if rerr != nil {
+				return nil, "", fmt.Errorf("line %d (%s): %w", op.line, op.raw, rerr)
+			}
+			results = append(results, res)
+		}
+		return results, commitMsg, nil
+	})
+}
+
+// runBatchOpUOW dispatches one parsed op against the unit of work, the proxied
+// twin of runBatchOp's dispatch against storage.Transaction. Same grammar, same
+// arity checks, same error strings, same per-op result — only the verb changes.
+//
+// Plane routing is explicit here because it has to be: the classic transaction
+// methods route an id to the issues or wisps tables themselves, while the
+// domain use cases expose the two planes as separate verbs. Every op that names
+// an existing id resolves it through workapi.GetIssueOrWisp first (both planes,
+// this transaction's own snapshot) and then calls the matching verb, so a batch
+// line that touches a wisp touches the wisp tables on both backends.
+func runBatchOpUOW(ctx context.Context, uw uow.UnitOfWork, op batchOp) (batchOpResult, error) {
+	actorName := getActor()
+	result := batchOpResult{Line: op.line, Op: op.cmd}
+	issues := uw.IssueUseCase()
+
+	switch op.cmd {
+	case "close":
+		if len(op.args) < 1 {
+			return result, fmt.Errorf("close requires <id>")
+		}
+		id := op.args[0]
+		reason := "Closed"
+		if len(op.args) > 1 {
+			reason = strings.Join(op.args[1:], " ")
+		}
+		resolved, isWisp, err := batchResolveOpTarget(ctx, uw, id)
+		if err != nil {
+			return result, err
+		}
+		// Deliberately the UNCHECKED close, matching the classic batch's
+		// issueops.CloseIssueInTx: `close <id>` in a batch does not apply close
+		// policy at all (the asymmetry with `update status=closed` is documented
+		// in the command's help and is contract, not oversight).
+		params := domain.CloseIssueParams{Reason: reason}
+		if isWisp {
+			_, err = issues.CloseWisp(ctx, resolved, params, actorName)
+		} else {
+			_, err = issues.CloseIssue(ctx, resolved, params, actorName)
+		}
+		if err != nil {
+			return result, err
+		}
+		result.Target = id
+		return result, nil
+
+	case "update":
+		if len(op.args) < 2 {
+			return result, fmt.Errorf("update requires <id> and at least one key=value")
+		}
+		id := op.args[0]
+		updates, err := parseUpdateKVs(op.args[1:])
+		if err != nil {
+			return result, err
+		}
+		resolved, isWisp, err := batchResolveOpTarget(ctx, uw, id)
+		if err != nil {
+			return result, err
+		}
+		if isWisp {
+			err = issues.UpdateWisp(ctx, resolved, updates, actorName)
+		} else {
+			err = issues.UpdateIssue(ctx, resolved, updates, actorName)
+		}
+		if err != nil {
+			return result, err
+		}
+		result.Target = id
+		return result, nil
+
+	case "create":
+		if len(op.args) < 3 {
+			return result, fmt.Errorf("create requires <type> <priority> <title>")
+		}
+		issueType := types.IssueType(op.args[0])
+		if strings.TrimSpace(op.args[0]) == "" {
+			return result, fmt.Errorf("create: type cannot be empty")
+		}
+		priority, err := strconv.Atoi(op.args[1])
+		if err != nil {
+			return result, fmt.Errorf("create: invalid priority %q: %w", op.args[1], err)
+		}
+		title := strings.Join(op.args[2:], " ")
+		if strings.TrimSpace(title) == "" {
+			return result, fmt.Errorf("create: title cannot be empty")
+		}
+		issue := &types.Issue{
+			Title:     title,
+			IssueType: issueType,
+			Status:    types.StatusOpen,
+			Priority:  priority,
+		}
+		created, err := issues.CreateIssue(ctx, domain.CreateIssueParams{Issue: issue}, actorName)
+		if err != nil {
+			return result, err
+		}
+		// The classic path reports the id the store minted into the caller's
+		// struct; the use case hands the same row back as a result.
+		if created.Issue != nil {
+			result.Target = created.Issue.ID
+		} else {
+			result.Target = issue.ID
+		}
+		return result, nil
+
+	case "dep.add":
+		if len(op.args) < 2 {
+			return result, fmt.Errorf("dep add requires <from-id> <to-id>")
+		}
+		from, to := op.args[0], op.args[1]
+		depType := "blocks"
+		if len(op.args) >= 3 {
+			depType = op.args[2]
+		}
+		dt := types.DependencyType(depType)
+		if !dt.IsValid() {
+			return result, fmt.Errorf("dep add: invalid dependency type %q", depType)
+		}
+		dep := &types.Dependency{
+			IssueID:     from,
+			DependsOnID: to,
+			Type:        dt,
+		}
+		// AddDependencies (not the single-edge AddDependency) because it lands
+		// each edge in the plane its own SOURCE lives in, which is the routing
+		// the classic transaction does from isActiveWisp. One edge is still one
+		// edge, and the per-edge cycle probe runs.
+		//
+		// KNOWN DIVERGENCE, in the HISTORY only: every domain edge verb records
+		// a dependency_added event, while the classic batch reaches
+		// storage.Transaction.AddDependency, whose zero DependencyAddOptions
+		// leaves EmitEvent false — the "structural, quiet" setting meant for
+		// create-with-deps and reparenting, not for a verb a user typed. So a
+		// batched `dep add` shows up in `bd history` here and does not there.
+		// The edge itself, its plane, its type and the cycle verdict are
+		// identical; `bd dep add` at the CLI emits the event on BOTH backends,
+		// which is why the classic batch's silence reads as the outlier.
+		// Silencing it here would need a quiet variant on the use case that
+		// nothing else wants, so this port takes the event and names it rather
+		// than growing the domain surface to reproduce an inconsistency.
+		if _, err := uw.DependencyUseCase().AddDependencies(ctx, []*types.Dependency{dep}, actorName, domain.BulkAddDepsOpts{}); err != nil {
+			return result, err
+		}
+		result.Target = fmt.Sprintf("%s->%s", from, to)
+		return result, nil
+
+	case "dep.remove":
+		if len(op.args) < 2 {
+			return result, fmt.Errorf("dep remove requires <from-id> <to-id>")
+		}
+		from, to := op.args[0], op.args[1]
+		// BySource for the same reason dep.add uses the bulk verb: the edge is
+		// removed from the plane its source lives in. A missing edge is not an
+		// error on either backend — the removal is idempotent, and a batch that
+		// re-runs must not roll back on an edge already gone. The
+		// dependency_removed event carries the same divergence, and the same
+		// reasoning, as the added one above.
+		if _, err := uw.DependencyUseCase().RemoveDependencyBySource(ctx, from, to, actorName); err != nil {
+			return result, err
+		}
+		result.Target = fmt.Sprintf("%s->%s", from, to)
+		return result, nil
+	}
+	return result, fmt.Errorf("internal: unhandled batch op %q", op.cmd)
+}
+
+// batchResolveOpTarget resolves an id an op names to the row it is about and
+// the plane that row lives in, inside this transaction. A missing id is an
+// error, which rolls the whole batch back — the same verdict the classic path
+// reaches when its store call cannot find the row.
+func batchResolveOpTarget(ctx context.Context, uw uow.UnitOfWork, id string) (string, bool, error) {
+	issue, isWisp, err := workapi.GetIssueOrWisp(ctx, workapi.NewUOWDetailSource(uw), id)
+	if err != nil {
+		return "", false, err
+	}
+	return issue.ID, isWisp, nil
+}

--- a/cmd/bd/cross_mode_parity_harness_test.go
+++ b/cmd/bd/cross_mode_parity_harness_test.go
@@ -1,0 +1,124 @@
+//go:build cgo
+
+package main
+
+// Cross-mode parity harness.
+//
+// A parity case runs the SAME command sequence against two equivalent, freshly
+// initialized workspaces — one classic (embedded Dolt) and one proxied-server —
+// records a plain, comparable outcome value per mode, and asserts the two are
+// identical. It is the oracle a proxied port owes: not "the proxied path works"
+// (a single-mode integration test says that) but "the proxied path is
+// indistinguishable from the classic one", which is the property a
+// shared-server constellation actually depends on.
+//
+// Identity is asserted on OUTCOMES, never on ids: the two workspaces mint their
+// own ids, so a case names rows by role and compares exit codes, row state, and
+// the machine-greppable substrings of the output.
+//
+// The cases are named TestProxiedServer* so the proxied CI lane's discovery
+// (.github/scripts/proxied-test-shard.sh) picks them up, and gate only on
+// BEADS_TEST_PROXIED_SERVER: the classic half needs no gate of its own, since
+// the same binary runs it with the proxied env removed.
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// crossModeEnv is one initialized workspace plus the environment that selects
+// its backend. Everything a parity case does goes through run(), so the only
+// difference between the two modes is the env and the directory.
+type crossModeEnv struct {
+	mode string
+	bd   string
+	dir  string
+	env  []string
+}
+
+// newCrossModeEnvs initializes one classic and one proxied workspace with
+// equivalent configuration. The prefixes differ only so the two workspaces are
+// telling apart in failure output; nothing compares ids across modes.
+func newCrossModeEnvs(t *testing.T, bd, classicPrefix, proxiedPrefix string) []crossModeEnv {
+	t.Helper()
+	classicDir, _, _ := bdInit(t, bd, "--prefix", classicPrefix)
+	proxied := newSharedProxiedProject(t, bd, proxiedPrefix)
+	return []crossModeEnv{
+		{mode: "classic", bd: bd, dir: classicDir, env: bdEnv(classicDir)},
+		{mode: "proxied", bd: bd, dir: proxied.dir, env: bdProxiedEnv(proxied.dir)},
+	}
+}
+
+// run executes bd in this workspace and returns stdout, stderr and the exit
+// code. A command that could not be started at all is fatal — that is a broken
+// harness, not a parity verdict.
+func (e crossModeEnv) run(t *testing.T, args ...string) (string, string, int) {
+	t.Helper()
+	return e.runWith(t, nil, args...)
+}
+
+// runStdin is run() with stdin content, for the commands that read a script.
+// It always attaches a reader, including for the empty script — "no stdin at
+// all" and "an empty stdin" are different inputs to `bd batch`, and only the
+// second is the no-op case.
+func (e crossModeEnv) runStdin(t *testing.T, stdin string, args ...string) (string, string, int) {
+	t.Helper()
+	return e.runWith(t, strings.NewReader(stdin), args...)
+}
+
+func (e crossModeEnv) runWith(t *testing.T, stdin io.Reader, args ...string) (string, string, int) {
+	t.Helper()
+	cmd := exec.Command(e.bd, args...)
+	cmd.Dir = e.dir
+	cmd.Env = e.env
+	if stdin != nil {
+		cmd.Stdin = stdin
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	code := 0
+	if err != nil {
+		var ee *exec.ExitError
+		if !errors.As(err, &ee) {
+			t.Fatalf("[%s] bd %s could not run: %v\nstdout:\n%s\nstderr:\n%s",
+				e.mode, strings.Join(args, " "), err, stdout.String(), stderr.String())
+		}
+		code = ee.ExitCode()
+	}
+	return stdout.String(), stderr.String(), code
+}
+
+// mustRun is run() for a step whose failure would make the rest of the case
+// meaningless (seeding, mostly).
+func (e crossModeEnv) mustRun(t *testing.T, args ...string) string {
+	t.Helper()
+	stdout, stderr, code := e.run(t, args...)
+	if code != 0 {
+		t.Fatalf("[%s] bd %s failed with exit %d\nstdout:\n%s\nstderr:\n%s",
+			e.mode, strings.Join(args, " "), code, stdout, stderr)
+	}
+	return stdout
+}
+
+// create seeds one issue and returns its id.
+func (e crossModeEnv) create(t *testing.T, title string, extra ...string) string {
+	t.Helper()
+	args := append([]string{"create", title, "--type", "task", "--json"}, extra...)
+	out := e.mustRun(t, args...)
+	return parseIssueJSON(t, []byte(out)).ID
+}
+
+// show reads one issue back.
+func (e crossModeEnv) show(t *testing.T, id string) *types.Issue {
+	t.Helper()
+	out := e.mustRun(t, "show", id, "--json")
+	return parseIssueJSON(t, []byte(out))
+}

--- a/cmd/bd/proxied_lookup_failure_test.go
+++ b/cmd/bd/proxied_lookup_failure_test.go
@@ -241,7 +241,7 @@ var proxiedLookupCommands = []struct {
 	{
 		name: "unclaim",
 		run: func(ctx context.Context) error {
-			return runUnclaimProxiedServer(ctx, []string{stubMissingID}, "", false)
+			return runUnclaimProxiedServer(ctx, []string{stubMissingID}, "", false, "")
 		},
 		wantNotFound: "Error resolving bd-missing: not found",
 		wantHardErr:  "Error resolving bd-missing: connection reset by peer",

--- a/cmd/bd/unclaim.go
+++ b/cmd/bd/unclaim.go
@@ -62,10 +62,11 @@ Examples:
 		CheckReadonly("unclaim")
 
 		if usesProxiedServer() {
+			expected := ""
 			if conditional {
-				return HandleErrorRespectJSON("--if-assignee is not supported in proxied-server mode")
+				expected = ifAssignee
 			}
-			return runUnclaimProxiedServer(rootCtx, args, reason, force)
+			return runUnclaimProxiedServer(rootCtx, args, reason, force, expected)
 		}
 
 		ctx := rootCtx

--- a/cmd/bd/unclaim_conditional_parity_test.go
+++ b/cmd/bd/unclaim_conditional_parity_test.go
@@ -1,0 +1,190 @@
+//go:build cgo
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// unclaimGuardOutcome is everything a caller of `bd unclaim --if-assignee` can
+// observe, recorded once per backend. Comparing two of these IS the parity
+// assertion: exit codes, the row state each step left behind, and whether the
+// refusal named the actual holder (the machine-greppable half of the contract).
+type unclaimGuardOutcome struct {
+	staleCode        int
+	staleNamesHolder bool
+	staleAssignee    string
+	staleStatus      types.Status
+
+	matchCode     int
+	matchAssignee string
+	matchStatus   types.Status
+
+	repeatCode int
+
+	emptyGuardCode     int
+	emptyGuardRejected bool
+	emptyGuardAssignee string
+	emptyGuardStatus   types.Status
+
+	forceComboCode     int
+	forceComboRejected bool
+	forceComboAssignee string
+	forceComboStatus   types.Status
+}
+
+// TestProxiedServerUnclaimIfAssigneeParity is the cross-mode oracle for the
+// conditional release ported to proxied-server mode: the same six steps run
+// against a classic embedded workspace and a proxied one, and every observable
+// must match.
+//
+// The compare-and-swap is the point. A supervisor returning a specific worker's
+// bead must never clobber a claim that has since moved on, so the refusal has
+// to leave the row EXACTLY as it found it — asserted here on both backends, in
+// the same test, rather than inferred from two suites that could drift apart.
+//
+// EXIT CODE, deliberately pinned: a stale guard exits 1 on both paths. `bd
+// unclaim` has never had `bd update`'s ExitGuardMismatch (13) verdict — its
+// help says so outright ("1 when any release failed (including an
+// --if-assignee mismatch)") — and this port does not invent one for the proxied
+// path, because a proxied exit code that differs from the embedded one for the
+// same refusal is precisely the divergence this lane exists to prevent. If
+// unclaim ever adopts 13 it must adopt it in BOTH modes, and this assertion
+// changes once, deliberately.
+func TestProxiedServerUnclaimIfAssigneeParity(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+
+	envs := newCrossModeEnvs(t, bd, "ucc", "ucp")
+	outcomes := make(map[string]unclaimGuardOutcome, len(envs))
+
+	for _, env := range envs {
+		var got unclaimGuardOutcome
+
+		// A live claim held by alice.
+		held := env.create(t, "Conditional release")
+		env.mustRun(t, "update", held, "--assignee", "alice", "--status", "in_progress")
+
+		// 1. Stale expectation: refuses, names the holder, writes nothing.
+		stdout, stderr, code := env.run(t, "unclaim", held, "--if-assignee", "bob")
+		got.staleCode = code
+		got.staleNamesHolder = strings.Contains(stdout+stderr, "alice")
+		row := env.show(t, held)
+		got.staleAssignee, got.staleStatus = row.Assignee, row.Status
+
+		// 2. Matching expectation: releases.
+		_, _, code = env.run(t, "unclaim", held, "--if-assignee", "alice")
+		got.matchCode = code
+		row = env.show(t, held)
+		got.matchAssignee, got.matchStatus = row.Assignee, row.Status
+
+		// 3. Releasing an already-released issue is a distinct failure, not a
+		// silent success — the exactly-once property a release-if-current
+		// supervisor depends on.
+		_, _, got.repeatCode = env.run(t, "unclaim", held, "--if-assignee", "alice")
+
+		// 4. An explicitly empty --if-assignee (an unset variable that expanded
+		// into the flag) must be REJECTED, not silently downgraded to an
+		// unconditional release. Run as the holder, so the pre-fix behavior
+		// would actually have released the claim.
+		second := env.create(t, "Empty expectation")
+		env.mustRun(t, "update", second, "--assignee", "alice", "--status", "in_progress")
+		stdout, stderr, code = env.run(t, "unclaim", second, "--if-assignee", "", "--actor", "alice")
+		got.emptyGuardCode = code
+		got.emptyGuardRejected = strings.Contains(stdout+stderr, "if-assignee requires a non-empty assignee")
+		row = env.show(t, second)
+		got.emptyGuardAssignee, got.emptyGuardStatus = row.Assignee, row.Status
+
+		// 5. --force and --if-assignee encode contradictory intent and are
+		// mutually exclusive; the combination writes nothing.
+		stdout, stderr, code = env.run(t, "unclaim", second, "--force", "--if-assignee", "alice")
+		got.forceComboCode = code
+		combined := stdout + stderr
+		got.forceComboRejected = strings.Contains(combined, "force") && strings.Contains(combined, "if-assignee")
+		row = env.show(t, second)
+		got.forceComboAssignee, got.forceComboStatus = row.Assignee, row.Status
+
+		outcomes[env.mode] = got
+
+		// Per-mode absolute expectations. Parity with a shared bug is still a
+		// bug, so each mode is also checked against the contract itself.
+		if got.staleCode == 0 {
+			t.Errorf("[%s] stale --if-assignee must fail, got exit 0", env.mode)
+		}
+		if got.staleCode != 1 {
+			t.Errorf("[%s] stale --if-assignee exit = %d, want 1 (bd unclaim does not use ExitGuardMismatch=%d)",
+				env.mode, got.staleCode, ExitGuardMismatch)
+		}
+		if !got.staleNamesHolder {
+			t.Errorf("[%s] stale --if-assignee error must name the current holder alice", env.mode)
+		}
+		if got.staleAssignee != "alice" || got.staleStatus != types.StatusInProgress {
+			t.Errorf("[%s] stale --if-assignee touched the row: assignee=%q status=%q, want alice/in_progress",
+				env.mode, got.staleAssignee, got.staleStatus)
+		}
+		if got.matchCode != 0 {
+			t.Errorf("[%s] matching --if-assignee exit = %d, want 0", env.mode, got.matchCode)
+		}
+		if got.matchAssignee != "" || got.matchStatus != types.StatusOpen {
+			t.Errorf("[%s] after matching --if-assignee: assignee=%q status=%q, want empty/open",
+				env.mode, got.matchAssignee, got.matchStatus)
+		}
+		if got.repeatCode == 0 {
+			t.Errorf("[%s] re-releasing an already-released issue must fail, got exit 0", env.mode)
+		}
+		if got.emptyGuardCode == 0 || !got.emptyGuardRejected {
+			t.Errorf("[%s] --if-assignee '' must be rejected (exit=%d rejected=%v)",
+				env.mode, got.emptyGuardCode, got.emptyGuardRejected)
+		}
+		if got.emptyGuardAssignee != "alice" || got.emptyGuardStatus != types.StatusInProgress {
+			t.Errorf("[%s] --if-assignee '' released the claim: assignee=%q status=%q",
+				env.mode, got.emptyGuardAssignee, got.emptyGuardStatus)
+		}
+		if got.forceComboCode == 0 || !got.forceComboRejected {
+			t.Errorf("[%s] --force with --if-assignee must be rejected (exit=%d rejected=%v)",
+				env.mode, got.forceComboCode, got.forceComboRejected)
+		}
+		if got.forceComboAssignee != "alice" || got.forceComboStatus != types.StatusInProgress {
+			t.Errorf("[%s] --force --if-assignee released the claim: assignee=%q status=%q",
+				env.mode, got.forceComboAssignee, got.forceComboStatus)
+		}
+	}
+
+	assertUnclaimGuardParity(t, outcomes["classic"], outcomes["proxied"])
+}
+
+// assertUnclaimGuardParity reports every field on which the two backends
+// disagree, rather than one opaque struct diff.
+func assertUnclaimGuardParity(t *testing.T, classic, proxied unclaimGuardOutcome) {
+	t.Helper()
+	type field struct {
+		name             string
+		classic, proxied any
+	}
+	for _, f := range []field{
+		{"stale exit code", classic.staleCode, proxied.staleCode},
+		{"stale names holder", classic.staleNamesHolder, proxied.staleNamesHolder},
+		{"stale assignee", classic.staleAssignee, proxied.staleAssignee},
+		{"stale status", classic.staleStatus, proxied.staleStatus},
+		{"match exit code", classic.matchCode, proxied.matchCode},
+		{"match assignee", classic.matchAssignee, proxied.matchAssignee},
+		{"match status", classic.matchStatus, proxied.matchStatus},
+		{"repeat exit code", classic.repeatCode, proxied.repeatCode},
+		{"empty-guard exit code", classic.emptyGuardCode, proxied.emptyGuardCode},
+		{"empty-guard rejected", classic.emptyGuardRejected, proxied.emptyGuardRejected},
+		{"empty-guard assignee", classic.emptyGuardAssignee, proxied.emptyGuardAssignee},
+		{"empty-guard status", classic.emptyGuardStatus, proxied.emptyGuardStatus},
+		{"force-combo exit code", classic.forceComboCode, proxied.forceComboCode},
+		{"force-combo rejected", classic.forceComboRejected, proxied.forceComboRejected},
+		{"force-combo assignee", classic.forceComboAssignee, proxied.forceComboAssignee},
+		{"force-combo status", classic.forceComboStatus, proxied.forceComboStatus},
+	} {
+		if f.classic != f.proxied {
+			t.Errorf("cross-mode divergence on %s: classic=%v proxied=%v", f.name, f.classic, f.proxied)
+		}
+	}
+}

--- a/cmd/bd/unclaim_proxied_server.go
+++ b/cmd/bd/unclaim_proxied_server.go
@@ -21,7 +21,27 @@ type unclaimProxiedResult struct {
 	errs      []string
 }
 
-func runUnclaimProxiedServer(ctx context.Context, args []string, reason string, force bool) error {
+// runUnclaimProxiedServer releases claims through the proxied-server unit of
+// work. expectedAssignee carries `--if-assignee`: a non-empty value selects the
+// compare-and-swap release, and empty means an unconditional one. There is no
+// third case — `--if-assignee ""` is rejected in unclaim.go before any issue is
+// touched, precisely so an unset shell variable can never downgrade a CAS to an
+// unconditional release.
+//
+// The two releases differ only in which use-case verb runs: both apply the same
+// transition through the same classic issueops implementation, so a conditional
+// release records the same "unclaimed" event and drops the same lease row as an
+// unconditional one, on this backend exactly as on the embedded one.
+//
+// EXIT CONTRACT (unchanged by the port, and deliberately identical to the
+// embedded path): a mismatched holder prints the storage.ErrAssigneeMismatch
+// error naming the current holder, writes NOTHING, and exits 1 via SilentExit.
+// `bd unclaim` has never had `bd update`'s ExitGuardMismatch(13) verdict —
+// see the "Exit status" paragraph of the command's help — and this port does
+// not invent one, because a proxied exit code that differs from the embedded
+// one for the same refusal is exactly the divergence this lane exists to
+// prevent.
+func runUnclaimProxiedServer(ctx context.Context, args []string, reason string, force bool, expectedAssignee string) error {
 	if uowProvider == nil {
 		return HandleError("proxied-server UOW provider not initialized")
 	}
@@ -40,7 +60,13 @@ func runUnclaimProxiedServer(ctx context.Context, args []string, reason string, 
 			}
 			fullID := issue.ID
 
-			if uerr := uw.IssueUseCase().Unclaim(ctx, fullID, actor, force); uerr != nil {
+			var uerr error
+			if expectedAssignee != "" {
+				uerr = uw.IssueUseCase().UnclaimIfAssignee(ctx, fullID, actor, expectedAssignee)
+			} else {
+				uerr = uw.IssueUseCase().Unclaim(ctx, fullID, actor, force)
+			}
+			if uerr != nil {
 				r.errs = append(r.errs, fmt.Sprintf("Error unclaiming %s: %v", fullID, uerr))
 				continue
 			}

--- a/internal/storage/domain/db/issue.go
+++ b/internal/storage/domain/db/issue.go
@@ -1125,6 +1125,19 @@ func (r *issueSQLRepositoryImpl) UnclaimIssue(ctx context.Context, id, actor str
 	return nil
 }
 
+// UnclaimIssueIfAssignee runs the classic compare-and-swap release against this
+// runner. Like UnclaimIssue it takes no IssueTableOpts: issueops routes the
+// write to the issues or wisps tables from the row itself, so a wisp's claim is
+// released against the wisp tables on both backends. The mismatch verdict
+// (storage.ErrAssigneeMismatch, nothing written) is produced by the shared
+// helper, not restated here.
+func (r *issueSQLRepositoryImpl) UnclaimIssueIfAssignee(ctx context.Context, id, actor, expectedAssignee string) error {
+	if err := issueops.UnclaimIssueIfAssigneeInTx(ctx, r.runner, id, actor, expectedAssignee); err != nil {
+		return fmt.Errorf("db: IssueSQLRepository.UnclaimIssueIfAssignee: %w", err)
+	}
+	return nil
+}
+
 // HeartbeatIssue refreshes the lease on an issue actor holds in_progress,
 // mirroring DoltStore.HeartbeatIssue: wisps are ephemeral and never leased,
 // and the SQL work is the classic issueops.HeartbeatIssueInTx — same clock

--- a/internal/storage/domain/issue.go
+++ b/internal/storage/domain/issue.go
@@ -76,6 +76,7 @@ type IssueSQLRepository interface {
 	GetStaleIssues(ctx context.Context, filter types.StaleFilter) ([]*types.Issue, error)
 	GetEpicsEligibleForClosure(ctx context.Context) ([]*types.EpicStatus, error)
 	UnclaimIssue(ctx context.Context, id, actor string, force bool) error
+	UnclaimIssueIfAssignee(ctx context.Context, id, actor, expectedAssignee string) error
 	HeartbeatIssue(ctx context.Context, id, actor string) error
 	ReclaimExpiredLeases(ctx context.Context, olderThan time.Duration, filter types.ReclaimFilter, actor string) ([]types.ReclaimedLease, error)
 }
@@ -284,6 +285,7 @@ type IssueUseCase interface {
 	GetStaleIssues(ctx context.Context, filter types.StaleFilter) ([]*types.Issue, error)
 	GetEpicsEligibleForClosure(ctx context.Context) ([]*types.EpicStatus, error)
 	Unclaim(ctx context.Context, id, actor string, force bool) error
+	UnclaimIfAssignee(ctx context.Context, id, actor, expectedAssignee string) error
 	Heartbeat(ctx context.Context, id, actor string) error
 	ReclaimExpiredLeases(ctx context.Context, olderThan time.Duration, filter types.ReclaimFilter, actor string) ([]types.ReclaimedLease, error)
 
@@ -1812,6 +1814,24 @@ func (u *issueUseCaseImpl) Unclaim(ctx context.Context, id, actor string, force 
 	}
 	if err := u.issueRepo.UnclaimIssue(ctx, id, actor, force); err != nil {
 		return fmt.Errorf("Unclaim: %w", err)
+	}
+	return nil
+}
+
+// UnclaimIfAssignee is the compare-and-swap release: it clears the claim only
+// while the issue is still assigned to expectedAssignee, and otherwise returns
+// storage.ErrAssigneeMismatch having written nothing. It is the conditional
+// twin of Unclaim and runs the SAME transition (assignee cleared, status
+// reopened, started_at cleared, lease dropped, row_lock rewritten, "unclaimed"
+// event recorded) because both reach the one classic implementation in
+// issueops — which is what makes `bd unclaim --if-assignee` behave identically
+// on the proxied-server and embedded backends.
+func (u *issueUseCaseImpl) UnclaimIfAssignee(ctx context.Context, id, actor, expectedAssignee string) error {
+	if id == "" {
+		return fmt.Errorf("UnclaimIfAssignee: id must not be empty")
+	}
+	if err := u.issueRepo.UnclaimIssueIfAssignee(ctx, id, actor, expectedAssignee); err != nil {
+		return fmt.Errorf("UnclaimIfAssignee: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Proxied parity F8 (bd-tb0yi, epic bd-vxavz): `bd unclaim --if-assignee` and `bd batch` in proxied-server mode. `--max-rows` deliberately deferred to its own PR (tail — zero wheelhouse call sites; see the 8/4 descope on the bead: update's `--if-assignee`/`--if-status` CAS already works proxied, so every wheelhouse CAS caller was already served).

## unclaim --if-assignee
- **Mechanism deviation from the bead recipe, deliberate:** not Lifecycle.Update+assignee-clearing patch (that would record a generic update event, not "unclaimed"); instead a new `UnclaimIfAssignee` verb on `domain.IssueUseCase`/`IssueSQLRepository` delegating to classic `issueops.UnclaimIssueIfAssigneeInTx` — no new SQL, same event/lease/wisp routing, same `storage.ErrAssigneeMismatch`.
- ⚠ **Exit-code finding for reviewer:** `unclaim --if-assignee` has NEVER exited 13 — classic exits 1 via SilentExit (the command's help says so). Exit 13 (`ExitGuardMismatch`) belongs to `bd update`, where wheelhouse CAS callers actually get it. This port preserves parity at 1 in both modes, pinned by test assertion; if 13 is wanted, adopt in BOTH modes as its own change. No cutover risk.

## batch
- `uow.RunTxResult` wrapping a `runBatchOpUOW` dispatch over the uow use cases; parser/grammar/dry-run/output stay shared in batch.go. One transaction, one commit message, whole-batch rollback on first failing line — same contract, per-mode transaction primitive only.
- Review edges called out: whole-batch replay on serialization retry (results built per attempt); plane routing via `workapi.GetIssueOrWisp` in-tx so a batch line touching a wisp hits the wisp tables on both backends; `CheckReadonly` now precedes the proxied gate (matches classic). NOT RunTxEphemeral (versioned tables).
- Pre-existing CLASSIC-side divergences found, documented not fixed, filed as **bd-eahq7**: classic batch accepts out-of-range priority=5, and classic batch dep add/remove emits no history event (proxied + CLI both validate/emit). Parity suite pins today's behavior.

## Verification
- New `cross_mode_parity_harness_test.go` + `unclaim_conditional_parity_test.go` + `batch_parity_test.go`; shard manifest updated (shards 4+9, verified SHARD_LIST_ONLY).
- Executor evidence: shards 4+9 full EXIT=0 (571s); ambient 29-fail set verified FAIL-set-IDENTICAL vs stashed baseline (bd-7xtsq / bd-pppsh env reds).
- Post-rebase onto 50763fcba: build green, both new parity suites green (40s, count=1).

Review: lion (comment-review per current convention). Beads: bd-tb0yi; follow-up bd-eahq7.