### PR TITLE
fix(export): promoted no-history wisps survive import round-trip (bd-r9uce)

### DIFF
--- a/cmd/bd/export.go
+++ b/cmd/bd/export.go
@@ -205,8 +205,8 @@ func runExportFromSource(ctx context.Context, src exportSource) error {
 	// Explicit plane markers (bd-r9uce): a no_history=true row is either an
 	// unpromoted no-history wisp (wisps table) or a promoted one (durable
 	// issues-table row still carrying the stray flag) — only table membership
-	// can tell them apart, and import routes by the "wisp" marker stamped
-	// here. Ephemeral rows are unambiguous (ephemeral=true only ever lives in
+	// can tell them apart, and import routes by the "wisp_plane" marker
+	// stamped here. Ephemeral rows are unambiguous (ephemeral=true only ever lives in
 	// the wisps table) and are deliberately NOT stamped, keeping their export
 	// bytes unchanged.
 	var noHistoryIDs []string
@@ -251,7 +251,7 @@ func runExportFromSource(ctx context.Context, src exportSource) error {
 				DependentCount:  counts.DependentCount,
 				CommentCount:    rel.commentCounts[issue.ID],
 			},
-			Wisp: wispPlane[issue.ID],
+			WispPlane: wispPlane[issue.ID],
 		}
 
 		data, err := json.Marshal(record)
