### PR TITLE
fix(test): pin DOCKER_HOST from the active docker context before TestMain swaps HOME (bd-84kos)

### DIFF
--- a/cmd/bd/test_repo_beads_guard_test.go
+++ b/cmd/bd/test_repo_beads_guard_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/doltserver"
 	"github.com/steveyegge/beads/internal/metrics"
+	"github.com/steveyegge/beads/internal/testutil"
 )
 
 // beforeTestsHook is set by CGO-tagged test files to perform setup before tests run
@@ -99,6 +100,12 @@ func testMainInner(m *testing.M) int {
 			_ = os.Setenv("GOMODCACHE", strings.TrimSpace(string(out)))
 		}
 	}
+
+	// The docker CLI's active context also lives under HOME
+	// (~/.docker/config.json); resolve it into DOCKER_HOST now or every
+	// container-gated test skips "Docker not available" on context-routed
+	// daemons like OrbStack (bd-84kos).
+	testutil.PinDockerHostFromContext()
 
 	_ = os.Setenv("HOME", tmp)
 	_ = os.Setenv("USERPROFILE", tmp) // Windows compatibility

--- a/internal/testutil/dockercontext.go
+++ b/internal/testutil/dockercontext.go
@@ -1,9 +1,11 @@
 package testutil
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 )
 
 // PinDockerHostFromContext resolves the Docker CLI's active context endpoint
@@ -22,12 +24,18 @@ func PinDockerHostFromContext() {
 	if os.Getenv("DOCKER_HOST") != "" {
 		return
 	}
-	out, err := exec.Command("docker", "context", "inspect", "-f", "{{.Endpoints.docker.Host}}").Output()
+	// context inspect reads local metadata only (never the daemon), so 5s is
+	// generous; the timeout guards against a pathological docker shim hanging
+	// TestMain.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "docker", "context", "inspect", "-f", "{{.Endpoints.docker.Host}}").Output()
 	if err != nil {
 		return
 	}
 	host := strings.TrimSpace(string(out))
-	if host == "" {
+	if !strings.Contains(host, "://") {
+		// Not endpoint-shaped (empty, or a shim CLI printed something else).
 		return
 	}
 	_ = os.Setenv("DOCKER_HOST", host)

--- a/internal/testutil/dockercontext.go
+++ b/internal/testutil/dockercontext.go
@@ -1,0 +1,34 @@
+package testutil
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// PinDockerHostFromContext resolves the Docker CLI's active context endpoint
+// and pins it into DOCKER_HOST, for TestMains that are about to swap HOME.
+//
+// The active context lives in ~/.docker/config.json; once a TestMain points
+// HOME at a temp dir, `docker info` (and testcontainers) silently falls back
+// to unix:///var/run/docker.sock. On machines where the daemon is reached via
+// a context (OrbStack, Docker Desktop's desktop-linux, remote daemons) that
+// socket does not exist, so every container-gated test SKIPs with "Docker not
+// available" even though docker works fine in the invoking shell (bd-84kos).
+//
+// Call it BEFORE the HOME swap. No-op when DOCKER_HOST is already set (an
+// explicit choice always wins) or when the endpoint cannot be resolved.
+func PinDockerHostFromContext() {
+	if os.Getenv("DOCKER_HOST") != "" {
+		return
+	}
+	out, err := exec.Command("docker", "context", "inspect", "-f", "{{.Endpoints.docker.Host}}").Output()
+	if err != nil {
+		return
+	}
+	host := strings.TrimSpace(string(out))
+	if host == "" {
+		return
+	}
+	_ = os.Setenv("DOCKER_HOST", host)
+}

--- a/internal/testutil/dockercontext_test.go
+++ b/internal/testutil/dockercontext_test.go
@@ -1,0 +1,45 @@
+//go:build !windows
+
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPinDockerHostFromContext_RespectsExistingValue(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "unix:///explicit/choice.sock")
+	PinDockerHostFromContext()
+	if got := os.Getenv("DOCKER_HOST"); got != "unix:///explicit/choice.sock" {
+		t.Fatalf("DOCKER_HOST = %q, want the pre-set value untouched", got)
+	}
+}
+
+func TestPinDockerHostFromContext_ResolvesActiveContext(t *testing.T) {
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "docker")
+	script := "#!/bin/sh\necho 'unix:///stub/context.sock'\n"
+	if err := os.WriteFile(stub, []byte(script), 0o755); err != nil {
+		t.Fatalf("writing docker stub: %v", err)
+	}
+	t.Setenv("PATH", dir)
+	t.Setenv("DOCKER_HOST", "")
+	_ = os.Unsetenv("DOCKER_HOST")
+
+	PinDockerHostFromContext()
+	if got := os.Getenv("DOCKER_HOST"); got != "unix:///stub/context.sock" {
+		t.Fatalf("DOCKER_HOST = %q, want the stub context endpoint", got)
+	}
+}
+
+func TestPinDockerHostFromContext_NoDockerIsANoOp(t *testing.T) {
+	t.Setenv("PATH", t.TempDir()) // no docker binary reachable
+	t.Setenv("DOCKER_HOST", "")
+	_ = os.Unsetenv("DOCKER_HOST")
+
+	PinDockerHostFromContext()
+	if got, set := os.LookupEnv("DOCKER_HOST"); set {
+		t.Fatalf("DOCKER_HOST = %q, want unset when docker is absent", got)
+	}
+}


### PR DESCRIPTION
## Problem

`cmd/bd`'s `testMainInner` points HOME at a temp dir before any test runs, which hides `~/.docker/config.json` — the file holding the docker CLI's **active context**. On machines where the daemon is reached via a context (OrbStack, Docker Desktop's `desktop-linux`, remote daemons), `docker info` then falls back to `unix:///var/run/docker.sock` and fails instantly, so every container-gated test SKIPs `Docker not available` even though docker works fine in the invoking shell.

Skips read as green, so this is a silent coverage hole: the proxied-server parity suites stopped running entirely on such machines until DOCKER_HOST was passed by hand (bit us on bd-i8qx8).

## Fix

- New `testutil.PinDockerHostFromContext()`: resolves the active context's endpoint via `docker context inspect -f '{{.Endpoints.docker.Host}}'` into DOCKER_HOST. No-op when DOCKER_HOST is already set (explicit choice wins) or when docker/the endpoint can't be resolved. On a default-context Linux box it resolves to `unix:///var/run/docker.sock`, i.e. harmless.
- `testMainInner` calls it immediately before the HOME swap.

cmd/bd is the only container-gated package that swaps HOME process-wide in TestMain, so that's the one call site; the helper is in testutil for any future TestMain that grows the same shape.

## Verification (macOS + OrbStack, NO DOCKER_HOST in env)

- main (92ad0295f): `BEADS_TEST_PROXIED_SERVER=1 go test ./cmd/bd/ -run TestProxiedServerExternalCreate` → `SKIP: Docker not available`
- with this change: same command → `PASS (22s)` against a live container
- unit tests for the helper (pre-set value respected, stub-context resolution, no-docker no-op): green

Bead: bd-84kos

🤖 Generated with [Claude Code](https://claude.com/claude-code)