### PR TITLE
fix(prime): route proxied memory read through the server plane (bd-mm8wf)

### DIFF
--- a/.github/scripts/proxied-cmd-test-shards.txt
+++ b/.github/scripts/proxied-cmd-test-shards.txt
@@ -60,6 +60,7 @@
 15 6 TestProxiedServerCleanDatabases
 15 6 TestProxiedServerEdit
 15 6 TestProxiedServerLink
+15 6 TestProxiedServerPrime
 15 6 TestProxiedServerReady2
 15 6 TestProxiedServerReadyConcurrent
 15 6 TestProxiedServerState

--- a/cmd/bd/prime.go
+++ b/cmd/bd/prime.go
@@ -424,6 +424,15 @@ func outputMemoriesOnlyContext(w io.Writer) error {
 // formatMemoriesForPrime queries memories from the k/v store and formats them for injection.
 // Returns empty string if no memories or if store is unavailable.
 func formatMemoriesForPrime(compact bool) string {
+	// bd-mm8wf: in a proxied-server workspace the memory read must ride the
+	// proxied plane (UOW provider), never ensureStoreActiveForPrime — the
+	// lazy direct-store open is the same seam class bd-m7zzd closed in
+	// relate.go and human.go, here in a read-only limb. The proxied dual
+	// preserves prime's silent-skip and timeout-banner contracts.
+	if usesProxiedServer() {
+		return formatMemoriesForPrimeProxied(compact)
+	}
+
 	// Try to initialize store if not already active (prime may run before other commands)
 	if store == nil {
 		timeout := primeStoreTimeout()
@@ -448,14 +457,15 @@ func formatMemoriesForPrime(compact bool) string {
 	if err != nil {
 		return ""
 	}
+	return renderPrimeMemoriesFromAllConfig(allConfig, compact)
+}
 
-	fullPrefix := kvPrefix + memoryPrefix
-	memories := make(map[string]string)
-	for k, v := range allConfig {
-		if strings.HasPrefix(k, fullPrefix) {
-			memories[strings.TrimPrefix(k, fullPrefix)] = v
-		}
-	}
+// renderPrimeMemoriesFromAllConfig extracts the kv.memory.* entries from a
+// full config-table read and renders them for injection — the shared tail of
+// the classic and proxied (bd-mm8wf) memory-read paths, so the two cannot
+// drift in what a memory looks like once fetched.
+func renderPrimeMemoriesFromAllConfig(allConfig map[string]string, compact bool) string {
+	memories := memoriesFromConfig(allConfig, "")
 	if len(memories) == 0 {
 		return ""
 	}

--- a/cmd/bd/prime_proxied_integration_test.go
+++ b/cmd/bd/prime_proxied_integration_test.go
@@ -1,0 +1,109 @@
+//go:build cgo
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/configfile"
+)
+
+// TestProxiedServerPrime covers the bd-mm8wf seam from lion's #5361 review:
+// `bd prime` sits in noDbCommands, so formatMemoriesForPrime lazily
+// initialized storage via ensureStoreActiveForPrime — a direct-store open
+// (the bd-m7zzd seam class) that in proxied mode the store factory refuses,
+// which the silent-skip contract then swallowed: proxied prime never carried
+// memories at all. The memory read now rides the proxied plane (one
+// read-only UOW, ConfigUseCase().GetAllConfig), so proxied prime has parity
+// with classic when the server is reachable and still degrades silently when
+// it is not.
+func TestProxiedServerPrime(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+
+	// A lazy direct open in this workspace would materialize an embedded
+	// store directory; the proxied plane never does.
+	assertNoEmbeddedStore := func(t *testing.T, p proxiedProject) {
+		t.Helper()
+		embeddedDir := filepath.Join(p.beadsDir, "embeddeddolt")
+		if _, err := os.Stat(embeddedDir); !os.IsNotExist(err) {
+			t.Errorf("expected no embedded store at %s after bd prime (direct-store seam), stat err=%v", embeddedDir, err)
+		}
+	}
+
+	t.Run("memories_only_injects_via_proxied_plane", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "ppr1")
+		content := "proxied prime memories ride the uow plane"
+		out := bdProxiedMem(t, bd, p.dir, "remember", content, "--key", "proxied-prime-seam")
+		if !strings.Contains(out, "Remembered [proxied-prime-seam]") {
+			t.Fatalf("expected 'Remembered [proxied-prime-seam]', got: %s", out)
+		}
+
+		db := openProxiedDB(t, p)
+		head := readDoltHead(t, db)
+
+		out = bdProxiedMem(t, bd, p.dir, "prime", "--memories-only")
+		if !strings.Contains(out, "## Persistent Memories") {
+			t.Errorf("expected Persistent Memories section in proxied prime output, got: %s", out)
+		}
+		if !strings.Contains(out, "proxied-prime-seam") || !strings.Contains(out, content) {
+			t.Errorf("expected memory key and content in proxied prime output, got: %s", out)
+		}
+
+		// The read is read-only on the proxied plane: no Dolt commit landed.
+		if n := readDoltLogCountSince(t, db, head); n != 0 {
+			t.Errorf("expected 0 commits from a prime memory read, got %d", n)
+		}
+		assertNoEmbeddedStore(t, p)
+	})
+
+	t.Run("full_prime_appends_memories_section", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "ppr2")
+		bdProxiedMem(t, bd, p.dir, "remember", "full prime carries memories in proxied mode", "--key", "full-prime-check")
+		out := bdProxiedMem(t, bd, p.dir, "prime", "--full")
+		if !strings.Contains(out, "## Persistent Memories") || !strings.Contains(out, "full-prime-check") {
+			t.Errorf("expected memories section with key 'full-prime-check' in full prime output, got: %s", out)
+		}
+		assertNoEmbeddedStore(t, p)
+	})
+
+	t.Run("no_memories_yields_stored_none_message", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "ppr3")
+		out := bdProxiedMem(t, bd, p.dir, "prime", "--memories-only")
+		if !strings.Contains(out, "No memories stored") {
+			t.Errorf("expected 'No memories stored' for empty proxied memory set, got: %s", out)
+		}
+	})
+
+	t.Run("degrades_silently_when_plane_unavailable", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "ppr4")
+		content := "this memory must not surface when the plane is down"
+		bdProxiedMem(t, bd, p.dir, "remember", content, "--key", "plane-down")
+
+		// Corrupt the proxied-server sidecar: provider open now fails before
+		// touching any server, the deterministic stand-in for an unreachable
+		// plane. Prime must still exit 0 (silent-skip contract) with no
+		// memories and no direct-store fallback.
+		sidecar := configfile.ProxiedServerClientInfoPath(p.beadsDir)
+		if err := os.WriteFile(sidecar, []byte("not json{"), 0o644); err != nil {
+			t.Fatalf("corrupting sidecar %s: %v", sidecar, err)
+		}
+
+		out := bdProxiedMem(t, bd, p.dir, "prime", "--memories-only")
+		if strings.Contains(out, content) || strings.Contains(out, "plane-down") {
+			t.Errorf("expected memory to be skipped when the proxied plane is unavailable, got: %s", out)
+		}
+		if !strings.Contains(out, "No memories stored") {
+			t.Errorf("expected the empty-memories fallback on silent skip, got: %s", out)
+		}
+		assertNoEmbeddedStore(t, p)
+	})
+}

