### PR TITLE
fix(dolt): honor --dolt-auto-commit batch/off in SQL-server mode (bd-4wamg)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sweep up another client's deferred rows — deferral bounds who *creates*
   commits, not commit contents.
 
+  Scope: embedded and direct SQL-server modes. Proxied-server routes never
+  apply auto-commit policy (they short-circuit before it resolves), so
+  batch/off remain inert there — tracked as a follow-up. A deployment that
+  had explicitly configured `dolt.auto-commit: off` from the old help text
+  note: in server mode that was behaving like `on`; it now genuinely stops
+  minting version commits until an explicit `bd dolt commit`.
+
 
 - **`bd delete --cascade` no longer marks LIVE issues as deleted in other
   issues' text** (bd-x82so). When the deletion named a wisp, the set used to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`--dolt-auto-commit batch`/`off` now actually defer version commits in
+  SQL-server mode** (bd-4wamg). The mode was silently inert there: the CLI's
+  auto-commit policy was embedded-only, and the storage layer minted one Dolt
+  commit inside every write transaction regardless — measured at one commit
+  per write through all five configuration paths (flag, config.yaml, env,
+  `bd config set`, no-daemon). The write verbs now thread the batch/off
+  deferral to the storage layer's commit sites, which leave writes in the
+  working set for an explicit commit point (`bd dolt commit`), in server and
+  embedded mode alike. The server-mode **default** changes spelling, not
+  behavior: it used to resolve to `off` (while behaving like `on`); it now
+  resolves to `on`, naming what a default server-mode write has always done.
+  The `--dolt-auto-commit` help also stops claiming `Default: off`. On a
+  shared server, staging is table-level, so an `on`-mode writer's commit may
+  sweep up another client's deferred rows — deferral bounds who *creates*
+  commits, not commit contents.
+
+
 - **`bd delete --cascade` no longer marks LIVE issues as deleted in other
   issues' text** (bd-x82so). When the deletion named a wisp, the set used to
   rewrite `[deleted:<id>]` citations was computed differently from the set that

--- a/cmd/bd/delete.go
+++ b/cmd/bd/delete.go
@@ -131,7 +131,11 @@ Force: Delete and orphan dependents
 			Force:  force,
 			DryRun: dryRun || !force,
 		}
