### PR TITLE
docs: re-review and bump the three 90-day-stale freshness markers

### DIFF
--- a/docs/integrations/azure-devops.md
+++ b/docs/integrations/azure-devops.md
@@ -3,11 +3,16 @@ title: Azure DevOps (ADO) Integration Configuration
 description: Configuration reference for bd ado sync, which bidirectionally syncs beads issues with Azure DevOps work items
 ---
 
-Last reviewed: 2026-05-08
+Last reviewed: 2026-08-07
 
 Freshness source: `cmd/bd/ado*.go` and `internal/ado/`.
 
 This guide covers all configuration options for the `bd ado sync` command, which synchronizes beads issues with Azure DevOps work items.
+
+**Proxied-server mode:** `bd ado sync`, `bd ado status`, and `bd ado projects`
+are not supported when bd is connected to a proxied server (error:
+`ado sync is not supported in proxied-server mode`); run them from a
+workspace with direct database access.
 
 ## Quick Start
 
@@ -50,6 +55,9 @@ bd ado sync --dry-run
 ² At least one project must be configured via `ado.project` or `ado.projects`.
 
 **Config vs env var precedence:** Config keys (set via `bd config set`) take priority over environment variables.
+
+`ado.pat` is a secret key stored in `config.yaml` (per-repo or user-global),
+never the shared database, so the PAT cannot leak via `dolt push`.
 
 ### On-Premises ADO Server
 
@@ -249,9 +257,10 @@ When the same issue has been modified both locally and in ADO:
 | `--bootstrap-match` | Enable heuristic title matching for first sync |
 | `--reconcile` | Force reconciliation scan for deleted items |
 | `--issues` | Sync specific issues by bead ID or ADO work item ID |
+| `--parent` | Push only a bead and its descendants (push mode only; mutually exclusive with `--issues`) |
+| `--project` | Project name(s) for this run, repeatable — overrides `ado.project`/`ado.projects` |
 | `--states` | Filter by work item states (comma-separated) |
 | `--types` | Filter by work item types (comma-separated) |
-| `--issues` | Sync specific beads by ID |
 
 ## PAT Permissions
 
@@ -308,7 +317,7 @@ bd config set ado.pat "your-pat-here"
 export AZURE_DEVOPS_PAT="your-pat-here"
 ```
 
-**"ado.organization not configured"**
+**`ado.org not configured: set via 'bd config set ado.org <org>' or AZURE_DEVOPS_ORG env var`**
 ```bash
 bd config set ado.org "your-org"
 # or for on-prem:

--- a/docs/reference/json-schema.md
+++ b/docs/reference/json-schema.md
@@ -3,7 +3,7 @@ title: JSON Output Schema Contract
 description: The stable JSON output contract for bd --json commands, covering the schema_version envelope, per-command fields, and consumer guidelines.
 ---
 
-Last reviewed: 2026-05-08
+Last reviewed: 2026-08-07
 
 Freshness source: `cmd/bd/output.go`, `cmd/bd/errors.go`, and
 `cmd/bd/protocol/json_contract_test.go`.
@@ -31,25 +31,37 @@ Every `--json` command wraps output as:
 The original payload is untouched inside `.data` — no type corruption,
 no field injection. Works identically for objects, arrays, and maps.
 
+When a `--limit`-truncated listing runs in envelope mode (currently wired
+for `bd ready`), the envelope also carries a `pagination` key:
+
+```json
+{"schema_version": 1, "data": [...], "pagination": {"returned": 10, "total": 42, "truncated": true}}
+```
+
+`total` is omitted when unknown; the whole `pagination` key is absent when
+the result was not truncated. Legacy mode keeps the stderr text hint instead.
+
 ### Updating consumers
 
 ```bash
 # Before (legacy):
 bd list --json | jq '.[0].id'
-bd show beads-abc --json | jq '.title'
+bd show beads-abc --json | jq '.[0].title'
 
 # After (envelope):
 bd list --json | jq '.data[0].id'
-bd show beads-abc --json | jq '.data.title'
+bd show beads-abc --json | jq '.data[0].title'
 
-# Version check:
-bd show beads-abc --json | jq '.schema_version'
+# Version check (object commands, e.g. create):
+bd create "Example" --json | jq '.schema_version'
 ```
 
 ### Timeline
 
 - **Current release**: Legacy format is default. Set `BD_JSON_ENVELOPE=1` to opt in.