--- a/cmd/bd/prime_proxied_server.go
+++ b/cmd/bd/prime_proxied_server.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/steveyegge/beads/internal/beads"
+	"github.com/steveyegge/beads/internal/storage/uow"
+)
+
+// Proxied-server dual of prime's memory read (bd-mm8wf, from lion's #5361
+// review). `bd prime` sits in noDbCommands, so the root pre-run opens neither
+// a store nor a UOW provider; formatMemoriesForPrime therefore lazily
+// initialized storage via ensureStoreActiveForPrime — which in a
+// proxied-server workspace meant a DIRECT dolt open against sidecar-owned
+// data, exactly the seam class bd-m7zzd closed in relate.go and human.go
+// (there in write verbs, here in a read-only limb).
+//
+// The read now rides the proxied plane: one read-only UOW
+// (ConfigUseCase().GetAllConfig, same verb the bd memories proxied dual
+// uses), through a provider opened scoped to this read. Prime's contract is
+// preserved on every failure edge: silent skip when the plane is unavailable,
+// the timeout banner on a deadline, and rendering through the same shared
+// tail as the classic path.
+
+// primeProxiedProviderOpen opens the proxied-plane provider for prime's
+// memory read; a var so unit tests can stub the plane. Production opens the
+// standard identity-asserting provider, exactly as the root pre-run would for
+// a data command in this workspace.
+var primeProxiedProviderOpen = func(ctx context.Context, beadsDir string) (uow.UnitOfWorkProvider, error) {
+	return newProxiedServerUOWProvider(ctx, beadsDir, "")
+}
+
+// formatMemoriesForPrimeProxied is the proxied-mode branch of
+// formatMemoriesForPrime. Returns "" whenever the read cannot be served (no
+// workspace, provider open failure, read failure): prime must degrade
+// silently, never fail the session-start hook.
+func formatMemoriesForPrimeProxied(compact bool) string {
+	timeout := primeStoreTimeout()
+	ctx := context.Background()
+	var cancel context.CancelFunc
+	if timeout > 0 {
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+	allConfig, err := primeProxiedAllConfig(ctx)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return formatPrimeMemoryTimeout(compact, timeout)
+		}
+		return "" // Silently skip — proxied plane unavailable
+	}
+	return renderPrimeMemoriesFromAllConfig(allConfig, compact)
+}
+
+// primeProxiedAllConfig reads the full config table through the proxied
+// plane. When the root pre-run opened the global provider (it never does for
+// prime itself — noDbCommands — but the branch keeps any future caller
+// honest), that provider is used and left open for its owner to close;
+// otherwise a provider is opened scoped to this one read and closed before
+// returning.
+func primeProxiedAllConfig(ctx context.Context) (map[string]string, error) {
+	provider := uowProvider
+	if provider == nil {
+		beadsDir := beads.FindBeadsDir()
+		if beadsDir == "" {
+			return nil, fmt.Errorf("no beads directory found")
+		}
+		p, err := primeProxiedProviderOpen(ctx, beadsDir)
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = p.Close(ctx) }()
+		provider = p
+	}
+	return uow.RunTxRead(ctx, provider, func(ctx context.Context, uw uow.UnitOfWork) (map[string]string, error) {
+		return uw.ConfigUseCase().GetAllConfig(ctx)
+	})
+}


