### PR TITLE
Reject "list"/"add" as the id in the singular "comment" shorthand

### DIFF
--- a/cmd/bd/cli_fast_test.go
+++ b/cmd/bd/cli_fast_test.go
@@ -1402,6 +1402,173 @@ func TestCLI_CommentsAddShortID(t *testing.T) {
 	})
 }
 
+// TestCLI_CommentListMisplacedSyntax is a regression test for the singular
+// "comment" shorthand silently mis-resolving a subcommand-like typo as an
+// issue id. "bd comment list <text>" (meant as an attempt to list comments,
+// using the singular noun by mistake) used to parse as id="list",
+// text=[<text>...] with no validation on the id — since no issue is
+// literally named "list", ResolvePartialID's substring/prefix fallback
+// would silently match it against whatever existing bead or wisp id
+// happened to contain "list" and post the comment there instead of
+// erroring. This asserts both halves of the fix: the command is rejected
+// with a helpful hint (mirroring TestCLI_CommentsListMisplacedSyntax for
+// the plural sibling), AND — the part that actually matters for this
+// specific bug — no comment silently landed on an unrelated real issue.
+func TestCLI_CommentListMisplacedSyntax(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := setupCLITestDB(t)
+
+	out := runBDInProcess(t, tmpDir, "create", "Bystander issue", "-p", "1", "--json")
+	jsonStart := strings.Index(out, "{")
+	if jsonStart < 0 {
+		t.Fatalf("No JSON found in create output: %s", out)
+	}
+	var issue map[string]interface{}
+	if err := json.Unmarshal([]byte(out[jsonStart:]), &issue); err != nil {
+		t.Fatalf("Failed to parse create JSON: %v\nOutput: %s", err, out)
+	}
+	fullID := issue["id"].(string)
+
+	stdout, stderr, err := runBDInProcessAllowError(t, tmpDir, "comment", "list", "accidental stray text")
+	if err == nil {
+		t.Fatalf("expected non-zero exit, got stdout=%q stderr=%q", stdout, stderr)
+	}
+	combined := stdout + stderr
+	if !strings.Contains(combined, "bd comments") || !strings.Contains(combined, "<issue-id>") {
+		t.Fatalf("expected hint pointing at bd comments <issue-id>, got stdout=%q stderr=%q", stdout, stderr)
+	}
+
+	// The regression check: the bystander issue must have received NO
+	// comment. Pre-fix, this could silently succeed and land a comment on
+	// whatever bead's id happened to contain "list" as a substring — this
+	// DB has exactly one issue, so any stray write would show up here.
+	commentsOut := runBDInProcess(t, tmpDir, "comments", fullID, "--json")
+	trimmed := strings.TrimSpace(commentsOut)
+	if trimmed != "[]" && trimmed != "null" {
+		t.Fatalf("expected no comments on bystander issue %s after rejected 'comment list', got: %s", fullID, commentsOut)
+	}
+}
+
+// TestCLI_CommentAddMisplacedSyntax mirrors TestCLI_CommentListMisplacedSyntax
+// for the symmetric "add" typo — a caller who confuses the singular shorthand
+// with the plural's "bd comments add <id> <text>" form might type
+// "bd comment add <id> <text>", which the same unguarded id-resolution bug
+// would parse as id="add", text=[<id>, <text>...].
+func TestCLI_CommentAddMisplacedSyntax(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := setupCLITestDB(t)
+
+	out := runBDInProcess(t, tmpDir, "create", "Bystander issue for add-typo", "-p", "1", "--json")
+	jsonStart := strings.Index(out, "{")
+	if jsonStart < 0 {
+		t.Fatalf("No JSON found in create output: %s", out)
+	}
+	var issue map[string]interface{}
+	if err := json.Unmarshal([]byte(out[jsonStart:]), &issue); err != nil {
+		t.Fatalf("Failed to parse create JSON: %v\nOutput: %s", err, out)
+	}
+	fullID := issue["id"].(string)
+
+	stdout, stderr, err := runBDInProcessAllowError(t, tmpDir, "comment", "add", fullID, "accidental stray text")
+	if err == nil {
+		t.Fatalf("expected non-zero exit, got stdout=%q stderr=%q", stdout, stderr)
+	}
+	combined := stdout + stderr
+	if !strings.Contains(combined, "bd comments add") {
+		t.Fatalf("expected hint pointing at bd comments add <issue-id>, got stdout=%q stderr=%q", stdout, stderr)
+	}
+
+	commentsOut := runBDInProcess(t, tmpDir, "comments", fullID, "--json")
+	trimmed := strings.TrimSpace(commentsOut)
+	if trimmed != "[]" && trimmed != "null" {
+		t.Fatalf("expected no comments on bystander issue %s after rejected 'comment add', got: %s", fullID, commentsOut)
+	}
+}
+
+// TestCLI_CommentMisplacedSyntaxRejectedBeforeStoreOpen proves the guard
+// fires from commentCmd's Args validator, before PersistentPreRunE ever
+// opens a store, mirroring
+// TestCLI_CommentsSwappedAddRejectedBeforeStoreOpen for the plural sibling.
+// Using a directory with no .beads/ at all proves the store was never
+// touched: a RunE-only check would have failed first with "no beads
+// database found".
+func TestCLI_CommentMisplacedSyntaxRejectedBeforeStoreOpen(t *testing.T) {
+	noBeadsCwd := t.TempDir()
+	if _, err := os.Stat(filepath.Join(noBeadsCwd, ".beads")); err == nil {
+		t.Fatalf("test setup: %s unexpectedly has a .beads dir", noBeadsCwd)
+	}
+
+	stdout, stderr, err := runBDInProcessAllowError(t, noBeadsCwd, "comment", "list", "should not be stored")
+	if err == nil {
+		t.Fatalf("expected non-zero exit for misplaced 'comment list', got success:\nstdout: %s", stdout)
+	}
+	combined := stdout + stderr
+	if strings.Contains(combined, "no beads database found") {
+		t.Fatalf("Args validation did not run before store open: got the pre-fix error.\nOutput:\n%s", combined)
+	}
+	if !strings.Contains(combined, "bd comments") {
+		t.Errorf("expected hint pointing to `bd comments`, got:\n%s", combined)
+	}
+}
+
+// TestCLI_CommentMisplacedSyntaxRejectedInProxiedServerMode is the
+// proxied-server counterpart, mirroring
+// TestCLI_CommentsSwappedAddRejectedInProxiedServerMode: because
+// validateCommentArgs runs in Args — before RunE ever branches on
+// usesProxiedServer() — the rejection fires identically regardless of
+// backend, without needing a real proxied server.
+func TestCLI_CommentMisplacedSyntaxRejectedInProxiedServerMode(t *testing.T) {
+	origProxied := proxiedServerMode
+	t.Cleanup(func() { proxiedServerMode = origProxied })
+	proxiedServerMode = true
+
+	tmpDir := setupCLITestDB(t)
+	stdout, stderr, err := runBDInProcessAllowError(t, tmpDir, "comment", "list", "should not be stored")
+	if err == nil {
+		t.Fatalf("expected non-zero exit for misplaced 'comment list' in proxied-server mode, got success:\nstdout: %s", stdout)
+	}
+	combined := stdout + stderr
+	if !strings.Contains(combined, "bd comments") {
+		t.Errorf("expected hint pointing to `bd comments`, got:\n%s", combined)
+	}
+}
+
+// TestCLI_CommentTextStartingWithReservedWordStillWorks confirms the fix is
+// scoped to the id positional argument only: a real id followed by comment
+// TEXT that happens to start with "list" or "add" must still work exactly
+// as before, since args[0] (the id slot) is what's checked, never the text.
+func TestCLI_CommentTextStartingWithReservedWordStillWorks(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := setupCLITestDB(t)
+
+	out := runBDInProcess(t, tmpDir, "create", "Issue for reserved-word-text test", "-p", "1", "--json")
+	jsonStart := strings.Index(out, "{")
+	if jsonStart < 0 {
+		t.Fatalf("No JSON found in create output: %s", out)
+	}
+	var issue map[string]interface{}
+	if err := json.Unmarshal([]byte(out[jsonStart:]), &issue); err != nil {
+		t.Fatalf("Failed to parse create JSON: %v\nOutput: %s", err, out)
+	}
+	fullID := issue["id"].(string)
+
+	stdout, stderr, err := runBDInProcessAllowError(t, tmpDir, "comment", fullID, "list", "of", "things", "to", "do")
+	if err != nil {
+		t.Fatalf("comment with text starting in 'list' unexpectedly failed: %v\nstdout: %s\nstderr: %s", err, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "Comment added") {
+		t.Errorf("Expected 'Comment added' in output, got: %s", stdout)
+	}
+
+	commentsOut := runBDInProcess(t, tmpDir, "comments", fullID, "--json")
+	if !strings.Contains(commentsOut, "list of things to do") {
+		t.Fatalf("expected comment text to be stored verbatim, got: %s", commentsOut)
+	}
+}
+
 // TestCLI_CreateRejectsFlagLikeTitles verifies that positional arguments starting
 // with - or -- are rejected as likely misinterpreted flags (bd-2c0).
 func TestCLI_CreateRejectsFlagLikeTitles(t *testing.T) {

--- a/cmd/bd/comment.go
+++ b/cmd/bd/comment.go
@@ -11,6 +11,46 @@ import (
 	"github.com/steveyegge/beads/internal/ui"
 )
 
+// validateCommentArgs runs as cobra's Args validation for the singular
+// "comment" shorthand, before RunE's usesProxiedServer() dispatch and (on
+// the local/embedded path) before the id ever reaches ResolvePartialID's
+// fuzzy/substring matching. "comment" has no subcommands of its own — its
+// only job is "add a comment to <id>" — so when the id positional argument
+// is exactly a word that IS a real subcommand on the plural sibling ("list",
+// "add"), the near-certain explanation is that the caller confused the
+// singular and plural forms, not that a bead is genuinely named "list" or
+// "add" (real ids always carry a prefix+hyphen — see looksLikePrefixedID).
+// Left unguarded, that word silently resolves via ResolvePartialID's
+// substring/prefix fallback to whatever existing bead or wisp id happens to
+// contain it, and the comment lands on the WRONG issue with no error.
+func validateCommentArgs(cmd *cobra.Command, args []string) error {
+	if err := cobra.MinimumNArgs(1)(cmd, args); err != nil {
+		return err
+	}
+	switch args[0] {
+	case "list":
+		return HandleErrorRespectJSON(`"bd comment list ..." is not valid — "comment" (singular) takes an issue id first and has no "list" subcommand.
+
+To list comments on an issue:
+  bd comments <issue-id>
+
+To add a comment:
+  bd comment <issue-id> "text"
+
+See: bd comment --help`)
+	case "add":
+		return HandleErrorRespectJSON(`"bd comment add ..." is not valid — "comment" (singular) already means "add a comment" and takes an issue id first, not the word "add".
+
+To add a comment:
+  bd comment <issue-id> "text"
+
+("add" is only a subcommand of the plural form: bd comments add <issue-id> "text".)
+
+See: bd comment --help`)
+	}
+	return nil
+}
+
 var commentCmd = &cobra.Command{
 	Use:     "comment <id> [text...]",
 	GroupID: "issues",
@@ -23,8 +63,11 @@ Examples:
   bd comment bd-123 "Working on this now"
   bd comment bd-123 Working on this now
   echo "comment from pipe" | bd comment bd-123 --stdin
-  bd comment bd-123 --file notes.txt`,
-	Args:          cobra.MinimumNArgs(1),
+  bd comment bd-123 --file notes.txt
+
+Note: "comment" (singular) only adds a comment — it has no "list" subcommand.
+To list comments on an issue, use the plural form: bd comments <id>`,
+	Args:          validateCommentArgs,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/bd/comment_test.go
+++ b/cmd/bd/comment_test.go
@@ -1,0 +1,42 @@
+package main
+
+import "testing"
+
+// TestValidateCommentArgs is a pure unit test for the singular "comment"
+// shorthand's Args guard — it calls the validator directly with no store, no
+// Dolt, and no cobra dispatch, so it runs regardless of cgo/Docker
+// availability. Message-content assertions for the two rejected cases live in
+// the CLI-level TestCLI_Comment{List,Add}MisplacedSyntax tests alongside the
+// plural sibling's equivalents; this test only pins down which shapes are
+// accepted vs rejected.
+func TestValidateCommentArgs(t *testing.T) {
+	origJSONOutput := jsonOutput
+	jsonOutput = false
+	t.Cleanup(func() { jsonOutput = origJSONOutput })
+
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{name: "bare list is rejected (the reported typo)", args: []string{"list", "some text"}, wantErr: true},
+		{name: "bare list with no text is still rejected", args: []string{"list"}, wantErr: true},
+		{name: "bare add is rejected (mirrors comments swapped-add)", args: []string{"add", "some text"}, wantErr: true},
+		{name: "real id with text starting with the word list is fine", args: []string{"test-abc123", "list", "of", "things", "to", "do"}, wantErr: false},
+		{name: "real id with text starting with the word add is fine", args: []string{"test-abc123", "add", "one", "more", "item"}, wantErr: false},
+		{name: "real id alone (text comes from --stdin/--file) is fine", args: []string{"test-abc123"}, wantErr: false},
+		{name: "no args at all is rejected by the base MinimumNArgs check", args: []string{}, wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateCommentArgs(commentCmd, tc.args)
+			if tc.wantErr && err == nil {
+				t.Fatalf("validateCommentArgs(%q): expected an error, got nil", tc.args)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("validateCommentArgs(%q): expected no error, got %v", tc.args, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

`bd comment <id> [text...]` had no validation on the `id` positional
argument. Typing `bd comment list <text>` (confusing the singular
shorthand with the plural `bd comments list` guard) parsed as
`id="list"`, and since no issue is literally named "list",
`ResolvePartialID`'s substring/prefix fallback silently matched "list"
against whichever existing bead/wisp id happened to contain it as a
prefix (after `wisp-` stripping) — posting the comment on the *wrong*
issue with no error or warning.

This adds `validateCommentArgs`, wired as `commentCmd`'s `Args`
validator, rejecting the literal words `"list"` and `"add"` as the id
(mirroring the existing guard on the plural sibling,
`validateCommentsArgs` in `comments.go`) with a message pointing at the
correct invocation. It runs before `RunE`'s dispatch, so both the
embedded and proxied-server backends reject identically.

## Why

This exact typo recurred 10+ times across multiple independent sessions
in one downstream deployment over a single day, each time silently
posting a stray comment onto an unrelated, real issue (evidenced by
that issue's comment history). No error, no warning — `✓ Comment added`
prints either way, so the mistake is only caught by noticing the
returned `issue_id` doesn't match what was intended.

The broader pattern — `ResolvePartialID`'s substring-fallback resolving
to an unintended issue for *any* wrong/typo'd id, on any command that
takes a mutating `<id>` positional, not just `comment` — is a separate,
larger question (worth asking: should write commands require an exact
match rather than fuzzy-resolve at all?). Deliberately **not** addressed
here, per this repo's "one issue per PR" hygiene rule — this PR only
closes the concrete, evidenced footgun in the singular/plural `comment`
shorthand pair, which is the only command pair of this shape in the
codebase (checked: no other singular command has a plural sibling with
real subcommands whose names could collide with its own id slot the
way `comment`/`comments` do).

## Verification

- `go build ./...` — clean.
- `go vet ./cmd/bd/...` — clean.
- `go test ./cmd/bd/... -run TestValidateCommentArgs -v` — all 7
  subtests pass (pure unit test, no store needed).
- `go test -tags integration ./cmd/bd/... -run TestCLI_Comment -v` —
  the DB-independent subset (`*RejectedBeforeStoreOpen`) passes; the
  rest of that suite requires a local Dolt/Docker test container that
  wasn't available in this sandbox, so those cases skip rather than
  run here (should execute under this repo's CI).
- Confirmed no regression: ran the full (non-integration)
  `./cmd/bd/` package suite both on this branch and on unmodified
  `origin/main` in the same sandbox — 4 pre-existing failures
  (`TestCheckHooksDriftNotGitRepo`,
  `TestCollectViperEntriesWithEnvOverride`,
  `TestPrepareSelectedCommandContext_RebindsTargetConfig`,
  `TestPrepareSelectedCommandContext_DoesNotMergeCallerConfigForUnsetKeys`)
  reproduce identically on both, caused by ambient `BD_ACTOR`/
  `BEADS_ACTOR`/git-ceiling env vars in this particular sandbox, not by
  this change. Not added to `.test-skip` since they appear
  environment-specific to this sandbox rather than general.