-  A deprecation notice is printed to stderr when `--json` is used without the env var.
+  A deprecation notice is printed to stderr when `--json` is used without the env
+  var — but only when stderr is a terminal, and at most once per invocation, so
+  scripts capturing stderr will not see it.
 - **v2.0**: Envelope becomes the default. `BD_JSON_ENVELOPE=0` available as
   temporary escape hatch for one release cycle.
 
@@ -95,9 +107,9 @@ Arrays are wrapped the same way:
 
 ### Legacy mode (default, until v2.0)
 
-### Object commands (show, create, close, update, etc.)
+### Object commands (create, ping, etc.)
 
-Commands that return a single issue or result emit a JSON object with
+Commands that return a single result emit a JSON object with
 `schema_version` as a top-level field alongside the data:
 
 ```json
@@ -112,9 +124,11 @@ Commands that return a single issue or result emit a JSON object with
 }
 ```
 
-### List commands (list, ready, search, stale, etc.)
+### List commands (list, ready, search, stale, show, close, update, etc.)
 
-Commands that return multiple items emit a raw JSON array:
+Commands that return one or more issues emit a raw JSON array — including
+`show`, `close`, and `update`, which return one element per requested ID.
+Array output carries no top-level `schema_version` field:
 
 ```json
 [
@@ -123,9 +137,10 @@ Commands that return multiple items emit a raw JSON array:
 ]
 ```
 
-### Error output (stderr)
+### Error output
 
-Errors with `--json` active emit JSON to stderr:
+Errors with `--json` active emit JSON — most error paths write it to stderr,
+though some command-result error paths emit the same shape to stdout:
 
 ```json
 {
@@ -134,6 +149,12 @@ Errors with `--json` active emit JSON to stderr:
   "code": "not_found"
 }
 ```
+
+`code` and `hint` (a remediation suggestion) are both optional — only
+`error` and `schema_version` are always present. In envelope mode
+(`BD_JSON_ENVELOPE=1`) the error payload moves inside the envelope:
+`{"schema_version": 1, "data": {"error": ..., "code": ..., "hint": ...}}`.
+JSON-mode errors exit with code 1.
 
 ## Field Contracts by Command
 
@@ -158,7 +179,8 @@ Optional fields:
 
 Same schema as `bd list --json`. Items are filtered to unblocked issues only.
 Each item includes `dependency_count`, `dependent_count`, `comment_count`,
-and optional `parent` fields.
+and optional `parent` fields. In envelope mode a `--limit`-truncated result
+adds the envelope-level `pagination` key (see the envelope section above).
 
 ### bd blocked --json
 
@@ -169,10 +191,14 @@ Each item includes all standard issue fields plus:
 
 ### bd show --json
 
-Returns a single object (not wrapped in `items`). Same required fields as list
+Returns a top-level JSON array with one element per requested ID; items do
+not carry `schema_version` (this shape is pinned by a contract test — a
+change here is a breaking wire change). Same required fields as list
 items, plus:
 - `description` (string)
 - `acceptance_criteria` (string)
+- `revision` (number): guarded-write optimistic-concurrency token; always
+  present, including a legacy `0`
 - `dependencies` (object[]): Full dependency records
 - `comments` (object[]): Comment thread — present only with `--include-comments`;
   the default response returns `comment_count` only (count-only, be-ijck6q)
@@ -186,6 +212,7 @@ Returns a summary object when `--json` is active:
 - `source` (string): File path or "stdin"
 - `created` (number): Issues created
 - `updated` (number): Existing issues updated
+- `unchanged` (number, optional): Rows identical to local state, untouched
 - `skipped` (number): Issues skipped (stale rows + dedup)
 - `dedup_skipped` (number): Issues skipped by `--dedup` title match
 - `memories` (number): Memory records imported

--- a/engdocs/design/otel/otel-data-model.md
+++ b/engdocs/design/otel/otel-data-model.md
@@ -1,6 +1,6 @@
 # OpenTelemetry Data Model
 
-Last reviewed: 2026-05-08
+Last reviewed: 2026-08-07
 
 Freshness source: `internal/telemetry/`, `internal/storage/dolt/store.go`,
 `internal/compact/haiku.go`, `cmd/bd/find_duplicates.go`, and hook execution
