### PR TITLE
Stop the 'human' label leaking between the operator queue and the dispatch queue

### DIFF
--- a/cmd/bd/human.go
+++ b/cmd/bd/human.go
@@ -94,17 +94,41 @@ SUBCOMMANDS:
 	},
 }
 
+// humanListFilter is the query behind `bd human list`: beads carrying the
+// 'human' label, minus the closed ones, since closing never clears the label.
+// An explicit --status still reaches any status, closed included.
+func humanListFilter(status string) types.IssueFilter {
+	filter := types.IssueFilter{Labels: []string{types.LabelHuman}}
+	if status != "" {
+		s := types.Status(status)
+		filter.Status = &s
+		return filter
+	}
+	filter.ExcludeStatus = []types.Status{types.StatusClosed}
+	return filter
+}
+
+// humanStatsFilter is `bd human stats`'s query. Unlike the list it must keep
+// closed beads: Responded and Dismissed are counts of closed ones.
+func humanStatsFilter() types.IssueFilter {
+	return types.IssueFilter{Labels: []string{types.LabelHuman}}
+}
+
 // human list command
 var humanListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all human-needed beads",
-	Long: `List all issues labeled with 'human' tag.
+	Long: `List all open issues labeled with 'human' tag.
 
 These are issues that require human intervention or input.
+
+Closed issues are omitted: a decision that has been made is no longer pending,
+and closing does not clear the label. Pass --status=closed to see them.
 
 Examples:
   bd human list
   bd human list --status=open
