### PR TITLE
Cut proxied-server list/ready latency: batch dependency reads, skip the union when unlimited

### DIFF
--- a/internal/storage/domain/db/dependency.go
+++ b/internal/storage/domain/db/dependency.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -348,31 +349,95 @@ func (r *dependencySQLRepositoryImpl) ListByIssueIDs(ctx context.Context, issueI
 		return result, nil
 	}
 
-	idPlaceholders, idArgs := buildInPlaceholders(issueIDs)
+	if len(issueIDs) > unfilteredDepScanThreshold {
+		return r.listByIssueIDsUnfiltered(ctx, issueIDs, opts)
+	}
+
 	typeWhere, typeArgs := buildTypeFilter(opts.Types)
 	table := pickDepTable(opts.UseWispsTable)
 
-	if opts.Direction == domain.DepDirectionBoth || opts.Direction == domain.DepDirectionOut {
-		//nolint:gosec // G201: table and depSelectColumns are hardcoded
-		q := fmt.Sprintf(
-			`SELECT %s FROM %s WHERE issue_id IN (%s)%s ORDER BY issue_id`,
-			depSelectColumns, table, idPlaceholders, typeWhere,
-		)
-		args := combineArgs(idArgs, typeArgs)
-		if err := r.queryDeps(ctx, q, args, result.Outgoing, true); err != nil {
-			return domain.DepBulkResult{}, fmt.Errorf("db: DependencySQLRepository.ListByIssueIDs (out): %w", err)
+	for _, batch := range chunkIDs(issueIDs) {
+		idPlaceholders, idArgs := buildInPlaceholders(batch)
+
+		if opts.Direction == domain.DepDirectionBoth || opts.Direction == domain.DepDirectionOut {
+			//nolint:gosec // G201: table and depSelectColumns are hardcoded
+			q := fmt.Sprintf(
+				`SELECT %s FROM %s WHERE issue_id IN (%s)%s ORDER BY issue_id`,
+				depSelectColumns, table, idPlaceholders, typeWhere,
+			)
+			args := combineArgs(idArgs, typeArgs)
+			if err := r.queryDeps(ctx, q, args, result.Outgoing, true); err != nil {
+				return domain.DepBulkResult{}, fmt.Errorf("db: DependencySQLRepository.ListByIssueIDs (out): %w", err)
+			}
+		}
+
+		if opts.Direction == domain.DepDirectionBoth || opts.Direction == domain.DepDirectionIn {
+			//nolint:gosec // G201: table, depSelectColumns, depTargetExpr are hardcoded
+			q := fmt.Sprintf(
+				`SELECT %s FROM %s WHERE %s IN (%s)%s ORDER BY issue_id`,
+				depSelectColumns, table, depTargetExpr, idPlaceholders, typeWhere,
+			)
+			args := combineArgs(idArgs, typeArgs)
+			if err := r.queryDeps(ctx, q, args, result.Incoming, false); err != nil {
+				return domain.DepBulkResult{}, fmt.Errorf("db: DependencySQLRepository.ListByIssueIDs (in): %w", err)
+			}
 		}
 	}
 
-	if opts.Direction == domain.DepDirectionBoth || opts.Direction == domain.DepDirectionIn {
-		//nolint:gosec // G201: table, depSelectColumns, depTargetExpr are hardcoded
-		q := fmt.Sprintf(
-			`SELECT %s FROM %s WHERE %s IN (%s)%s ORDER BY issue_id`,
-			depSelectColumns, table, depTargetExpr, idPlaceholders, typeWhere,
-		)
-		args := combineArgs(idArgs, typeArgs)
-		if err := r.queryDeps(ctx, q, args, result.Incoming, false); err != nil {
-			return domain.DepBulkResult{}, fmt.Errorf("db: DependencySQLRepository.ListByIssueIDs (in): %w", err)
+	return result, nil
+}
+
+func (r *dependencySQLRepositoryImpl) listByIssueIDsUnfiltered(ctx context.Context, issueIDs []string, opts domain.DepListOpts) (domain.DepBulkResult, error) {
+	result := domain.DepBulkResult{
+		Outgoing: make(map[string][]*types.Dependency),
+		Incoming: make(map[string][]*types.Dependency),
+	}
+
+	wantOutgoing := opts.Direction == domain.DepDirectionBoth || opts.Direction == domain.DepDirectionOut
+	wantIncoming := opts.Direction == domain.DepDirectionBoth || opts.Direction == domain.DepDirectionIn
+	if !wantOutgoing && !wantIncoming {
+		return result, nil
+	}
+
+	wanted := make(map[string]struct{}, len(issueIDs))
+	for _, id := range issueIDs {
+		wanted[id] = struct{}{}
+	}
+
+	typeWhere, typeArgs := buildTypeFilter(opts.Types)
+	whereSQL := ""
+	if typeWhere != "" {
+		whereSQL = " WHERE " + strings.TrimPrefix(typeWhere, " AND ")
+	}
+	table := pickDepTable(opts.UseWispsTable)
+
+	//nolint:gosec // G201: table and depSelectColumns are hardcoded; the type filter is parameterized.
+	q := fmt.Sprintf(`SELECT %s FROM %s%s ORDER BY issue_id`, depSelectColumns, table, whereSQL)
+	bySource := make(map[string][]*types.Dependency)
+	if err := r.queryDeps(ctx, q, typeArgs, bySource, true); err != nil {
+		return domain.DepBulkResult{}, fmt.Errorf("db: DependencySQLRepository.ListByIssueIDs (unfiltered): %w", err)
+	}
+
+	if wantOutgoing {
+		for id := range wanted {
+			if deps, ok := bySource[id]; ok {
+				result.Outgoing[id] = deps
+			}
+		}
+	}
+
+	if wantIncoming {
+		sources := make([]string, 0, len(bySource))
+		for id := range bySource {
+			sources = append(sources, id)
+		}
+		sort.Strings(sources)
+		for _, source := range sources {
+			for _, dep := range bySource[source] {
+				if _, ok := wanted[dep.DependsOnID]; ok {
+					result.Incoming[dep.DependsOnID] = append(result.Incoming[dep.DependsOnID], dep)
+				}
+			}
 		}
 	}
 
@@ -388,25 +453,28 @@ func (r *dependencySQLRepositoryImpl) CountsByIssueIDs(ctx context.Context, issu
 		result[id] = &types.DependencyCounts{}
 	}
 
-	idPlaceholders, idArgs := buildInPlaceholders(issueIDs)
 	table := pickDepTable(opts.UseWispsTable)
 
-	//nolint:gosec // G201: table is one of two hardcoded constants
-	outQ := fmt.Sprintf(
-		`SELECT issue_id, COUNT(*) FROM %s WHERE issue_id IN (%s) AND type = 'blocks' GROUP BY issue_id`,
-		table, idPlaceholders,
-	)
-	if err := scanCounts(ctx, r.runner, outQ, idArgs, result, func(c *types.DependencyCounts, n int) { c.DependencyCount = n }); err != nil {
-		return nil, fmt.Errorf("db: DependencySQLRepository.CountsByIssueIDs (out): %w", err)
-	}
+	for _, batch := range chunkIDs(issueIDs) {
+		idPlaceholders, idArgs := buildInPlaceholders(batch)
 
-	//nolint:gosec // G201: table and depTargetExpr are hardcoded
-	inQ := fmt.Sprintf(
-		`SELECT %s AS depends_on_id, COUNT(*) FROM %s WHERE %s IN (%s) AND type = 'blocks' GROUP BY %s`,
-		depTargetExpr, table, depTargetExpr, idPlaceholders, depTargetExpr,
-	)
-	if err := scanCounts(ctx, r.runner, inQ, idArgs, result, func(c *types.DependencyCounts, n int) { c.DependentCount = n }); err != nil {
-		return nil, fmt.Errorf("db: DependencySQLRepository.CountsByIssueIDs (in): %w", err)
+		//nolint:gosec // G201: table is one of two hardcoded constants
+		outQ := fmt.Sprintf(
+			`SELECT issue_id, COUNT(*) FROM %s WHERE issue_id IN (%s) AND type = 'blocks' GROUP BY issue_id`,
+			table, idPlaceholders,
+		)
+		if err := scanCounts(ctx, r.runner, outQ, idArgs, result, func(c *types.DependencyCounts, n int) { c.DependencyCount = n }); err != nil {
+			return nil, fmt.Errorf("db: DependencySQLRepository.CountsByIssueIDs (out): %w", err)
+		}
+
+		//nolint:gosec // G201: table and depTargetExpr are hardcoded
+		inQ := fmt.Sprintf(
+			`SELECT %s AS depends_on_id, COUNT(*) FROM %s WHERE %s IN (%s) AND type = 'blocks' GROUP BY %s`,
+			depTargetExpr, table, depTargetExpr, idPlaceholders, depTargetExpr,
+		)
+		if err := scanCounts(ctx, r.runner, inQ, idArgs, result, func(c *types.DependencyCounts, n int) { c.DependentCount = n }); err != nil {
+			return nil, fmt.Errorf("db: DependencySQLRepository.CountsByIssueIDs (in): %w", err)
+		}
 	}
 
 	return result, nil
@@ -423,26 +491,32 @@ func (r *dependencySQLRepositoryImpl) GetBlockingInfo(ctx context.Context, issue
 	}
 
 	table := pickDepTable(opts.UseWispsTable)
-	idPlaceholders, idArgs := buildInPlaceholders(issueIDs)
 
-	//nolint:gosec // G201: table and depTargetExpr are hardcoded constants
-	outQ := fmt.Sprintf(
-		"SELECT issue_id, %s AS depends_on_id, type FROM %s WHERE issue_id IN (%s) AND type IN ('blocks', 'parent-child')",
-		depTargetExpr, table, idPlaceholders,
-	)
-	outRows, err := r.scanBlockingRows(ctx, outQ, idArgs)
-	if err != nil {
-		return domain.BlockingInfo{}, fmt.Errorf("db: DependencySQLRepository.GetBlockingInfo: outbound: %w", err)
-	}
+	var outRows, inRows []blockingRow
+	for _, batch := range chunkIDs(issueIDs) {
+		idPlaceholders, idArgs := buildInPlaceholders(batch)
 
-	//nolint:gosec // G201: table and depTargetExpr are hardcoded constants
-	inQ := fmt.Sprintf(
-		"SELECT issue_id, %s AS depends_on_id, type FROM %s WHERE %s IN (%s) AND type = 'blocks'",
-		depTargetExpr, table, depTargetExpr, idPlaceholders,
-	)
-	inRows, err := r.scanBlockingRows(ctx, inQ, idArgs)
-	if err != nil {
-		return domain.BlockingInfo{}, fmt.Errorf("db: DependencySQLRepository.GetBlockingInfo: inbound: %w", err)
+		//nolint:gosec // G201: table and depTargetExpr are hardcoded constants
+		outQ := fmt.Sprintf(
+			"SELECT issue_id, %s AS depends_on_id, type FROM %s WHERE issue_id IN (%s) AND type IN ('blocks', 'parent-child')",
+			depTargetExpr, table, idPlaceholders,
+		)
+		batchOut, err := r.scanBlockingRows(ctx, outQ, idArgs)
+		if err != nil {
+			return domain.BlockingInfo{}, fmt.Errorf("db: DependencySQLRepository.GetBlockingInfo: outbound: %w", err)
+		}
+		outRows = append(outRows, batchOut...)
+
+		//nolint:gosec // G201: table and depTargetExpr are hardcoded constants
+		inQ := fmt.Sprintf(
+			"SELECT issue_id, %s AS depends_on_id, type FROM %s WHERE %s IN (%s) AND type = 'blocks'",
+			depTargetExpr, table, depTargetExpr, idPlaceholders,
+		)
+		batchIn, err := r.scanBlockingRows(ctx, inQ, idArgs)
+		if err != nil {
+			return domain.BlockingInfo{}, fmt.Errorf("db: DependencySQLRepository.GetBlockingInfo: inbound: %w", err)
+		}
+		inRows = append(inRows, batchIn...)
 	}
 
 	statusIDs := make(map[string]struct{})
@@ -537,13 +611,15 @@ func (r *dependencySQLRepositoryImpl) loadStatusByID(ctx context.Context, idSet 
 	for id := range idSet {
 		ids = append(ids, id)
 	}
-	placeholders, args := buildInPlaceholders(ids)
 	sourceByID := make(map[string]string, len(idSet))
 	for _, table := range []string{"issues", "wisps"} {
-		//nolint:gosec // G201: table is a hardcoded constant
-		q := fmt.Sprintf("SELECT id, status FROM %s WHERE id IN (%s)", table, placeholders)
-		if err := r.scanStatusRows(ctx, q, args, table, statusByID, sourceByID); err != nil {
-			return nil, err
+		for _, batch := range chunkIDs(ids) {
+			placeholders, args := buildInPlaceholders(batch)
+			//nolint:gosec // G201: table is a hardcoded constant
+			q := fmt.Sprintf("SELECT id, status FROM %s WHERE id IN (%s)", table, placeholders)
+			if err := r.scanStatusRows(ctx, q, args, table, statusByID, sourceByID); err != nil {
+				return nil, err
+			}
 		}
 	}
 	return statusByID, nil
@@ -633,6 +709,26 @@ func scanCounts(ctx context.Context, runner Runner, q string, args []any, into m
 		}
 	}
 	return rows.Err()
+}
+
+const unfilteredDepScanThreshold = 2000
+
+func chunkIDs[T ~string](values []T) [][]T {
+	if len(values) == 0 {
+		return nil
+	}
+	if len(values) <= queryBatchSize {
+		return [][]T{values}
+	}
+	out := make([][]T, 0, (len(values)+queryBatchSize-1)/queryBatchSize)
+	for start := 0; start < len(values); start += queryBatchSize {
+		end := start + queryBatchSize
+		if end > len(values) {
+			end = len(values)
+		}
+		out = append(out, values[start:end])
+	}
+	return out
 }
 
 func buildInPlaceholders[T ~string](values []T) (string, []any) {

--- a/internal/storage/domain/db/issue_search.go
+++ b/internal/storage/domain/db/issue_search.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/steveyegge/beads/internal/storage/dberrors"
@@ -55,7 +56,55 @@ func (r *issueSQLRepositoryImpl) searchAcrossIssuesAndWisps(ctx context.Context,
 		return page, nil
 	}
 
+	if filter.Limit <= 0 && filter.Offset <= 0 {
+		return r.searchMerged(ctx, query, filter)
+	}
+
 	return r.searchUnion(ctx, query, filter)
+}
+
+func (r *issueSQLRepositoryImpl) searchMerged(ctx context.Context, query string, filter types.IssueFilter) (domain.SearchPage, error) {
+	issuePage, err := r.searchTable(ctx, query, filter, issuesFilterTables)
+	if err != nil {
+		return domain.SearchPage{}, fmt.Errorf("search merged (issues): %w", err)
+	}
+
+	wispPage, err := r.searchTable(ctx, query, filter, wispsFilterTables)
+	if err != nil && !dberrors.IsTableNotExist(err) {
+		return domain.SearchPage{}, fmt.Errorf("search merged (wisps): %w", err)
+	}
+
+	merged, err := mergeIssuePlanes(issuePage.Items, wispPage.Items, filter.SortBy, filter.SortDesc)
+	if err != nil {
+		return domain.SearchPage{}, fmt.Errorf("search merged: %w", err)
+	}
+	return domain.SearchPage{Items: merged}, nil
+}
+
+func mergeIssuePlanes(issues, wisps []*types.Issue, sortBy string, sortDesc bool) ([]*types.Issue, error) {
+	out := make([]*types.Issue, 0, len(issues)+len(wisps))
+	seen := make(map[string]struct{}, len(issues))
+	for _, issue := range issues {
+		if issue == nil {
+			continue
+		}
+		seen[issue.ID] = struct{}{}
+		out = append(out, issue)
+	}
+	for _, w := range wisps {
+		if w == nil {
+			continue
+		}
+		if _, dup := seen[w.ID]; dup {
+			return nil, fmt.Errorf("id %q exists in both issues and wisps", w.ID)
+		}
+		seen[w.ID] = struct{}{}
+		out = append(out, w)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return sqlbuild.Less(out[i], out[j], sortBy, sortDesc)
+	})
+	return out, nil
 }
 
 func (r *issueSQLRepositoryImpl) searchUnion(ctx context.Context, query string, filter types.IssueFilter) (domain.SearchPage, error) {

--- a/internal/storage/domain/db/issue_search_counts.go
+++ b/internal/storage/domain/db/issue_search_counts.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/steveyegge/beads/internal/storage/dberrors"
@@ -55,7 +56,55 @@ func (r *issueSQLRepositoryImpl) searchAcrossIssuesAndWispsWithCounts(ctx contex
 		return finishSearchCountsPage(out, filter.Limit), nil
 	}
 
+	if filter.Limit <= 0 && filter.Offset <= 0 {
+		return r.searchMergedWithCounts(ctx, query, filter, wispDepsExist)
+	}
+
 	return r.searchUnionWithCounts(ctx, query, filter, wispDepsExist)
+}
+
+func (r *issueSQLRepositoryImpl) searchMergedWithCounts(ctx context.Context, query string, filter types.IssueFilter, wispDepsExist bool) (domain.SearchCountsPage, error) {
+	issues, err := r.runFilterSearchQuery(ctx, query, filter, issuesFilterTables, wispDepsExist)
+	if err != nil {
+		return domain.SearchCountsPage{}, fmt.Errorf("search merged with counts (issues): %w", err)
+	}
+
+	wisps, err := r.runFilterSearchQuery(ctx, query, filter, wispsFilterTables, true)
+	if err != nil && !dberrors.IsTableNotExist(err) {
+		return domain.SearchCountsPage{}, fmt.Errorf("search merged with counts (wisps): %w", err)
+	}
+
+	merged, err := mergeCountsPlanes(issues, wisps, filter.SortBy, filter.SortDesc)
+	if err != nil {
+		return domain.SearchCountsPage{}, fmt.Errorf("search merged with counts: %w", err)
+	}
+	return domain.SearchCountsPage{Items: merged}, nil
+}
+
+func mergeCountsPlanes(issues, wisps []*types.IssueWithCounts, sortBy string, sortDesc bool) ([]*types.IssueWithCounts, error) {
+	out := make([]*types.IssueWithCounts, 0, len(issues)+len(wisps))
+	seen := make(map[string]struct{}, len(issues))
+	for _, iwc := range issues {
+		if iwc == nil || iwc.Issue == nil {
+			continue
+		}
+		seen[iwc.Issue.ID] = struct{}{}
+		out = append(out, iwc)
+	}
+	for _, w := range wisps {
+		if w == nil || w.Issue == nil {
+			continue
+		}
+		if _, dup := seen[w.Issue.ID]; dup {
+			return nil, fmt.Errorf("id %q exists in both issues and wisps", w.Issue.ID)
+		}
+		seen[w.Issue.ID] = struct{}{}
+		out = append(out, w)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return sqlbuild.Less(out[i].Issue, out[j].Issue, sortBy, sortDesc)
+	})
+	return out, nil
 }
 
 func (r *issueSQLRepositoryImpl) searchUnionWithCounts(ctx context.Context, query string, filter types.IssueFilter, wispDepsExist bool) (domain.SearchCountsPage, error) {


### PR DESCRIPTION
Two fan-out problems in the `internal/storage/domain/db` stack made proxied-server `bd list` and `bd ready` much slower than their server-mode equivalents at large result sets. Both are fixed here; limited pages are untouched.

Measured on a ~400MB test repo, comparing proxied-server against server mode:

| command | span | server | proxied (before) |
|---|---|---|---|
| `bd list --limit 0` | dependency load | 10.4ms | 465.0ms |
| `bd list --limit 0 --json --include-infra` | search-with-counts | 82.3ms | 693.5ms |
| `bd ready --limit 0` | dependency load for epics | 25.4ms | 225.7ms |

## Fix 1: batch the IN clause in the dependency repo

`dependencySQLRepositoryImpl` built a single `WHERE id IN (...)` over the *entire* id list with no chunking, so an unlimited page bound one placeholder per issue. The classic `issueops` path has always batched the equivalent query at `queryBatchSize` (200).

The `bd ready --limit 0` row above is a direct A/B on the same id set and the same logical query, differing only in batching — the batched form is ~9x faster.

- Added `chunkIDs`, applied to `ListByIssueIDs`, `CountsByIssueIDs`, `GetBlockingInfo`, and `loadStatusByID`.
- Added `listByIssueIDsUnfiltered`, taken above `unfilteredDepScanThreshold` (2000 ids): drops the predicate and does the unbounded two-table read that server mode gets from `GetAllDependencyRecords`, filtering to the requested set in Go. It scans once even for `DepDirectionBoth`, and walks sources in sorted order so the incoming-direction grouping keeps the `ORDER BY issue_id` the batched path produces.

Each id lives in exactly one batch and every caller keys results by that id, so per-batch grouping is equivalent to the single-statement form.

## Fix 2: skip the union when the query is unlimited

`searchUnionWithCounts` exists to get a global ORDER BY + LIMIT across the issues and wisps planes. It pays for that with `fetchCountsByIDs`, which runs `ceil(N/200)` copies of the counts mega-query in its by-IDs form — and that form binds the id list eight separate times per statement. At 200 ids that is ~1600 placeholders per statement, times N/200 statements, times two planes.

When there is no LIMIT, the global ordering buys nothing a Go sort cannot do. `searchAcrossIssuesAndWisps` and `searchAcrossIssuesAndWispsWithCounts` now route `Limit <= 0 && Offset <= 0` to new `searchMerged` / `searchMergedWithCounts`: one predicate-form query per plane (filter pushed into the derived driver table, zero id bindings), merged in Go via `sqlbuild.Less` — the same comparator the classic stack sorts with, so ordering matches by construction rather than by convention.

Cross-table duplicate ids still hard-error, matching what `scanIDSrcPage(strictCrossTable: true)` does on the union path.

## Testing

Passing: `internal/storage/domain/...`, `internal/storage/issueops/...`, `internal/workapi/...`, and `cmd/bd` filtered to `TestList|TestReady|TestSearch` and `Proxied`.

Not verified: the full `./internal/storage/...` suite. It fails in `internal/storage/dolt` with `connection refused` and a 10m timeout, against a Dolt server that was not running locally. That package does not depend on `storage/domain/db` (`go list -deps` returns no match), but I have not established a clean-checkout baseline for those failures.

The end-to-end latency numbers with these changes applied have not been re-measured yet — the table above is the before state.

`unfilteredDepScanThreshold = 2000` is a first pick at where the IN-clause form stops winning, and is worth tuning against a real trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)