### PR TITLE
/{cmd,internal}: hydrate list/ready dependencies via a page semi-join

### DIFF
--- a/cmd/bd/list_proxied_server.go
+++ b/cmd/bd/list_proxied_server.go
@@ -65,14 +65,14 @@ func runListProxiedSearch(_ *cobra.Command, ctx context.Context, in listInput) e
 		return emitProxiedListJSONResult(page.Items, in, page.HasMore)
 	}
 
-	page, err := uw.IssueUseCase().SearchIssues(ctx, "", filter)
+	page, deps, err := uw.IssueUseCase().ListWithDependencies(ctx, "", filter)
 	if err != nil {
 		return err
 	}
 
 	issues, hasMore := workapi.FinishPage(page.Items, in.SortBy, in.Reverse, in.effectiveLimit, page.HasMore)
 
-	return renderProxiedListText(ctx, uw, issues, in, hasMore)
+	return renderProxiedListText(ctx, uw, issues, in, hasMore, deps)
 }
 
 func runListProxiedReady(_ *cobra.Command, ctx context.Context, in listInput) error {
@@ -92,14 +92,14 @@ func runListProxiedReady(_ *cobra.Command, ctx context.Context, in listInput) er
 		return emitProxiedListJSONResult(page.Items, in, page.HasMore)
 	}
 
-	page, err := uw.IssueUseCase().GetReadyWork(ctx, wf)
+	page, deps, err := uw.IssueUseCase().GetReadyWorkWithDependencies(ctx, wf)
 	if err != nil {
 		return err
 	}
 
 	issues, hasMore := workapi.FinishPage(page.Items, in.SortBy, in.Reverse, in.effectiveLimit, page.HasMore)
 
-	return renderProxiedListText(ctx, uw, issues, in, hasMore)
+	return renderProxiedListText(ctx, uw, issues, in, hasMore, deps)
 }
 
 func runListProxiedWatch(_ *cobra.Command, ctx context.Context, in listInput) error {
@@ -147,7 +147,7 @@ func runListProxiedWatch(_ *cobra.Command, ctx context.Context, in listInput) er
 			issues, hasMore = workapi.FinishPage(page.Items, in.SortBy, in.Reverse, in.effectiveLimit, page.HasMore)
 		}
 
-		deps, err := loadDepsForIssues(ctx, uw, issues)
+		deps, err := loadDepsForIssues(ctx, uw, issues, nil)
 		if err != nil {
 			return nil, false, nil, err
 		}
@@ -208,7 +208,14 @@ func emitProxiedListJSONResult(iwc []*types.IssueWithCounts, in listInput, hasMo
 	return nil
 }
 