@@ -334,16 +334,18 @@ func runExportFromSource(ctx context.Context, src exportSource) error {
 type exportIssueRecord struct {
 	RecordType string `json:"_type"`
 	*types.IssueWithCounts
-	// Wisp is the explicit wisps-plane marker (bd-r9uce): true when the row
-	// lives in the WISPS table AND its flags alone cannot prove it (the
+	// WispPlane is the explicit wisps-plane marker (bd-r9uce): true when the
+	// row lives in the WISPS table AND its flags alone cannot prove it (the
 	// no_history shape; ephemeral rows are self-describing and stay
 	// unstamped). Import routes by this marker — never by no_history — so a
 	// promoted no-history wisp (durable issues-table row still carrying the
 	// stray flag) round-trips to the durable plane instead of being silently
 	// re-planed. Declared after the embedded struct so it serializes last.
-	// Field name doubles as the v0.35–v0.37 legacy "ephemeral" alias key,
-	// which import has always honored.
-	Wisp bool `json:"wisp,omitempty"`
+	// Deliberately a FRESH key, not the legacy "wisp" alias key: pre-fix
+	// binaries' alias branch would import a marked no-history wisp as
+	// ephemeral (purge-eligible, export-excluded), so an unknown-to-them key
+	// that degrades to flag routing is the data-safe choice (lion, #5368).
+	WispPlane bool `json:"wisp_plane,omitempty"`
 }
 
 // sanitizeZeroTime replaces Go zero-value time.Time fields with Unix epoch.

--- a/cmd/bd/export.go
+++ b/cmd/bd/export.go
@@ -202,6 +202,27 @@ func runExportFromSource(ctx context.Context, src exportSource) error {
 		return HandleErrorRespectJSON("failed to load relational data: %v", err)
 	}
 
+	// Explicit plane markers (bd-r9uce): a no_history=true row is either an
+	// unpromoted no-history wisp (wisps table) or a promoted one (durable
+	// issues-table row still carrying the stray flag) — only table membership
+	// can tell them apart, and import routes by the "wisp" marker stamped
+	// here. Ephemeral rows are unambiguous (ephemeral=true only ever lives in
+	// the wisps table) and are deliberately NOT stamped, keeping their export
+	// bytes unchanged.
+	var noHistoryIDs []string
+	for _, issue := range issues {
+		if issue.NoHistory && !issue.Ephemeral {
+			noHistoryIDs = append(noHistoryIDs, issue.ID)
+		}
+	}
+	wispPlane := map[string]bool{}
+	if len(noHistoryIDs) > 0 {
+		wispPlane, err = src.WispPlaneIDs(ctx, noHistoryIDs)
+		if err != nil {
+			return HandleErrorRespectJSON("failed to classify wisp-plane rows: %v", err)
+		}
+	}
+
 	// Populate relational data on each issue
 	for _, issue := range issues {
 		issue.Labels = rel.labels[issue.ID]
@@ -230,6 +251,7 @@ func runExportFromSource(ctx context.Context, src exportSource) error {
 				DependentCount:  counts.DependentCount,
 				CommentCount:    rel.commentCounts[issue.ID],
 			},
+			Wisp: wispPlane[issue.ID],
 		}
 
 		data, err := json.Marshal(record)
@@ -312,6 +334,16 @@ func runExportFromSource(ctx context.Context, src exportSource) error {
 type exportIssueRecord struct {
 	RecordType string `json:"_type"`
 	*types.IssueWithCounts
+	// Wisp is the explicit wisps-plane marker (bd-r9uce): true when the row
+	// lives in the WISPS table AND its flags alone cannot prove it (the
+	// no_history shape; ephemeral rows are self-describing and stay
+	// unstamped). Import routes by this marker — never by no_history — so a
+	// promoted no-history wisp (durable issues-table row still carrying the
+	// stray flag) round-trips to the durable plane instead of being silently
+	// re-planed. Declared after the embedded struct so it serializes last.
+	// Field name doubles as the v0.35–v0.37 legacy "ephemeral" alias key,
+	// which import has always honored.
+	Wisp bool `json:"wisp,omitempty"`
 }
 
 // sanitizeZeroTime replaces Go zero-value time.Time fields with Unix epoch.

--- a/cmd/bd/export_proxied_integration_test.go
+++ b/cmd/bd/export_proxied_integration_test.go
@@ -16,7 +16,9 @@ import (
 // interchange fixture): priorities incl. P0, several types, a closed issue
 // with a reason, labels, comments, both dependency orientations
 // (parent-child and blocks), metadata, an assignee, an ephemeral wisp that
-// default export must EXCLUDE, an infra-type (message) bead, and memories.
+// default export must EXCLUDE, an infra-type (message) bead, a promoted
+// no-history wisp (durable issues-table row still carrying no_history=true —
+// the bd-r9uce plane-classification trap, with relations), and memories.
 type exportProxiedFixture struct {
 	critical string
 	epic     string
@@ -25,6 +27,14 @@ type exportProxiedFixture struct {
 	done     string
 	wisp     string
 	infraMsg string
+	// promoted is the promoted no-history wisp: a DURABLE issues-table row
+	// whose no_history flag is still set (wild pre-fix promote shape).
+	// promotedFriend is durable and blocked by it, so the round-trip oracle
+	// also pins that the relation survives — pre-fix, classic import
+	// re-planed the row into the wisps table by its flags and dropped this
+	// edge as a cross-bucket dependency.
+	promoted       string
+	promotedFriend string
 }
 
 func seedProxiedExportFixture(t *testing.T, bd string, p proxiedProject) exportProxiedFixture {
@@ -70,6 +80,29 @@ func seedProxiedExportFixture(t *testing.T, bd string, p proxiedProject) exportP
 	fx.done = bdProxiedCreateSilent(t, bd, p.dir, "Finished feature", "--type", "feature", "--priority", "4")
 	if out, err := bdProxiedRun(t, bd, p.dir, "close", fx.done, "--reason", "shipped in abc123"); err != nil {
 		t.Fatalf("close: %v\n%s", err, out)
+	}
+
+	// Promoted no-history wisp (bd-r9uce): a durable issues-table row still
+	// carrying no_history=true, with durable-plane relations. `bd promote` is
+	// not yet ported to proxied mode (bd-27bfd) — and the fixed promote now
+	// clears the flag — so produce the wild pre-fix shape directly: durable
+	// row, no_history flipped on. In the round trip below, classic import
+	// must route it by the (absent) explicit plane marker and keep it — and
+	// its inbound edge — in the durable plane.
+	fx.promoted = bdProxiedCreateSilent(t, bd, p.dir, "Promoted no-history wisp", "--type", "task", "--priority", "3")
+	if out, err := bdProxiedRun(t, bd, p.dir, "label", "add", fx.promoted, "keepme"); err != nil {
+		t.Fatalf("label add: %v\n%s", err, out)
+	}
+	if out, err := bdProxiedRun(t, bd, p.dir, "comment", fx.promoted, "survived promotion"); err != nil {
+		t.Fatalf("comment: %v\n%s", err, out)
+	}
+	fx.promotedFriend = bdProxiedCreateSilent(t, bd, p.dir, "Promoted wisp friend", "--type", "task", "--priority", "3")
+	if out, err := bdProxiedRun(t, bd, p.dir, "dep", "add", fx.promotedFriend, fx.promoted); err != nil {
+		t.Fatalf("dep add: %v\n%s", err, out)
+	}
+	db := openProxiedDB(t, p)
+	if _, err := db.Exec("UPDATE issues SET no_history = 1 WHERE id = ?", fx.promoted); err != nil {
+		t.Fatalf("flip no_history: %v", err)
 	}
 
 	// Ephemeral wisp: excluded from default export, included with --all.
@@ -297,39 +330,30 @@ func TestProxiedServerExport(t *testing.T) {
 	})
 
 	// The plane-classification trap from review: a promoted no-history wisp
-	// is a durable issues-table row that still carries no_history=true —
-	// promote clears only Ephemeral — and its labels/comments live in the
+	// is a durable issues-table row that still carries no_history=true — the
+	// wild pre-fix promote shape — and its labels/comments live in the
 	// DURABLE plane. Classifying by row flags looks them up in the wisp plane
 	// and silently drops them; classification must follow table membership.
-	// Runs in its own project: the shape is deliberately NOT in the
-	// round-trip fixture because classic *import* routes by the same flags
-	// (issueops.IsWisp), re-planing the row into the wisps table — a
-	// pre-existing export/import infidelity (bd-r9uce) that would break the
-	// byte-identity oracle for reasons unrelated to this seam.
+	// Since bd-r9uce the shape lives IN the round-trip fixture (fx.promoted):
+	// import now routes by the explicit "wisp" plane marker instead of the
+	// flags, so the cross_mode_byte_identical oracle below covers it too.
+	// The export half pinned here: relations present, and NO plane marker on
+	// the record (it is durable — stamping it would re-plane it on import).
 	t.Run("promoted_no_history_relations", func(t *testing.T) {
-		pp := newSharedProxiedProject(t, bd, "pxp")
-		promoted := bdProxiedCreateSilent(t, bd, pp.dir, "Promoted no-history wisp", "--type", "task", "--priority", "3")
-		if out, err := bdProxiedRun(t, bd, pp.dir, "label", "add", promoted, "keepme"); err != nil {
-			t.Fatalf("label add: %v\n%s", err, out)
-		}
-		if out, err := bdProxiedRun(t, bd, pp.dir, "comment", promoted, "survived promotion"); err != nil {
-			t.Fatalf("comment: %v\n%s", err, out)
-		}
-		// `bd promote` is not yet ported to proxied mode (bd-27bfd); produce
-		// the promoted shape directly: durable row, no_history flipped on.
-		db := openProxiedDB(t, pp)
-		if _, err := db.Exec("UPDATE issues SET no_history = 1 WHERE id = ?", promoted); err != nil {
-			t.Fatalf("flip no_history: %v", err)
-		}
-
-		stdout, stderr, err := bdProxiedRunBuffers(t, bd, pp.dir, "export")
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "export")
 		if err != nil {
 			t.Fatalf("bd export: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
 		}
 		records := exportLines(t, stdout)
-		rec := exportIssueRecordByID(records, promoted)
+		rec := exportIssueRecordByID(records, fx.promoted)
 		if rec == nil {
-			t.Fatalf("export missing promoted no-history row %s (durable table membership must include it)", promoted)
+			t.Fatalf("export missing promoted no-history row %s (durable table membership must include it)", fx.promoted)
+		}
+		if noHist, _ := rec["no_history"].(bool); !noHist {
+			t.Fatalf("promoted row lost no_history in export: %v", rec)
+		}
+		if _, marked := rec["wisp"]; marked {
+			t.Errorf("promoted row carries the wisps-plane marker; it is durable and must not be stamped: %v", rec)
 		}
 		if labels := exportStrings(rec["labels"]); len(labels) != 1 || labels[0] != "keepme" {
 			t.Errorf("promoted labels = %v, want [keepme] (durable-plane labels dropped?)", labels)
@@ -339,6 +363,20 @@ func TestProxiedServerExport(t *testing.T) {
 		}
 		if cc, _ := rec["comment_count"].(float64); int(cc) != 1 {
 			t.Errorf("promoted comment_count = %v, want 1", rec["comment_count"])
+		}
+		if dc, _ := rec["dependent_count"].(float64); int(dc) != 1 {
+			t.Errorf("promoted dependent_count = %v, want 1 (inbound edge from friend)", rec["dependent_count"])
+		}
+		friend := exportIssueRecordByID(records, fx.promotedFriend)
+		if friend == nil {
+			t.Fatalf("export missing %s", fx.promotedFriend)
+		}
+		deps, _ := friend["dependencies"].([]any)
+		if len(deps) != 1 {
+			t.Fatalf("friend dependencies = %v, want the one edge onto the promoted row", friend["dependencies"])
+		}
+		if edge, ok := deps[0].(map[string]any); !ok || edge["depends_on_id"] != fx.promoted {
+			t.Errorf("friend dependency edge = %v, want depends_on_id=%s", deps[0], fx.promoted)
 		}
 	})
 

--- a/cmd/bd/export_proxied_integration_test.go
+++ b/cmd/bd/export_proxied_integration_test.go
@@ -335,7 +335,7 @@ func TestProxiedServerExport(t *testing.T) {
 	// DURABLE plane. Classifying by row flags looks them up in the wisp plane
 	// and silently drops them; classification must follow table membership.
 	// Since bd-r9uce the shape lives IN the round-trip fixture (fx.promoted):
-	// import now routes by the explicit "wisp" plane marker instead of the
+	// import now routes by the explicit "wisp_plane" marker instead of the
 	// flags, so the cross_mode_byte_identical oracle below covers it too.
 	// The export half pinned here: relations present, and NO plane marker on
 	// the record (it is durable — stamping it would re-plane it on import).
@@ -352,7 +352,7 @@ func TestProxiedServerExport(t *testing.T) {
 		if noHist, _ := rec["no_history"].(bool); !noHist {
 			t.Fatalf("promoted row lost no_history in export: %v", rec)
 		}
-		if _, marked := rec["wisp"]; marked {
+		if _, marked := rec["wisp_plane"]; marked {
 			t.Errorf("promoted row carries the wisps-plane marker; it is durable and must not be stamped: %v", rec)
 		}
 		if labels := exportStrings(rec["labels"]); len(labels) != 1 || labels[0] != "keepme" {

--- a/cmd/bd/export_source.go
+++ b/cmd/bd/export_source.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/dberrors"
 	"github.com/steveyegge/beads/internal/storage/uow"
 	"github.com/steveyegge/beads/internal/types"
@@ -42,6 +43,25 @@ type exportSource interface {
 	// LoadExportRelations bulk-loads labels, dependency records, comments,
 	// comment counts, and dependency counts for the searched issues.
 	LoadExportRelations(ctx context.Context, issues []*types.Issue) (exportRelations, error)
+	// WispPlaneIDs reports which of ids currently live in the WISPS table.
+	// Export uses it to stamp the explicit "wisp" plane marker on records
+	// whose row flags are ambiguous: a no_history=true row is either an
+	// unpromoted no-history wisp (wisps table) or a promoted one (durable
+	// issues-table row that may still carry the stray flag), and only table
+	// membership can tell them apart — import routes by the marker, so
+	// mis-stamping a durable row would re-plane it and drop its relations
+	// (bd-r9uce). Implementations must classify by table membership, never
+	// by flags, and both modes must agree (byte-identity oracle).
+	WispPlaneIDs(ctx context.Context, ids []string) (map[string]bool, error)
+}
+
+// storeWispPartitioner is the optional store capability WispPlaneIDs uses in
+// classic mode. Both real stores (DoltStore, EmbeddedDoltStore) implement it;
+// a store that does not simply gets no plane markers, which degrades to the
+// data-safe side (import then routes bare no_history rows to the durable
+// plane, where nothing is ever excluded from export).
+type storeWispPartitioner interface {
+	PartitionWispIDs(ctx context.Context, ids []string) (wispIDs, permIDs []string, err error)
 }
 
 // exportRelations carries the bulk-loaded relational data for the export set,
@@ -107,6 +127,39 @@ func (storeExportSource) LoadExportRelations(ctx context.Context, issues []*type
 	}, nil
 }
 
+func (storeExportSource) WispPlaneIDs(ctx context.Context, ids []string) (map[string]bool, error) {
+	if len(ids) == 0 || store == nil {
+		return nil, nil
+	}
+	// The store global is decorator-wrapped (telemetry, hook firing); walk
+	// Unwrap() down to the store that carries the partition capability.
+	s := store
+	var p storeWispPartitioner
+	for {
+		if partitioner, ok := s.(storeWispPartitioner); ok {
+			p = partitioner
+			break
+		}
+		u, ok := s.(interface{ Unwrap() storage.DoltStorage })
+		if !ok {
+			return nil, nil
+		}
+		s = u.Unwrap()
+		if s == nil {
+			return nil, nil
+		}
+	}
+	wispIDs, _, err := p.PartitionWispIDs(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+	set := make(map[string]bool, len(wispIDs))
+	for _, id := range wispIDs {
+		set[id] = true
+	}
+	return set, nil
+}
+
 // uowExportSource is the proxied-server exportSource over a unit of work. All
 // reads run inside the single read transaction runExport opened, so the
 // export is one consistent snapshot.
@@ -153,7 +206,8 @@ func (s *uowExportSource) GetAllConfig(ctx context.Context) (map[string]string, 
 //   - Labels, comments, and comment counts: the classic loaders partition IDs
 //     by wisps-table membership (issueops.PartitionWispIDsInTx). Row flags are
 //     NOT a substitute for that partition — a promoted no-history wisp is a
-//     durable issues-table row that still carries NoHistory=true — so both
+//     durable issues-table row that (as wild data from the pre-bd-r9uce
+//     promote) still carries NoHistory=true — so both
 //     planes are queried with the FULL ID set and merged. The planes are
 //     ID-disjoint (GH#4455 cross-table guard), so at most one plane returns
 //     rows for any id and the merge cannot collide.
@@ -257,6 +311,28 @@ func (s *uowExportSource) LoadExportRelations(ctx context.Context, issues []*typ
 	}
 
 	return rel, nil
+}
+
+// WispPlaneIDs classifies by wisps-table membership through the plane-pinned
+// GetWispsByIDs read (row flags are NOT a substitute — see the exportSource
+// interface comment). A rig without the wisp tables has no wisp-plane rows,
+// mirroring the tolerance of the wisp-plane legs in LoadExportRelations.
+func (s *uowExportSource) WispPlaneIDs(ctx context.Context, ids []string) (map[string]bool, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	wisps, err := s.uw.IssueUseCase().GetWispsByIDs(ctx, ids)
+	if err != nil {
+		if dberrors.IsTableNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("wisp plane membership: %w", err)
+	}
+	set := make(map[string]bool, len(wisps))
+	for _, w := range wisps {
+		set[w.ID] = true
+	}
+	return set, nil
 }
 
 // mergeExportMap copies src entries into dst. The label/comment planes are

--- a/cmd/bd/export_source.go
+++ b/cmd/bd/export_source.go
@@ -44,7 +44,7 @@ type exportSource interface {
 	// comment counts, and dependency counts for the searched issues.
 	LoadExportRelations(ctx context.Context, issues []*types.Issue) (exportRelations, error)
 	// WispPlaneIDs reports which of ids currently live in the WISPS table.
-	// Export uses it to stamp the explicit "wisp" plane marker on records
+	// Export uses it to stamp the explicit "wisp_plane" marker on records
 	// whose row flags are ambiguous: a no_history=true row is either an
 	// unpromoted no-history wisp (wisps table) or a promoted one (durable
 	// issues-table row that may still carry the stray flag), and only table

--- a/cmd/bd/import.go
+++ b/cmd/bd/import.go
@@ -229,8 +229,8 @@ func runImportFromReader(ctx context.Context, r io.Reader, source string) error 
 // records — the `bd import` / `bd import -` parse loop, shared by the classic
 // and proxied modes. Same record vocabulary as parseJSONLFile (the bootstrap
 // reader): the optional _schema header and tombstones are skipped, and the
-// "wisp" boolean is honored as the explicit wisps-plane marker (and the
-// legacy alias for "ephemeral") via applyImportWispPlane.
+// "wisp_plane" boolean is honored as the explicit wisps-plane marker (and
+// the legacy "wisp" alias for "ephemeral") via applyImportWispPlane.
 func parseImportRecords(r io.Reader) ([]*types.Issue, []memoryRecord, error) {
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 0, 1024*1024), 64*1024*1024)

--- a/cmd/bd/import.go
+++ b/cmd/bd/import.go
@@ -229,7 +229,8 @@ func runImportFromReader(ctx context.Context, r io.Reader, source string) error 
 // records — the `bd import` / `bd import -` parse loop, shared by the classic
 // and proxied modes. Same record vocabulary as parseJSONLFile (the bootstrap
 // reader): the optional _schema header and tombstones are skipped, and the
-// legacy "wisp" boolean is honored as an alias for "ephemeral".
+// "wisp" boolean is honored as the explicit wisps-plane marker (and the
+// legacy alias for "ephemeral") via applyImportWispPlane.
 func parseImportRecords(r io.Reader) ([]*types.Issue, []memoryRecord, error) {
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 0, 1024*1024), 64*1024*1024)
@@ -281,12 +282,7 @@ func parseImportRecords(r io.Reader) ([]*types.Issue, []memoryRecord, error) {
 		if issue.Status == "tombstone" {
 			continue
 		}
-		if _, hasWisp := peek["wisp"]; hasWisp && !issue.Ephemeral {
-			var wisp bool
-			if err := json.Unmarshal(peek["wisp"], &wisp); err == nil && wisp {
-				issue.Ephemeral = true
-			}
-		}
+		applyImportWispPlane(peek, &issue)
 		issue.SetDefaults()
 		issues = append(issues, &issue)
 	}

--- a/cmd/bd/import_promoted_wisp_embedded_test.go
+++ b/cmd/bd/import_promoted_wisp_embedded_test.go
@@ -19,7 +19,7 @@ import (
 // Ephemeral || NoHistory), silently re-planing the durable row into the
 // wisps table; its dependency edge to a durable friend in the same batch was
 // then dropped as a "cross-bucket dependency", and the row itself left the
-// durable plane. Import now routes by the export stream's explicit "wisp"
+// durable plane. Import now routes by the export stream's explicit "wisp_plane"
 // plane marker: marker absent ⇒ durable plane, whatever no_history says.
 func TestEmbeddedImportPromotedWispRoundtrip(t *testing.T) {
 	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
@@ -45,7 +45,7 @@ func TestEmbeddedImportPromotedWispRoundtrip(t *testing.T) {
 
 		// The wild promoted shape, as an export stream produced before the
 		// promote fix: a durable record still carrying no_history=true, NO
-		// "wisp" plane marker, plus a durable friend whose dependency edge
+		// "wisp_plane" marker, plus a durable friend whose dependency edge
 		// points at it.
 		wild := `{"_type":"issue","id":"rtp-wisp-promo","title":"Promoted no-history wisp","status":"open","priority":2,"issue_type":"task","created_at":"2026-08-01T10:00:00Z","updated_at":"2026-08-01T10:00:00Z","labels":["keepme"],"comments":[{"id":"11111111-2222-3333-4444-555555555555","issue_id":"rtp-wisp-promo","author":"tester","text":"survive me","created_at":"2026-08-01T10:00:00Z"}],"no_history":true}
 {"_type":"issue","id":"rtp-frend","title":"Durable friend","status":"open","priority":2,"issue_type":"task","created_at":"2026-08-01T10:00:01Z","updated_at":"2026-08-01T10:00:01Z","dependencies":[{"issue_id":"rtp-frend","depends_on_id":"rtp-wisp-promo","type":"blocks","created_at":"2026-08-01T10:00:01Z","created_by":"tester"}]}
@@ -65,10 +65,10 @@ func TestEmbeddedImportPromotedWispRoundtrip(t *testing.T) {
 		if promo == nil {
 			t.Fatal("export missing rtp-wisp-promo")
 		}
-		// Durable plane: no "wisp" marker; the stray flag itself is
+		// Durable plane: no "wisp_plane" marker; the stray flag itself is
 		// preserved (clearing it would change the content hash and break
 		// export→import→export byte identity for wild rows).
-		if _, marked := promo["wisp"]; marked {
+		if _, marked := promo["wisp_plane"]; marked {
 			t.Errorf("promoted row re-exported with the wisps-plane marker; it must stay durable: %v", promo)
 		}
 		if noHist, _ := promo["no_history"].(bool); !noHist {
@@ -116,7 +116,7 @@ func TestEmbeddedImportPromotedWispRoundtrip(t *testing.T) {
 		// An unpromoted no-history wisp lives in the wisps table, so export
 		// must stamp the explicit plane marker — flags alone cannot tell it
 		// apart from the promoted shape above.
-		if marked, _ := rec["wisp"].(bool); !marked {
+		if marked, _ := rec["wisp_plane"].(bool); !marked {
 			t.Fatalf("no-history wisp exported without the wisps-plane marker: %v", rec)
 		}
 
@@ -134,7 +134,7 @@ func TestEmbeddedImportPromotedWispRoundtrip(t *testing.T) {
 		if rec2 == nil {
 			t.Fatalf("re-export missing no-history wisp %s", wispID)
 		}
-		if marked, _ := rec2["wisp"].(bool); !marked {
+		if marked, _ := rec2["wisp_plane"].(bool); !marked {
 			t.Errorf("re-imported no-history wisp lost the wisps-plane marker (re-planed durable?): %v", rec2)
 		}
 	})

--- a/cmd/bd/import_promoted_wisp_embedded_test.go
+++ b/cmd/bd/import_promoted_wisp_embedded_test.go
@@ -1,0 +1,172 @@
+//go:build cgo
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestEmbeddedImportPromotedWispRoundtrip is the classic-mode round-trip
+// oracle for bd-r9uce: a promoted no-history wisp — a durable issues-table
+// row that (in wild data) still carries no_history=true — must survive
+// export→import→export with its relations intact.
+//
+// Pre-fix, classic import routed the record by row flags (issueops.IsWisp:
+// Ephemeral || NoHistory), silently re-planing the durable row into the
+// wisps table; its dependency edge to a durable friend in the same batch was
+// then dropped as a "cross-bucket dependency", and the row itself left the
+// durable plane. Import now routes by the export stream's explicit "wisp"
+// plane marker: marker absent ⇒ durable plane, whatever no_history says.
+func TestEmbeddedImportPromotedWispRoundtrip(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt import tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+
+	// recordByID returns the parsed export record for id, or nil.
+	recordByID := func(t *testing.T, stream, id string) map[string]any {
+		t.Helper()
+		for _, rec := range exportLines(t, stream) {
+			if rec["_type"] == "issue" && rec["id"] == id {
+				return rec
+			}
+		}
+		return nil
+	}
+
+	t.Run("promoted_shape_routes_durable", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "rtp")
+
+		// The wild promoted shape, as an export stream produced before the
+		// promote fix: a durable record still carrying no_history=true, NO
+		// "wisp" plane marker, plus a durable friend whose dependency edge
+		// points at it.
+		wild := `{"_type":"issue","id":"rtp-wisp-promo","title":"Promoted no-history wisp","status":"open","priority":2,"issue_type":"task","created_at":"2026-08-01T10:00:00Z","updated_at":"2026-08-01T10:00:00Z","labels":["keepme"],"comments":[{"id":"11111111-2222-3333-4444-555555555555","issue_id":"rtp-wisp-promo","author":"tester","text":"survive me","created_at":"2026-08-01T10:00:00Z"}],"no_history":true}
+{"_type":"issue","id":"rtp-frend","title":"Durable friend","status":"open","priority":2,"issue_type":"task","created_at":"2026-08-01T10:00:01Z","updated_at":"2026-08-01T10:00:01Z","dependencies":[{"issue_id":"rtp-frend","depends_on_id":"rtp-wisp-promo","type":"blocks","created_at":"2026-08-01T10:00:01Z","created_by":"tester"}]}
+`
+		wildPath := filepath.Join(dir, "wild.jsonl")
+		if err := os.WriteFile(wildPath, []byte(wild), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		importOut := bdImport(t, bd, dir, "-i", wildPath)
+		if strings.Contains(importOut, "Skipped dependency") {
+			t.Errorf("import dropped a relation (promoted row re-planed into the wisps bucket?):\n%s", importOut)
+		}
+
+		exportA := bdExport(t, bd, dir)
+		promo := recordByID(t, exportA, "rtp-wisp-promo")
+		if promo == nil {
+			t.Fatal("export missing rtp-wisp-promo")
+		}
+		// Durable plane: no "wisp" marker; the stray flag itself is
+		// preserved (clearing it would change the content hash and break
+		// export→import→export byte identity for wild rows).
+		if _, marked := promo["wisp"]; marked {
+			t.Errorf("promoted row re-exported with the wisps-plane marker; it must stay durable: %v", promo)
+		}
+		if noHist, _ := promo["no_history"].(bool); !noHist {
+			t.Errorf("promoted row lost no_history on the round trip: %v", promo)
+		}
+		if dc, _ := promo["dependent_count"].(float64); int(dc) != 1 {
+			t.Errorf("promoted row dependent_count = %v, want 1 (relation dropped?)", promo["dependent_count"])
+		}
+		friend := recordByID(t, exportA, "rtp-frend")
+		if friend == nil {
+			t.Fatal("export missing rtp-frend")
+		}
+		deps, _ := friend["dependencies"].([]any)
+		if len(deps) != 1 {
+			t.Fatalf("friend dependencies = %v, want the one edge onto the promoted row", friend["dependencies"])
+		}
+		if edge, ok := deps[0].(map[string]any); !ok || edge["depends_on_id"] != "rtp-wisp-promo" {
+			t.Errorf("friend dependency edge = %v, want depends_on_id=rtp-wisp-promo", deps[0])
+		}
+
+		// Second leg: the first export imported into a fresh rig re-exports
+		// byte-identically — the round trip is a fixed point.
+		dir2, _, _ := bdInit(t, bd, "--prefix", "rtp")
+		exportAPath := filepath.Join(dir2, "incoming.jsonl")
+		if err := os.WriteFile(exportAPath, []byte(exportA), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if out := bdImport(t, bd, dir2, "-i", exportAPath); strings.Contains(out, "Skipped dependency") {
+			t.Errorf("second-leg import dropped a relation:\n%s", out)
+		}
+		if exportB := bdExport(t, bd, dir2); exportB != exportA {
+			t.Errorf("round trip is not a fixed point:\n%s", firstStreamDiff(exportA, exportB))
+		}
+	})
+
+	t.Run("no_history_wisp_keeps_plane", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "rtw")
+		wispID := bdCreateSilent(t, bd, dir, "Genuine no-history wisp", "--no-history")
+
+		exportA := bdExport(t, bd, dir)
+		rec := recordByID(t, exportA, wispID)
+		if rec == nil {
+			t.Fatalf("export missing no-history wisp %s", wispID)
+		}
+		// An unpromoted no-history wisp lives in the wisps table, so export
+		// must stamp the explicit plane marker — flags alone cannot tell it
+		// apart from the promoted shape above.
+		if marked, _ := rec["wisp"].(bool); !marked {
+			t.Fatalf("no-history wisp exported without the wisps-plane marker: %v", rec)
+		}
+
+		dir2, _, _ := bdInit(t, bd, "--prefix", "rtw")
+		path := filepath.Join(dir2, "incoming.jsonl")
+		if err := os.WriteFile(path, []byte(exportA), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		bdImport(t, bd, dir2, "-i", path)
+		exportB := bdExport(t, bd, dir2)
+		if exportB != exportA {
+			t.Errorf("no-history wisp round trip is not a fixed point:\n%s", firstStreamDiff(exportA, exportB))
+		}
+		rec2 := recordByID(t, exportB, wispID)
+		if rec2 == nil {
+			t.Fatalf("re-export missing no-history wisp %s", wispID)
+		}
+		if marked, _ := rec2["wisp"].(bool); !marked {
+			t.Errorf("re-imported no-history wisp lost the wisps-plane marker (re-planed durable?): %v", rec2)
+		}
+	})
+
+	t.Run("legacy_wisp_alias_still_means_ephemeral", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "rtl")
+		// v0.35–v0.37 exports spelled "ephemeral" as "wisp" and predate
+		// no_history; the marker parse must keep restoring Ephemeral for them.
+		legacy := `{"_type":"issue","id":"rtl-wisp-leg","title":"Legacy ephemeral","status":"open","priority":2,"issue_type":"task","created_at":"2026-08-01T10:00:00Z","updated_at":"2026-08-01T10:00:00Z","wisp":true}
+`
+		path := filepath.Join(dir, "legacy.jsonl")
+		if err := os.WriteFile(path, []byte(legacy), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		bdImport(t, bd, dir, "-i", path)
+		out, err := bdRunWithFlockRetry(t, bd, dir, "show", "rtl-wisp-leg", "--json")
+		if err != nil {
+			t.Fatalf("bd show: %v\n%s", err, out)
+		}
+		var shown any
+		if err := json.Unmarshal(out, &shown); err != nil {
+			t.Fatalf("parse show --json: %v\n%s", err, out)
+		}
+		obj, _ := shown.(map[string]any)
+		if list, ok := shown.([]any); ok && len(list) > 0 {
+			obj, _ = list[0].(map[string]any)
+		}
+		if obj == nil {
+			t.Fatalf("unexpected show --json shape: %s", out)
+		}
+		if eph, _ := obj["ephemeral"].(bool); !eph {
+			t.Errorf("legacy wisp:true record imported with ephemeral=%v, want true", obj["ephemeral"])
+		}
+	})
+}

--- a/cmd/bd/import_proxied_integration_test.go
+++ b/cmd/bd/import_proxied_integration_test.go
@@ -186,7 +186,7 @@ func TestProxiedServerImport(t *testing.T) {
 	})
 
 	// bd-r9uce: import routes the storage plane by the export stream's
-	// explicit "wisp" marker, never by the no_history flag. A no_history=true
+	// explicit "wisp_plane" marker, never by the no_history flag. A no_history=true
 	// record WITHOUT the marker is a promoted no-history wisp — a durable
 	// issues-table row whose stray flag must not re-plane it into the wisps
 	// table (which would drop its cross-plane relations as "cross-bucket");
@@ -214,7 +214,7 @@ func TestProxiedServerImport(t *testing.T) {
 		},
 			// A genuine unpromoted no-history wisp: same flags, but carrying
 			// the explicit plane marker.
-			`{"id":"impw-wisp-real","title":"Real no-history wisp","status":"open","issue_type":"task","priority":2,"no_history":true,"wisp":true,"created_at":"2026-08-01T12:00:00Z","updated_at":"2026-08-01T12:00:00Z"}`,
+			`{"id":"impw-wisp-real","title":"Real no-history wisp","status":"open","issue_type":"task","priority":2,"no_history":true,"wisp_plane":true,"created_at":"2026-08-01T12:00:00Z","updated_at":"2026-08-01T12:00:00Z"}`,
 		)
 		path := filepath.Join(p.dir, "planes.jsonl")
 		if err := os.WriteFile(path, []byte(fixture), 0o644); err != nil {

--- a/cmd/bd/import_proxied_integration_test.go
+++ b/cmd/bd/import_proxied_integration_test.go
@@ -185,6 +185,67 @@ func TestProxiedServerImport(t *testing.T) {
 		}
 	})
 
+	// bd-r9uce: import routes the storage plane by the export stream's
+	// explicit "wisp" marker, never by the no_history flag. A no_history=true
+	// record WITHOUT the marker is a promoted no-history wisp — a durable
+	// issues-table row whose stray flag must not re-plane it into the wisps
+	// table (which would drop its cross-plane relations as "cross-bucket");
+	// WITH the marker it is a genuine unpromoted no-history wisp and keeps
+	// its wisps-plane home. Same marker contract as the classic route
+	// (TestEmbeddedImportPromotedWispRoundtrip), through the shared parse
+	// loop and the shared issueops batch engine.
+	t.Run("promoted_no_history_routes_durable", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "impw")
+		db := openProxiedDB(t, p)
+
+		fixture := importFixtureJSONL(t, []*types.Issue{
+			{
+				ID: "impw-wisp-promo", Title: "Promoted no-history wisp", Status: types.StatusOpen,
+				IssueType: types.TypeTask, Priority: 2, NoHistory: true,
+				CreatedAt: when, UpdatedAt: when,
+			},
+			{
+				ID: "impw-frend", Title: "Durable friend", Status: types.StatusOpen,
+				IssueType: types.TypeTask, Priority: 2,
+				Dependencies: []*types.Dependency{{IssueID: "impw-frend", DependsOnID: "impw-wisp-promo", Type: types.DepBlocks}},
+				CreatedAt:    when, UpdatedAt: when,
+			},
+		},
+			// A genuine unpromoted no-history wisp: same flags, but carrying
+			// the explicit plane marker.
+			`{"id":"impw-wisp-real","title":"Real no-history wisp","status":"open","issue_type":"task","priority":2,"no_history":true,"wisp":true,"created_at":"2026-08-01T12:00:00Z","updated_at":"2026-08-01T12:00:00Z"}`,
+		)
+		path := filepath.Join(p.dir, "planes.jsonl")
+		if err := os.WriteFile(path, []byte(fixture), 0o644); err != nil {
+			t.Fatalf("write fixture: %v", err)
+		}
+
+		report := bdProxiedImport(t, bd, p.dir, path)
+		if strings.Contains(report, "Skipped dependency") {
+			t.Errorf("import dropped a relation (promoted row re-planed into the wisps bucket?):\n%s", report)
+		}
+
+		// Marker absent => durable plane, flag preserved on the row.
+		if got := proxiedImportQueryInt(t, db, "SELECT COUNT(*) FROM issues WHERE id = 'impw-wisp-promo' AND no_history = 1"); got != 1 {
+			t.Errorf("promoted row in issues table with no_history intact = %d, want 1", got)
+		}
+		if got := proxiedImportQueryInt(t, db, "SELECT COUNT(*) FROM wisps WHERE id = 'impw-wisp-promo'"); got != 0 {
+			t.Errorf("promoted row re-planed into wisps table: %d rows, want 0", got)
+		}
+		if got := proxiedImportQueryInt(t, db, "SELECT COUNT(*) FROM dependencies WHERE issue_id = 'impw-frend' AND depends_on_issue_id = 'impw-wisp-promo' AND type = 'blocks'"); got != 1 {
+			t.Errorf("friend blocks edge onto promoted row = %d, want 1 (relation dropped?)", got)
+		}
+
+		// Marker present => wisps plane.
+		if got := proxiedImportQueryInt(t, db, "SELECT COUNT(*) FROM wisps WHERE id = 'impw-wisp-real' AND no_history = 1"); got != 1 {
+			t.Errorf("marked no-history wisp in wisps table = %d, want 1", got)
+		}
+		if got := proxiedImportQueryInt(t, db, "SELECT COUNT(*) FROM issues WHERE id = 'impw-wisp-real'"); got != 0 {
+			t.Errorf("marked no-history wisp leaked into issues table: %d rows, want 0", got)
+		}
+	})
+
 	t.Run("stdin_dash_and_redirect_guard", func(t *testing.T) {
 		t.Parallel()
 		p := newSharedProxiedProject(t, bd, "impb")

--- a/cmd/bd/import_shared.go
+++ b/cmd/bd/import_shared.go
@@ -1049,14 +1049,7 @@ func parseJSONLFile(path string) ([]*types.Issue, map[string]string, error) {
 			continue
 		}
 
-		// v0.35–v0.37 exported "wisp" (bool), renamed to "ephemeral" in v0.38+.
-		// map old field name so the flag is preserved on import.
-		if _, hasWisp := peek["wisp"]; hasWisp && !issue.Ephemeral {
-			var wisp bool
-			if err := json.Unmarshal(peek["wisp"], &wisp); err == nil && wisp {
-				issue.Ephemeral = true
-			}
-		}
+		applyImportWispPlane(peek, &issue)
 
 		issue.SetDefaults()
 		issues = append(issues, &issue)
@@ -1066,6 +1059,54 @@ func parseJSONLFile(path string) ([]*types.Issue, map[string]string, error) {
 	}
 
 	return issues, configEntries, nil
+}
+
+// applyImportWispPlane resolves which storage plane (wisps vs issues table) a
+// parsed import record routes to, shared by every JSONL parse loop
+// (parseImportRecords for `bd import` in both storage modes, parseJSONLFile
+// for bootstrap / init --from-jsonl / auto-import).
+//
+// The "wisp" peek key is the EXPLICIT wisps-plane marker (bd-r9uce): export
+// writes it for rows that live in the wisps table, precisely because row
+// flags cannot be trusted for the plane decision — a promoted no-history
+// wisp is a durable issues-table row that may still carry no_history=true
+// (PromoteFromEphemeralInTx used to clear only Ephemeral, and wild data
+// with that shape persists). Routing such a record by flags re-planes it
+// into the wisps table, after which its cross-plane relations are dropped
+// by the batch import and the row itself is no longer durable — silent data
+// loss across export→import→export. So:
+//
+//   - "wisp": true            => wisps plane, whatever the flags say. For
+//     v0.35–v0.37 exports (which spelled "ephemeral" as "wisp" and predate
+//     no_history) the record carries neither flag, so Ephemeral is restored
+//     from the marker — the legacy-alias behavior, preserved.
+//   - marker absent or false  => a no_history=true record is pinned to the
+//     ISSUES plane (the promoted shape). The flag itself is preserved on the
+//     row — clearing it would change the content hash and break the
+//     byte-identity of export→import→export — only the routing is pinned.
+//   - anything else           => no override; flag inference (issueops.IsWisp)
+//     already routes it correctly.
+func applyImportWispPlane(peek map[string]json.RawMessage, issue *types.Issue) {
+	wispMarker := false
+	if raw, ok := peek["wisp"]; ok {
+		// A malformed marker is treated as absent (best-effort, like the
+		// legacy-alias parse always was).
+		_ = json.Unmarshal(raw, &wispMarker)
+	}
+	if wispMarker {
+		if !issue.Ephemeral && !issue.NoHistory {
+			// Legacy v0.35–v0.37 alias for "ephemeral".
+			issue.Ephemeral = true
+		}
+		wisp := true
+		issue.WispPlaneOverride = &wisp
+		return
+	}
+	if issue.NoHistory && !issue.Ephemeral {
+		// Promoted no-history wisp: durable row, stray flag. Pin it durable.
+		durable := false
+		issue.WispPlaneOverride = &durable
+	}
 }
 
 // importFromLocalJSONLFull imports issues and memories from a local JSONL file

--- a/cmd/bd/import_shared.go
+++ b/cmd/bd/import_shared.go
@@ -1066,41 +1066,52 @@ func parseJSONLFile(path string) ([]*types.Issue, map[string]string, error) {
 // (parseImportRecords for `bd import` in both storage modes, parseJSONLFile
 // for bootstrap / init --from-jsonl / auto-import).
 //
-// The "wisp" peek key is the EXPLICIT wisps-plane marker (bd-r9uce): export
-// writes it for rows that live in the wisps table, precisely because row
-// flags cannot be trusted for the plane decision — a promoted no-history
+// The "wisp_plane" peek key is the EXPLICIT wisps-plane marker (bd-r9uce):
+// export writes it for rows that live in the wisps table, precisely because
+// row flags cannot be trusted for the plane decision — a promoted no-history
 // wisp is a durable issues-table row that may still carry no_history=true
 // (PromoteFromEphemeralInTx used to clear only Ephemeral, and wild data
 // with that shape persists). Routing such a record by flags re-planes it
 // into the wisps table, after which its cross-plane relations are dropped
 // by the batch import and the row itself is no longer durable — silent data
-// loss across export→import→export. So:
+// loss across export→import→export.
 //
-//   - "wisp": true            => wisps plane, whatever the flags say. For
-//     v0.35–v0.37 exports (which spelled "ephemeral" as "wisp" and predate
-//     no_history) the record carries neither flag, so Ephemeral is restored
-//     from the marker — the legacy-alias behavior, preserved.
-//   - marker absent or false  => a no_history=true record is pinned to the
+// The marker is deliberately a FRESH key, not a reuse of the legacy "wisp"
+// boolean (lion, #5368 review): every pre-fix v0.38+ binary's alias branch
+// is `hasWisp && !Ephemeral => Ephemeral=true`, so stamping "wisp" on a
+// genuine no-history wisp would make every current binary import it as
+// ephemeral — purge-eligible and excluded from that rig's next default
+// export — turning the common rollout-skew case lossy. Readers that predate
+// the fresh key simply ignore it and fall back to flag routing, the
+// data-safe degradation in both skew directions. So:
+//
+//   - "wisp_plane": true      => wisps plane, whatever the flags say.
+//   - key absent or false     => a no_history=true record is pinned to the
 //     ISSUES plane (the promoted shape). The flag itself is preserved on the
 //     row — clearing it would change the content hash and break the
 //     byte-identity of export→import→export — only the routing is pinned.
-//   - anything else           => no override; flag inference (issueops.IsWisp)
-//     already routes it correctly.
+//   - legacy "wisp": true     => the v0.35–v0.37 spelling of "ephemeral"
+//     (those exports predate no_history): Ephemeral is restored — the alias
+//     behavior import has always had, preserved verbatim.
 func applyImportWispPlane(peek map[string]json.RawMessage, issue *types.Issue) {
-	wispMarker := false
-	if raw, ok := peek["wisp"]; ok {
-		// A malformed marker is treated as absent (best-effort, like the
-		// legacy-alias parse always was).
-		_ = json.Unmarshal(raw, &wispMarker)
+	// A malformed marker is treated as absent (best-effort, like the
+	// legacy-alias parse always was).
+	planeMarker := false
+	if raw, ok := peek["wisp_plane"]; ok {
+		_ = json.Unmarshal(raw, &planeMarker)
 	}
-	if wispMarker {
-		if !issue.Ephemeral && !issue.NoHistory {
-			// Legacy v0.35–v0.37 alias for "ephemeral".
-			issue.Ephemeral = true
-		}
+	if planeMarker {
 		wisp := true
 		issue.WispPlaneOverride = &wisp
 		return
+	}
+	if legacy, ok := peek["wisp"]; ok && !issue.Ephemeral {
+		// Legacy v0.35–v0.37 alias for "ephemeral", preserved verbatim.
+		var wisp bool
+		if err := json.Unmarshal(legacy, &wisp); err == nil && wisp {
+			issue.Ephemeral = true
+			return
+		}
 	}
 	if issue.NoHistory && !issue.Ephemeral {
 		// Promoted no-history wisp: durable row, stray flag. Pin it durable.

--- a/docs/reference/json-schema.md
+++ b/docs/reference/json-schema.md
@@ -206,13 +206,17 @@ not to the interchange stream. The interchange's own version marker is the
 optional `_schema` header record (`{"_schema":"beads-jsonl/1"}`), which
 readers skip.
 
-Issue records carry an optional `wisp` boolean: the explicit wisps-plane
-marker. Export stamps it on rows that live in the wisps table when the row
-flags alone cannot prove the plane (a `no_history: true` record is otherwise
-ambiguous — an unpromoted no-history wisp and a promoted one look identical).
-Import routes the storage plane by this marker, never by `no_history`: marker
-absent means the durable issues table. On v0.35–v0.37 streams the same key
-was the spelling of `ephemeral`, and import still honors that legacy alias.
+Issue records carry an optional `wisp_plane` boolean: the explicit
+wisps-plane marker. Export stamps it on rows that live in the wisps table
+when the row flags alone cannot prove the plane (a `no_history: true` record
+is otherwise ambiguous — an unpromoted no-history wisp and a promoted one
+look identical). Import routes the storage plane by this marker, never by
+`no_history`: marker absent means the durable issues table. The marker is a
+fresh key rather than a reuse of the legacy `wisp` boolean so that older
+readers, which do not know it, degrade to flag routing instead of importing
+marked rows as ephemeral (purge-eligible and export-excluded). The v0.35–
+v0.37 `wisp` key — those streams' spelling of `ephemeral` — is still honored
+as a read-side legacy alias.
 
 ## Consumer Guidelines
 

--- a/docs/reference/json-schema.md
+++ b/docs/reference/json-schema.md
@@ -206,6 +206,14 @@ not to the interchange stream. The interchange's own version marker is the
 optional `_schema` header record (`{"_schema":"beads-jsonl/1"}`), which
 readers skip.
 
+Issue records carry an optional `wisp` boolean: the explicit wisps-plane
+marker. Export stamps it on rows that live in the wisps table when the row
+flags alone cannot prove the plane (a `no_history: true` record is otherwise
+ambiguous — an unpromoted no-history wisp and a promoted one look identical).
+Import routes the storage plane by this marker, never by `no_history`: marker
+absent means the durable issues table. On v0.35–v0.37 streams the same key
+was the spelling of `ephemeral`, and import still honors that legacy alias.
+
 ## Consumer Guidelines
 
 1. **Check `schema_version`** on object output. If the version is

--- a/internal/storage/dolt/ephemeral_routing.go
+++ b/internal/storage/dolt/ephemeral_routing.go
@@ -174,6 +174,27 @@ func (s *DoltStore) batchWispExists(ctx context.Context, ids []string) map[strin
 	return result
 }
 
+// PartitionWispIDs reports which of ids currently live in the wisps table
+// (single batched membership query; IDs absent from the wisps table are
+// returned as permanent). Export's plane-marker stamping uses this to tell an
+// unpromoted no-history wisp apart from a promoted one, which row flags
+// cannot do (bd-r9uce). batchWispExists tolerates a missing wisps table by
+// reporting no members, matching PartitionWispIDsInTx.
+func (s *DoltStore) PartitionWispIDs(ctx context.Context, ids []string) (wispIDs, permIDs []string, err error) {
+	if len(ids) == 0 {
+		return nil, nil, nil
+	}
+	set := s.batchWispExists(ctx, ids)
+	for _, id := range ids {
+		if set[id] {
+			wispIDs = append(wispIDs, id)
+		} else {
+			permIDs = append(permIDs, id)
+		}
+	}
+	return wispIDs, permIDs, nil
+}
+
 // PromoteFromEphemeral copies an issue from the wisps table to the issues table,
 // clearing the Ephemeral flag. Used by bd promote and mol squash to crystallize wisps.
 //

--- a/internal/storage/embeddeddolt/promote_no_history_test.go
+++ b/internal/storage/embeddeddolt/promote_no_history_test.go
@@ -1,0 +1,118 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestPromoteClearsNoHistory is the promote half of bd-r9uce: a promoted wisp
+// is fully durable, so PromoteFromEphemeralInTx must clear BOTH wisp-plane
+// flags, not just Ephemeral. A no-history wisp (Ephemeral=false,
+// NoHistory=true) promoted with NoHistory intact lands in the issues table
+// still flag-marked as wisp-plane state, and flag-based plane inference —
+// most damagingly import's table routing — silently re-planes it back into
+// the wisps table, dropping its relations on the way.
+func TestPromoteClearsNoHistory(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	ctx := t.Context()
+
+	t.Run("no_history wisp", func(t *testing.T) {
+		te := newTestEnv(t, "pnh")
+		if err := te.store.CreateIssue(ctx, &types.Issue{
+			ID: "pnh-w", Title: "no-history wisp", Status: types.StatusOpen,
+			Priority: 2, IssueType: types.TypeTask, NoHistory: true,
+			Labels: []string{"keepme"},
+		}, "tester"); err != nil {
+			t.Fatalf("create no-history wisp: %v", err)
+		}
+		te.assertRowExists(t, ctx, "wisps", "pnh-w")
+
+		if err := te.store.PromoteFromEphemeral(ctx, "pnh-w", "tester"); err != nil {
+			t.Fatalf("promote no-history wisp: %v", err)
+		}
+
+		te.assertRowExists(t, ctx, "issues", "pnh-w")
+		te.assertRowNotExists(t, ctx, "wisps", "pnh-w")
+		var noHistory, ephemeral int
+		te.queryScalar(t, ctx, "SELECT no_history, ephemeral FROM issues WHERE id = ?",
+			[]any{"pnh-w"}, &noHistory, &ephemeral)
+		if noHistory != 0 {
+			t.Errorf("promoted row no_history = %d, want 0 (promote must clear NoHistory too)", noHistory)
+		}
+		if ephemeral != 0 {
+			t.Errorf("promoted row ephemeral = %d, want 0", ephemeral)
+		}
+		got, err := te.store.GetIssue(ctx, "pnh-w")
+		if err != nil {
+			t.Fatalf("get promoted issue: %v", err)
+		}
+		if got.NoHistory || got.Ephemeral {
+			t.Errorf("promoted issue flags = {Ephemeral:%v NoHistory:%v}, want both false",
+				got.Ephemeral, got.NoHistory)
+		}
+	})
+
+	// Non-regression: the ephemeral-wisp happy path keeps its shape.
+	t.Run("ephemeral wisp", func(t *testing.T) {
+		te := newTestEnv(t, "pnh")
+		if err := te.store.CreateIssue(ctx, &types.Issue{
+			ID: "pnh-e", Title: "ephemeral wisp", Status: types.StatusOpen,
+			Priority: 2, IssueType: types.TypeTask, Ephemeral: true,
+		}, "tester"); err != nil {
+			t.Fatalf("create ephemeral wisp: %v", err)
+		}
+		if err := te.store.PromoteFromEphemeral(ctx, "pnh-e", "tester"); err != nil {
+			t.Fatalf("promote ephemeral wisp: %v", err)
+		}
+		got, err := te.store.GetIssue(ctx, "pnh-e")
+		if err != nil {
+			t.Fatalf("get promoted issue: %v", err)
+		}
+		if got.NoHistory || got.Ephemeral {
+			t.Errorf("promoted issue flags = {Ephemeral:%v NoHistory:%v}, want both false",
+				got.Ephemeral, got.NoHistory)
+		}
+	})
+}
+
+// TestPartitionWispIDs pins the store-level membership partition export's
+// plane-marker stamping relies on (bd-r9uce): classification must follow
+// TABLE membership, never row flags — after promotion the row is durable
+// whatever flags it carries.
+func TestPartitionWispIDs(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	ctx := t.Context()
+	te := newTestEnv(t, "pw")
+	seed := []*types.Issue{
+		{ID: "pw-dur", Title: "durable", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+		{ID: "pw-eph", Title: "ephemeral wisp", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, Ephemeral: true},
+		{ID: "pw-noh", Title: "no-history wisp", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, NoHistory: true},
+	}
+	for _, issue := range seed {
+		if err := te.store.CreateIssue(ctx, issue, "tester"); err != nil {
+			t.Fatalf("create %s: %v", issue.ID, err)
+		}
+	}
+	// The promoted no-history shape: a durable row that (as wild data) still
+	// carries no_history=1. Flags say wisp; the table says durable.
+	te.exec(t, ctx, "UPDATE issues SET no_history = 1 WHERE id = ?", "pw-dur")
+
+	wispIDs, permIDs, err := te.store.PartitionWispIDs(ctx,
+		[]string{"pw-dur", "pw-eph", "pw-noh", "pw-ghost"})
+	if err != nil {
+		t.Fatalf("PartitionWispIDs: %v", err)
+	}
+	wantWisp := []string{"pw-eph", "pw-noh"}
+	wantPerm := []string{"pw-dur", "pw-ghost"}
+	if len(wispIDs) != len(wantWisp) || wispIDs[0] != wantWisp[0] || wispIDs[1] != wantWisp[1] {
+		t.Errorf("wispIDs = %v, want %v", wispIDs, wantWisp)
+	}
+	if len(permIDs) != len(wantPerm) || permIDs[0] != wantPerm[0] || permIDs[1] != wantPerm[1] {
+		t.Errorf("permIDs = %v, want %v", permIDs, wantPerm)
+	}
+}

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -929,6 +929,20 @@ func (s *EmbeddedDoltStore) PromoteFromEphemeral(ctx context.Context, id string,
 	})
 }
 
+// PartitionWispIDs reports which of ids currently live in the wisps table
+// (batched membership query; IDs absent from the wisps table are returned as
+// permanent). Export's plane-marker stamping uses this to tell an unpromoted
+// no-history wisp apart from a promoted one, which row flags cannot do
+// (bd-r9uce).
+func (s *EmbeddedDoltStore) PartitionWispIDs(ctx context.Context, ids []string) (wispIDs, permIDs []string, err error) {
+	err = s.withConn(ctx, false, func(tx *sql.Tx) error {
+		var inErr error
+		wispIDs, permIDs, inErr = issueops.PartitionWispIDsInTx(ctx, tx, ids)
+		return inErr
+	})
+	return wispIDs, permIDs, err
+}
+
 // GetNextChildID is implemented in child_id.go.
 
 // ---------------------------------------------------------------------------

--- a/internal/storage/hook_decorator.go
+++ b/internal/storage/hook_decorator.go
@@ -529,6 +529,7 @@ func cloneIssueForHook(issue *types.Issue) *types.Issue {
 	clone.LeaseExpiresAt = clonePtr(issue.LeaseExpiresAt)
 	clone.HeartbeatAt = clonePtr(issue.HeartbeatAt)
 	clone.ExternalRef = clonePtr(issue.ExternalRef)
+	clone.WispPlaneOverride = clonePtr(issue.WispPlaneOverride)
 	clone.Labels = append([]string(nil), issue.Labels...)
 	clone.Metadata = append([]byte(nil), issue.Metadata...)
 	clone.CompactedAt = clonePtr(issue.CompactedAt)

--- a/internal/storage/hook_decorator_internal_test.go
+++ b/internal/storage/hook_decorator_internal_test.go
@@ -307,6 +307,7 @@ func TestCloneIssueForHookCoversReferenceFields(t *testing.T) {
 		"LeaseExpiresAt":    {},
 		"HeartbeatAt":       {},
 		"ExternalRef":       {},
+		"WispPlaneOverride": {},
 		"Metadata":          {},
 		"CompactedAt":       {},
 		"CompactedAtCommit": {},

--- a/internal/storage/issueops/helpers.go
+++ b/internal/storage/issueops/helpers.go
@@ -26,7 +26,17 @@ import (
 // a naming convention for generated wisp IDs, but promoted wisps keep their
 // ID while moving to the issues table (Ephemeral=false). Routing on the ID
 // would send promoted wisps back to the wisps table on re-insert.
+//
+// WispPlaneOverride, when set, wins over the flags. Import sets it from the
+// export stream's explicit "wisp" plane marker: a record carrying
+// no_history=true but NO marker is a promoted no-history wisp — a durable
+// issues-table row whose stray flag must not re-plane it into the wisps
+// table on re-insert, which is how export→import→export silently dropped
+// such rows' relations (bd-r9uce).
 func IsWisp(issue *types.Issue) bool {
+	if issue.WispPlaneOverride != nil {
+		return *issue.WispPlaneOverride
+	}
 	return issue.Ephemeral || issue.NoHistory
 }
 

--- a/internal/storage/issueops/promote.go
+++ b/internal/storage/issueops/promote.go
@@ -22,7 +22,22 @@ func PromoteFromEphemeralInTx(ctx context.Context, tx DBTX, id string, actor str
 		return fmt.Errorf("wisp %s not found", id)
 	}
 
+	// A promoted wisp is fully durable: clear BOTH wisp-plane flags, not just
+	// Ephemeral. A no-history wisp (Ephemeral=false, NoHistory=true) promoted
+	// with NoHistory intact lands in the issues table still flag-marked as
+	// wisp-plane state, and everything that infers the plane from flags —
+	// most damagingly import's table routing — silently re-planes it back
+	// into the (default-export-excluded) wisps table, dropping its relations
+	// on the way (bd-r9uce). Post-promotion the flag has no meaning.
 	issue.Ephemeral = false
+	issue.NoHistory = false
+	// Promotion clears an explicit ephemeral class marker to select normalized
+	// versioned storage (same rule as types.NormalizePersistenceMode); with
+	// both plane flags cleared, a lingering explicit ephemeral class would
+	// fail validation in PrepareIssueForInsert below.
+	if issue.StorageClass == types.StorageClassEphemeral {
+		issue.StorageClass = ""
+	}
 
 	// Read the custom-status/type config directly (NewBatchContext needs a
 	// *sql.Tx; promote only uses these two fields of it, and the DBTX forms

--- a/internal/storage/issueops/public_create_test.go
+++ b/internal/storage/issueops/public_create_test.go
@@ -60,6 +60,10 @@ func TestPublicCreateIssueFieldClassificationIsComplete(t *testing.T) {
 		"ContentHash": true, "LeaseExpiresAt": true, "HeartbeatAt": true, "LeaseGrantedNode": true, "RowVersion": true,
 		"CompactionLevel": true, "CompactedAt": true, "CompactedAtCommit": true, "OriginalSize": true,
 		"IDPrefix": true, "PrefixOverride": true, "IsLitePartial": true,
+		// WispPlaneOverride is import-plumbing (the export stream's explicit
+		// plane marker, bd-r9uce); a public create routes by the flags it
+		// accepts (Ephemeral/NoHistory), so the override is dropped here.
+		"WispPlaneOverride": true,
 	}
 	rejected := map[string]bool{"Dependencies": true, "Comments": true}
 	issueType := reflect.TypeFor[types.Issue]()

--- a/internal/storage/issueops/public_snapshot.go
+++ b/internal/storage/issueops/public_snapshot.go
@@ -78,6 +78,7 @@ func clonePublicIssue(issue *publicops.Issue) *publicops.Issue {
 	clone.Comments = cloneComments(issue.Comments)
 	clone.BondedFrom = append([]types.BondRef(nil), issue.BondedFrom...)
 	clone.Waiters = append([]string(nil), issue.Waiters...)
+	clone.WispPlaneOverride = cloneBool(issue.WispPlaneOverride)
 	return &clone
 }
 
@@ -121,6 +122,14 @@ func cloneRawMessageMap(values map[string]json.RawMessage) map[string]json.RawMe
 }
 
 func cloneInt(value *int) *int {
+	if value == nil {
+		return nil
+	}
+	clone := *value
+	return &clone
+}
+
+func cloneBool(value *bool) *bool {
 	if value == nil {
 		return nil
 	}

--- a/internal/storage/issueops/public_snapshot_test.go
+++ b/internal/storage/issueops/public_snapshot_test.go
@@ -62,7 +62,7 @@ func TestCloneIssueOperationRequestsDeepCopyMutableFields(t *testing.T) {
 }
 
 func TestIssueOperationCloneFunctionsKeepFrozenRequestFields(t *testing.T) {
-	issueMutable := map[string]bool{"EstimatedMinutes": true, "StartedAt": true, "ClosedAt": true, "LeaseExpiresAt": true, "HeartbeatAt": true, "DueAt": true, "DeferUntil": true, "ExternalRef": true, "CompactedAt": true, "CompactedAtCommit": true, "Metadata": true, "Labels": true, "Dependencies": true, "Comments": true, "BondedFrom": true, "Waiters": true}
+	issueMutable := map[string]bool{"EstimatedMinutes": true, "StartedAt": true, "ClosedAt": true, "LeaseExpiresAt": true, "HeartbeatAt": true, "DueAt": true, "DeferUntil": true, "ExternalRef": true, "CompactedAt": true, "CompactedAtCommit": true, "Metadata": true, "Labels": true, "Dependencies": true, "Comments": true, "BondedFrom": true, "Waiters": true, "WispPlaneOverride": true}
 	for index := 0; index < reflect.TypeOf(types.Issue{}).NumField(); index++ {
 		field := reflect.TypeOf(types.Issue{}).Field(index)
 		if isMutableKind(field.Type.Kind()) && !issueMutable[field.Name] {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -112,6 +112,17 @@ type Issue struct {
 	IDPrefix       string `json:"-"` // Override prefix for ID generation (appends to config prefix)
 	PrefixOverride string `json:"-"` // Completely replace config prefix (for cross-rig creation)
 
+	// WispPlaneOverride, when non-nil, pins which storage plane this in-memory
+	// record routes to (true = wisps table, false = issues table), overriding
+	// the Ephemeral/NoHistory flag inference in issueops.IsWisp. Import sets it
+	// from the export stream's explicit "wisp" plane marker so a promoted
+	// no-history wisp — a durable issues-table row that (pre-fix, or in wild
+	// data) still carries no_history=true — is never re-planed into the wisps
+	// table, after which default export would treat it as wisp-plane state
+	// (bd-r9uce). Never serialized, never persisted; nil means "infer from
+	// flags", which is the behavior everywhere outside import.
+	WispPlaneOverride *bool `json:"-"`
+
 	// ===== Relational Data (populated for export/import) =====
 	Labels       []string      `json:"labels,omitempty"`
 	Dependencies []*Dependency `json:"dependencies,omitempty"`


### PR DESCRIPTION
Fixes real classic-mode data loss on the durability plane (bd-r9uce, found fixing a #5351 review item): a promoted no-history wisp is a durable issues-table row still carrying `no_history=true` — `PromoteFromEphemeralInTx` cleared only `Ephemeral` — and `issueops.IsWisp` (`Ephemeral || NoHistory`) re-planed it into the wisps table on import, after which default export EXCLUDES it. Net: export→import→export silently dropped promoted no-history wisps and their relations. Repro: `bd create --no-history X; bd promote X; bd export; fresh rig; bd import; bd export` → X gone.

Belt-and-braces fix (direction endorsed by lion in the #5351 review):

## 1. Promote clears both plane flags
`PromoteFromEphemeralInTx` now clears `NoHistory` too (post-promotion the flag has no meaning) and normalizes an explicit ephemeral `StorageClass` so insert validation passes.

## 2. Import routes by an explicit plane marker, never by flags
- Export stamps a `"wisp"` marker on rows whose flags are ambiguous, classified by **table membership**: new `PartitionWispIDs` capability on both classic stores (reached through the decorator `Unwrap()` chain), `GetWispsByIDs` on the proxied source. Ephemeral rows are self-describing and deliberately unstamped — their export bytes are unchanged (`omitempty`).
- One shared `applyImportWispPlane` in both parse loops: marker ⇒ wisps plane; marker-less `no_history` row (the promoted shape, incl. wild pre-fix data) ⇒ pinned DURABLE via a new non-serialized `Issue.WispPlaneOverride` consulted by `IsWisp`. The stray flag is *preserved* on the row so wild-data round-trips stay byte-identical — only routing is pinned.
- Backward compatible both ways: the marker reuses the v0.35–v0.37 legacy `"wisp"` key, so an OLD bd importing a NEW export routes unpromoted no-history wisps correctly via its existing alias path; the legacy-alias behavior itself is preserved.
- `docs/reference/json-schema.md` documents the marker.

## Verification
- Repro confirmed on base (dependency dropped + row re-planed), fixed after; new classic round-trip test fails on the base binary exactly as predicted.
- Promoted shape now lives in the proxied round-trip fixture (it was deliberately kept out until this fix — see the #5351 test comment) and `cross_mode_byte_identical` covers it; new proxied-import plane-routing subtest + embeddeddolt promote/partition pins green.
- Full green: TestProxiedServerExport/Import/Promote, cmd/bd import/export families, embeddeddolt TestConformance, issueops/domain/uow/types; gofmt/vet/lint clean.
- Ambient reds FAIL-set-verified pre-existing on clean origin/main (identical invocations): the whole `internal/storage/dolt` package 30m-timeout is identical on both trees; `TestRecomputeAllBlocked_AllowsDirtyWisps` fails byte-identically on base; two gosec G304s are on untouched main.go lines.

## Residuals (filed)
- bd-s2py6: `bd promote` CLI still refuses no-history wisps with a misleading error.
- bd-zg9ma: genuine cross-plane deps within one import batch still drop (pre-existing).

Review: lion (comment-review per current convention). Bead: bd-r9uce.