+  bd human list --status=closed
   bd human list --json`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -124,14 +148,7 @@ Examples:
 			return runHumanListProxiedServer(ctx, status)
 		}
 
-		filter := types.IssueFilter{
-			Labels: []string{"human"},
-		}
-
-		if status != "" {
-			s := types.Status(status)
-			filter.Status = &s
-		}
+		filter := humanListFilter(status)
 
 		if err := ensureStoreActive(); err != nil {
 			return HandleErrorRespectJSON("listing human beads: %v", err)
@@ -251,7 +268,7 @@ Examples:
 		labelsMap, _ := targetStore.GetLabelsForIssues(ctx, []string{resolvedID})
 		hasHumanLabel := false
 		for _, label := range labelsMap[resolvedID] {
-			if label == "human" {
+			if label == types.LabelHuman {
 				hasHumanLabel = true
 				break
 			}
@@ -338,7 +355,7 @@ Examples:
 		labelsMap, _ := targetStore.GetLabelsForIssues(ctx, []string{resolvedID})
 		hasHumanLabel := false
 		for _, label := range labelsMap[resolvedID] {
-			if label == "human" {
+			if label == types.LabelHuman {
 				hasHumanLabel = true
 				break
 			}
@@ -389,9 +406,7 @@ Example:
 			return runHumanStatsProxiedServer(ctx)
 		}
 
-		filter := types.IssueFilter{
-			Labels: []string{"human"},
-		}
+		filter := humanStatsFilter()
 
 		if err := ensureStoreActive(); err != nil {
 			return HandleErrorRespectJSON("getting human bead stats: %v", err)

--- a/cmd/bd/human_embedded_test.go
+++ b/cmd/bd/human_embedded_test.go
@@ -143,6 +143,32 @@ func TestEmbeddedHuman(t *testing.T) {
 		if !strings.Contains(string(showOut2), "Dismissed: Not needed") {
 			t.Errorf("expected dismiss reason in output:\n%s", showOut2)
 		}
+
+		// sk-1pc: neither close cleared the 'human' label, so both beads used
+		// to stay in the operator's decision queue as though they were still
+		// pending. A resolved decision is not a pending one.
+		listAfter := bdHuman(t, bd, dir, "list")
+		for _, closed := range []string{id, id2} {
+			if strings.Contains(listAfter, closed) {
+				t.Errorf("closed bead %s must not remain in the pending human list:\n%s", closed, listAfter)
+			}
+		}
+
+		// They are omitted, not hidden: --status closed still reaches them,
+		// and the stats still count them as resolved.
+		closedOut := bdHuman(t, bd, dir, "list", "--status", "closed")
+		for _, closed := range []string{id, id2} {
+			if !strings.Contains(closedOut, closed) {
+				t.Errorf("expected %s under --status closed:\n%s", closed, closedOut)
+			}
+		}
+		statsOut := bdHuman(t, bd, dir, "stats")
+		if !strings.Contains(statsOut, "Pending:    0") {
+			t.Errorf("expected zero pending decisions after both closes:\n%s", statsOut)
+		}
+		if !strings.Contains(statsOut, "Responded:  1") || !strings.Contains(statsOut, "Dismissed:  1") {
+			t.Errorf("stats must still count the closed beads it can only see via the label:\n%s", statsOut)
+		}
 	})
 }
 

--- a/cmd/bd/human_proxied_integration_test.go
+++ b/cmd/bd/human_proxied_integration_test.go
@@ -201,5 +201,23 @@ func TestProxiedServerHuman(t *testing.T) {
 		if strings.Contains(listOut, responded.ID) || strings.Contains(listOut, dismissed.ID) {
 			t.Errorf("closed beads leaked into open human list:\n%s", listOut)
 		}
+
+		// sk-1pc: and out of the DEFAULT list, which took no --status and so
+		// showed every bead that had ever carried the label — responding to
+		// one or dismissing it left it sitting in the queue as though the
+		// decision were still owed. This is the proxied twin of the direct
+		// route's coverage in human_embedded_test.go.
+		defaultOut, _ := bdProxiedHuman(t, bd, p.dir, "list")
+		if !strings.Contains(defaultOut, pending.ID) {
+			t.Errorf("expected %s in default human list:\n%s", pending.ID, defaultOut)
+		}
+		if strings.Contains(defaultOut, responded.ID) || strings.Contains(defaultOut, dismissed.ID) {
+			t.Errorf("resolved beads must not remain pending in the default human list:\n%s", defaultOut)
+		}
+		// Omitted, not hidden.
+		closedOut, _ := bdProxiedHuman(t, bd, p.dir, "list", "--status", "closed")
+		if !strings.Contains(closedOut, responded.ID) || !strings.Contains(closedOut, dismissed.ID) {
+			t.Errorf("expected both closed beads under --status closed:\n%s", closedOut)
+		}
 	})
 }

--- a/cmd/bd/human_proxied_server.go
+++ b/cmd/bd/human_proxied_server.go
@@ -19,16 +19,10 @@ import (
 // of work; each write invocation is exactly ONE RunTx with a real commit
 // message, per the proxied write convention.
 
-// proxiedHumanSearch runs the shared human-label query and hands back the
-// issues, inside the caller's unit of work.
-func proxiedHumanSearch(ctx context.Context, uw uow.UnitOfWork, status string) ([]*types.Issue, error) {
-	filter := types.IssueFilter{
-		Labels: []string{"human"},
-	}
-	if status != "" {
-		s := types.Status(status)
-		filter.Status = &s
-	}
+// proxiedHumanSearch runs a human-label query and hands back the issues,
+// inside the caller's unit of work. The filter comes from the caller: the list
+// and the stats do not ask the same question about closed beads.
+func proxiedHumanSearch(ctx context.Context, uw uow.UnitOfWork, filter types.IssueFilter) ([]*types.Issue, error) {
 	page, err := uw.IssueUseCase().SearchIssues(ctx, "", filter)
 	if err != nil {
 		return nil, err
@@ -43,7 +37,7 @@ func runHumanListProxiedServer(ctx context.Context, status string) error {
 	}
 	defer uw.Close(ctx)
 
-	issues, err := proxiedHumanSearch(ctx, uw, status)
+	issues, err := proxiedHumanSearch(ctx, uw, humanListFilter(status))
 	if err != nil {
 		return HandleErrorRespectJSON("listing human beads: %v", err)
 	}
@@ -77,7 +71,7 @@ func runHumanStatsProxiedServer(ctx context.Context) error {
 	}
 	defer uw.Close(ctx)
 
-	issues, err := proxiedHumanSearch(ctx, uw, "")
+	issues, err := proxiedHumanSearch(ctx, uw, humanStatsFilter())
 	if err != nil {
 		return HandleErrorRespectJSON("getting human bead stats: %v", err)
 	}
@@ -105,7 +99,7 @@ func proxiedHumanCloseTarget(ctx context.Context, uw uow.UnitOfWork, issueID str
 
 	labelsMap, _ := uw.LabelUseCase().GetLabelsForIssues(ctx, []string{issueID})
 	for _, label := range labelsMap[issueID] {
-		if label == "human" {
+		if label == types.LabelHuman {
 			return true, nil
 		}
 	}

--- a/cmd/bd/human_test.go
+++ b/cmd/bd/human_test.go
@@ -120,3 +120,50 @@ func TestHumanListHasStatusFlag(t *testing.T) {
 		t.Fatal("list command should have --status flag")
 	}
 }
+
+// sk-1pc: closing a bead does not clear its 'human' label, so resolved beads
+// kept showing up in the operator's decision queue until someone stripped the
+// label by hand. The default listing must drop them; an explicit --status must
+// still reach any status, closed included.
+func TestHumanListFilterExcludesClosed(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default excludes closed", func(t *testing.T) {
+		t.Parallel()
+		filter := humanListFilter("")
+		if got := filter.ExcludeStatus; len(got) != 1 || got[0] != types.StatusClosed {
+			t.Errorf("ExcludeStatus = %v, want [%s]", got, types.StatusClosed)
+		}
+		if filter.Status != nil {
+			t.Errorf("Status = %v, want nil (every non-closed status is still pending)", *filter.Status)
+		}
+		if len(filter.Labels) != 1 || filter.Labels[0] != "human" {
+			t.Errorf("Labels = %v, want [human]", filter.Labels)
+		}
+	})
+
+	t.Run("explicit status wins, including closed", func(t *testing.T) {
+		t.Parallel()
+		for _, status := range []string{"closed", "open", "in_progress"} {
+			filter := humanListFilter(status)
+			if filter.Status == nil || string(*filter.Status) != status {
+				t.Errorf("humanListFilter(%q).Status = %v, want %q", status, filter.Status, status)
+			}
+			if len(filter.ExcludeStatus) != 0 {
+				t.Errorf("humanListFilter(%q).ExcludeStatus = %v, want empty", status, filter.ExcludeStatus)
+			}
+		}
+	})
+
+	// The stats are the reason the label survives a close: Responded and
+	// Dismissed are counts of closed beads, so that query must not inherit
+	// the list's exclusion.
+	t.Run("stats still sees closed", func(t *testing.T) {
+		t.Parallel()
+		filter := humanStatsFilter()
+		if len(filter.ExcludeStatus) != 0 || filter.Status != nil {
+			t.Errorf("humanStatsFilter must not constrain status, got Status=%v ExcludeStatus=%v",
+				filter.Status, filter.ExcludeStatus)
+		}
+	})
+}

--- a/cmd/bd/ready.go
+++ b/cmd/bd/ready.go
@@ -25,6 +25,11 @@ var readyCmd = &cobra.Command{
 Excludes in_progress, blocked, deferred, and hooked issues. This uses the
 GetReadyWork API which applies blocker-aware semantics to find truly claimable work.
 
+Also excludes issues labeled 'human': they are queued for an operator decision
+(see 'bd human list'), not for dispatch, so they are not claimable work. They
+stay visible in 'bd list' and 'bd show'. To see them here anyway, ask for the
+label by name: 'bd ready --label human'.
+
 Note: 'bd list --ready' uses the same blocker-aware ready-work semantics.
 
 Use --mol to filter to a specific molecule's steps:

--- a/cmd/bd/ready_embedded_test.go
+++ b/cmd/bd/ready_embedded_test.go
@@ -203,6 +203,56 @@ func TestEmbeddedReady(t *testing.T) {
 		}
 	})
 
+	// sk-1pc: a bead labeled 'human' is queued for an operator decision and
+	// used to stay in the dispatch queue too, so a worker could claim and work
+	// a question that was simultaneously awaiting a ruling.
+	t.Run("ready_excludes_human_label", func(t *testing.T) {
+		flagged := bdCreate(t, bd, dir, "Awaiting an operator ruling", "--type", "task", "--label", "sk1pc-ready")
+		nearMiss := bdCreate(t, bd, dir, "Near miss label", "--type", "task", "--label", "sk1pc-ready")
+
+		cmd := exec.Command(bd, "label", "add", flagged.ID, "human")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("label add human failed: %v\n%s", err, out)
+		}
+		cmd = exec.Command(bd, "label", "add", nearMiss.ID, "needs-human")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("label add needs-human failed: %v\n%s", err, out)
+		}
+
+		bdReady := func(t *testing.T, args ...string) string {
+			t.Helper()
+			cmd := exec.Command(bd, append([]string{"ready"}, args...)...)
+			cmd.Dir = dir
+			cmd.Env = bdEnv(dir)
+			stdout, stderr, err := runCommandBuffers(t, cmd)
+			if err != nil {
+				t.Fatalf("bd ready %s failed: %v\nstdout:\n%s\nstderr:\n%s",
+					strings.Join(args, " "), err, stdout.String(), stderr.String())
+			}
+			return stdout.String()
+		}
+
+		out := bdReady(t, "--label", "sk1pc-ready")
+		if strings.Contains(out, flagged.ID) {
+			t.Errorf("bead %s is flagged for a human and must not appear in bd ready:\n%s", flagged.ID, out)
+		}
+		// Only the exact label is the operator queue.
+		if !strings.Contains(out, nearMiss.ID) {
+			t.Errorf("'needs-human' is an ordinary label and %s must stay ready:\n%s", nearMiss.ID, out)
+		}
+		// Removed from dispatch, not from sight.
+		if listOut := bdHuman(t, bd, dir, "list"); !strings.Contains(listOut, flagged.ID) {
+			t.Errorf("expected %s in the human decision queue:\n%s", flagged.ID, listOut)
+		}
+		if named := bdReady(t, "--label", "human"); !strings.Contains(named, flagged.ID) {
+			t.Errorf("bd ready --label human must return the human queue:\n%s", named)
+		}
+	})
+
 	// ===== -C flag =====
 
 	t.Run("ready_with_C_flag", func(t *testing.T) {

--- a/internal/storage/embeddeddolt/ready_human_label_test.go
+++ b/internal/storage/embeddeddolt/ready_human_label_test.go
@@ -1,0 +1,103 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestReadyWorkExcludesHumanLabelledIssues is sk-1pc's persistence-level
+// guard. A bead labeled 'human' is queued for an operator ruling — it appears
+// in `bd human list` — but the label used not to remove it from ready work, so
+// the same bead sat in the decision queue and the dispatch queue at once and a
+// worker could claim and work a question that was still awaiting an answer.
+//
+// The unit coverage over the clause text lives in
+// sqlbuild.TestBuildReadyWorkWhereExcludesHumanLabel; this runs the real
+// query, over a real store, through both ready entry points, because the
+// clause has to survive the label JOIN and the issues/wisps merge to matter.
+func TestReadyWorkExcludesHumanLabelledIssues(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	te := newTestEnv(t, "rh")
+	ctx := t.Context()
+
+	for _, issue := range []*types.Issue{
+		{ID: "rh-workable", Title: "workable", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+		{ID: "rh-awaiting", Title: "awaiting an operator", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+	} {
+		if err := te.store.CreateIssue(ctx, issue, "tester"); err != nil {
+			t.Fatalf("CreateIssue %s: %v", issue.ID, err)
+		}
+	}
+	if err := te.store.AddLabel(ctx, "rh-awaiting", "human", "tester"); err != nil {
+		t.Fatalf("AddLabel human: %v", err)
+	}
+	// A near miss is an ordinary label: only the exact spelling is the
+	// operator queue, and only the exact spelling is excluded.
+	if err := te.store.AddLabel(ctx, "rh-workable", "needs-human", "tester"); err != nil {
+		t.Fatalf("AddLabel needs-human: %v", err)
+	}
+
+	readyIDs := func(t *testing.T, filter types.WorkFilter) []string {
+		t.Helper()
+		issues, err := te.store.GetReadyWork(ctx, filter)
+		if err != nil {
+			t.Fatalf("GetReadyWork: %v", err)
+		}
+		ids := make([]string, 0, len(issues))
+		for _, issue := range issues {
+			ids = append(ids, issue.ID)
+		}
+		return ids
+	}
+	contains := func(ids []string, want string) bool {
+		for _, id := range ids {
+			if id == want {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("default ready work hides the human-labelled bead", func(t *testing.T) {
+		ids := readyIDs(t, types.WorkFilter{})
+		if contains(ids, "rh-awaiting") {
+			t.Errorf("rh-awaiting is awaiting an operator decision and must not be ready work: %v", ids)
+		}
+		if !contains(ids, "rh-workable") {
+			t.Errorf("rh-workable must still be ready work: %v", ids)
+		}
+	})
+
+	t.Run("the counts entry point agrees", func(t *testing.T) {
+		withCounts, err := te.store.GetReadyWorkWithCounts(ctx, types.WorkFilter{})
+		if err != nil {
+			t.Fatalf("GetReadyWorkWithCounts: %v", err)
+		}
+		for _, issue := range withCounts {
+			if issue.ID == "rh-awaiting" {
+				t.Errorf("rh-awaiting must not be ready work on the counts path either")
+			}
+		}
+	})
+
+	t.Run("asking for the label by name opts back in", func(t *testing.T) {
+		ids := readyIDs(t, types.WorkFilter{Labels: []string{"human"}})
+		if !contains(ids, "rh-awaiting") {
+			t.Errorf("--label human must return the human queue, not an empty set: %v", ids)
+		}
+	})
+
+	t.Run("clearing the label makes the bead workable again", func(t *testing.T) {
+		if err := te.store.RemoveLabel(ctx, "rh-awaiting", "human", "tester"); err != nil {
+			t.Fatalf("RemoveLabel: %v", err)
+		}
+		ids := readyIDs(t, types.WorkFilter{})
+		if !contains(ids, "rh-awaiting") {
+			t.Errorf("rh-awaiting must be ready work once the operator has released it: %v", ids)
+		}
+	})
+}

--- a/internal/storage/issueops/ready_work.go
+++ b/internal/storage/issueops/ready_work.go
@@ -300,10 +300,13 @@ func readyWorkExcludeTypes(extra []types.IssueType) []types.IssueType {
 func readyWorkWispIssueFilter(filter types.WorkFilter) types.IssueFilter {
 	pinnedFalse := false
 	wispFilter := types.IssueFilter{
-		Priority:       filter.Priority,
-		Labels:         filter.Labels,
-		LabelsAny:      filter.LabelsAny,
-		ExcludeLabels:  filter.ExcludeLabels,
+		Priority:  filter.Priority,
+		Labels:    filter.Labels,
+		LabelsAny: filter.LabelsAny,
+		// Not filter.ExcludeLabels: this branch reaches the wisps table
+		// through BuildLabelDrivenSearch rather than BuildReadyWorkWhere, so
+		// it must apply the default ready-work label exclusions itself.
+		ExcludeLabels:  sqlbuild.ReadyWorkExcludeLabels(filter),
 		Limit:          filter.Limit,
 		MolType:        filter.MolType,
 		WispType:       filter.WispType,

--- a/internal/storage/sqlbuild/ready.go
+++ b/internal/storage/sqlbuild/ready.go
@@ -37,6 +37,33 @@ func ReadyWorkExcludeTypes(extra []types.IssueType) []types.IssueType {
 	return out
 }
 
+// ReadyWorkExcludeLabels returns the labels ready work excludes by default,
+// plus the caller's own --exclude-label set: a bead carrying types.LabelHuman
+// is queued for an operator decision, not for dispatch.
+//
+// Naming the label in Labels or LabelsAny opts back in, so `bd ready --label
+// human` returns that queue rather than the empty set an unconditional
+// exclusion would produce.
+func ReadyWorkExcludeLabels(filter types.WorkFilter) []string {
+	out := append([]string(nil), filter.ExcludeLabels...)
+	for _, label := range filter.Labels {
+		if label == types.LabelHuman {
+			return out
+		}
+	}
+	for _, label := range filter.LabelsAny {
+		if label == types.LabelHuman {
+			return out
+		}
+	}
+	for _, label := range out {
+		if label == types.LabelHuman {
+			return out
+		}
+	}
+	return append(out, types.LabelHuman)
+}
+
 // ReadyWorkOrder is an ORDER BY fragment plus any args its CASE expressions
 // need (the hybrid policy parameterizes a recency cutoff).
 type ReadyWorkOrder struct {
@@ -164,9 +191,9 @@ func BuildReadyWorkWhere(filter types.WorkFilter, tables FilterTables, in ReadyW
 		}
 		whereClauses = append(whereClauses, fmt.Sprintf("id IN (SELECT issue_id FROM %s WHERE label IN (%s))", tables.Labels, strings.Join(placeholders, ", ")))
 	}