-func loadDepsForIssues(ctx context.Context, uw uow.UnitOfWork, issues []*types.Issue) (map[string][]*types.Dependency, error) {
+// loadDepsForIssues falls back to an id-list read for pages that no filter
+// subquery reproduces: the watch loop and the hierarchical --parent tree, which
+// is built by recursive traversal rather than one filtered query. A non-nil
+// preloaded map is used as-is.
+func loadDepsForIssues(ctx context.Context, uw uow.UnitOfWork, issues []*types.Issue, preloaded map[string][]*types.Dependency) (map[string][]*types.Dependency, error) {
+	if preloaded != nil {
+		return preloaded, nil
+	}
 	ids := make([]string, len(issues))
 	for i, issue := range issues {
 		ids[i] = issue.ID
@@ -216,9 +223,9 @@ func loadDepsForIssues(ctx context.Context, uw uow.UnitOfWork, issues []*types.I
 	return uw.DependencyUseCase().GetForIssueIDs(ctx, ids)
 }
 
-func renderProxiedListText(ctx context.Context, uw uow.UnitOfWork, issues []*types.Issue, in listInput, truncated bool) error {
+func renderProxiedListText(ctx context.Context, uw uow.UnitOfWork, issues []*types.Issue, in listInput, truncated bool, deps map[string][]*types.Dependency) error {
 	if in.formatStr != "" {
-		depsByIssueID, err := loadDepsForIssues(ctx, uw, issues)
+		depsByIssueID, err := loadDepsForIssues(ctx, uw, issues, deps)
 		if err != nil {
 			return err
 		}
@@ -230,7 +237,7 @@ func renderProxiedListText(ctx context.Context, uw uow.UnitOfWork, issues []*typ
 	}
 
 	if in.prettyFormat {
-		depsByIssueID, err := loadDepsForIssues(ctx, uw, issues)
+		depsByIssueID, err := loadDepsForIssues(ctx, uw, issues, deps)
 		if err != nil {
 			return err
 		}

--- a/cmd/bd/list_show_filter_modes.go
+++ b/cmd/bd/list_show_filter_modes.go
@@ -239,7 +239,7 @@ func runListProxiedHierarchicalParent(ctx context.Context, uw uow.UnitOfWork, in
 		return nil
 	}
 
-	depsByIssueID, err := loadDepsForIssues(ctx, uw, treeIssues)
+	depsByIssueID, err := loadDepsForIssues(ctx, uw, treeIssues, nil)
 	if err != nil {
 		return err
 	}

--- a/cmd/bd/ready_proxied_server.go
+++ b/cmd/bd/ready_proxied_server.go
@@ -140,7 +140,7 @@ func runReadyProxiedList(ctx context.Context, uw uow.UnitOfWork, in readyInput) 
 		return nil
 	}
 
-	page, err := uw.IssueUseCase().GetReadyWork(ctx, in.filter)
+	page, allDeps, err := uw.IssueUseCase().GetReadyWorkWithDependencies(ctx, in.filter)
 	if err != nil {
 		return HandleError("%v", err)
 	}
@@ -163,7 +163,7 @@ func runReadyProxiedList(ctx context.Context, uw uow.UnitOfWork, in readyInput) 
 		return nil
 	}
 
-	parentEpicMap := buildParentEpicMapProxied(ctx, uw, issues)
+	parentEpicMap := buildParentEpicMapProxied(ctx, uw, issues, allDeps)
 	usePlain := in.plainFormat || !in.prettyFormat
 	if usePlain {
 		fmt.Printf("\n%s Ready work (%d issues with no active blockers):\n\n", ui.RenderAccent("📋"), len(issues))
@@ -247,7 +247,7 @@ func runReadyProxiedExplain(ctx context.Context, uw uow.UnitOfWork, _ readyInput
 	if err != nil {
 		return HandleErrorRespectJSON("%v", err)
 	}
-	readyPage, err := uw.IssueUseCase().GetReadyWork(ctx, filter)
+	readyPage, allDeps, err := uw.IssueUseCase().GetReadyWorkWithDependencies(ctx, filter)
 	if err != nil {
 		return HandleErrorRespectJSON("%v", err)
 	}
@@ -269,10 +269,6 @@ func runReadyProxiedExplain(ctx context.Context, uw uow.UnitOfWork, _ readyInput
 	depCounts := make(map[string]*types.DependencyCounts, len(depCountsMap))
 	for k, v := range depCountsMap {
 		depCounts[k] = v
-	}
-	allDeps, err := uw.DependencyUseCase().GetForIssueIDs(ctx, readyIDs)
-	if err != nil {
-		debug.Logf("warning: failed to get dependency records: %v", err)
 	}
 
 	cycles, err := uw.DependencyUseCase().DetectCycles(ctx)
@@ -456,16 +452,11 @@ func runReadyProxiedGated(ctx context.Context, uw uow.UnitOfWork, _ readyInput) 
 	return renderGatedReadyMolecules(molecules)
 }
 
-func buildParentEpicMapProxied(ctx context.Context, uw uow.UnitOfWork, issues []*types.Issue) map[string]string {
-	if len(issues) == 0 {
-		return nil
-	}
-	ids := make([]string, len(issues))
-	for i, issue := range issues {
-		ids[i] = issue.ID
-	}
-	allDeps, err := uw.DependencyUseCase().GetForIssueIDs(ctx, ids)
-	if err != nil {
+// buildParentEpicMapProxied takes the caller's already-hydrated edges for the
+// same page rather than re-reading them; allDeps nil means the caller had none
+// to share and the map cannot be built.
+func buildParentEpicMapProxied(ctx context.Context, uw uow.UnitOfWork, issues []*types.Issue, allDeps map[string][]*types.Dependency) map[string]string {
+	if len(issues) == 0 || allDeps == nil {
 		return nil
 	}
 	parentIDs := make(map[string]bool)

--- a/internal/storage/domain/db/dependency.go
+++ b/internal/storage/domain/db/dependency.go
@@ -379,6 +379,71 @@ func (r *dependencySQLRepositoryImpl) ListByIssueIDs(ctx context.Context, issueI
 	return result, nil
 }
 
+// listByPageSubquery scopes a dependency read to a page of issues by joining
+// against the page's own id subquery. Unlike ListByIssueIDs it sends no id list,
+// so the statement size does not grow with the page.
+//
+// The ORDER BY is a total order: issue_id alone leaves rows with the same source
+// in whatever order the join produced them.
+func (r *dependencySQLRepositoryImpl) listByPageSubquery(ctx context.Context, idSub string, idArgs []any, opts domain.DepListOpts) (domain.DepBulkResult, error) {
+	result := domain.DepBulkResult{
+		Outgoing: make(map[string][]*types.Dependency),
+		Incoming: make(map[string][]*types.Dependency),
+	}
+
+	table := pickDepTable(opts.UseWispsTable)
+	typeWhere, typeArgs := buildTypeFilter(opts.Types)
+	args := combineArgs(idArgs, typeArgs)
+
+	if opts.Direction == domain.DepDirectionBoth || opts.Direction == domain.DepDirectionOut {
+		//nolint:gosec // G201: table and depSelectColumns are hardcoded; idSub is composed from fixed table names and ? placeholders.
+		q := fmt.Sprintf(
+			`SELECT %s FROM %s JOIN (%s) page ON %s.issue_id = page.id%s ORDER BY issue_id, depends_on_id, type`,
+			depSelectColumns, table, idSub, table, typeWhere,
+		)
+		if err := r.queryDeps(ctx, q, args, result.Outgoing, true); err != nil {
+			return domain.DepBulkResult{}, fmt.Errorf("out: %w", err)
+		}
+	}
+
+	if opts.Direction == domain.DepDirectionBoth || opts.Direction == domain.DepDirectionIn {
+		//nolint:gosec // G201: table, depSelectColumns, depTargetExpr are hardcoded; idSub is composed from fixed table names and ? placeholders.
+		q := fmt.Sprintf(
+			`SELECT %s FROM %s JOIN (%s) page ON %s = page.id%s ORDER BY issue_id, depends_on_id, type`,
+			depSelectColumns, table, idSub, depTargetExpr, typeWhere,
+		)
+		if err := r.queryDeps(ctx, q, args, result.Incoming, false); err != nil {
+			return domain.DepBulkResult{}, fmt.Errorf("in: %w", err)
+		}
+	}
+
+	return result, nil
+}
+
+func (r *dependencySQLRepositoryImpl) ListByIssueFilter(ctx context.Context, query string, filter types.IssueFilter, opts domain.DepListOpts) (domain.DepBulkResult, error) {
+	idSub, idArgs, err := buildPageIDSubquery(ctx, r.runner, query, filter)
+	if err != nil {
+		return domain.DepBulkResult{}, fmt.Errorf("db: DependencySQLRepository.ListByIssueFilter: %w", err)
+	}
+	res, err := r.listByPageSubquery(ctx, idSub, idArgs, opts)
+	if err != nil {
+		return domain.DepBulkResult{}, fmt.Errorf("db: DependencySQLRepository.ListByIssueFilter: %w", err)
+	}
+	return res, nil
+}
+
+func (r *dependencySQLRepositoryImpl) ListByReadyFilter(ctx context.Context, filter types.WorkFilter, opts domain.DepListOpts) (domain.DepBulkResult, error) {
+	idSub, idArgs, err := newIssueSQLRepository(r.runner).buildReadyWorkIDSubquery(ctx, filter)
+	if err != nil {
+		return domain.DepBulkResult{}, fmt.Errorf("db: DependencySQLRepository.ListByReadyFilter: %w", err)
+	}
+	res, err := r.listByPageSubquery(ctx, idSub, idArgs, opts)
+	if err != nil {
+		return domain.DepBulkResult{}, fmt.Errorf("db: DependencySQLRepository.ListByReadyFilter: %w", err)
+	}
+	return res, nil
+}
+
 func (r *dependencySQLRepositoryImpl) CountsByIssueIDs(ctx context.Context, issueIDs []string, opts domain.DepCountsOpts) (map[string]*types.DependencyCounts, error) {
 	result := make(map[string]*types.DependencyCounts)
 	if len(issueIDs) == 0 {

--- a/internal/storage/domain/db/issue.go
+++ b/internal/storage/domain/db/issue.go
@@ -19,6 +19,12 @@ import (
 )
 
 func NewIssueSQLRepository(runner Runner) domain.IssueSQLRepository {
+	return newIssueSQLRepository(runner)
+}
+
+// newIssueSQLRepository returns the concrete type so callers inside this package
+// can reach the unexported query builders that are not on the exported interface.
+func newIssueSQLRepository(runner Runner) *issueSQLRepositoryImpl {
 	return &issueSQLRepositoryImpl{
 		runner: runner,
 		events: NewEventsSQLRepository(runner),

--- a/internal/storage/domain/db/issue_search.go
+++ b/internal/storage/domain/db/issue_search.go
@@ -103,6 +103,10 @@ func (r *issueSQLRepositoryImpl) searchUnion(ctx context.Context, query string, 
 }
 
 func (r *issueSQLRepositoryImpl) buildUnionSubquery(query string, filter types.IssueFilter, tables filterTables, srcTag string) (string, []any, error) {
+	return buildUnionSubquery(query, filter, tables, srcTag)
+}
+
+func buildUnionSubquery(query string, filter types.IssueFilter, tables filterTables, srcTag string) (string, []any, error) {
 	plan := buildLabelDrivenSearch(filter, tables)
 	whereClauses, args, err := buildIssueFilterClauses(query, plan.Filter, tables)
 	if err != nil {
@@ -386,8 +390,12 @@ func scanDepRow(rows *sql.Rows) (*types.Dependency, error) {
 }
 
 func (r *issueSQLRepositoryImpl) wispsTableEmptyOrMissing(ctx context.Context) (bool, error) {
+	return wispsTableEmptyOrMissing(ctx, r.runner)
+}
+
+func wispsTableEmptyOrMissing(ctx context.Context, runner Runner) (bool, error) {
 	var probe int
-	err := r.runner.QueryRowContext(ctx, "SELECT 1 FROM wisps LIMIT 1").Scan(&probe)
+	err := runner.QueryRowContext(ctx, "SELECT 1 FROM wisps LIMIT 1").Scan(&probe)
 	switch {
 	case err == nil:
 		return false, nil
@@ -398,6 +406,75 @@ func (r *issueSQLRepositoryImpl) wispsTableEmptyOrMissing(ctx context.Context) (
 	default:
 		return false, err
 	}
+}
+
+func buildTableIDSubquery(query string, filter types.IssueFilter, tables filterTables) (string, []any, error) {
+	plan := buildLabelDrivenSearch(filter, tables)
+	whereClauses, args, err := buildIssueFilterClauses(query, plan.Filter, tables)
+	if err != nil {
+		return "", nil, err
+	}
+	whereClauses, args = plan.MergeInto(whereClauses, args)
+
+	whereSQL := ""
+	if len(whereClauses) > 0 {
+		whereSQL = "WHERE " + strings.Join(whereClauses, " AND ")
+	}
+	selectKw := "SELECT"
+	if plan.Distinct {
+		selectKw = "SELECT DISTINCT"
+	}
+
+	//nolint:gosec // G201: fragments composed from fixed table names and ? placeholders.
+	sub := fmt.Sprintf("%s id FROM %s %s %s %s",
+		selectKw, plan.FromSQL, whereSQL,
+		orderBySQL(filter.SortBy, filter.SortDesc, ""),
+		limitOffsetSQL(filter.Limit, filter.Offset))
+	return sub, args, nil
+}
+
+// buildPageIDSubquery reproduces, as a subquery selecting ids alone, the row set
+// searchAcrossIssuesAndWisps returns for the same (query, filter). Callers join
+// against it to scope a second query to the page without materializing the ids.
+//
+// It deliberately errs toward a superset: every branch that could touch wisps
+// builds the union, including the Ephemeral case that searchAcrossIssuesAndWisps
+// handles by trying wisps first and falling through. A joined row that the page
+// then drops is harmless; a missing one loses data from the render.
+func buildPageIDSubquery(ctx context.Context, runner Runner, query string, filter types.IssueFilter) (string, []any, error) {
+	if filter.SkipWisps {
+		return buildTableIDSubquery(query, filter, issuesFilterTables)
+	}
+
+	// Not an optimization: a UNION against a wisps table that does not exist
+	// fails outright, so the probe has to gate the union, not just skip it.
+	empty, err := wispsTableEmptyOrMissing(ctx, runner)
+	if err != nil {
+		return "", nil, fmt.Errorf("probe wisps: %w", err)
+	}
+	if empty {
+		return buildTableIDSubquery(query, filter, issuesFilterTables)
+	}
+
+	iSub, iArgs, err := buildUnionSubquery(query, filter, issuesFilterTables, "i")
+	if err != nil {
+		return "", nil, fmt.Errorf("page ids (issues): %w", err)
+	}
+	wSub, wArgs, err := buildUnionSubquery(query, filter, wispsFilterTables, "w")
+	if err != nil {
+		return "", nil, fmt.Errorf("page ids (wisps): %w", err)
+	}
+
+	//nolint:gosec // G201: subqueries built from hardcoded table names and ? placeholders.
+	sub := fmt.Sprintf("SELECT id FROM (%s UNION ALL %s) merged %s %s",
+		iSub, wSub,
+		unionOrderBySQL(filter.SortBy, filter.SortDesc),
+		limitOffsetSQL(filter.Limit, filter.Offset))
+
+	args := make([]any, 0, len(iArgs)+len(wArgs))
+	args = append(args, iArgs...)
+	args = append(args, wArgs...)
+	return sub, args, nil
 }
 
 func buildLabelDrivenSearch(filter types.IssueFilter, tables filterTables) sqlbuild.LabelSearchPlan {

--- a/internal/storage/domain/db/ready_work_union.go
+++ b/internal/storage/domain/db/ready_work_union.go
@@ -11,14 +11,37 @@ import (
 )
 
 func (r *issueSQLRepositoryImpl) getReadyWorkIDPage(ctx context.Context, filter types.WorkFilter) (idSrcPage, bool, error) {
-	issuePreds, err := r.buildReadyWorkPredicates(ctx, filter, issuesFilterTables)
+	unionSQL, allArgs, err := r.buildReadyWorkIDSubquery(ctx, filter)
 	if err != nil {
 		return idSrcPage{}, false, err
 	}
 
+	rows, err := r.runner.QueryContext(ctx, unionSQL, allArgs...)
+	if err != nil {
+		return idSrcPage{}, false, fmt.Errorf("ready work union: query: %w", err)
+	}
+	page, err := scanIDSrcPage(rows, true)
+	if err != nil {
+		return idSrcPage{}, false, fmt.Errorf("ready work union: %w", err)
+	}
+	hasMore := page.trimToLimit(filter.Limit)
+	return page, hasMore, nil
+}
+
+// buildReadyWorkIDSubquery returns the id-and-source page query getReadyWorkIDPage
+// executes. It is split out so the dependency repository can embed it as a
+// subquery and scope a dependency read to the ready page without materializing
+// the ids. The returned args are ordered issue-predicates, wisp-predicates, then
+// sort args, matching the placeholder order in the SQL.
+func (r *issueSQLRepositoryImpl) buildReadyWorkIDSubquery(ctx context.Context, filter types.WorkFilter) (string, []any, error) {
+	issuePreds, err := r.buildReadyWorkPredicates(ctx, filter, issuesFilterTables)
+	if err != nil {
+		return "", nil, err
+	}
+
 	wispsEmpty, probeErr := r.wispsTableEmptyOrMissing(ctx)
 	if probeErr != nil {
-		return idSrcPage{}, false, fmt.Errorf("ready work union: wisps probe: %w", probeErr)
+		return "", nil, fmt.Errorf("ready work union: wisps probe: %w", probeErr)
 	}
 
 	subqueries := make([]string, 0, 2)
@@ -39,7 +62,7 @@ func (r *issueSQLRepositoryImpl) getReadyWorkIDPage(ctx context.Context, filter 
 		// work — issueops.getReadyWispsInTx filters them the same way.
 		wispPreds, err := r.buildReadyWorkPredicates(ctx, filter, wispsFilterTables)
 		if err != nil {
-			return idSrcPage{}, false, err
+			return "", nil, err
 		}
 		//nolint:gosec // G201: whereSQL composed from hardcoded fragments and ? placeholders.
 		wispSub := fmt.Sprintf(
@@ -65,16 +88,7 @@ func (r *issueSQLRepositoryImpl) getReadyWorkIDPage(ctx context.Context, filter 
 	)
 	allArgs = append(allArgs, sortOrder.Args...)
 
-	rows, err := r.runner.QueryContext(ctx, unionSQL, allArgs...)
-	if err != nil {
-		return idSrcPage{}, false, fmt.Errorf("ready work union: query: %w", err)
-	}
-	page, err := scanIDSrcPage(rows, true)
-	if err != nil {
-		return idSrcPage{}, false, fmt.Errorf("ready work union: %w", err)
-	}
-	hasMore := page.trimToLimit(filter.Limit)
-	return page, hasMore, nil
+	return unionSQL, allArgs, nil
 }
 
 func (r *issueSQLRepositoryImpl) getReadyWorkUnion(ctx context.Context, filter types.WorkFilter) (domain.SearchPage, error) {

--- a/internal/storage/domain/dependency.go
+++ b/internal/storage/domain/dependency.go
@@ -136,6 +136,10 @@ type DependencySQLRepository interface {
 	Delete(ctx context.Context, issueID, dependsOnID, actor string, opts DepInsertOpts) (DepDeleteResult, error)
 	HasCycle(ctx context.Context, issueID, dependsOnID string) (bool, error)
 	ListByIssueIDs(ctx context.Context, issueIDs []string, opts DepListOpts) (DepBulkResult, error)
+	// ListByIssueFilter and ListByReadyFilter scope a dependency read to a page
+	// by joining against the page's own id subquery, so no id list is sent.
+	ListByIssueFilter(ctx context.Context, query string, filter types.IssueFilter, opts DepListOpts) (DepBulkResult, error)
+	ListByReadyFilter(ctx context.Context, filter types.WorkFilter, opts DepListOpts) (DepBulkResult, error)
 	ListWithIssueMetadata(ctx context.Context, sourceID string, opts DepListOpts) ([]*types.IssueWithDependencyMetadata, error)
 	IterWithIssueMetadata(ctx context.Context, sourceID string, opts DepListOpts) (storage.Iter[types.IssueWithDependencyMetadata], error)
 	CountByID(ctx context.Context, sourceID string, opts DepListOpts) (int64, error)
@@ -177,6 +181,8 @@ type DependencyUseCase interface {
 	GetBlockingInfo(ctx context.Context, issueIDs []string) (BlockingInfo, error)
 	IsBlocked(ctx context.Context, issueID string) (bool, []string, error)
 	GetForIssueIDs(ctx context.Context, ids []string) (map[string][]*types.Dependency, error)
+	GetForIssueFilter(ctx context.Context, query string, filter types.IssueFilter) (map[string][]*types.Dependency, error)
+	GetForReadyFilter(ctx context.Context, filter types.WorkFilter) (map[string][]*types.Dependency, error)
 	DetectCycles(ctx context.Context) ([][]*types.Issue, error)
 
 	GetDependencyTree(ctx context.Context, rootID string, opts DepTreeOpts) ([]*types.TreeNode, error)
@@ -444,6 +450,53 @@ func (u *dependencyUseCaseImpl) GetForIssueIDs(ctx context.Context, ids []string
 		out[id] = append(out[id], deps...)
 	}
 	return out, nil
+}
+
+// hydrateDepsForPage merges a page's outgoing edges from both dependency planes.
+// A missing wisp_dependencies table is tolerated the same way GetForIssueIDs
+// tolerates it. The returned map is never nil on success, which lets callers use
+// a nil map to mean "not preloaded".
+func hydrateDepsForPage(
+	issues func(DepListOpts) (DepBulkResult, error),
+	label string,
+) (map[string][]*types.Dependency, error) {
+	issueRes, err := issues(DepListOpts{Direction: DepDirectionOut})
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", label, err)
+	}
+	out := issueRes.Outgoing
+	if out == nil {
+		out = make(map[string][]*types.Dependency)
+	}
+
+	wispRes, err := issues(DepListOpts{Direction: DepDirectionOut, UseWispsTable: true})
+	if err != nil && !dberrors.IsTableNotExist(err) {
+		return nil, fmt.Errorf("%s (wisps): %w", label, err)
+	}
+	for id, deps := range wispRes.Outgoing {
+		out[id] = append(out[id], deps...)
+	}
+	return out, nil
+}
+
+func hydrateDepsForIssueFilter(ctx context.Context, depRepo DependencySQLRepository, query string, filter types.IssueFilter) (map[string][]*types.Dependency, error) {
+	return hydrateDepsForPage(func(opts DepListOpts) (DepBulkResult, error) {
+		return depRepo.ListByIssueFilter(ctx, query, filter, opts)
+	}, "GetForIssueFilter")
+}
+
+func hydrateDepsForReadyFilter(ctx context.Context, depRepo DependencySQLRepository, filter types.WorkFilter) (map[string][]*types.Dependency, error) {
+	return hydrateDepsForPage(func(opts DepListOpts) (DepBulkResult, error) {
+		return depRepo.ListByReadyFilter(ctx, filter, opts)
+	}, "GetForReadyFilter")
+}
+
+func (u *dependencyUseCaseImpl) GetForIssueFilter(ctx context.Context, query string, filter types.IssueFilter) (map[string][]*types.Dependency, error) {
+	return hydrateDepsForIssueFilter(ctx, u.depRepo, query, filter)
+}
+
+func (u *dependencyUseCaseImpl) GetForReadyFilter(ctx context.Context, filter types.WorkFilter) (map[string][]*types.Dependency, error) {
+	return hydrateDepsForReadyFilter(ctx, u.depRepo, filter)
 }
 
 func (u *dependencyUseCaseImpl) ListByWispIDs(ctx context.Context, wispIDs []string, filter DepListFilter) (DepBulkResult, error) {

--- a/internal/storage/domain/issue.go
+++ b/internal/storage/domain/issue.go
@@ -272,6 +272,11 @@ type IssueUseCase interface {
 	SearchIssues(ctx context.Context, query string, filter types.IssueFilter) (SearchPage, error)
 	SearchIssuesWithCounts(ctx context.Context, query string, filter types.IssueFilter) (SearchCountsPage, error)
 	SearchIssueIDs(ctx context.Context, query string, filter types.IssueFilter) ([]string, error)
+	// ListWithDependencies and GetReadyWorkWithDependencies return a page together
+	// with its outgoing dependency edges, hydrated by joining against the page's
+	// own id subquery rather than an id list built from the returned rows.
+	ListWithDependencies(ctx context.Context, query string, filter types.IssueFilter) (SearchPage, map[string][]*types.Dependency, error)
+	GetReadyWorkWithDependencies(ctx context.Context, filter types.WorkFilter) (SearchPage, map[string][]*types.Dependency, error)
 	GetReadyWork(ctx context.Context, filter types.WorkFilter) (SearchPage, error)
 	GetReadyWorkWithCounts(ctx context.Context, filter types.WorkFilter) (SearchCountsPage, error)
 	GetDescendants(ctx context.Context, rootID string, filter types.IssueFilter) ([]*types.Issue, error)
@@ -770,6 +775,30 @@ func (u *issueUseCaseImpl) SearchIssues(ctx context.Context, query string, filte
 		return SearchPage{}, fmt.Errorf("SearchIssues: %w", err)
 	}
 	return out, nil
+}
+
+func (u *issueUseCaseImpl) ListWithDependencies(ctx context.Context, query string, filter types.IssueFilter) (SearchPage, map[string][]*types.Dependency, error) {
+	page, err := u.SearchIssues(ctx, query, filter)
+	if err != nil {
+		return SearchPage{}, nil, err
+	}
+	deps, err := hydrateDepsForIssueFilter(ctx, u.depRepo, query, filter)
+	if err != nil {
+		return SearchPage{}, nil, fmt.Errorf("ListWithDependencies: %w", err)
+	}
+	return page, deps, nil
+}
+
+func (u *issueUseCaseImpl) GetReadyWorkWithDependencies(ctx context.Context, filter types.WorkFilter) (SearchPage, map[string][]*types.Dependency, error) {
+	page, err := u.GetReadyWork(ctx, filter)
+	if err != nil {
+		return SearchPage{}, nil, err
+	}
+	deps, err := hydrateDepsForReadyFilter(ctx, u.depRepo, filter)
+	if err != nil {
+		return SearchPage{}, nil, fmt.Errorf("GetReadyWorkWithDependencies: %w", err)
+	}
+	return page, deps, nil
 }
 
 func (u *issueUseCaseImpl) SearchIssueIDs(ctx context.Context, query string, filter types.IssueFilter) ([]string, error) {


### PR DESCRIPTION
## Problem

Hydrating dependencies for a page of issues built an `IN (...)` clause out of the page's issue ids. The statement grew with the page, and the whole id list had to be materialized in Go and sent to the server on every `bd list` / `bd ready`.

## Change

Join the dependency tables against the page's *own* id subquery instead. The filter is expressed once, in SQL, and the statement size no longer depends on how many issues came back — no id list crosses the wire at all.

- `buildPageIDSubquery` (`issue_search.go`) mirrors `searchAcrossIssuesAndWisps`' branching for the `IssueFilter` side.
- `buildReadyWorkIDSubquery` is split out of `getReadyWorkIDPage` for the `WorkFilter` side.
- Both err deliberately toward a **superset** of the page: a joined row the page later drops is harmless, a missing one loses data from the render. The wisps-empty/missing probe still gates the union — a `UNION` against a nonexistent `wisps` table errors outright, so that branch is required, not an optimization.
- Dependency rows now order by `issue_id, depends_on_id, type`. `issue_id` alone is not a total order when one source has several edges.

The page and its edges come back from a single use-case call — `ListWithDependencies` / `GetReadyWorkWithDependencies` — so the two halves cannot drift apart at the call site. `bd ready`'s parent-epic map reuses the edges the caller already loaded rather than re-reading them, which removes a second full hydration outright.

The watch loop and the hierarchical `--parent` tree keep the id-list path: neither page comes from a single filtered query, so no subquery reproduces them. `ListByIssueIDs` / `GetForIssueIDs` are unchanged and still serve those callers.

## Verification

- `go build ./...`, `go vet ./internal/storage/... ./cmd/bd/...` clean.
- `go test ./internal/storage/domain/...` and `go test ./cmd/bd/... ./internal/storage/...` pass.
- Behavioral diff against `main`: two binaries run side by side on a seeded workspace (8 issues, 3 `blocks` edges, 1 `parent-child`, 1 label). **17 command variants byte-identical** — plain / `--limit` / `--offset` / `--sort --reverse` / `--json` / `--deps full` / `--format` / `--tree` / `--label` / `--status --priority` / `--parent` / `--ready`, plus `ready`, `ready --json`, `ready explain`, and an explicit `--proxied-server` run.

## Notes for review

- The filter is still evaluated twice per list — once for the page, once inside the dep query's subquery. Collapsing that into one statement was considered and deliberately deferred; it would mean scanning issue columns repeated per edge.
- The highest-risk path is a label-driven filter, where `plan.Distinct` puts a `SELECT DISTINCT id` inside the join. That changes row multiplicity in a way the search's own hydration never had to handle, and it is worth a careful look.
- Not verified by hand: a repo with no `wisps` table (covered only by the existing suite), and a page large enough for the old `IN` clause to actually hurt — the manual diff confirms correctness, not the speedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)