### PR TITLE
feat(search): include closed issues by default (bd-t5yex)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   works and is now redundant. Applies to both the embedded and proxied-server
   paths.
 
+  Two consequences to know: matches beyond `--limit` (default 50) are dropped
+  under a status-blind sort (priority, then created), so a broad query on a
+  large DB can now fill the page with closed matches and silently drop open
+  ones — use `--status open` or raise `--limit` when hunting live work. And
+  `bd query` (plus the HTTP `q=` endpoint) deliberately keeps its closed-
+  exclusion default with opt-in `--all`; only `bd search` changed.
+
 ### Fixed
 
 - **`bd delete --cascade` no longer marks LIVE issues as deleted in other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`bd search` now includes closed issues by default** (bd-t5yex). The
+  dominant real-world search query is "was this already found/filed/fixed?" —
+  exactly the query where silently excluding closed issues produced a false
+  "no" (downstream repos grew shell wrappers purely to undo the old default).
+  `bd list` keeps its open-only default. Narrow explicitly with `--status open`
+  (or any status list) where the old behavior is wanted; `--status all` still
+  works and is now redundant. Applies to both the embedded and proxied-server
+  paths.
+
 ### Fixed
 
 - **`bd delete --cascade` no longer marks LIVE issues as deleted in other

--- a/cmd/bd/search.go
+++ b/cmd/bd/search.go
@@ -18,11 +18,12 @@ var searchCmd = &cobra.Command{
 	Use:     "search [query]",
 	GroupID: "issues",
 	Short:   "Search issues by text query",
-	Long: `Search issues across title and ID (excludes closed issues by default).
+	Long: `Search issues across title and ID (all statuses, including closed).
 
 ID-like queries (e.g., "bd-123", "hq-319") use fast exact/prefix matching.
 Text queries search titles. Use --desc-contains for description search.
-Use --status all to include closed issues.
+Use --status open (etc.) to narrow; closed issues are included by default
+so "was this already filed/fixed?" cannot silently answer no.
 
 Examples:
   bd search "authentication bug"
@@ -32,7 +33,7 @@ Examples:
   bd search "bd-5q" # Search by partial ID (fast prefix match)
   bd search "security" --priority-min 0 --priority-max 2
   bd search "bug" --created-after 2025-01-01
-  bd search "refactor" --status all  # Include closed issues
+  bd search "refactor" --status open  # Only open issues
   bd search "bug" --sort priority
   bd search "task" --sort created --reverse
   bd search "api" --desc-contains "endpoint"
@@ -116,13 +117,13 @@ Examples:
 			if err := workapi.ApplyStatusFilter(&filter, status, cfg.CustomStatusNames()); err != nil {
 				return HandleError("%v", err)
 			}
-		} else if status != "all" {
-			// Default: exclude closed issues to reduce scan scope (hq-319).
-			// With 12K+ issues, ~60-70% are closed — excluding them lets the
-			// query use the status index to skip the majority of rows.
-			// Use --status all to search everything including closed.
-			filter.ExcludeStatus = []types.Status{types.StatusClosed}
 		}