-		result, err := deleter.Delete(ctx, request)
+		opsCtx, err := issueOpsContext(ctx)
+		if err != nil {
+			return HandleError("%v", err)
+		}
+		result, err := deleter.Delete(opsCtx, request)
 		if request.DryRun {
 			if err != nil {
 				if previewErr := outputDeletionPreview([]string{issueID}, map[string]*types.Issue{issueID: issue}, false, dryRun, nil, err, jsonOutput); previewErr != nil {
@@ -332,7 +336,11 @@ func deleteBatch(_ *cobra.Command, issueIDs []string, force bool, dryRun bool, c
 		Force:   force,
 		DryRun:  dryRun || !force,
 	}
-	result, err := deleter.Delete(ctx, request)
+	opsCtx, err := issueOpsContext(ctx)
+	if err != nil {
+		return HandleError("%v", err)
+	}
+	result, err := deleter.Delete(opsCtx, request)
 	if request.DryRun {
 		if err != nil {
 			if previewErr := outputDeletionPreview(resolvedIDs, issues, cascade, dryRun, nil, err, jsonOutput); previewErr != nil {

--- a/cmd/bd/dolt_autocommit.go
+++ b/cmd/bd/dolt_autocommit.go
@@ -23,38 +23,36 @@ func transact(ctx context.Context, s storage.DoltStorage, commitMsg string, fn f
 }
 
 // transactHonoringAutoCommit wraps transactional CLI writes whose Dolt commit is
-// part of command auto-commit policy. In embedded batch/off modes the SQL
-// transaction still commits, but no Dolt version commit is created.
+// part of command auto-commit policy. In batch/off modes the SQL transaction
+// still commits, but no Dolt version commit is created — the blank message
+// makes StageAndCommit a no-op, in embedded and SQL-server mode alike
+// (bd-4wamg: batch used to be silently inert in server mode).
 func transactHonoringAutoCommit(ctx context.Context, s storage.DoltStorage, commitMsg string, fn func(tx storage.Transaction) error) error {
 	msg := commitMsg
 	committedExplicitly := strings.TrimSpace(msg) != ""
-	if isEmbeddedMode() {
-		mode, err := getDoltAutoCommitMode()
-		if err != nil {
-			return err
-		}
-		if mode != doltAutoCommitOn {
-			msg = ""
-			committedExplicitly = false
-		}
+	commitNow, err := writesCommitNow()
+	if err != nil {
+		return err
+	}
+	if !commitNow {
+		msg = ""
+		committedExplicitly = false
 	}
 
-	err := s.RunInTransaction(ctx, msg, fn)
+	err = s.RunInTransaction(ctx, msg, fn)
 	if err == nil && committedExplicitly {
 		commandDidExplicitDoltCommit = true
 	}
 	return err
 }
 
-// embeddedWritesCommitNow reports whether an embedded-mode CLI write should
-// create its Dolt version commit now. Batch and off defer it to an explicit
-// commit point (bd dolt commit); an unset value is the embedded default, which
-// PersistentPreRun resolves to "on". Server mode is never the CLI's commit to
-// make — the storage layer versions those writes itself.
-func embeddedWritesCommitNow() (bool, error) {
-	if !isEmbeddedMode() {
-		return false, nil
-	}
+// writesCommitNow reports whether a CLI write should create its Dolt version
+// commit as part of the write (mode "on"), rather than leaving it in the
+// working set for a later explicit commit point (batch/off; bd dolt commit).
+// An unset value means no Dolt store resolved a default (e.g. a non-Dolt
+// backend), where per-write version commits are the only behavior that
+// exists — treat it as "on".
+func writesCommitNow() (bool, error) {
 	if strings.TrimSpace(doltAutoCommit) == "" {
 		return true, nil
 	}
@@ -65,15 +63,25 @@ func embeddedWritesCommitNow() (bool, error) {
 	return mode == doltAutoCommitOn, nil
 }
 
+// embeddedWritesCommitNow is writesCommitNow for the embedded-only commit
+// points (the PersistentPostRun working-set flush and create's post-write
+// flush). In SQL-server mode those flushes never run — mode "on" writes
+// version themselves inside the storage layer.
+func embeddedWritesCommitNow() (bool, error) {
+	if !isEmbeddedMode() {
+		return false, nil
+	}
+	return writesCommitNow()
+}
+
 // issueOpsContext applies command auto-commit policy to the context a write verb
 // hands the issue-operations facade. The facade creates its Dolt version commit
 // inside the storage layer, so batch mode cannot blank a commit message the way
 // transactHonoringAutoCommit does — it has to say so on the context instead.
+// This is mode-driven, not embedded-only: in SQL-server mode the storage
+// layer's per-write commit sites honor the same deferral (bd-4wamg).
 func issueOpsContext(ctx context.Context) (context.Context, error) {
-	if !isEmbeddedMode() {
-		return ctx, nil
-	}
-	commitNow, err := embeddedWritesCommitNow()
+	commitNow, err := writesCommitNow()
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/bd/dolt_autocommit_integration_test.go
+++ b/cmd/bd/dolt_autocommit_integration_test.go
@@ -218,10 +218,29 @@ func TestDoltAutoCommit_Batch_DefersCommit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("bd create (2) failed: %v\n%s", err, out)
 	}
+	var created struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(out[strings.Index(out, "{"):]), &created); err != nil || created.ID == "" {
+		t.Fatalf("parse create JSON id: %v\n%s", err, out)
+	}
+	secondID := created.ID
 
 	afterCreate2 := doltHeadCommit(t, tmpDir, env)
 	if afterCreate2 != before {
 		t.Fatalf("expected Dolt HEAD still unchanged; before=%s after=%s", before, afterCreate2)
+	}
+
+	// Delete rides the issueops facade, not transactHonoringAutoCommit — it
+	// must defer too (the bd-4wamg review caught it passing a bare rootCtx).
+	out, err = runBDExecAllowErrorWithEnv(t, tmpDir, env, "--dolt-auto-commit", "batch", "delete", secondID, "--force")
+	if err != nil {
+		t.Fatalf("bd delete failed: %v\n%s", err, out)
+	}
+
+	afterDelete := doltHeadCommit(t, tmpDir, env)
+	if afterDelete != before {
+		t.Fatalf("expected Dolt HEAD unchanged after batch-mode delete; before=%s after=%s", before, afterDelete)
 	}
 
 	// An explicit "bd dolt commit" should commit all accumulated changes.

--- a/cmd/bd/dolt_autocommit_server_test.go
+++ b/cmd/bd/dolt_autocommit_server_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/steveyegge/beads/internal/storage"
+	storageissueops "github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -201,6 +202,84 @@ func TestShouldCommitCreatePostWritesHonorsEmbeddedBatchAndOffModes(t *testing.T
 			}
 			if got, err := shouldCommitCreatePostWrites(&types.Issue{}, false); err != nil || got {
 				t.Fatalf("embedded create without post-writes should not commit in %s mode", mode)
+			}
+		})
+	}
+}
+
+// fakeTransactStore captures the commit message RunInTransaction receives so
+// tests can assert the auto-commit policy blanked (or preserved) it.
+type fakeTransactStore struct {
+	storage.DoltStorage
+	msgs []string
+}
+
+func (f *fakeTransactStore) RunInTransaction(_ context.Context, commitMsg string, fn func(tx storage.Transaction) error) error {
+	f.msgs = append(f.msgs, commitMsg)
+	return fn(nil)
+}
+
+// TestIssueOpsContextDefersByModeInServerMode covers bd-4wamg: batch/off must
+// defer the storage layer's per-write version commit in SQL-server mode, not
+// only embedded mode. An unset mode means no Dolt default was resolved
+// (non-Dolt backend) and must not defer.
+func TestIssueOpsContextDefersByModeInServerMode(t *testing.T) {
+	for _, tc := range []struct {
+		mode         string
+		wantDeferred bool
+	}{
+		{mode: string(doltAutoCommitOn), wantDeferred: false},
+		{mode: string(doltAutoCommitBatch), wantDeferred: true},
+		{mode: string(doltAutoCommitOff), wantDeferred: true},
+		{mode: "", wantDeferred: false},
+	} {
+		t.Run("mode="+tc.mode, func(t *testing.T) {
+			saveStorageMode(t)
+			serverMode = true
+			doltAutoCommit = tc.mode
+
+			ctx, err := issueOpsContext(context.Background())
+			if err != nil {
+				t.Fatalf("issueOpsContext: %v", err)
+			}
+			if got := storageissueops.VersionCommitDeferred(ctx); got != tc.wantDeferred {
+				t.Fatalf("VersionCommitDeferred = %v, want %v for mode %q in server mode", got, tc.wantDeferred, tc.mode)
+			}
+		})
+	}
+}
+
+// TestTransactHonoringAutoCommitBlanksMessageInServerBatch: the blank message
+// is what makes StageAndCommit skip the version commit, and it must happen in
+// server mode too (bd-4wamg).
+func TestTransactHonoringAutoCommitBlanksMessageInServerBatch(t *testing.T) {
+	for _, tc := range []struct {
+		mode    string
+		wantMsg string
+	}{
+		{mode: string(doltAutoCommitOn), wantMsg: "bd: test write"},
+		{mode: string(doltAutoCommitBatch), wantMsg: ""},
+		{mode: string(doltAutoCommitOff), wantMsg: ""},
+	} {
+		t.Run("mode="+tc.mode, func(t *testing.T) {
+			saveStorageMode(t)
+			serverMode = true
+			doltAutoCommit = tc.mode
+			commandDidExplicitDoltCommit = false
+
+			fake := &fakeTransactStore{}
+			err := transactHonoringAutoCommit(context.Background(), fake, "bd: test write", func(tx storage.Transaction) error {
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("transactHonoringAutoCommit: %v", err)
+			}
+			if len(fake.msgs) != 1 || fake.msgs[0] != tc.wantMsg {
+				t.Fatalf("RunInTransaction messages = %q, want [%q] for mode %q", fake.msgs, tc.wantMsg, tc.mode)
+			}
+			wantExplicit := tc.wantMsg != ""
+			if commandDidExplicitDoltCommit != wantExplicit {
+				t.Fatalf("commandDidExplicitDoltCommit = %v, want %v for mode %q", commandDidExplicitDoltCommit, wantExplicit, tc.mode)
 			}
 		})
 	}

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -761,7 +761,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&sandboxMode, "sandbox", false, "Sandbox mode: disables Dolt auto-push")
 	rootCmd.PersistentFlags().BoolVar(&readonlyMode, "readonly", false, "Read-only mode: block write operations (for worker sandboxes)")
 	rootCmd.PersistentFlags().BoolVar(&globalFlag, "global", false, "Use the global shared-server database (beads_global)")
-	rootCmd.PersistentFlags().StringVar(&doltAutoCommit, "dolt-auto-commit", "", "Dolt auto-commit policy (off|on|batch). 'on': commit after each write. 'batch': defer commits to bd dolt commit; uncommitted changes persist in the working set until then. SIGTERM/SIGHUP flush pending batch commits. Default: off. Override via config key dolt.auto-commit")
+	rootCmd.PersistentFlags().StringVar(&doltAutoCommit, "dolt-auto-commit", "", "Dolt auto-commit policy (off|on|batch). 'on': commit after each write. 'batch': defer commits to bd dolt commit; uncommitted changes persist in the working set until then. SIGTERM/SIGHUP flush pending batch commits. Default: on. Override via config key dolt.auto-commit")
 	rootCmd.PersistentFlags().BoolVar(&cpuProfileEnabled, "cpu-profile", false, "Generate CPU profile for performance analysis")
 	rootCmd.PersistentFlags().StringVar(&memProfilePath, "mem-profile", "", "Write heap profile to FILE on exit (also respects BEADS_MEM_PROFILE)")
 	rootCmd.PersistentFlags().BoolVarP(&verboseFlag, "verbose", "v", false, "Enable verbose/debug output")
@@ -1565,18 +1565,17 @@ var rootCmd = &cobra.Command{
 			return nil
 		}
 
-		// Default auto-commit based on mode when the user hasn't set a value:
-		// - Server mode: OFF — the server handles commits via its own transaction
-		//   lifecycle; firing DOLT_COMMIT after every write under concurrent load
-		//   causes 'database is read only' errors.
-		// - Embedded mode: ON — each command writes to the working set and needs
-		//   a Dolt commit in PersistentPostRun to persist changes to history.
+		// Default auto-commit to ON when the user hasn't set a value, in both
+		// modes — "on" names what each mode already does per write:
+		// - Embedded mode: each command writes to the working set and commits
+		//   it in PersistentPostRun.
+		// - Server mode: the storage layer creates one Dolt commit inside each
+		//   write transaction (the post-run flush stays embedded-only). The
+		//   default here used to be OFF, but the mode was inert in server mode
+		//   — every value behaved like ON — so ON is the compatible default
+		//   now that batch/off actually defer version commits (bd-4wamg).
 		if strings.TrimSpace(doltAutoCommit) == "" {
-			if !usesSQLServer() {
-				doltAutoCommit = string(doltAutoCommitOn)
-			} else {
-				doltAutoCommit = string(doltAutoCommitOff)
-			}
+			doltAutoCommit = string(doltAutoCommitOn)
 		}
 
 		doltCfg.Path = doltPath

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -761,7 +761,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&sandboxMode, "sandbox", false, "Sandbox mode: disables Dolt auto-push")
 	rootCmd.PersistentFlags().BoolVar(&readonlyMode, "readonly", false, "Read-only mode: block write operations (for worker sandboxes)")
 	rootCmd.PersistentFlags().BoolVar(&globalFlag, "global", false, "Use the global shared-server database (beads_global)")
-	rootCmd.PersistentFlags().StringVar(&doltAutoCommit, "dolt-auto-commit", "", "Dolt auto-commit policy (off|on|batch). 'on': commit after each write. 'batch': defer commits to bd dolt commit; uncommitted changes persist in the working set until then. SIGTERM/SIGHUP flush pending batch commits. Default: on. Override via config key dolt.auto-commit")
+	rootCmd.PersistentFlags().StringVar(&doltAutoCommit, "dolt-auto-commit", "", "Dolt auto-commit policy (off|on|batch). 'on': commit after each write. 'batch': defer commits to bd dolt commit; uncommitted changes persist in the working set until then (a live batch-mode bd process also flushes on SIGTERM/SIGHUP). Applies to embedded and direct SQL-server modes; proxied-server routes are unaffected. Default: on. Override via config key dolt.auto-commit")
 	rootCmd.PersistentFlags().BoolVar(&cpuProfileEnabled, "cpu-profile", false, "Generate CPU profile for performance analysis")
 	rootCmd.PersistentFlags().StringVar(&memProfilePath, "mem-profile", "", "Write heap profile to FILE on exit (also respects BEADS_MEM_PROFILE)")
 	rootCmd.PersistentFlags().BoolVarP(&verboseFlag, "verbose", "v", false, "Enable verbose/debug output")

--- a/internal/storage/dolt/deleter.go
+++ b/internal/storage/dolt/deleter.go
@@ -74,6 +74,11 @@ func (s *deleter) Delete(ctx context.Context, req issueops.DeleteRequest) (issue
 		if result.Deleted == 0 {
 			return nil
 		}
+		// Batch/off auto-commit (bd-4wamg): defer the version commit to an
+		// explicit commit point, matching doltAddAndCommitInTx.
+		if storeops.VersionCommitDeferred(ctx) {
+			return nil
+		}
 		// The same tables a sweep stages; the neighbor rewrite lands in
 		// `issues`, which is already on the list.
 		for _, table := range sweptTables {

--- a/internal/storage/dolt/ephemeral_routing.go
+++ b/internal/storage/dolt/ephemeral_routing.go
@@ -320,6 +320,12 @@ func (s *DoltStore) demoteToWispInTx(ctx context.Context, tx *sql.Tx, id string,
 }
 
 func (s *DoltStore) doltAddAndCommitInTx(ctx context.Context, tx *sql.Tx, tables []string, commitMsg string) error {
+	// Batch/off auto-commit (bd-4wamg): leave the writes in the working set
+	// for a later explicit commit point (bd dolt commit / CommitPending)
+	// instead of minting one Dolt version commit per write.
+	if issueops.VersionCommitDeferred(ctx) {
+		return nil
+	}
 	for _, table := range tables {
 		if err := schema.DrainCall(ctx, tx, "CALL DOLT_ADD(?)", table); err != nil {
 			return fmt.Errorf("dolt add %s: %w", table, err)

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -3102,6 +3102,12 @@ func (s *DoltStore) CommitWithConfig(ctx context.Context, message string) error 
 // already committed its SQL mutation, so any publication failure here has an
 // indeterminate durable outcome and must not be replayed.
 func (s *DoltStore) doltAddAndCommit(ctx context.Context, tables []string, commitMsg string) error {
+	// Batch/off auto-commit (bd-4wamg): leave the writes in the working set
+	// for a later explicit commit point (bd dolt commit / CommitPending),
+	// matching doltAddAndCommitInTx.
+	if issueops.VersionCommitDeferred(ctx) {
+		return nil
+	}
 	return s.withCircuitWrite(ctx, func(ctx context.Context) error {
 		conn, err := s.db.Conn(ctx)
 		if err != nil {

--- a/internal/storage/dolt/version_commit_deferred_test.go
+++ b/internal/storage/dolt/version_commit_deferred_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/types"
+	rootissueops "github.com/steveyegge/beads/issueops"
 )
 
 // bd-4wamg: a context carrying WithDeferredVersionCommit must leave writes in
@@ -82,5 +83,55 @@ func TestDeferredVersionCommitUpdatePath(t *testing.T) {
 	}
 	if !committed {
 		t.Fatal("CommitPending reported nothing to commit after deferred update")
+	}
+}
+
+// TestDeferredVersionCommitDeletePath covers the delete verb's commit site
+// (deleter.Delete's in-tx DOLT_COMMIT) under deferral — the site the bd-4wamg
+// review found unwired at the CLI layer (delete.go passed a bare rootCtx).
+func TestDeferredVersionCommitDeletePath(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+	seedIssues(ctx, t, store, "test-defer-del-a", "test-defer-del-b")
+
+	del, err := store.Deleter()
+	if err != nil {
+		t.Fatalf("Deleter: %v", err)
+	}
+
+	// Plain ctx: a forced delete advances history (per-write commit).
+	before := doltCommitCount(ctx, t, store)
+	if _, err := del.Delete(ctx, rootissueops.DeleteRequest{
+		Actor: "tester", IDs: []string{"test-defer-del-a"}, Force: true,
+	}); err != nil {
+		t.Fatalf("plain delete: %v", err)
+	}
+	if after := doltCommitCount(ctx, t, store); after <= before {
+		t.Fatalf("plain delete: commit count %d -> %d, want an advance", before, after)
+	}
+
+	// Deferred ctx: the delete lands in SQL but must not advance history.
+	deferredCtx := issueops.WithDeferredVersionCommit(ctx)
+	before = doltCommitCount(ctx, t, store)
+	if _, err := del.Delete(deferredCtx, rootissueops.DeleteRequest{
+		Actor: "tester", IDs: []string{"test-defer-del-b"}, Force: true,
+	}); err != nil {
+		t.Fatalf("deferred delete: %v", err)
+	}
+	if after := doltCommitCount(ctx, t, store); after != before {
+		t.Fatalf("deferred delete advanced history: commit count %d -> %d, want unchanged", before, after)
+	}
+	if got, err := store.GetIssue(ctx, "test-defer-del-b"); err == nil && got != nil {
+		t.Fatal("deferred delete did not remove the row from SQL")
+	}
+
+	committed, err := store.CommitPending(ctx, "tester")
+	if err != nil {
+		t.Fatalf("CommitPending: %v", err)
+	}
+	if !committed {
+		t.Fatal("CommitPending reported nothing to commit after deferred delete")
 	}
 }

--- a/internal/storage/dolt/version_commit_deferred_test.go
+++ b/internal/storage/dolt/version_commit_deferred_test.go
@@ -1,0 +1,86 @@
+package dolt
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// bd-4wamg: a context carrying WithDeferredVersionCommit must leave writes in
+// the Dolt working set — no per-write version commit — until an explicit
+// commit point flushes them (CommitPending / bd dolt commit). This is the
+// server-mode half of --dolt-auto-commit batch/off; the CLI sets the context
+// in issueOpsContext, and this store honors it in doltAddAndCommitInTx.
+func TestDeferredVersionCommitLeavesWritesForCommitPending(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	// Baseline: a plain create advances history.
+	before := doltCommitCount(ctx, t, store)
+	seedIssues(ctx, t, store, "test-defer-baseline")
+	if after := doltCommitCount(ctx, t, store); after <= before {
+		t.Fatalf("plain create: commit count %d -> %d, want an advance", before, after)
+	}
+
+	// Deferred: the same write must not advance history.
+	deferredCtx := issueops.WithDeferredVersionCommit(ctx)
+	before = doltCommitCount(ctx, t, store)
+	if err := store.CreateIssues(deferredCtx, []*types.Issue{
+		{ID: "test-defer-pending", Title: "deferred write", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+	}, "tester"); err != nil {
+		t.Fatalf("deferred create: %v", err)
+	}
+	if after := doltCommitCount(ctx, t, store); after != before {
+		t.Fatalf("deferred create advanced history: commit count %d -> %d, want unchanged", before, after)
+	}
+
+	// The write is durable in SQL regardless of version-commit deferral.
+	got, err := store.GetIssue(ctx, "test-defer-pending")
+	if err != nil || got == nil {
+		t.Fatalf("deferred issue not readable back: %v", err)
+	}
+
+	// An explicit commit point flushes the pending working set as one commit.
+	committed, err := store.CommitPending(ctx, "tester")
+	if err != nil {
+		t.Fatalf("CommitPending: %v", err)
+	}
+	if !committed {
+		t.Fatal("CommitPending reported nothing to commit; deferred write missing from working set")
+	}
+	if after := doltCommitCount(ctx, t, store); after != before+1 {
+		t.Fatalf("CommitPending: commit count %d -> %d, want exactly +1", before, after)
+	}
+}
+
+// TestDeferredVersionCommitUpdatePath covers the update verb's commit site
+// (RunInIssueLifecycleTransaction -> doltAddAndCommitInTx) under deferral.
+func TestDeferredVersionCommitUpdatePath(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+	seedIssues(ctx, t, store, "test-defer-update")
+
+	deferredCtx := issueops.WithDeferredVersionCommit(ctx)
+	before := doltCommitCount(ctx, t, store)
+	if err := store.UpdateIssue(deferredCtx, "test-defer-update", map[string]interface{}{
+		"priority": 1,
+	}, "tester"); err != nil {
+		t.Fatalf("deferred update: %v", err)
+	}
+	if after := doltCommitCount(ctx, t, store); after != before {
+		t.Fatalf("deferred update advanced history: commit count %d -> %d, want unchanged", before, after)
+	}
+
+	committed, err := store.CommitPending(ctx, "tester")
+	if err != nil {
+		t.Fatalf("CommitPending: %v", err)
+	}
+	if !committed {
+		t.Fatal("CommitPending reported nothing to commit after deferred update")
+	}
+}


### PR DESCRIPTION
Fixes bd-4wamg (local bead; measured by wyvern/ganon under wy-x1gca): in SQL-server mode, `--dolt-auto-commit batch` was **silently inert** — one Dolt commit per write through all five configuration paths (per-invocation flag, `config.yaml`, env, `bd config set`, no-daemon), because the CLI's auto-commit policy hooks were all embedded-gated and the storage layer's per-write commit sites are unconditional.

## What changes

- **`issueOpsContext` / `transactHonoringAutoCommit` become mode-driven, not embedded-only.** batch/off set `WithDeferredVersionCommit` on the write-verb context / blank the `RunInTransaction` commit message, in server mode too. (`StageAndCommit` already no-ops on a blank message.)
- **The storage layer's three per-write commit sites honor the deferral** — `doltAddAndCommitInTx`, `doltAddAndCommit`, and the deleter's inline site — leaving writes in the working set for an explicit commit point (`bd dolt commit` / `CommitPending`). The explicit commit APIs (`Commit`, `CommitWithConfig`, `CommitPending`) and the federation sync point stay unguarded on purpose: they ARE the commit points.
- **Server-mode default flips `off`→`on` — spelling, not behavior.** The old default *resolved* to `off` while every value *behaved* like `on` (the storage layer committed per write regardless). With batch/off now real, keeping an `off` default would silently stop versioning server-mode writes on upgrade; `on` names what a default server-mode write has always done. Help text stops claiming `Default: off` (the other half of the bead's report).
- Embedded-only flush points (PersistentPostRun, create post-writes) keep their embedded gate via `embeddedWritesCommitNow`, now layered on the shared `writesCommitNow`.

## Semantics on a shared server

Staging is table-level (`DOLT_ADD(<table>)`), so an `on`-mode writer's commit sweeps up any deferred rows other clients left in the same tables. Deferral bounds who *creates* commits, not commit contents — that's the right shape for coalescing (nothing is ever lost; attribution of swept-up rows lands on the committing writer) and is documented in the changelog. This is also the substrate the app-layer interval-coalescing design (bd-e6oq6, Tim Sehn thread) schedules on top of; nothing here pre-empts that design.

## Tests

- `TestIssueOpsContextDefersByModeInServerMode`, `TestTransactHonoringAutoCommitBlanksMessageInServerBatch` (new unit, `cmd/bd`).
- `TestDeferredVersionCommitLeavesWritesForCommitPending`, `TestDeferredVersionCommitUpdatePath` (new, `internal/storage/dolt`, real Dolt container): deferred create/update leave `dolt_log` untouched while staying durable in SQL; `CommitPending` flushes as exactly one commit.
- All existing embedded-gate tests pass unchanged; embedded integration `TestDoltAutoCommit_{Batch,Off}` pass (`_On` fails on this box on an unmodified tree too — pre-existing env issue, not this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)