@@ -8,8 +8,10 @@ code under `internal/hooks/`.
 
 Complete schema of all telemetry events emitted by Beads. Each event consists of:
 
-1. **Span** (→ any OTLP v1.x+ backend, stdout when `BD_OTEL_STDOUT=true`) with full structured attributes
+1. **Span** (→ stdout/console only, when `OTEL_TRACES_EXPORTER=console`; the legacy `BD_OTEL_STDOUT=true` translates to that — no remote/OTLP trace backend is wired) with full structured attributes
 2. **Metric counter/histogram** (→ any OTLP v1.x+ backend, defaults to VictoriaMetrics) for aggregation
+
+Telemetry is hard opt-in: nothing is emitted unless `BD_OTEL_ENABLED=true` is set (a legacy `BD_OTEL_*` variable also activates it); standard `OTEL_*` variables on their own do not.
 
 All command spans automatically carry `bd.command`, `bd.version`, `bd.args` from startup context; `bd.actor` is added after actor resolution.
 
@@ -82,12 +84,14 @@ Emitted once per `bd` subcommand execution. Anchors all subsequent events for th
 |---|---|---|
 | `bd.command` | string | Subcommand name |
 | `bd.version` | string | bd version |
-| `bd.args` | string | Full arguments passed to command |
+| `bd.args` | string | Full arguments passed to command, scrubbed via `scrubArgsForTelemetry` (secret-flag values and DSN userinfo redacted) |
 | `bd.actor` | string | Actor identity (set after actor resolution) |
 
 ---
 
 ## 3. Storage Events
+
+Every `storage.DoltStorage` method AND every issueops role method is instrumented: the facade wave's role decorators in `internal/telemetry/` emit `storage.<Method>` and `storage.<Role>.<Method>` spans (e.g. `storage.IssueReader.Ready`, `storage.ReadyClaimer.ClaimNext`, `storage.Sweeper.Sweep`), all feeding the same `bd.storage.*` metrics with `db.operation` as the label. The tables below are representative examples, not an exhaustive enumeration.
 
 ### `storage.CreateIssue`
 
@@ -160,6 +164,8 @@ Emitted when executing a transaction.
 
 ## 4. Dolt Backend Events
 
+**Shared attributes**: every `dolt.*` SQL span carries the fixed attribute set from `doltSpanAttrs()` — `db.system` (string, `"dolt"`), `db.readonly` (bool, whether the store is read-only), and `db.server_mode` (bool, currently always `true`). The tables below list only each span's additional attributes.
+
 ### `dolt.query`
 
 Emitted for each SQL read query via `queryContext()`.
@@ -168,8 +174,6 @@ Emitted for each SQL read query via `queryContext()`.
 |---|---|---|
 | `db.operation` | string | `"query"` |
 | `db.statement` | string | SQL statement (truncated to 300 chars) |
-| `db.system` | string | `"dolt"` |
-| `db.readonly` | bool | Whether store is read-only |
 
 ### `dolt.exec`
 
@@ -179,7 +183,6 @@ Emitted for each SQL write statement via `execContext()`.
 |---|---|---|
 | `db.operation` | string | `"exec"` |
 | `db.statement` | string | SQL statement (truncated to 300 chars) |
-| `db.system` | string | `"dolt"` |
 
 ### `dolt.query_row`
 
@@ -189,22 +192,18 @@ Emitted for single-row queries via `queryRowContext()`.
 |---|---|---|
 | `db.operation` | string | `"query_row"` |
 | `db.statement` | string | SQL statement (truncated to 300 chars) |
-| `db.system` | string | `"dolt"` |
 
 ### `dolt.commit`
 
-Emitted for DOLT_COMMIT operations.
-
-| Attribute | Type | Description |
-|---|---|---|
-| `commit_msg` | string | Commit message |
+Emitted for DOLT_COMMIT operations. Carries only the shared `doltSpanAttrs()` (see the note at the top of this section) — the commit message no longer appears on this span. It survives only as `db.commit_msg` on the `storage.RunInTransaction` / `storage.RunInIssueLifecycleTransaction` spans (`internal/telemetry/storage.go:556,564`).
 
 ### `dolt.push`
 
-Emitted for DOLT_PUSH operations.
+Emitted for DOLT_PUSH operations. The span name is `dolt.push`, or `dolt.force_push` for force pushes.
 
 | Attribute | Type | Description |
 |---|---|---|
