### PR TITLE
fix(test): roll ignored-migration cursor back to 0011 so the orphan-cleanup body re-runs (bd-g43r6)

### DIFF
--- a/internal/storage/dolt/schema_version_test.go
+++ b/internal/storage/dolt/schema_version_test.go
@@ -315,6 +315,13 @@ func TestIgnoredMigration0011CleansOrphanedChildCounters(t *testing.T) {
 		t.Fatalf("commit counter fixture: %v", err)
 	}
 
+	// Bind the const to its file: if the ignored series is ever renumbered,
+	// fail here with a self-explaining message instead of silently replaying
+	// the wrong tail.
+	if _, err := schema.IgnoredMigrationSQL("0011_cleanup_orphaned_child_counters.up.sql"); err != nil {
+		t.Fatalf("orphanCleanupIgnoredVersion (%d) no longer matches an ignored migration file: %v", orphanCleanupIgnoredVersion, err)
+	}
+
 	// Pending detection is MAX-based (currentVersion = MAX(version)), so
 	// deleting only one cursor row re-runs only the LATEST ignored migration.
 	// Roll the cursor back to before 0011 so the orphan cleanup itself re-runs;

--- a/internal/storage/dolt/schema_version_test.go
+++ b/internal/storage/dolt/schema_version_test.go
@@ -271,6 +271,10 @@ func TestMigration0053RepairsIssuesMissingRigColumns(t *testing.T) {
 	}
 }
 
+// orphanCleanupIgnoredVersion is migrations/ignored/0011_cleanup_orphaned_
+// child_counters.up.sql — the migration under test below.
+const orphanCleanupIgnoredVersion = 11
+
 // TestIgnoredMigration0011CleansOrphanedChildCounters reproduces #4534: a
 // child_counters row orphaned while fk_counter_parent was dropped (0039)
 // survives the FK's re-add (ignored 0002 runs under FOREIGN_KEY_CHECKS=0),
@@ -311,7 +315,11 @@ func TestIgnoredMigration0011CleansOrphanedChildCounters(t *testing.T) {
 		t.Fatalf("commit counter fixture: %v", err)
 	}
 
-	if _, err := store.db.ExecContext(ctx, "DELETE FROM ignored_schema_migrations WHERE version = ?", schema.LatestIgnoredVersion()); err != nil {
+	// Pending detection is MAX-based (currentVersion = MAX(version)), so
+	// deleting only one cursor row re-runs only the LATEST ignored migration.
+	// Roll the cursor back to before 0011 so the orphan cleanup itself re-runs;
+	// the 0011..latest tail is idempotent by series contract.
+	if _, err := store.db.ExecContext(ctx, "DELETE FROM ignored_schema_migrations WHERE version >= ?", orphanCleanupIgnoredVersion); err != nil {
 		t.Fatalf("mark ignored 0011 pending: %v", err)
 	}
 	if _, err := schema.MigrateUp(ctx, store.db); err != nil {


### PR DESCRIPTION
## Problem

`TestIgnoredMigration0011CleansOrphanedChildCounters` (internal/storage/dolt) fails on clean main: `orphaned counter rows = 1, want 0`.

The test marks the 0011 cleanup pending via `DELETE FROM ignored_schema_migrations WHERE version = schema.LatestIgnoredVersion()`. Pending detection is MAX-based (`currentVersion` = `MAX(version)` over the cursor table), so that delete re-runs only the **latest** ignored migration — which was 0011 when the test was written (#4538), but the series has since grown to 0021. The cleanup body never re-runs, and the seeded orphan survives.

## Fix

Roll the cursor back to before 0011 (`DELETE ... WHERE version >= 11`, anchored by a named const pointing at `0011_cleanup_orphaned_child_counters.up.sql`). The 0011..latest tail is idempotent by series contract (temp-table renames + INFORMATION_SCHEMA-gated ALTERs), so re-running it is safe and the migration under test actually executes.

## Verification

- On main (92ad0295f): test FAILS (`orphaned counter rows = 1, want 0`). After this change: PASSES.
- Sibling FAIL set in `schema_version_test.go` is unchanged before/after (verified by stash-diff): `TestSchemaRunsInitWhenMissing` and `TestMigration0053RepairsIssuesMissingRigColumns` fail on clean main locally too — pre-existing, filed as bd-17gmo, not touched here.

Bead: bd-g43r6

🤖 Generated with [Claude Code](https://claude.com/claude-code)