+		// Default (no --status) searches ALL statuses including closed
+		// (bd-t5yex): the dominant real-world query is "was this already
+		// found/filed/fixed?" — exactly where silently excluding closed
+		// issues produces a false "no". This reverses the hq-319 open-only
+		// default, which traded that correctness for scan scope; narrow
+		// explicitly (e.g. --status open) when performance matters.
 
 		if assignee != "" {
 			filter.Assignee = &assignee
@@ -355,7 +356,7 @@ func outputSearchResults(issues []*types.Issue, query string, longFormat bool) {
 
 func init() {
 	searchCmd.Flags().String("query", "", "Search query (alternative to positional argument)")
-	searchCmd.Flags().StringP("status", "s", "", "Filter by stored status (comma-separated for OR; open, in_progress, blocked, deferred, closed, all). Default excludes closed; use 'all' to include closed. Note: dependency-blocked issues use 'bd blocked'")
+	searchCmd.Flags().StringP("status", "s", "", "Filter by stored status (comma-separated for OR; open, in_progress, blocked, deferred, closed, all). Default searches all statuses including closed. Note: dependency-blocked issues use 'bd blocked'")
 	searchCmd.Flags().StringP("assignee", "a", "", "Filter by assignee")
 	searchCmd.Flags().StringP("type", "t", "", "Filter by type (bug, feature, task, epic, chore, decision, merge-request, molecule, gate)")
 	searchCmd.Flags().StringSliceP("label", "l", []string{}, "Filter by labels (AND: must have ALL)")

--- a/cmd/bd/search.go
+++ b/cmd/bd/search.go
@@ -23,7 +23,9 @@ var searchCmd = &cobra.Command{
 ID-like queries (e.g., "bd-123", "hq-319") use fast exact/prefix matching.
 Text queries search titles. Use --desc-contains for description search.
 Use --status open (etc.) to narrow; closed issues are included by default
-so "was this already filed/fixed?" cannot silently answer no.
+so "was this already filed/fixed?" cannot silently answer no. Matches
+beyond --limit are dropped status-blind, so when hunting live work in a
+large DB, narrow with --status open or raise --limit.
 
 Examples:
   bd search "authentication bug"

--- a/cmd/bd/search_embedded_test.go
+++ b/cmd/bd/search_embedded_test.go
@@ -152,6 +152,19 @@ func TestEmbeddedSearch(t *testing.T) {
 		}
 	})
 
+	t.Run("search_default_includes_closed", func(t *testing.T) {
+		// bd-t5yex: "was this already filed/fixed?" is the dominant search
+		// query, so the default must not silently hide closed issues.
+		results := bdSearchJSON(t, bd, dir, "sr-")
+		ids := map[string]bool{}
+		for _, r := range results {
+			ids[r["id"].(string)] = true
+		}
+		if !ids[taskA.ID] || !ids[closedTask.ID] {
+			t.Error("expected default search to include open and closed issues")
+		}
+	})
+
 	t.Run("search_status_comma_separated", func(t *testing.T) {
 		results := bdSearchJSON(t, bd, dir, "sr-", "--status", "open,closed")
 		ids := map[string]bool{}

--- a/cmd/bd/search_proxied_integration_test.go
+++ b/cmd/bd/search_proxied_integration_test.go
@@ -105,9 +105,12 @@ func TestProxiedServerSearch(t *testing.T) {
 		}
 	})
 
-	t.Run("default_excludes_closed", func(t *testing.T) {
-		if searchResultIDs(bdProxiedSearchJSON(t, bd, p.dir, "sp-"))[closedTask.ID] {
-			t.Error("default search should exclude closed issues")
+	t.Run("default_includes_closed", func(t *testing.T) {
+		// bd-t5yex: "was this already filed/fixed?" is the dominant search
+		// query, so the default must not silently hide closed issues.
+		ids := searchResultIDs(bdProxiedSearchJSON(t, bd, p.dir, "sp-"))
+		if !ids[taskA.ID] || !ids[closedTask.ID] {
+			t.Error("default search should include open and closed issues")
 		}
 	})
 

--- a/cmd/bd/search_proxied_server.go
+++ b/cmd/bd/search_proxied_server.go
@@ -65,9 +65,8 @@ func runSearchProxiedServer(cmd *cobra.Command, ctx context.Context, args []stri
 		Limit: limit,
 	}
 
-	if status == "" {
-		filter.ExcludeStatus = []types.Status{types.StatusClosed}
-	}
+	// Default (no --status) searches all statuses including closed
+	// (bd-t5yex) — keep in lockstep with the embedded path in search.go.
 
 	if assignee != "" {
 		filter.Assignee = &assignee

--- a/test/conformance/e2e_test.go
+++ b/test/conformance/e2e_test.go
@@ -205,16 +205,17 @@ var corpus = []scenario{
 		{"blocked", "--json"},
 	}},
 
-	// bd search --desc-contains (LOWER(description) LIKE) + default closed-exclusion.
-	// Lowercase 'endpoint' matches stored 'ENDPOINT' -> [cf-sd1]; plain search hides
-	// closed cf-sd3 -> []; --status all surfaces it -> [cf-sd3].
+	// bd search --desc-contains (LOWER(description) LIKE) + status defaulting.
+	// Lowercase 'endpoint' matches stored 'ENDPOINT' -> [cf-sd1]; plain search
+	// INCLUDES closed cf-sd3 by default (bd-t5yex) -> [cf-sd3]; --status open
+	// excludes it -> [].
 	{name: "search-desc-contains-and-status", steps: [][]string{
 		{"create", "alpha", "--id", "cf-sd1", "-t", "task", "--description", "Login ENDPOINT here"},
 		{"create", "gamma", "--id", "cf-sd3", "-t", "task"},
 		{"close", "cf-sd3"},
 		{"search", "alpha", "--desc-contains", "endpoint", "--json"},
 		{"search", "gamma", "--json"},
-		{"search", "gamma", "--status", "all", "--json"},
+		{"search", "gamma", "--status", "open", "--json"},
 	}},
 
 	// bd list --parent <id> --flat: non-recursive ParentID filter (deps parent-child


### PR DESCRIPTION
## Problem

`bd search` silently excludes closed issues unless you pass `--status all`. The dominant real-world search query is **"was this already found/filed/fixed?"** — exactly the query where excluding closed issues produces a false "no". Downstream repos grew shell wrappers (wyvern's `bd-find.sh`) purely to undo this default; when a repo writes a wrapper to change a default, the default is probably wrong.

## Change

- Default (no `--status`) now searches **all** statuses, on both the embedded path (`search.go`) and the proxied-server path (`search_proxied_server.go`).
- `bd list` keeps its open-only default — this is search-specific.
- `--status open` (or any status list) narrows explicitly where the old behavior is wanted; `--status all` still works, now redundantly.
- Help text + flag description updated; CHANGELOG entry under Unreleased/Changed. `docs/cli-reference` is release-pinned (`docs/cli-docs.pin`) and regenerates at release, so no hand-edits there.

This reverses the hq-319 performance default (open-only to use the status index on 12K+-issue DBs). That trade bought scan scope at the cost of wrong answers to the most common query; callers who care can still narrow.

## Callers audit

No in-repo programmatic caller depends on open-only search output: `prime.go` and the skill docs mention the command generically; nothing shells `bd search` and assumes closed-exclusion.

## Verification

- `TestEmbeddedSearch` (BEADS_TEST_EMBEDDED_DOLT=1): PASS, including new `search_default_includes_closed` subtest.
- `TestProxiedServerSearch` (BEADS_TEST_PROXIED_SERVER=1, live container): PASS, with `default_excludes_closed` flipped to `default_includes_closed`.
- Explicit-status subtests (open / closed / all / comma-separated) unchanged and green.

The bead's second ask (folding archive-jsonl search in, since closed beads get swept out of the live DB) is out of scope here — filed separately.

Bead: bd-t5yex

🤖 Generated with [Claude Code](https://claude.com/claude-code)