+| `dolt.remote` | string | Remote being pushed to |
 | `dolt.branch` | string | Branch being pushed |
 
 ### `dolt.pull`
@@ -213,6 +212,7 @@ Emitted for DOLT_PULL operations.
 
 | Attribute | Type | Description |
 |---|---|---|
+| `dolt.remote` | string | Remote being pulled from |
 | `dolt.branch` | string | Branch being pulled |
 
 ### `dolt.merge`
@@ -222,6 +222,16 @@ Emitted for DOLT_MERGE operations.
 | Attribute | Type | Description |
 |---|---|---|
 | `dolt.merge_branch` | string | Branch being merged |
+| `dolt.conflicts` | int | Conflict count (set when conflicts are detected) |
+
+### `dolt.merge_with_strategy`
+
+Emitted for `bd vc merge --strategy` merges (pinned-connection merge/resolve/commit sequence).
+
+| Attribute | Type | Description |
+|---|---|---|
+| `dolt.merge_branch` | string | Branch being merged |
+| `dolt.merge_strategy` | string | Conflict-resolution strategy |
 
 ### `dolt.branch`
 
@@ -284,7 +294,7 @@ Stdout/stderr are added as span **events** (not attributes):
 
 Emitted by the compaction engine (`bd compact`) via `internal/compact/haiku.go`, and by duplicate detection (`bd find-duplicates --method ai`) via `cmd/bd/find_duplicates.go`. Both use the Anthropic SDK with Anthropic-compatible credentials from `ANTHROPIC_API_KEY`, `MINIMAX_API_KEY`, or `ai.api_key`.
 
-> **Note**: Only `compact/haiku.go` records to the `bd.ai.*` OTel metric instruments. `find_duplicates.go` records token counts as span attributes only.
+> **Note**: Only `compact/haiku.go` records to the `bd.ai.*` OTel metric instruments. `find_duplicates.go` records token counts and duration as span attributes only.
 
 ### `anthropic.messages.new`
 
@@ -296,10 +306,11 @@ One span per Anthropic API call. The `bd.ai.operation` attribute distinguishes t
 | `bd.ai.operation` | string | `"compact"` or `"find_duplicates"` |
 | `bd.ai.input_tokens` | int | Input tokens consumed |
 | `bd.ai.output_tokens` | int | Output tokens generated |
-| `bd.ai.attempts` | int | Number of attempts (including retries) |
+| `bd.ai.attempts` | int | Number of attempts, including retries (`compact` only) |
 | `bd.ai.batch_size` | int | Candidate pairs evaluated (`find_duplicates` only) |
+| `bd.ai.duration_ms` | float | Request duration in ms (`find_duplicates` only; `compact` records the `bd.ai.request.duration` metric instead) |
 
-**Retry policy**: exponential backoff, up to 3 attempts, on HTTP 429, 5xx, and network timeout errors.
+**Retry policy**: exponential backoff, up to 4 attempts (1 initial + up to 3 retries, `maxRetries = 3`), on HTTP 429, 5xx, and network timeout errors.
 
 ---
 
@@ -315,6 +326,13 @@ One span per Anthropic API call. The `bd.ai.operation` attribute distinguishes t
 | `bd.db.lock_wait_ms` | Histogram | — | 🔲 Registered, not recorded |
 | `bd.db.circuit_trips` | Counter | — | ✅ Implemented |
 | `bd.db.circuit_rejected` | Counter | — | ✅ Implemented |
+| `bd.db.serialization_errors` | Counter | — | ✅ Implemented |
+| `bd.write_retries_total` | Counter | `type` (`serialization` \| `connection`) | ✅ Implemented |
+| `bd.db.conn_acquire_ms` | Histogram | — | ✅ Implemented |
+| `bd.db.pool_wait_count` | Counter | — | ✅ Implemented |
+| `bd.db.pool_wait_ms` | Histogram | — | ✅ Implemented |
+| `bd.claim_verify_lost_total` | Counter | `op` (`claim` \| `unclaim`) | ✅ Implemented |
+| `bd.claim_verify_recovered_total` | Counter | `op`, `outcome` | 🔲 Registered, not recorded |
 | `bd.ai.input_tokens` | Counter | `bd.ai.model` | ✅ Implemented (compact only) |
 | `bd.ai.output_tokens` | Counter | `bd.ai.model` | ✅ Implemented (compact only) |
 | `bd.ai.request.duration` | Histogram (ms) | `bd.ai.model` | ✅ Implemented (compact only) |
