### PR TITLE
fix(kv,gate): wave-1 review nits — schema_version pin, commandDidWrite, double-resolve guard (bd-858o0)

### DIFF
--- a/cmd/bd/gate_lifecycle_proxied_integration_test.go
+++ b/cmd/bd/gate_lifecycle_proxied_integration_test.go
@@ -161,6 +161,17 @@ func TestProxiedServerGateLifecycle(t *testing.T) {
 		if ids := gateReadyIDs(t, bd, p); !ids[target.ID] {
 			t.Errorf("target %s should be ready again after resolve", target.ID)
 		}
+
+		// Double-resolve is a reported no-op: exit 0, gate stays closed.
+		// (Audit + close hooks are guarded on CloseIssueResult.Closed, so the
+		// second resolve records nothing new.)
+		_, stderr, err = bdProxiedRunBuffers(t, bd, p.dir, "gate", "resolve", gateID, "--reason", "again")
+		if err != nil {
+			t.Fatalf("double gate resolve should be idempotent, failed: %v\nstderr:\n%s", err, stderr)
+		}
+		if got := readStatus(t, db, gateID); got != types.StatusClosed {
+			t.Errorf("gate should stay closed after double resolve, got %q", got)
+		}
 	})
 
 	// The wh-park shape: a bead gate names the awaited bead in --await-id, and

--- a/cmd/bd/gate_proxied_server.go
+++ b/cmd/bd/gate_proxied_server.go
@@ -393,6 +393,7 @@ type gateResolveApply struct {
 	before    *types.Issue
 	after     *types.Issue
 	oldStatus string
+	closed    bool // CloseIssueResult.Closed: false when the gate was already closed
 }
 
 func runGateResolveProxiedServer(cmd *cobra.Command, ctx context.Context, args []string) error {
@@ -437,17 +438,23 @@ func runGateResolveProxiedServer(cmd *cobra.Command, ctx context.Context, args [
 		if issue.Status != "" {
 			out.oldStatus = string(issue.Status)
 		}
+		out.closed = res.Closed
 		return out, fmt.Sprintf("bd: gate resolve %s", gateID), nil
 	})
 	if err != nil {
 		return HandleError("%v", err)
 	}
 
-	if applied.after != nil {
-		audit.LogFieldChange(applied.after.ID, "status", applied.oldStatus, "closed", actor, reason)
-	}
-	if err := fireProxiedCloseHooks(ctx, applied.before, applied.after); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: %s: %v\n", gateID, err)
+	// Audit + hooks only when this invocation actually closed the gate —
+	// a double-resolve must not re-fire them (same guard as the o.closed
+	// check in close_proxied_server.go).
+	if applied.closed {
+		if applied.after != nil {
+			audit.LogFieldChange(applied.after.ID, "status", applied.oldStatus, "closed", actor, reason)
+		}
+		if err := fireProxiedCloseHooks(ctx, applied.before, applied.after); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: %s: %v\n", gateID, err)
+		}
 	}
 	commandDidWrite.Store(true)
 

--- a/cmd/bd/kv_proxied_integration_test.go
+++ b/cmd/bd/kv_proxied_integration_test.go
@@ -52,6 +52,13 @@ func kvListJSONRaw(t *testing.T, bd, dir string) (string, map[string]string) {
 	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
 		t.Fatalf("kv list --json did not parse: %v\n%s", err, raw)
 	}
+	sv, ok := parsed["schema_version"]
+	if !ok {
+		t.Fatalf("kv list --json missing schema_version (shape drift): %s", raw)
+	}
+	if _, isNum := sv.(float64); !isNum {
+		t.Fatalf("kv list --json schema_version is not numeric (shape drift): %T %v\n%s", sv, sv, raw)
+	}
 	m := make(map[string]string, len(parsed))
 	for k, v := range parsed {
 		if k == "schema_version" {

--- a/cmd/bd/kv_proxied_server.go
+++ b/cmd/bd/kv_proxied_server.go
@@ -34,6 +34,7 @@ func runKVSetProxiedServer(ctx context.Context, key, value string) error {
 	if err != nil {
 		return HandleErrorRespectJSON("setting key: %v", err)
 	}
+	commandDidWrite.Store(true)
 
 	return printKVSetResult(key, value)
 }
@@ -69,6 +70,7 @@ func runKVClearProxiedServer(ctx context.Context, key string) error {
 	if err != nil {
 		return HandleErrorRespectJSON("deleting key: %v", err)
 	}
+	commandDidWrite.Store(true)
 
 	return printKVClearResult(key)
 }


### PR DESCRIPTION
The three non-blocking nits from lion's wave-1 verdicts (bd-858o0), one commit:

1. **#5344 nit — kvListJSONRaw pin made real**: the helper now fatals if `schema_version` is missing or non-numeric before skipping it (previously the comment claimed a pin the code didn't enforce).
2. **#5344 nit — kv proxied write handlers set commandDidWrite**: `runKVSetProxiedServer` / `runKVClearProxiedServer` now `commandDidWrite.Store(true)` after a successful write, matching the label/gate/mutate proxied idiom. Scoping note: classic `kv.go` (and `config_proxied_server.go`) do NOT set it either — only the "sibling proxied handlers" half of the rationale holds, so this stays scoped to kv.
3. **#5346 nit — gate resolve double-fire guard**: `gateResolveApply` carries `CloseIssueResult.Closed`; audit + `fireProxiedCloseHooks` are guarded on it, same as `close_proxied_server.go`'s `o.closed`. Nuance found while fixing: `audit.LogFieldChange` self-guards `old==new`, so the bogus closed→closed record never actually landed — the real double-resolve leak was the on_update close hook re-firing; both are now behind the guard. Added a double-resolve idempotency step to `TestProxiedServerGateLifecycle/human_gate_journey`.

Verification: gofmt/vet/build clean; `TestProxiedServerKV` + `TestProxiedServerGateLifecycle` PASS under BEADS_TEST_PROXIED_SERVER=1 (31.8s, count=1, all subtests ran). No ambient reds hit.

Review: lion (comment-review per current convention). Bead: bd-858o0.