-	if len(filter.ExcludeLabels) > 0 {
-		placeholders := make([]string, len(filter.ExcludeLabels))
-		for i, label := range filter.ExcludeLabels {
+	if excludeLabels := ReadyWorkExcludeLabels(filter); len(excludeLabels) > 0 {
+		placeholders := make([]string, len(excludeLabels))
+		for i, label := range excludeLabels {
 			placeholders[i] = "?"
 			args = append(args, label)
 		}

--- a/internal/storage/sqlbuild/sqlbuild_test.go
+++ b/internal/storage/sqlbuild/sqlbuild_test.go
@@ -138,12 +138,108 @@ func TestBuildReadyWorkWhereBatchesIDSets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got := strings.Count(where, "id NOT IN ("); got != 2 {
+	// "id NOT IN (?" is the deferred-children shape specifically; the label
+	// exclusion emits "id NOT IN (SELECT ..." and is counted separately.
+	if got := strings.Count(where, "id NOT IN (?"); got != 2 {
 		t.Errorf("expected 2 batched NOT IN clauses for %d IDs, got %d", len(ids), got)
 	}
-	wantArgs := len(ids) + len(ReadyWorkExcludeTypes(nil))
+	wantArgs := len(ids) + len(ReadyWorkExcludeTypes(nil)) + len(ReadyWorkExcludeLabels(types.WorkFilter{}))
 	if len(args) != wantArgs {
 		t.Errorf("args = %d, want %d", len(args), wantArgs)
+	}
+}
+
+// sk-1pc: a bead labeled 'human' is waiting on an operator ruling, and used to
+// sit in `bd human list` and `bd ready` at once — so a worker could claim and
+// work a question that was simultaneously awaiting a decision. Ready work must
+// exclude the label by default, on every table family, alongside whatever the
+// caller excluded.
+func TestReadyWorkExcludeLabels(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		filter types.WorkFilter
+		want   []string
+	}{
+		{
+			name:   "bare filter excludes the human label",
+			filter: types.WorkFilter{},
+			want:   []string{types.LabelHuman},
+		},
+		{
+			name:   "caller exclusions are kept and the human label appended",
+			filter: types.WorkFilter{ExcludeLabels: []string{"wontfix"}},
+			want:   []string{"wontfix", types.LabelHuman},
+		},
+		{
+			name:   "an explicit --exclude-label human is not duplicated",
+			filter: types.WorkFilter{ExcludeLabels: []string{types.LabelHuman}},
+			want:   []string{types.LabelHuman},
+		},
+		{
+			// Asking for the queue by name is an opt-in, not a
+			// contradiction that returns nothing.
+			name:   "--label human opts back in",
+			filter: types.WorkFilter{Labels: []string{types.LabelHuman}},
+			want:   nil,
+		},
+		{
+			name:   "--label-any human opts back in",
+			filter: types.WorkFilter{LabelsAny: []string{"lane-a", types.LabelHuman}},
+			want:   nil,
+		},
+		{
+			// Only this exact spelling is the operator queue; a near
+			// miss is an ordinary label.
+			name:   "a near-miss label does not opt in",
+			filter: types.WorkFilter{Labels: []string{"needs-human"}},
+			want:   []string{types.LabelHuman},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ReadyWorkExcludeLabels(tt.filter)
+			if len(got) != len(tt.want) {
+				t.Fatalf("ReadyWorkExcludeLabels = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("ReadyWorkExcludeLabels = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+// The exclusion has to reach the SQL, not just the helper: BuildReadyWorkWhere
+// is the one place both stacks render ready semantics from.
+func TestBuildReadyWorkWhereExcludesHumanLabel(t *testing.T) {
+	t.Parallel()
+
+	for _, tables := range []FilterTables{IssuesFilterTables, WispsFilterTables} {
+		where, args, err := BuildReadyWorkWhere(types.WorkFilter{}, tables, ReadyWorkWhereInputs{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		wantClause := "id NOT IN (SELECT issue_id FROM " + tables.Labels + " WHERE label IN (?))"
+		if !strings.Contains(where, wantClause) {
+			t.Errorf("human-label exclusion missing.\n where = %s\n want substring = %s", where, wantClause)
+		}
+		if len(args) == 0 || args[len(args)-1] != types.LabelHuman {
+			t.Errorf("args tail = %v, want last arg %q", args, types.LabelHuman)
+		}
+	}
+
+	// ...and is dropped when the caller names the label.
+	where, _, err := BuildReadyWorkWhere(types.WorkFilter{Labels: []string{types.LabelHuman}}, IssuesFilterTables, ReadyWorkWhereInputs{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(where, "NOT IN (SELECT issue_id FROM "+IssuesFilterTables.Labels) {
+		t.Errorf("--label human must not also exclude the label: %s", where)
 	}
 }
 
@@ -180,9 +276,10 @@ func TestBuildReadyWorkWhereLabelsAny(t *testing.T) {
 		t.Errorf("parent filter clause missing when combined with labels.\n where = %s", where)
 	}
 	// The label + parent args land in filter order (AND labels, then LabelsAny
-	// values, then the parent LIKE arg) as the tail of the arg list — the
-	// default issue_type exclusion prepends its own args.
-	wantTail := []interface{}{"tier:opus", "lane-a", "lane-c", parent}
+	// values, then the default 'human' exclusion, then the parent LIKE arg) as
+	// the tail of the arg list — the default issue_type exclusion prepends its
+	// own args.
+	wantTail := []interface{}{"tier:opus", "lane-a", "lane-c", types.LabelHuman, parent}
 	if len(args) < len(wantTail) {
 		t.Fatalf("args = %v, want at least %d trailing values %v", args, len(wantTail), wantTail)
 	}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -684,6 +684,16 @@ const (
 	TypeMilestone IssueType = "milestone" // Marks completion of a set of related issues (no work itself)
 )
 
+// LabelHuman marks a bead as awaiting an operator decision: it is what puts
+// the bead in `bd human list`, and what keeps it OUT of ready work, since a
+// question waiting on a ruling is not claimable work (see
+// sqlbuild.ReadyWorkExcludeLabels).
+//
+// Only this exact spelling means that. A near miss like "needs-human" is an
+// ordinary label to every surface in bd — it neither joins the operator queue
+// nor leaves the dispatch queue.
+const LabelHuman = "human"
+
 // TypeEvent is a system-internal type used by set-state for audit trail beads.
 // Originally an orchestrator type, promoted to built-in internal type. It is not a
 // core work type (not in IsValid) but is accepted by IsValidWithCustom /


### PR DESCRIPTION
The `human` label is how a bead gets escalated to an operator: adding it puts the bead in `bd human list`, which is the whole decision queue. But the label is a free-floating tag rather than a state that participates in queue membership, and it leaks in both directions.

**(a) Adding `human` does not remove a bead from `bd ready`.** The same bead sits in the decision queue and the dispatch queue at once, so an agent can claim and work a question that is simultaneously awaiting a ruling — exactly the double-handling the human queue exists to prevent. Observed with a bead annotated DO NOT DISPATCH after an explicit "do not pursue" ruling: it kept being offered as workable. The workaround was `bd defer`, which means "will be revisited" and says the wrong thing about a question with no instrument to answer it.

**(b) Closing a bead does not remove it from `bd human list`.** Not `bd close`, and not `bd human respond` / `bd human dismiss`, which close the bead themselves. Nothing ever retires the label, so the queue accumulates resolved items and keeps presenting decisions that have already been made as though they were still owed. An operator had to strip labels by hand.

The two halves are the same missing notion, and fixing only (a) leaves the operator's queue eroding just as fast.

## What changed

**(a) — storage layer.** Ready work now excludes the `human` label by default. It goes in `sqlbuild.BuildReadyWorkWhere`, the one place both stacks render ready semantics, so every dispatch surface gets it: `bd ready`, `bd ready --claim`, `bd list --ready`, the counts path, and the claim path. The `issueops` wisps branch reaches the wisps table through `BuildLabelDrivenSearch` instead of that builder, so it applies the same exclusion itself.

Naming the label opts back in — `bd ready --label human` (or `--label-any`) returns that queue rather than the empty set an unconditional exclusion would produce, so nothing becomes unreachable. Only the exact spelling counts: `needs-human` is an ordinary label, and it does not appear in `bd human list` either. Flagged beads stay fully visible in `bd list` and `bd show`.

**(b) — `cmd/bd`.** `bd human list` excludes closed beads by default. Clearing the label on close was the other option and does not fit this codebase: the label is what lets `bd human stats` count a closed bead as Responded or Dismissed, and it is the record of why the bead was escalated at all. An explicit `--status` still reaches any status, closed included, so resolved items are omitted rather than hidden. The list and stats queries are now built separately, since they disagree about closed beads by design; both routes (direct and proxied-server) build both filters from the same two helpers.

The two halves are separate commits, split by layer, and can be read — or split into stacked PRs — independently.

## Docs

Per `docs/cli-docs.pin`, the docs corpus targets the pinned release rather than main, and `docs/cli-reference/` is generated. The user-facing wording therefore lives where it regenerates from: the `Long` strings on `bd ready` and `bd human list`. No hand edits under `docs/`.

## Tests

| Seam | Test |
|---|---|
| ready-work clause | `sqlbuild.TestReadyWorkExcludeLabels` (table: default, caller exclusions, no-duplicate, `--label`/`--label-any` opt-in, near-miss) and `TestBuildReadyWorkWhereExcludesHumanLabel` (SQL text, both table families) |
| ready work over a real store | `embeddeddolt.TestReadyWorkExcludesHumanLabelledIssues` — both entry points, opt-in, and that clearing the label makes the bead workable again |
| `bd ready` end to end | `TestEmbeddedReady/ready_excludes_human_label` |
| human list filter | `TestHumanListFilterExcludesClosed` — default excludes closed, explicit `--status` wins, stats keeps closed |
| `bd human list` end to end | `TestEmbeddedHuman/human_respond_and_dismiss` extended: closed beads leave the queue, `--status closed` still finds them, stats still counts Responded/Dismissed |
| proxied-server route | `TestProxiedServerHuman/stats_counts` extended with the default listing and `--status closed` |

Two existing `sqlbuild` assertions were updated for the added default arg: `TestBuildReadyWorkWhereBatchesIDSets` (now counts the deferred-children `NOT IN` shape specifically) and `TestBuildReadyWorkWhereLabelsAny` (arg tail).

Also verified by hand against a throwaway workspace with a locally built binary: a `human`-labelled bead disappears from `bd ready` while a `needs-human` one stays; `bd ready --label human` returns it; closing it removes it from `bd human list` while `--status closed`, `bd human stats` and `bd list` still show it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