@@ -334,13 +352,13 @@ bd.issue.id, bd.issue.type, hook.event, hook.path, bd.ai.model, bd.ai.operation
 
 Environment variables, backend compatibility, Dolt system tables, and roadmap are documented in [otel-architecture.md](otel-architecture.md) to avoid duplication.
 
-Key variables: `BD_OTEL_METRICS_URL`, `BD_OTEL_LOGS_URL`, `BD_OTEL_STDOUT`.
+Key variables: `BD_OTEL_ENABLED=true` (master switch) plus the standard SDK vars — `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`, `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`, `OTEL_TRACES_EXPORTER`/`OTEL_METRICS_EXPORTER=console`, `OTEL_SDK_DISABLED`. The legacy `BD_OTEL_METRICS_URL`/`BD_OTEL_LOGS_URL`/`BD_OTEL_STDOUT` trio is deprecated but still honored: each is translated to its `OTEL_*` equivalent with a stderr deprecation warning (commit `1cf7490c7`, #3859).
 
 ---
 
 ## Appendix: Source Reference Audit
 
-Audited against **`main` @ `371df32b`**. All line numbers below refer to that commit.
+Audited against **`main` @ `5eb7c25dd`**. All line numbers below refer to that commit.
 
 Every metric name, span name, and attribute listed in this document is backed by a specific source location. This table exists to prevent documentation drift and to make re-verification straightforward after code changes.
 
@@ -348,36 +366,44 @@ Every metric name, span name, and attribute listed in this document is backed by
 
 | Metric (SDK name) | Type | Source |
 |-------------------|------|--------|
-| `bd.storage.operations` | Counter | `storage.go:38` — `m.Int64Counter("bd.storage.operations")` |
-| `bd.storage.operation.duration` | Histogram | `storage.go:41` — `m.Float64Histogram("bd.storage.operation.duration")` |
-| `bd.storage.errors` | Counter | `storage.go:45` — `m.Int64Counter("bd.storage.errors")` |
-| `bd.issue.count` | Gauge | `storage.go:48` — `m.Int64Gauge("bd.issue.count")` |
-| `bd.db.retry_count` | Counter | `store.go:302` — `m.Int64Counter("bd.db.retry_count")` |
-| `bd.db.lock_wait_ms` | Histogram | `store.go:306` — registered; `.Record()` not called anywhere |
-| `bd.db.circuit_trips` | Counter | `store.go:310` — `m.Int64Counter("bd.db.circuit_trips")` |
-| `bd.db.circuit_rejected` | Counter | `store.go:314` — `m.Int64Counter("bd.db.circuit_rejected")` |
-| `bd.ai.input_tokens` | Counter | `haiku.go:110` — `m.Int64Counter("bd.ai.input_tokens")` |
-| `bd.ai.output_tokens` | Counter | `haiku.go:114` — `m.Int64Counter("bd.ai.output_tokens")` |
-| `bd.ai.request.duration` | Histogram | `haiku.go:118` — `m.Float64Histogram("bd.ai.request.duration")` |
+| `bd.storage.operations` | Counter | `storage.go:46` — `m.Int64Counter("bd.storage.operations")` |
+| `bd.storage.operation.duration` | Histogram | `storage.go:49` — `m.Float64Histogram("bd.storage.operation.duration")` |
+| `bd.storage.errors` | Counter | `storage.go:53` — `m.Int64Counter("bd.storage.errors")` |
+| `bd.issue.count` | Gauge | `storage.go:56` — `m.Int64Gauge("bd.issue.count")` |
+| `bd.db.retry_count` | Counter | `store.go:872` — `m.Int64Counter("bd.db.retry_count")` |
+| `bd.db.lock_wait_ms` | Histogram | `store.go:876` — registered; `.Record()` not called anywhere |
+| `bd.db.circuit_trips` | Counter | `store.go:880` — `m.Int64Counter("bd.db.circuit_trips")` |
+| `bd.db.circuit_rejected` | Counter | `store.go:884` — `m.Int64Counter("bd.db.circuit_rejected")` |
+| `bd.db.serialization_errors` | Counter | `store.go:888` — registered; recorded at `store.go:1103,1116` |
+| `bd.write_retries_total` | Counter | `store.go:892` — registered; recorded at `store.go:1104,1117,1124` (`type=serialization\|connection`) |
+| `bd.db.conn_acquire_ms` | Histogram | `store.go:896` — registered; recorded at `transaction.go:167` |
+| `bd.db.pool_wait_count` | Counter | `store.go:900` — registered; recorded at `transaction.go:174` |
+| `bd.db.pool_wait_ms` | Histogram | `store.go:904` — registered; recorded at `transaction.go:176` |
+| `bd.claim_verify_lost_total` | Counter | `store.go:908` — registered; recorded at `claim_verify.go:196`, `issues.go:439` |
+| `bd.claim_verify_recovered_total` | Counter | `store.go:912` — registered; `.Add()` not called anywhere |
+| `bd.ai.input_tokens` | Counter | `haiku.go:117` — `m.Int64Counter("bd.ai.input_tokens")` |
+| `bd.ai.output_tokens` | Counter | `haiku.go:121` — `m.Int64Counter("bd.ai.output_tokens")` |
+| `bd.ai.request.duration` | Histogram | `haiku.go:125` — `m.Float64Histogram("bd.ai.request.duration")` |
 
 ### Spans and attributes
 
 | Span name | Attributes | Source |
 |-----------|-----------|--------|
-| `bd.command.<name>` | `bd.command`, `bd.version`, `bd.args` | `cmd/bd/main.go:262-266` |
-| `bd.command.<name>` | `bd.actor` (added later) | `cmd/bd/main.go:474` |
-| `storage.<op>` (all methods) | `db.operation` + method-specific attrs | `internal/telemetry/storage.go:62-69` |
-| `dolt.query` | `db.operation="query"`, `db.statement`, `db.system="dolt"` | `store.go:400-405` |
-| `dolt.exec` | `db.operation="exec"`, `db.statement`, `db.system="dolt"` | `store.go:363-368` |
-| `dolt.query_row` | `db.operation="query_row"`, `db.statement`, `db.system="dolt"` | `store.go:429-434` |
-| `dolt.commit` | `commit_msg` | `store.go:1086` |
-| `dolt.push` | `dolt.branch` | `store.go:1231, 1266` |
-| `dolt.pull` | `dolt.branch` | `store.go:1295` |
-| `dolt.merge` | `dolt.merge_branch` | `store.go:1389` |
-| `dolt.branch` | `dolt.branch` | `store.go:1357` |
-| `dolt.checkout` | `dolt.branch` | `store.go:1372` |
+| `bd.command.<name>` | `bd.command`, `bd.version`, `bd.args` (scrubbed) | built in `cmd/bd/command_telemetry.go` (`startCommandSpan`/`commandSpanAttrs`), called from `cmd/bd/main.go:938` |
+| `bd.command.<name>` | `bd.actor` (added later) | `cmd/bd/main.go:1367` |
+| `storage.<op>` / `storage.<Role>.<Method>` (all methods) | `db.operation` + method-specific attrs | `internal/telemetry/storage.go:75-76` (role decorators throughout `internal/telemetry/`) |
+| `dolt.query` | `db.operation="query"`, `db.statement` + `doltSpanAttrs()` | `store.go:1309` |
+| `dolt.exec` | `db.operation="exec"`, `db.statement` + `doltSpanAttrs()` | `store.go:1168` |
+| `dolt.query_row` | `db.operation="query_row"`, `db.statement` + `doltSpanAttrs()` | `store.go:1338` |
+| `dolt.commit` | `doltSpanAttrs()` only | `store.go:2901` |
+| `dolt.push` / `dolt.force_push` | `dolt.remote`, `dolt.branch` | `store.go:3674-3682` |
+| `dolt.pull` | `dolt.remote`, `dolt.branch` | `store.go:3777-3781` |
+| `dolt.merge` | `dolt.merge_branch`; `dolt.conflicts` | `store.go:4348`; conflicts at `store.go:4370` |
+| `dolt.merge_with_strategy` | `dolt.merge_branch`, `dolt.merge_strategy` | `store.go:4395` |
+| `dolt.branch` | `dolt.branch` | `store.go:4309-4312` |
+| `dolt.checkout` | `dolt.branch` | `store.go:4326-4329` |
 | `hook.exec` | `hook.event`, `hook.path`, `bd.issue_id` | `hooks_unix.go:31-36` |
 | `hook.exec` events | `hook.stdout` / `hook.stderr` with `output`, `bytes` | `hooks_otel.go:14, 20` |
-| `anthropic.messages.new` | `bd.ai.model`, `bd.ai.operation` | `haiku.go:129-130` |
-| `anthropic.messages.new` | `bd.ai.input_tokens`, `bd.ai.output_tokens`, `bd.ai.attempts` | `haiku.go:165-167` |
-| `anthropic.messages.new` | `bd.ai.batch_size` (find_duplicates only) | `find_duplicates.go:433` |
+| `anthropic.messages.new` | `bd.ai.model`, `bd.ai.operation` | `haiku.go:133-138` |
+| `anthropic.messages.new` | `bd.ai.input_tokens`, `bd.ai.output_tokens`, `bd.ai.attempts` | `haiku.go:171-175` |
+| `anthropic.messages.new` | `bd.ai.batch_size`; `bd.ai.duration_ms` (find_duplicates only) | `find_duplicates.go:466-470`; `find_duplicates.go:491` |

--- a/engdocs/design/otel/otel-data-model.md
+++ b/engdocs/design/otel/otel-data-model.md
@@ -310,7 +310,7 @@ One span per Anthropic API call. The `bd.ai.operation` attribute distinguishes t
 | `bd.ai.batch_size` | int | Candidate pairs evaluated (`find_duplicates` only) |
 | `bd.ai.duration_ms` | float | Request duration in ms (`find_duplicates` only; `compact` records the `bd.ai.request.duration` metric instead) |
 
-**Retry policy**: exponential backoff, up to 4 attempts (1 initial + up to 3 retries, `maxRetries = 3`), on HTTP 429, 5xx, and network timeout errors.
+**Retry policy** (compact only; `find_duplicates` makes a single unretried call): exponential backoff, up to 4 attempts (1 initial + up to 3 retries, `maxRetries = 3`), on HTTP 429, 5xx, and network timeout errors.
 
 ---
 
@@ -331,7 +331,7 @@ One span per Anthropic API call. The `bd.ai.operation` attribute distinguishes t
 | `bd.db.conn_acquire_ms` | Histogram | — | ✅ Implemented |
 | `bd.db.pool_wait_count` | Counter | — | ✅ Implemented |
 | `bd.db.pool_wait_ms` | Histogram | — | ✅ Implemented |
-| `bd.claim_verify_lost_total` | Counter | `op` (`claim` \| `unclaim`) | ✅ Implemented |
+| `bd.claim_verify_lost_total` | Counter | `op` (`claim` \| `unclaim` \| `guarded-update` \| `ready-claim`) | ✅ Implemented |
 | `bd.claim_verify_recovered_total` | Counter | `op`, `outcome` | 🔲 Registered, not recorded |
 | `bd.ai.input_tokens` | Counter | `bd.ai.model` | ✅ Implemented (compact only) |
 | `bd.ai.output_tokens` | Counter | `bd.ai.model` | ✅ Implemented (compact only) |


### PR DESCRIPTION
The doc-flags freshness gate went red on every branch today: azure-devops.md, json-schema.md, and otel-data-model.md all carried `Last reviewed: 2026-05-08` — exactly 91 days old against the 90-day fence. This blocks unrelated PRs (e.g. #4839, whose review is otherwise complete).

Each doc got a genuine re-review against its Freshness source paths on main (one fresh-context reviewer per doc), not a blind date bump. Real drift was found and fixed in all three — details in the commit message. Highlights:

- **json-schema.md** taught `jq` recipes that fail against current `bd show --json` (it returns a top-level array, pinned by contract test); envelope `pagination`, show's `revision`, import's `unchanged`, and the error-envelope shape were missing or wrong.
- **azure-devops.md** was missing proxied-server behavior, `--parent`/`--project` flags, and the yaml-only PAT note. The review also surfaced a real source bug — the cmd-level config reader can't see a yaml-only `ado.pat`, so the documented Quick Start fails on main — filed as **bd-wvf77** rather than papered over in the doc.
- **otel-data-model.md** predated the env-var refactor (#3859), the facade-wave storage role spans, and seven newer Dolt metrics; appendix re-pinned to current main.

`scripts/check-doc-freshness.sh` passes locally with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)