### PR DESCRIPTION
Closes the residual direct-store seam lion flagged in the #5361 review (bd-mm8wf, blocks epic bd-vxavz): `bd prime` is in noDbCommands, so `formatMemoriesForPrime` lazily initialized storage via `ensureStoreActiveForPrime` — in a proxied-server workspace that is a DIRECT dolt open against sidecar-owned data, the same seam class #5361 closed in relate.go/human.go (there in write verbs, here read-only).

**Finding along the way:** pre-fix, proxied prime never actually opened a live direct store — the lazy open hit the store factory's proxied refusal and silent-skip swallowed it, so proxied `bd prime` silently carried **no memories at all**. This fix closes the seam class AND restores memory parity with classic.

## Change
- `formatMemoriesForPrime` gates on `usesProxiedServer()` and dispatches to a proxied dual (`cmd/bd/prime_proxied_server.go`): one read-only UOW (`ConfigUseCase().GetAllConfig` via `uow.RunTxRead` — the same verb the `bd memories` proxied dual uses), through a provider opened scoped to the read and closed after (reuses the global provider if a pre-run ever opens one).
- Prime's contracts preserved on every failure edge: silent skip when the plane is unavailable, timeout banner on deadline, exit-0 degrade always.
- Render tail factored into shared `renderPrimeMemoriesFromAllConfig` + the existing `memoriesFromConfig` filter, so classic and proxied cannot drift in what a rendered memory looks like.

## Verification
- New `TestProxiedServerPrime` (4 subtests): memory injection via memories-only and full prime; zero dolt commits from the read; no embedded store dir created; corrupt-sidecar exit-0 degrade. Shard manifest: `15 6 TestProxiedServerPrime`.
- Red-baseline proven: with the fix stashed, the injection subtest fails with "No memories stored".
- vet/build clean; prime/memory unit tests green; `BEADS_TEST_PROXIED_SERVER=1` TestProxiedServerPrime 4/4 + TestProxiedServerMemory 3/3; `golangci-lint --new-from-rev=origin/main ./cmd/bd/` → 0 issues.

Review: lion (comment-review per current convention). Bead: bd-mm8wf (blocks bd-vxavz).