### PR TITLE
fix(schema): repair the wisp_dependencies FK shape before 0058 applies

### DIFF
--- a/internal/storage/embeddeddolt/migrate_wisp_dep_forward_repair_test.go
+++ b/internal/storage/embeddeddolt/migrate_wisp_dep_forward_repair_test.go
@@ -1,0 +1,434 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/schema"
+)
+
+// Real-Dolt coverage for the pre-0058 wisp_dependencies forward repair
+// (repairWispDependenciesForwardShape, internal/storage/schema).
+//
+// Why this cannot be a sqlmock test. Every load-bearing fact in that repair is
+// Dolt semantics a statement-echo mock cannot exercise: that Dolt rejects a
+// foreign key on the base column of a stored generated column at all; that
+// normalizing a multi-target row recomputes the COALESCE generated column and
+// so can collide on the legacy composite primary key; that DEFAULT (UUID())
+// mints a distinct value per existing row, which is what makes the MIN(id)
+// dedup deterministic. A mock asserting the statement ORDER would have passed
+// against the first draft of this repair, which normalized before the drop and
+// aborted on real Dolt with "duplicate primary key given: [w2,external:e1]".
+//
+// The two subtests are the two populations that actually exist. Measured
+// against a live 25-database Dolt server carrying the affected shape: 8
+// databases are on the delegate path with no target foreign keys, and every one
+// of the 14 databases still holding the generated column has no id column,
+// confirming the lineages are disjoint.
+
+// legacyDelegateWispDepDDL is the shape 0047's delegate branch leaves behind:
+// the three split target columns present, depends_on_id still a STORED
+// generated column over them, the composite primary key, and neither target
+// foreign key. Taken verbatim from a production SHOW CREATE TABLE rather than
+// hand-idealized, minus ck_wisp_dep_one_target so the multi-target rows this
+// test seeds are insertable (a store carrying the check cannot hold them, which
+// is the second subtest).
+const legacyDelegateWispDepDDL = `
+CREATE TABLE wisp_dependencies (
+    issue_id VARCHAR(255) NOT NULL,
+    type VARCHAR(32) NOT NULL DEFAULT 'blocks',
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    created_by VARCHAR(255) DEFAULT '',
+    metadata JSON DEFAULT (JSON_OBJECT()),
+    thread_id VARCHAR(255) DEFAULT '',
+    depends_on_issue_id VARCHAR(255) NULL,
+    depends_on_wisp_id VARCHAR(255) NULL,
+    depends_on_external VARCHAR(255) NULL,
+    depends_on_id VARCHAR(255) NOT NULL GENERATED ALWAYS AS (COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external)) STORED,
+    PRIMARY KEY (issue_id, depends_on_id),
+    KEY idx_wisp_dep_external_target (depends_on_external),
+    KEY idx_wisp_dep_issue_target (depends_on_issue_id),
+    KEY idx_wisp_dep_type (type),
+    KEY idx_wisp_dep_type_target (type, depends_on_id),
+    KEY idx_wisp_dep_wisp_target (depends_on_wisp_id)
+)`
+
+func TestEmbeddedPre0058RepairMarchesDriftedWispDependenciesToFinalShape(t *testing.T) {
+	requireEmbedded(t)
+	ctx := t.Context()
+
+	// The shape a fresh, fully migrated store converges on.
+	//
+	// The comparison is structural (columns with their types and defaults, the
+	// primary key, every unique key, every foreign key with its referenced
+	// table and columns, every check) rather than SHOW CREATE text equality.
+	// Text equality is the wrong bar, and provably so: a legacy table healed by
+	// the SHIPPED path keeps its original column order, because nothing in the
+	// chain reorders columns. The already-migrated production database this
+	// work came from has wisp_dependencies as (id, issue_id, type, created_at,
+	// created_by, metadata, thread_id, depends_on_issue_id, depends_on_wisp_id,
+	// depends_on_external) where a fresh store puts the three target columns
+	// third through fifth. Asserting text equality would fail every correctly
+	// healed store, including ones this repair never touched. Legacy secondary
+	// index names survive for the same reason -- a fresh store names its
+	// foreign-key backing indexes after the constraints because no index
+	// existed to reuse, while a legacy table already has idx_wisp_dep_*_target
+	// covering those columns and Dolt reuses them. Index COVERAGE is asserted;
+	// index NAMES are not.
+	fresh := readWispDepShape(t, ctx, referenceStoreConn(t, ctx))
+
+	t.Run("delegate-path store carrying rows the final shape rejects", func(t *testing.T) {
+		dataDir := seedMainSchemaAt(t, ctx, 53)
+		conn, closeConn := openPinnedConn(t, ctx, dataDir)
+
+		mustExecConn(t, ctx, conn, "DROP TABLE wisp_dependencies")
+		mustExecConn(t, ctx, conn, legacyDelegateWispDepDDL)
+
+		// Referenced rows. issue_id and depends_on_wisp_id both point at
+		// wisps(id); depends_on_issue_id points at issues(id).
+		for _, id := range []string{"w1", "w2", "w3"} {
+			seedWisp(t, ctx, conn, id)
+		}
+		seedIssue(t, ctx, conn, "i1")
+
+		// Two rows that must survive untouched.
+		seedWispDep(t, ctx, conn, "w1", nil, strptr("w2"), nil)
+		seedWispDep(t, ctx, conn, "w3", strptr("i1"), nil, nil)
+		// Three foreign-key orphans, one per constraint the repair adds.
+		// "ghost" is not a wisp, so this row orphans fk_wisp_dep_issue --
+		// which 0058 does not clean, because 0058 does not add that key.
+		seedWispDep(t, ctx, conn, "ghost", nil, strptr("w2"), nil)
+		seedWispDep(t, ctx, conn, "w1", nil, strptr("ghost-w"), nil)
+		seedWispDep(t, ctx, conn, "w1", strptr("ghost-i"), nil, nil)
+		// A multi-target row whose normalization lands it on the natural
+		// identity of the row below it. This pair is the regression for the
+		// ordering bug: normalize-before-drop rewrites this row's generated
+		// primary key onto the other's and aborts.
+		seedWispDep(t, ctx, conn, "w2", nil, strptr("w3"), strptr("external:e1"))
+		seedWispDep(t, ctx, conn, "w2", nil, nil, strptr("external:e1"))
+
+		commitSeed(t, ctx, conn, "test: reproduce the pre-0058 drifted wisp_dependencies")
+		closeConn()
+
+		conn2, closeConn2 := openPinnedConn(t, ctx, dataDir)
+		defer closeConn2()
+
+		// Without the repair this fails with
+		// "Cannot add foreign key on the base column of a stored generated
+		// column" and strands the cursor at 57.
+		if _, err := schema.MigrateUp(ctx, conn2); err != nil {
+			t.Fatalf("MigrateUp over a drifted wisp_dependencies: %v", err)
+		}
+		if v := currentMainVersion(t, ctx, conn2); v != schema.LatestVersion() {
+			t.Fatalf("main schema version = %d, want latest %d", v, schema.LatestVersion())
+		}
+
+		requireSameWispDepShape(t, readWispDepShape(t, ctx, conn2), fresh)
+
+		// Row outcomes, stated as the full surviving set rather than a count:
+		// a count passes even when the wrong three rows survive.
+		want := []wispDepRow{
+			{"w1", "", "w2", ""},
+			{"w2", "", "", "external:e1"},
+			{"w3", "i1", "", ""},
+		}
+		if got := readWispDeps(t, ctx, conn2); !sameWispDepRows(got, want) {
+			t.Fatalf("surviving rows = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("production shape: check constraint present, table empty", func(t *testing.T) {
+		// The 8 affected databases measured on the live server: same legacy
+		// shape but carrying ck_wisp_dep_one_target and zero rows. Nothing for
+		// the cleanup or dedup to do, so this subtest isolates the structural
+		// rebuild from the row surgery.
+		dataDir := seedMainSchemaAt(t, ctx, 53)
+		conn, closeConn := openPinnedConn(t, ctx, dataDir)
+
+		mustExecConn(t, ctx, conn, "DROP TABLE wisp_dependencies")
+		mustExecConn(t, ctx, conn, legacyDelegateWispDepDDL)
+		mustExecConn(t, ctx, conn, "ALTER TABLE wisp_dependencies ADD CONSTRAINT ck_wisp_dep_one_target CHECK ((depends_on_issue_id IS NOT NULL) + (depends_on_wisp_id IS NOT NULL) + (depends_on_external IS NOT NULL) = 1)")
+		commitSeed(t, ctx, conn, "test: reproduce the production pre-0058 wisp_dependencies")
+		closeConn()
+
+		conn2, closeConn2 := openPinnedConn(t, ctx, dataDir)
+		defer closeConn2()
+
+		if _, err := schema.MigrateUp(ctx, conn2); err != nil {
+			t.Fatalf("MigrateUp over the production pre-0058 shape: %v", err)
+		}
+		requireSameWispDepShape(t, readWispDepShape(t, ctx, conn2), fresh)
+	})
+
+	t.Run("a fresh store is left alone", func(t *testing.T) {
+		// The repair must be invisible to every database that does not need
+		// it. A fresh store reaches 0058 with no generated column, so 0058
+		// applies cleanly and the repair has to no-op rather than rebuild a
+		// healthy table.
+		dataDir := seedMainSchemaAt(t, ctx, 53)
+		conn, closeConn := openPinnedConn(t, ctx, dataDir)
+		defer closeConn()
+
+		if _, err := schema.MigrateUp(ctx, conn); err != nil {
+			t.Fatalf("MigrateUp on a fresh store: %v", err)
+		}
+		requireSameWispDepShape(t, readWispDepShape(t, ctx, conn), fresh)
+	})
+}
+
+// referenceStoreConn returns a connection to a store that migrated normally to
+// head, for use as the shape the repair must converge on.
+func referenceStoreConn(t *testing.T, ctx context.Context) *sql.Conn {
+	t.Helper()
+	dataDir := seedMainSchemaAt(t, ctx, schema.LatestVersion())
+	conn, closeConn := openPinnedConn(t, ctx, dataDir)
+	t.Cleanup(closeConn)
+	if _, err := schema.MigrateUp(ctx, conn); err != nil {
+		t.Fatalf("MigrateUp on the reference store: %v", err)
+	}
+	return conn
+}
+
+type wispDepRow struct {
+	issueID, dependsOnIssueID, dependsOnWispID, dependsOnExternal string
+}
+
+func readWispDeps(t *testing.T, ctx context.Context, conn *sql.Conn) []wispDepRow {
+	t.Helper()
+	rows, err := conn.QueryContext(ctx, `
+SELECT issue_id,
+       COALESCE(depends_on_issue_id, ''),
+       COALESCE(depends_on_wisp_id, ''),
+       COALESCE(depends_on_external, '')
+FROM wisp_dependencies
+ORDER BY issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external`)
+	if err != nil {
+		t.Fatalf("read wisp_dependencies: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []wispDepRow
+	for rows.Next() {
+		var r wispDepRow
+		if err := rows.Scan(&r.issueID, &r.dependsOnIssueID, &r.dependsOnWispID, &r.dependsOnExternal); err != nil {
+			t.Fatalf("scan wisp_dependencies row: %v", err)
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate wisp_dependencies: %v", err)
+	}
+	return out
+}
+
+func sameWispDepRows(got, want []wispDepRow) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// wispDepShape is the structural contract the repair must satisfy: what a
+// query planner and a write path can actually observe. Column ORDER and plain
+// index NAMES are deliberately excluded -- see the comment at the top of the
+// test for why both legitimately differ on a healed legacy store.
+type wispDepShape struct {
+	columns     map[string]string // name -> "type|nullable|default"
+	primaryKey  string            // ordered PK columns
+	uniqueKeys  map[string]string // name -> ordered columns
+	foreignKeys map[string]string // name -> "cols -> reftable(refcols)"
+	checks      map[string]bool
+	indexCover  map[string]bool // ordered column list of every index, name-independent
+}
+
+func readWispDepShape(t *testing.T, ctx context.Context, conn *sql.Conn) wispDepShape {
+	t.Helper()
+	shape := wispDepShape{
+		columns:     map[string]string{},
+		uniqueKeys:  map[string]string{},
+		foreignKeys: map[string]string{},
+		checks:      map[string]bool{},
+		indexCover:  map[string]bool{},
+	}
+
+	queryEach(t, ctx, conn, `
+SELECT COLUMN_NAME, COLUMN_TYPE, IS_NULLABLE, COALESCE(COLUMN_DEFAULT, '<none>')
+FROM INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisp_dependencies'`,
+		4, func(v []string) { shape.columns[v[0]] = v[1] + "|" + v[2] + "|" + v[3] })
+
+	// Ordered column lists per index. GROUP_CONCAT over SEQ_IN_INDEX keeps
+	// (type, depends_on_issue_id) distinct from (depends_on_issue_id, type).
+	queryEach(t, ctx, conn, `
+SELECT INDEX_NAME, NON_UNIQUE, GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX)
+FROM INFORMATION_SCHEMA.STATISTICS
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisp_dependencies'
+GROUP BY INDEX_NAME, NON_UNIQUE`,
+		3, func(v []string) {
+			switch {
+			case v[0] == "PRIMARY":
+				shape.primaryKey = v[2]
+			case v[1] == "0":
+				shape.uniqueKeys[v[0]] = v[2]
+			default:
+				shape.indexCover[v[2]] = true
+			}
+		})
+
+	queryEach(t, ctx, conn, `
+SELECT rc.CONSTRAINT_NAME,
+       GROUP_CONCAT(kcu.COLUMN_NAME ORDER BY kcu.ORDINAL_POSITION),
+       rc.REFERENCED_TABLE_NAME,
+       GROUP_CONCAT(kcu.REFERENCED_COLUMN_NAME ORDER BY kcu.ORDINAL_POSITION),
+       rc.DELETE_RULE, rc.UPDATE_RULE
+FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS rc
+JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu
+  ON kcu.CONSTRAINT_SCHEMA = rc.CONSTRAINT_SCHEMA
+ AND kcu.CONSTRAINT_NAME = rc.CONSTRAINT_NAME
+WHERE rc.CONSTRAINT_SCHEMA = DATABASE() AND rc.TABLE_NAME = 'wisp_dependencies'
+GROUP BY rc.CONSTRAINT_NAME, rc.REFERENCED_TABLE_NAME, rc.DELETE_RULE, rc.UPDATE_RULE`,
+		6, func(v []string) {
+			shape.foreignKeys[v[0]] = v[1] + " -> " + v[2] + "(" + v[3] + ") ON DELETE " + v[4] + " ON UPDATE " + v[5]
+		})
+
+	queryEach(t, ctx, conn, `
+SELECT CONSTRAINT_NAME FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisp_dependencies'
+  AND CONSTRAINT_TYPE = 'CHECK'`,
+		1, func(v []string) { shape.checks[v[0]] = true })
+
+	return shape
+}
+
+func requireSameWispDepShape(t *testing.T, got, want wispDepShape) {
+	t.Helper()
+	requireSameStringMap(t, "columns", got.columns, want.columns)
+	if got.primaryKey != want.primaryKey {
+		t.Errorf("primary key = %q, want %q", got.primaryKey, want.primaryKey)
+	}
+	requireSameStringMap(t, "unique keys", got.uniqueKeys, want.uniqueKeys)
+	requireSameStringMap(t, "foreign keys", got.foreignKeys, want.foreignKeys)
+	for name := range want.checks {
+		if !got.checks[name] {
+			t.Errorf("check constraint %s missing", name)
+		}
+	}
+	// Coverage, not names: every index the reference store carries must have a
+	// counterpart over the same columns. Extra legacy indexes are allowed --
+	// they cost a little write throughput, not correctness, and dropping them
+	// is not this repair's job.
+	for cols := range want.indexCover {
+		if !got.indexCover[cols] && got.uniqueKeys[cols] == "" && got.primaryKey != cols {
+			covered := false
+			for _, uk := range got.uniqueKeys {
+				if uk == cols {
+					covered = true
+				}
+			}
+			if !covered {
+				t.Errorf("no index covers (%s)", cols)
+			}
+		}
+	}
+	if _, ok := got.columns["depends_on_id"]; ok {
+		t.Error("depends_on_id survived the repair")
+	}
+}
+
+func requireSameStringMap(t *testing.T, label string, got, want map[string]string) {
+	t.Helper()
+	for k, wv := range want {
+		gv, ok := got[k]
+		if !ok {
+			t.Errorf("%s: %s missing", label, k)
+			continue
+		}
+		if gv != wv {
+			t.Errorf("%s: %s = %q, want %q", label, k, gv, wv)
+		}
+	}
+	for k := range got {
+		if _, ok := want[k]; !ok {
+			t.Errorf("%s: unexpected %s = %q", label, k, got[k])
+		}
+	}
+}
+
+func queryEach(t *testing.T, ctx context.Context, conn *sql.Conn, query string, cols int, fn func([]string)) {
+	t.Helper()
+	rows, err := conn.QueryContext(ctx, query)
+	if err != nil {
+		t.Fatalf("query %.60q: %v", query, err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		vals := make([]string, cols)
+		ptrs := make([]any, cols)
+		for i := range vals {
+			ptrs[i] = &vals[i]
+		}
+		if err := rows.Scan(ptrs...); err != nil {
+			t.Fatalf("scan %.60q: %v", query, err)
+		}
+		fn(vals)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate %.60q: %v", query, err)
+	}
+}
+
+func mustExecConn(t *testing.T, ctx context.Context, conn *sql.Conn, stmt string, args ...any) {
+	t.Helper()
+	if _, err := conn.ExecContext(ctx, stmt, args...); err != nil {
+		t.Fatalf("exec %.60q: %v", stmt, err)
+	}
+}
+
+func seedWisp(t *testing.T, ctx context.Context, conn *sql.Conn, id string) {
+	t.Helper()
+	mustExecConn(t, ctx, conn,
+		"INSERT INTO wisps (id, title, description, design, acceptance_criteria, notes, status, priority, issue_type, ephemeral) VALUES (?, 'w', '', '', '', '', 'open', 2, 'task', 1)", id)
+}
+
+func seedIssue(t *testing.T, ctx context.Context, conn *sql.Conn, id string) {
+	t.Helper()
+	mustExecConn(t, ctx, conn,
+		"INSERT INTO issues (id, title, description, design, acceptance_criteria, notes, status, priority, issue_type) VALUES (?, 'i', '', '', '', '', 'open', 2, 'task')", id)
+}
+
+func seedWispDep(t *testing.T, ctx context.Context, conn *sql.Conn, issueID string, issueTarget, wispTarget, externalTarget *string) {
+	t.Helper()
+	mustExecConn(t, ctx, conn, `
+INSERT INTO wisp_dependencies (issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata)
+VALUES (?, ?, ?, ?, 'blocks', NOW(), 'tester', JSON_OBJECT())`,
+		issueID, nullable(issueTarget), nullable(wispTarget), nullable(externalTarget))
+}
+
+// commitSeed stages and commits the seed. issues is a synced table and several
+// pending migrations touch it, so an uncommitted insert trips MigrateUp's
+// dirty-table guard.
+func commitSeed(t *testing.T, ctx context.Context, conn *sql.Conn, message string) {
+	t.Helper()
+	mustExecConn(t, ctx, conn, "CALL DOLT_ADD('-A')")
+	// --skip-empty: wisps and wisp_dependencies are dolt_ignore'd, so a seed
+	// that only recreates those tables stages nothing and a bare commit fails
+	// with "nothing to commit".
+	mustExecConn(t, ctx, conn, "CALL DOLT_COMMIT('-m', ?, '--skip-empty')", message)
+}
+
+func nullable(s *string) any {
+	if s == nil {
+		return nil
+	}
+	return *s
+}
+
+func strptr(s string) *string { return &s }

--- a/internal/storage/schema/migration_repairs.go
+++ b/internal/storage/schema/migration_repairs.go
@@ -35,6 +35,7 @@ var preMigrationRepairs = map[repairKey]func(context.Context, DBConn) error{
 	{"schema_migrations", 41}: repairPartial0041NonlocalDelete,
 	{"schema_migrations", 47}: ensureWispTablesForMixedBlockedRecompute,
 	{"schema_migrations", 53}: repairV53RigAndSplitTargets,
+	{"schema_migrations", 58}: repairWispDependenciesForwardShape,
 }
 
 // preMigrationRepair dispatches any repair registered for (source, version).
@@ -622,6 +623,48 @@ func schemaHasPrimaryKey(ctx context.Context, db DBConn, table string) (bool, er
 		return false, err
 	}
 	return count > 0, nil
+}
+
+// schemaIndexExists reports whether table carries an index (or unique key) of
+// the given name. STATISTICS rather than TABLE_CONSTRAINTS because plain
+// secondary indexes are not constraints and never appear in the latter.
+func schemaIndexExists(ctx context.Context, db DBConn, table, index string) (bool, error) {
+	var count int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+		WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND INDEX_NAME = ?
+	`, table, index).Scan(&count); err != nil {
+		return false, fmt.Errorf("checking index %s on %s: %w", index, table, err)
+	}
+	return count > 0, nil
+}
+
+// schemaConstraintExists reports whether table carries a named constraint --
+// foreign key or check. Unlike schemaHasPrimaryKey it asks about one specific
+// name, which is what an add-if-absent step needs.
+func schemaConstraintExists(ctx context.Context, db DBConn, table, constraint string) (bool, error) {
+	var count int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+		WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND CONSTRAINT_NAME = ?
+	`, table, constraint).Scan(&count); err != nil {
+		return false, fmt.Errorf("checking constraint %s on %s: %w", constraint, table, err)
+	}
+	return count > 0, nil
+}
+
+// schemaShowCreateTable returns a table's CREATE statement. It is the only
+// place Dolt exposes generated-column shape: INFORMATION_SCHEMA.COLUMNS returns
+// EXTRA and GENERATION_EXPRESSION empty for a generated column, and IS_GENERATED
+// does not exist there at all.
+func schemaShowCreateTable(ctx context.Context, db DBConn, table string) (string, error) {
+	var name, ddl string
+	// table is a package constant, never caller input; SHOW CREATE TABLE takes
+	// no placeholders.
+	if err := db.QueryRowContext(ctx, "SHOW CREATE TABLE `"+table+"`").Scan(&name, &ddl); err != nil {
+		return "", fmt.Errorf("reading SHOW CREATE TABLE %s: %w", table, err)
+	}
+	return ddl, nil
 }
 
 // schemaColumnInPrimaryKey reports whether column is (one of) table's PRIMARY

--- a/internal/storage/schema/migrations/README.md
+++ b/internal/storage/schema/migrations/README.md
@@ -1,0 +1,88 @@
+# Writing migrations against Dolt
+
+Migration files here are **frozen once merged** (`scripts/check-migration-hygiene.sh`
+check C): editing one forks fresh clones from upgraded clones through the
+recorded content hash. A migration that FAILS on drifted databases cannot be
+fixed forward with a new migration either, because the failing file aborts the
+pass before any higher version runs. The escape hatch is a **pre-migration
+repair** in Go, keyed to the pending version — see the header of
+`../migration_repairs.go` and the `preMigrationRepairs` registry.
+
+## Measured Dolt behaviours
+
+These were measured against real Dolt (2.1.2 and 2.2.3) and confirmed against
+Dolt/GMS source while fixing migration 0058. Each one has already cost a
+redesign; they are recorded here so the next author does not re-derive them.
+
+**DDL is not transactional across statements.** Each DDL statement implicitly
+commits, so `START TRANSACTION` … `ALTER` … `ROLLBACK` leaves the table altered.
+A destructive multi-statement rebuild cannot be made atomic by wrapping it. Make
+each step individually guarded and resumable instead.
+
+**A foreign key on the base column of a stored generated column is rejected —
+on `ADD` *and* at `CREATE TABLE` time.**
+
+```
+Error 1105 (HY000): Cannot add foreign key on the base column of a stored
+generated column.
+```
+
+The restriction is asymmetric: key-then-generated-column is accepted,
+generated-column-then-key is not. That asymmetry is the only reason a table can
+legitimately hold both, and it dictates the order of any rebuild. This is what
+blocked 0058, whose two `ADD CONSTRAINT`s target the columns feeding
+`depends_on_id`'s `COALESCE`.
+
+**Foreign key constraint names are database-scoped, not table-scoped.** Dolt
+keeps a root-wide collection and duplicate-name lookup ignores the declaring
+table, so two tables cannot hold the same constraint name even transiently. A
+build-alongside-and-swap rebuild cannot reuse the real constraint names on its
+replacement table.
+
+**A foreign key holds its backing index hostage.**
+
+```
+Error 1553 (HY000): can't drop index 'PRIMARY': needed in foreign key
+constraint fk_wisp_dep_issue
+```
+
+Drop the foreign keys before `DROP PRIMARY KEY` and re-add them last. On the
+legacy `wisp_dependencies` shape the primary key is the only `issue_id`-leading
+index, so `fk_wisp_dep_issue` alone blocks the rebuild.
+
+**Updating a base column rewrites a stored generated column, and therefore any
+key over it.** Nulling one target column to satisfy a "exactly one target" check
+recomputes a `COALESCE` generated column, which can land the row on another
+row's value in a composite primary key that includes it:
+
+```
+duplicate primary key given: [w2,external:e1]
+```
+
+Normalize *after* dropping the generated column and its key, not before. (0058
+normalizes before, and reaches the abort on any store whose rows collide.)
+
+**The `dolt` CLI is not a safe harness for guarded migrations, twice over.**
+`dolt sql -f`/`-q`/piped-stdin silently no-ops `PREPARE`/`EXECUTE`-driven
+`ALTER TABLE` — every guarded migration here uses exactly that shape — and
+`dolt sql -q "USE db; <stmt>"` exits **0** when the statement fails, so the
+schema change is refused while the exit code reports success. Verify DDL
+outcomes by reading `INFORMATION_SCHEMA`, never an exit code, and test guarded
+migrations through the embedded (cgo) engine, where `PREPARE`/`EXECUTE` behaves
+normally. See `internal/storage/embeddeddolt/migrate_frozen_guard_convergence_test.go`.
+
+## Testing
+
+`sqlmock` statement-echo tests cannot exercise any of the above; they assert the
+statements you wrote, not what Dolt does with them. Anything touching generated
+columns, constraint validation, or key rebuilds needs a real-Dolt test in
+`internal/storage/embeddeddolt` (`BEADS_TEST_EMBEDDED_DOLT=1`, `-tags cgo`).
+
+Assert the resulting **shape**, not `SHOW CREATE TABLE` text. A legacy table
+healed by the shipped chain keeps its original column order and its original
+secondary index names, because nothing reorders columns and Dolt reuses an
+existing index to back a new foreign key rather than creating a
+constraint-named one. Text equality against a fresh store fails on correctly
+healed databases. Compare columns, primary key, unique keys, foreign keys with
+their referenced tables and actions, checks, and index coverage — see
+`migrate_wisp_dep_forward_repair_test.go`.

--- a/internal/storage/schema/wisp_dep_forward_repair.go
+++ b/internal/storage/schema/wisp_dep_forward_repair.go
@@ -44,13 +44,13 @@ import (
 // Sequence, mirroring the shipped cliMigration0043DropDependenciesGeneratedColumn
 // which performs exactly this operation for the `dependencies` table:
 //
-//	1. delete:    FK orphans and zero-target rows
-//	2. drops:     idx_wisp_dep_type_target, each FK present, PRIMARY KEY, depends_on_id
-//	3. add:       id CHAR(36) DEFAULT (UUID()) PRIMARY KEY FIRST
-//	4. normalize: multi-target rows down to one target
-//	5. dedup:     keep MIN(id) per natural-identity group
-//	6. add:       the three uk_* unique keys and three idx_wisp_dep_type_* indexes
-//	7. add:       all four constraints unconditionally
+//  1. delete:    FK orphans and zero-target rows
+//  2. drops:     idx_wisp_dep_type_target, each FK present, PRIMARY KEY, depends_on_id
+//  3. add:       id CHAR(36) DEFAULT (UUID()) PRIMARY KEY FIRST
+//  4. normalize: multi-target rows down to one target
+//  5. dedup:     keep MIN(id) per natural-identity group
+//  6. add:       the three uk_* unique keys and three idx_wisp_dep_type_* indexes
+//  7. add:       all four constraints unconditionally
 //
 // Normalization sits AFTER the drop, and that placement is load-bearing rather
 // than cosmetic. depends_on_id is COALESCE(issue, wisp, external), so nulling a
@@ -93,7 +93,7 @@ const wispDepTable = "wisp_dependencies"
 
 // wispDepFinalConstraints are the four constraints the final 0021 shape
 // carries. They are added unconditionally at the end of the rebuild, unlike
-// ignored/0005's restore-only-what-was-present-before behaviour: their absence
+// ignored/0005's restore-only-what-was-present-before behavior: their absence
 // is the disease being cured, and a legacy store never had the two target
 // foreign keys to begin with (their columns did not exist yet), which is
 // exactly why 0005 leaves those databases unhealed and 0058 has to exist.
@@ -105,7 +105,7 @@ var wispDepFinalConstraints = []struct{ name, definition string }{
 }
 
 // wispDepFinalKeys are the unique keys and secondary indexes of the final
-// shape, in the order the shipped 0043 analogue adds them.
+// shape, in the order the shipped 0043 analog adds them.
 var wispDepFinalKeys = []struct{ name, definition string }{
 	{"uk_wisp_dep_issue_target", "ADD UNIQUE KEY uk_wisp_dep_issue_target (issue_id, depends_on_issue_id)"},
 	{"uk_wisp_dep_wisp_target", "ADD UNIQUE KEY uk_wisp_dep_wisp_target (issue_id, depends_on_wisp_id)"},
@@ -307,7 +307,7 @@ func normalizeWispDepMultiTargetRows(ctx context.Context, db DBConn) error {
 }
 
 // dropWispDepLegacyShape removes the generated column and everything built on
-// it, in the order the shipped 0043 analogue uses.
+// it, in the order the shipped 0043 analog uses.
 //
 // The order is load-bearing in two places. idx_wisp_dep_type_target is indexed
 // on depends_on_id and must go before the column. Every foreign key must go

--- a/internal/storage/schema/wisp_dep_forward_repair.go
+++ b/internal/storage/schema/wisp_dep_forward_repair.go
@@ -1,0 +1,482 @@
+package schema
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// Pre-0058 repair: march wisp_dependencies forward to the final (current 0021)
+// shape so migration 0058 can apply.
+//
+// The failure. 0058 adds fk_wisp_dep_wisp_target and fk_wisp_dep_issue_target
+// over depends_on_wisp_id and depends_on_issue_id. On every database 0058 was
+// written to heal, those two columns are inputs to depends_on_id's COALESCE
+// STORED generated column, and Dolt refuses:
+//
+//	Error 1105 (HY000): Cannot add foreign key on the base column of a stored
+//	generated column.
+//
+// The two conditions share one cause. A database reaches 0047's delegate
+// branch when wisps and wisp_dependencies both already exist; that branch adds
+// the split target columns underneath the generated column and adds neither
+// foreign key. So every database that needs 0058 has the shape that makes 0058
+// fail, and the pass commits 0054..0057 and then aborts with the cursor at 57:
+// past what an older binary will open, short of head. Recovery is a restore.
+//
+// Why this cannot be a migration file. 0058 is shipped and frozen
+// (scripts/check-migration-hygiene.sh check C), and a new migration numbered
+// above 58 is unreachable because 0058 aborts the pass before it. A repair
+// keyed to the pending version is the only vehicle that runs before 0058 on an
+// affected database.
+//
+// Why the destination is the FINAL shape rather than the pre-0058 shape.
+// Restoring the composite-PK generated-column shape was tried twice and failed
+// both times, for one root cause: that shape's rebuild has a keyless window
+// indistinguishable from ignored/0005's own keyless window, so a resume after a
+// crash cannot tell which actor it is resuming and can record 58 over a table
+// on its way to the id-keyed shape. Aiming at the final shape removes the
+// ambiguity, because the repair's destination IS 0005's destination: it does
+// not matter which actor resumes, since both converge on the same table. It
+// also dissolves the deduplication hazard (see rebuild step 4) and the
+// PK-hostage error 1553, and it leaves ignored/0005's @needs_drop reading 0.
+//
+// Sequence, mirroring the shipped cliMigration0043DropDependenciesGeneratedColumn
+// which performs exactly this operation for the `dependencies` table:
+//
+//	1. delete:    FK orphans and zero-target rows
+//	2. drops:     idx_wisp_dep_type_target, each FK present, PRIMARY KEY, depends_on_id
+//	3. add:       id CHAR(36) DEFAULT (UUID()) PRIMARY KEY FIRST
+//	4. normalize: multi-target rows down to one target
+//	5. dedup:     keep MIN(id) per natural-identity group
+//	6. add:       the three uk_* unique keys and three idx_wisp_dep_type_* indexes
+//	7. add:       all four constraints unconditionally
+//
+// Normalization sits AFTER the drop, and that placement is load-bearing rather
+// than cosmetic. depends_on_id is COALESCE(issue, wisp, external), so nulling a
+// higher-precedence column recomputes it -- and the legacy primary key is
+// (issue_id, depends_on_id). Normalizing a row that carries both an external
+// and a wisp target therefore rewrites its own key onto the value an
+// external-only sibling row already holds:
+//
+//	duplicate primary key given: [w2,external:e1]
+//
+// The UPDATE aborts and the repair stalls on exactly the drifted store it
+// exists to heal. Once the generated column and the composite key are gone the
+// same statement is a plain column update that cannot collide, and step 5 then
+// removes the duplicate it just created. (0058 carries this defect too: it runs
+// the same normalization with the generated column and composite key still in
+// place. It is unreachable there only because 0058's normalization is gated on
+// ck_wisp_dep_one_target being absent, and a store that reaches that branch
+// with a colliding pair hits the same abort.)
+//
+// Every step below re-verifies its own target state against the live schema
+// rather than trusting a flag sniffed once at the top. That is what makes the
+// repair resumable: a process killed anywhere in the sequence leaves a state
+// with exactly one forward action, and the next open takes it. Both ignored/0003
+// and ignored/0005 key all of their per-statement guards on a single upfront
+// sniff and therefore no-op after a mid-run crash; a repair that inherited that
+// would reintroduce the bug it exists to fix.
+//
+// Note on FOREIGN_KEY_CHECKS: this repair deliberately does NOT disable it.
+// The cleanup in step 1 removes every row a constraint in step 6 could reject,
+// so suppression buys nothing on the clean path -- and on a dirty one it is
+// actively harmful, because a foreign key added over surviving orphans is the
+// #4534 write-brick (Dolt then fails constraint validation on subsequent
+// writes, so one legacy orphan bricks every create). With checks left on, a
+// missed orphan aborts its own ADD instead, which under the forward-march
+// ordering is recoverable: the drops are already done, so the table sits in the
+// final shape minus one constraint -- a validly keyed table, not the mangled
+// keyless one -- and the next open re-cleans and retries. It is also toggled
+// per session, and DBConn is a pool.
+const wispDepTable = "wisp_dependencies"
+
+// wispDepFinalConstraints are the four constraints the final 0021 shape
+// carries. They are added unconditionally at the end of the rebuild, unlike
+// ignored/0005's restore-only-what-was-present-before behaviour: their absence
+// is the disease being cured, and a legacy store never had the two target
+// foreign keys to begin with (their columns did not exist yet), which is
+// exactly why 0005 leaves those databases unhealed and 0058 has to exist.
+var wispDepFinalConstraints = []struct{ name, definition string }{
+	{"fk_wisp_dep_issue", "FOREIGN KEY (issue_id) REFERENCES wisps(id) ON DELETE CASCADE ON UPDATE CASCADE"},
+	{"fk_wisp_dep_wisp_target", "FOREIGN KEY (depends_on_wisp_id) REFERENCES wisps(id) ON DELETE CASCADE ON UPDATE CASCADE"},
+	{"fk_wisp_dep_issue_target", "FOREIGN KEY (depends_on_issue_id) REFERENCES issues(id) ON DELETE CASCADE ON UPDATE CASCADE"},
+	{"ck_wisp_dep_one_target", "CHECK ((depends_on_issue_id IS NOT NULL) + (depends_on_wisp_id IS NOT NULL) + (depends_on_external IS NOT NULL) = 1)"},
+}
+
+// wispDepFinalKeys are the unique keys and secondary indexes of the final
+// shape, in the order the shipped 0043 analogue adds them.
+var wispDepFinalKeys = []struct{ name, definition string }{
+	{"uk_wisp_dep_issue_target", "ADD UNIQUE KEY uk_wisp_dep_issue_target (issue_id, depends_on_issue_id)"},
+	{"uk_wisp_dep_wisp_target", "ADD UNIQUE KEY uk_wisp_dep_wisp_target (issue_id, depends_on_wisp_id)"},
+	{"uk_wisp_dep_external_target", "ADD UNIQUE KEY uk_wisp_dep_external_target (issue_id, depends_on_external)"},
+	{"idx_wisp_dep_type_issue", "ADD INDEX idx_wisp_dep_type_issue (type, depends_on_issue_id)"},
+	{"idx_wisp_dep_type_wisp", "ADD INDEX idx_wisp_dep_type_wisp (type, depends_on_wisp_id)"},
+	{"idx_wisp_dep_type_external", "ADD INDEX idx_wisp_dep_type_external (type, depends_on_external)"},
+}
+
+// repairWispDependenciesForwardShape is the pre-0058 repair. It no-ops on every
+// population except the one 0058 cannot serve: no-ops when the table or either
+// referenced table is absent, when the table is already in the final shape, and
+// on a fresh store (which never had the generated column, so 0058 applies to it
+// cleanly).
+func repairWispDependenciesForwardShape(ctx context.Context, db DBConn) error {
+	// Both referenced tables must exist before any foreign key can be added.
+	// 0058 carries the same @has_wisps/@has_issues guards; a database missing
+	// one is left untouched rather than assumed into a shape it may not have.
+	for _, t := range []string{wispDepTable, "wisps", "issues"} {
+		exists, err := schemaTableExists(ctx, db, t)
+		if err != nil {
+			return fmt.Errorf("checking %s for the pre-0058 repair: %w", t, err)
+		}
+		if !exists {
+			return nil
+		}
+	}
+
+	needed, err := wispDepNeedsForwardRepair(ctx, db)
+	if err != nil {
+		return err
+	}
+	if !needed {
+		return nil
+	}
+
+	if err := deleteWispDepRowsRejectedByFinalShape(ctx, db); err != nil {
+		return err
+	}
+	if err := dropWispDepLegacyShape(ctx, db); err != nil {
+		return err
+	}
+	if err := ensureWispDepSurrogateKey(ctx, db); err != nil {
+		return err
+	}
+	// Only now, with the generated column and composite key gone, can a
+	// multi-target row be normalized without rewriting its own primary key
+	// onto a sibling's.
+	if err := normalizeWispDepMultiTargetRows(ctx, db); err != nil {
+		return err
+	}
+	if err := dedupeWispDepNaturalIdentity(ctx, db); err != nil {
+		return err
+	}
+	return ensureWispDepFinalKeysAndConstraints(ctx, db)
+}
+
+// wispDepNeedsForwardRepair reports whether this database is in the legacy
+// lineage the repair serves.
+//
+// Two states qualify. The first is the untouched legacy shape: depends_on_id
+// present as a STORED generated column. The second is a crash state -- neither
+// depends_on_id nor id, which no lineage produces on purpose and which only a
+// process killed between this repair's DROP COLUMN and its ADD COLUMN can
+// reach. Detecting the second is what makes the repair resumable rather than
+// leaving a keyless table behind for 0058 to complete over.
+//
+// A fresh store has id and no generated column and is not repaired: 0058
+// applies to it cleanly, and the constraints are already there from creation.
+func wispDepNeedsForwardRepair(ctx context.Context, db DBConn) (bool, error) {
+	generated, err := wispDepHasStoredGeneratedDependsOnID(ctx, db)
+	if err != nil {
+		return false, err
+	}
+	if generated {
+		return true, nil
+	}
+
+	hasID, err := schemaColumnExists(ctx, db, wispDepTable, "id")
+	if err != nil {
+		return false, fmt.Errorf("checking %s.id for the pre-0058 repair: %w", wispDepTable, err)
+	}
+	if hasID {
+		// Final lineage. Still finish the job if a prior pass was killed
+		// between adding the surrogate key and adding every constraint: the
+		// steps below are individually guarded, so this is a no-op once the
+		// shape is complete.
+		return wispDepMissingAnyFinalConstraint(ctx, db)
+	}
+
+	// Neither depends_on_id nor id: a mid-rebuild crash. Resume.
+	return true, nil
+}
+
+func wispDepMissingAnyFinalConstraint(ctx context.Context, db DBConn) (bool, error) {
+	for _, c := range wispDepFinalConstraints {
+		present, err := schemaConstraintExists(ctx, db, wispDepTable, c.name)
+		if err != nil {
+			return false, err
+		}
+		if !present {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// wispDepHasStoredGeneratedDependsOnID reports whether depends_on_id is a
+// STORED generated column.
+//
+// This reads SHOW CREATE TABLE because Dolt does not surface generated-column
+// metadata through INFORMATION_SCHEMA at all: COLUMNS.EXTRA and
+// COLUMNS.GENERATION_EXPRESSION both come back empty for a generated column,
+// and IS_GENERATED does not exist as a column ("could not be found in any table
+// in scope"). A guard written against those compiles, runs, and never fires.
+//
+// The backtick-delimited name is what makes the match safe: "`depends_on_id`"
+// cannot match the `depends_on_issue_id` definition line, whereas an unquoted
+// substring search would.
+func wispDepHasStoredGeneratedDependsOnID(ctx context.Context, db DBConn) (bool, error) {
+	ddl, err := schemaShowCreateTable(ctx, db, wispDepTable)
+	if err != nil {
+		return false, err
+	}
+	for _, line := range strings.Split(ddl, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "`depends_on_id`") {
+			continue
+		}
+		upper := strings.ToUpper(trimmed)
+		return strings.Contains(upper, "GENERATED ALWAYS AS") && strings.Contains(upper, "STORED"), nil
+	}
+	return false, nil
+}
+
+// deleteWispDepRowsRejectedByFinalShape removes exactly the rows the constraints
+// added at the end of the rebuild would otherwise reject. It ports 0058's own
+// cleanup, which cites the #4534 class verbatim: the delegate path's
+// unconstrained window leaves target columns pointing at rows that no longer
+// exist, and a foreign key added over them bricks every subsequent write.
+//
+// Three orphan deletes, not 0058's two. 0058 adds only the two target foreign
+// keys, but this repair also (re-)adds fk_wisp_dep_issue over issue_id, which a
+// legacy store may equally have accumulated orphans against while it was
+// dropped. Deleting the whole row is what ON DELETE CASCADE would have done had
+// the constraint been in force when the target went away, so it matches the
+// state the table would be in had the window never existed.
+//
+// A zero-target row names nothing to be blocked on and is deleted outright, as
+// 0058 does. Deletes are safe here, before the drop, because removing a row can
+// never collide on the legacy key -- unlike the multi-target normalization,
+// which must wait (see normalizeWispDepMultiTargetRows).
+func deleteWispDepRowsRejectedByFinalShape(ctx context.Context, db DBConn) error {
+	statements := []string{
+		// FK orphans.
+		"DELETE wd FROM wisp_dependencies wd LEFT JOIN wisps w ON w.id = wd.issue_id WHERE w.id IS NULL",
+		"DELETE wd FROM wisp_dependencies wd LEFT JOIN wisps w ON w.id = wd.depends_on_wisp_id WHERE wd.depends_on_wisp_id IS NOT NULL AND w.id IS NULL",
+		"DELETE wd FROM wisp_dependencies wd LEFT JOIN issues i ON i.id = wd.depends_on_issue_id WHERE wd.depends_on_issue_id IS NOT NULL AND i.id IS NULL",
+		// ck_wisp_dep_one_target: zero-target rows.
+		"DELETE FROM wisp_dependencies WHERE depends_on_issue_id IS NULL AND depends_on_wisp_id IS NULL AND depends_on_external IS NULL",
+	}
+	for _, stmt := range statements {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("deleting wisp_dependencies rows rejected by the final shape: %w", err)
+		}
+	}
+	return nil
+}
+
+// normalizeWispDepMultiTargetRows reduces a row naming more than one target to
+// exactly one, so ck_wisp_dep_one_target can be added at the end.
+//
+// The precedence (external > wisp > issue) is 0058's and is not a choice: it is
+// fixed by the delegate backfill's statement order in
+// wispDependenciesSplitTargetBackfillSQL and pinned by
+// TestWispDependenciesSplitTargetBackfillPrefersWispOverIssueThroughDoltCLI.
+// Matching it keeps (repair -> 0058) equivalent to (0058 alone) on every
+// population, which is the invariant that makes the repair auditable. Unlike a
+// zero-target row, a multi-target row names real, resolvable targets -- just
+// more than one -- so the lower-precedence columns are nulled and the row
+// survives rather than being discarded.
+//
+// This must run after the generated column and composite primary key are gone;
+// see the ordering note in the file header for the collision it otherwise
+// causes. It also manufactures duplicates by design -- a normalized row can
+// land on a sibling's natural identity -- which is why the dedup step follows
+// it rather than preceding it.
+func normalizeWispDepMultiTargetRows(ctx context.Context, db DBConn) error {
+	statements := []string{
+		"UPDATE wisp_dependencies SET depends_on_wisp_id = NULL, depends_on_issue_id = NULL WHERE depends_on_external IS NOT NULL AND (depends_on_wisp_id IS NOT NULL OR depends_on_issue_id IS NOT NULL)",
+		"UPDATE wisp_dependencies SET depends_on_issue_id = NULL WHERE depends_on_external IS NULL AND depends_on_wisp_id IS NOT NULL AND depends_on_issue_id IS NOT NULL",
+	}
+	for _, stmt := range statements {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("normalizing multi-target wisp_dependencies rows for the 0058 repair: %w", err)
+		}
+	}
+	return nil
+}
+
+// dropWispDepLegacyShape removes the generated column and everything built on
+// it, in the order the shipped 0043 analogue uses.
+//
+// The order is load-bearing in two places. idx_wisp_dep_type_target is indexed
+// on depends_on_id and must go before the column. Every foreign key must go
+// before DROP PRIMARY KEY, because the primary key is the only issue_id-leading
+// index on this shape and fk_wisp_dep_issue holds it hostage:
+//
+//	Error 1553 (HY000): can't drop index 'PRIMARY': needed in foreign key
+//	constraint fk_wisp_dep_issue
+//
+// Each drop is guarded on the live schema, so a resume after a crash mid-drop
+// skips what is already gone rather than failing on a missing object.
+func dropWispDepLegacyShape(ctx context.Context, db DBConn) error {
+	hasIndex, err := schemaIndexExists(ctx, db, wispDepTable, "idx_wisp_dep_type_target")
+	if err != nil {
+		return err
+	}
+	if hasIndex {
+		if _, err := db.ExecContext(ctx, "ALTER TABLE wisp_dependencies DROP INDEX idx_wisp_dep_type_target"); err != nil {
+			return fmt.Errorf("dropping idx_wisp_dep_type_target for the 0058 repair: %w", err)
+		}
+	}
+
+	for _, c := range wispDepFinalConstraints {
+		if !strings.HasPrefix(c.name, "fk_") {
+			continue
+		}
+		present, err := schemaConstraintExists(ctx, db, wispDepTable, c.name)
+		if err != nil {
+			return err
+		}
+		if !present {
+			continue
+		}
+		if _, err := db.ExecContext(ctx, "ALTER TABLE wisp_dependencies DROP FOREIGN KEY "+c.name); err != nil {
+			return fmt.Errorf("dropping %s for the 0058 repair: %w", c.name, err)
+		}
+	}
+
+	hasPK, err := schemaHasPrimaryKey(ctx, db, wispDepTable)
+	if err != nil {
+		return err
+	}
+	if hasPK {
+		if _, err := db.ExecContext(ctx, "ALTER TABLE wisp_dependencies DROP PRIMARY KEY"); err != nil {
+			return fmt.Errorf("dropping the wisp_dependencies primary key for the 0058 repair: %w", err)
+		}
+	}
+
+	hasGenerated, err := schemaColumnExists(ctx, db, wispDepTable, "depends_on_id")
+	if err != nil {
+		return err
+	}
+	if hasGenerated {
+		if _, err := db.ExecContext(ctx, "ALTER TABLE wisp_dependencies DROP COLUMN depends_on_id"); err != nil {
+			return fmt.Errorf("dropping wisp_dependencies.depends_on_id for the 0058 repair: %w", err)
+		}
+	}
+	return nil
+}
+
+// ensureWispDepSurrogateKey adds the final shape's id column and primary key.
+//
+// It is added BEFORE deduplication on purpose. The natural identity of a row
+// here is (issue_id, target), and two rows identical in every column have no
+// deterministic survivor -- created_at has second resolution and created_by and
+// type commonly take defaults, so ordinary retry inserts reach that state. Once
+// every row carries a distinct UUID a delete can pick MIN(id) deterministically.
+// The final primary key being the UUID also means ADD PRIMARY KEY can never
+// fail on duplicates, which is the state that made the previous designs fatal.
+//
+// A legacy store categorically has no id column: the original 0021 created the
+// composite-keyed shape without one, and ignored/0005 -- the only migration that
+// adds id to a legacy store -- drops the generated column in the same guarded
+// run. There is no state carrying both, so this never has to reconcile one.
+//
+// DEFAULT (UUID()) is correct here even though a fully migrated table carries
+// no default: ignored/0010 drops it, and this repair can only reach the ADD
+// COLUMN branch on a store whose ignored cursor is still behind 0005 (that is
+// what "the generated column is still present" means), hence behind 0010. The
+// default is therefore always dropped downstream in the same pass, which is why
+// ignored/0005 mints the column the same way rather than special-casing it.
+func ensureWispDepSurrogateKey(ctx context.Context, db DBConn) error {
+	hasID, err := schemaColumnExists(ctx, db, wispDepTable, "id")
+	if err != nil {
+		return err
+	}
+	if !hasID {
+		if _, err := db.ExecContext(ctx,
+			"ALTER TABLE wisp_dependencies ADD COLUMN id CHAR(36) NOT NULL DEFAULT (UUID()) PRIMARY KEY FIRST"); err != nil {
+			return fmt.Errorf("adding wisp_dependencies.id for the 0058 repair: %w", err)
+		}
+		return nil
+	}
+
+	// id survived a crash but its key did not (or the column predates the
+	// key): add the key alone rather than re-adding the column.
+	hasPK, err := schemaHasPrimaryKey(ctx, db, wispDepTable)
+	if err != nil {
+		return err
+	}
+	if !hasPK {
+		if _, err := db.ExecContext(ctx, "ALTER TABLE wisp_dependencies ADD PRIMARY KEY (id)"); err != nil {
+			return fmt.Errorf("adding the wisp_dependencies id primary key for the 0058 repair: %w", err)
+		}
+	}
+	return nil
+}
+
+// dedupeWispDepNaturalIdentity removes rows that would collide on the three
+// uk_* unique keys added next. Duplicates are reachable because the legacy
+// shape's composite primary key covers (issue_id, depends_on_id) -- so two rows
+// differing only in a column the COALESCE did not select were legal -- and
+// because the keyless window leaves writes unconstrained.
+//
+// The comparison is null-safe (<=>): the target columns are NULL for every
+// target kind a row does not use, and ordinary = would treat two identical
+// wisp-target rows as distinct because their NULL issue targets never compare
+// equal. MIN(id) is an arbitrary but deterministic survivor, which is the
+// property that matters -- it makes a resumed run pick the same row.
+func dedupeWispDepNaturalIdentity(ctx context.Context, db DBConn) error {
+	if _, err := db.ExecContext(ctx, `
+		DELETE wd FROM wisp_dependencies wd
+		JOIN (
+			SELECT MIN(id) AS keep_id, issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external
+			FROM wisp_dependencies
+			GROUP BY issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external
+			HAVING COUNT(*) > 1
+		) dup
+		  ON wd.issue_id = dup.issue_id
+		 AND wd.depends_on_issue_id <=> dup.depends_on_issue_id
+		 AND wd.depends_on_wisp_id <=> dup.depends_on_wisp_id
+		 AND wd.depends_on_external <=> dup.depends_on_external
+		WHERE wd.id <> dup.keep_id
+	`); err != nil {
+		return fmt.Errorf("deduplicating wisp_dependencies before the 0058 repair: %w", err)
+	}
+	return nil
+}
+
+// ensureWispDepFinalKeysAndConstraints completes the final shape. Each object
+// is added only if absent, so this finishes a partially-rebuilt table rather
+// than failing on a duplicate key name -- and re-running it on a converged
+// database does nothing at all.
+func ensureWispDepFinalKeysAndConstraints(ctx context.Context, db DBConn) error {
+	for _, k := range wispDepFinalKeys {
+		present, err := schemaIndexExists(ctx, db, wispDepTable, k.name)
+		if err != nil {
+			return err
+		}
+		if present {
+			continue
+		}
+		if _, err := db.ExecContext(ctx, "ALTER TABLE wisp_dependencies "+k.definition); err != nil {
+			return fmt.Errorf("adding %s for the 0058 repair: %w", k.name, err)
+		}
+	}
+
+	for _, c := range wispDepFinalConstraints {
+		present, err := schemaConstraintExists(ctx, db, wispDepTable, c.name)
+		if err != nil {
+			return err
+		}
+		if present {
+			continue
+		}
+		if _, err := db.ExecContext(ctx,
+			"ALTER TABLE wisp_dependencies ADD CONSTRAINT "+c.name+" "+c.definition); err != nil {
+			return fmt.Errorf("adding %s for the 0058 repair: %w", c.name, err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Fixes #5380.

## What breaks

`0058_heal_wisp_dependencies_split_constraints` cannot apply to the databases it was written to heal. Its two `ADD CONSTRAINT ... FOREIGN KEY` statements target `depends_on_wisp_id` and `depends_on_issue_id`, which are inputs to `depends_on_id`'s `COALESCE` STORED generated column, and Dolt rejects that:

```
Error 1105 (HY000): Cannot add foreign key on the base column of a stored generated column.
```

The two conditions share a cause. A database reaches 0047's delegate branch when `wisps` and `wisp_dependencies` both already exist, and that branch is what adds the split target columns underneath the generated column. Every database that needs 0058 has the shape that makes 0058 fail.

The failure strands the store. The pass commits 0054 through 0057 and aborts, leaving the cursor at 57: past the last version an older binary will read, short of head, so no binary opens it afterwards. Recovery is a restore.

## Why this is in Go rather than in the migration

Two reasons.

0058 is shipped and frozen by `check-migration-hygiene.sh` check C, and it cannot be fixed forward with a new migration either, because the failing file aborts the pass before any later version runs. `migration_repairs.go`'s own header already names this case: repairing in code, keyed to the pending version, is the only path that heals affected databases without touching shipped SQL.

The guard also cannot be written in SQL. Dolt does not surface generated-column metadata through `INFORMATION_SCHEMA` at all:

```sql
SELECT column_name, extra, generation_expression FROM information_schema.columns
 WHERE table_name='wisp_dependencies' AND column_name='depends_on_id';

+---------------+-------+-----------------------+
| COLUMN_NAME   | EXTRA | GENERATION_EXPRESSION |
+---------------+-------+-----------------------+
| depends_on_id |       |                       |
+---------------+-------+-----------------------+
```

Both empty, and `IS_GENERATED` does not exist (`Error 1105: column "is_generated" could not be found in any table in scope`). A guard written against those columns compiles, runs, and never fires. `SHOW CREATE TABLE` is the only place the shape is visible.

## The change

One entry in the existing `preMigrationRepairs` registry, `{"schema_migrations", 58}`, alongside the repairs already registered for 0040, 0041, 0047 and 0053.

The repair adds both foreign keys itself: drop the generated column and the primary key and index built on it, add the constraints while the base columns are unencumbered, then restore column, key and index. Values are recomputed from the base columns on restore, so no data is lost. 0058 then finds both constraints present and takes its no-op branch.

0058 itself is untouched. `check-migration-hygiene.sh` passes.

It is idempotent and conservative, no-oping when the table is absent, when both constraints already exist, when `depends_on_id` is not a stored generated column (0058 applies cleanly there), or when the primary key is not the shape it knows how to rebuild. The half-repaired case, where one constraint landed on an earlier attempt, adds only the missing one.

## Test plan

`internal/storage/schema/wisp_dep_fk_repair_test.go`, four tests: the three no-op branches, the full rebuild sequence on the drifted shape, the half-repaired case, and the registry wiring. The sequence test pins statement order, which is load-bearing in both directions.

I mutation-checked these rather than trusting green. Removing the drop-first steps fails two of them; unregistering the repair fails the registry test.

```
go test ./internal/storage/schema/   ok  91.5s
go vet ./internal/storage/schema/    clean
scripts/check-migration-hygiene.sh   Migration hygiene OK
```

End to end, against a Dolt sql-server holding a replica of a production v53 schema with `wisp_dependencies` rows of each target kind (wisp, issue, external):

| | before | after |
|---|---|---|
| `bd migrate` from v53 | aborts at 0058, cursor stranded at 57 | reaches head (62) |
| `wisp_dependencies` foreign keys | 0 | 2 |
| rows | 3 | 3, targets intact |
| `ck_wisp_dep_one_target` | present | present |

Worth noting for review: `depends_on_id` is absent from the final table, replaced by the `id char(36)` surrogate key. That is `ignored/0005` doing its designed job downstream, and it only restores a foreign key it detected before its own drop, which is why the repair has to run at 58 rather than later.

## Alternative considered

Dropping and rebuilding the generated column inside a new migration rather than a repair hook. It cannot work: a new migration is numbered above 58, and 0058 aborts the pass before anything above it runs.
