### PR TITLE
Four DependencyEditor contract cases for state the contract never seeded

### DIFF
--- a/backend/conformance/dependency_editor_contract.go
+++ b/backend/conformance/dependency_editor_contract.go
@@ -3,6 +3,7 @@ package conformance
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/types"
@@ -1113,6 +1114,317 @@ func RunDependencyEditorRecordsOneHistoryEntryForAMixedPlaneRequest(t *testing.T
 		"a request spanning both planes is one transaction with one versioned half, so it is ONE history entry")
 }
 
+// RunDependencyEditorWritesTheTargetIntoItsTypedColumn pins the target
+// CLASSIFICATION (issueops.ClassifyDepTarget) that dependencyeditor.go:150-156
+// only describes from the outside. A dependency row holds its target in one of
+// three typed columns — depends_on_issue_id, depends_on_wisp_id,
+// depends_on_external — and which one it is is not cosmetic: only
+// depends_on_issue_id carries fk_dep_issue_target into issues(id)
+// (internal/storage/schema/cli_migrations.go:141,155,168), so a wisp or a
+// foreign id filed there is a write that fails, and a local issue filed
+// anywhere else is an edge no foreign key protects from a later delete.
+//
+// EVERY OTHER CASE IN THIS FILE IS BLIND TO THIS. They read the target through
+// COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external), which
+// resolves to the same id whichever column holds it — so a body that filed a
+// wisp target as external passes all of them and fails only here.
+//
+// Both source planes are exercised because routing the SOURCE (which table the
+// row lands in) and classifying the TARGET (which column inside it) are
+// independent decisions, and a wisp-sourced edge is where they are easiest to
+// conflate.
+func RunDependencyEditorWritesTheTargetIntoItsTypedColumn(t *testing.T, ctx context.Context, fixture DependencyEditorFixture) {
+	t.Helper()
+	issue := fixture.IssuePrefix + "-tcol-issue"
+	wisp := fixture.IssuePrefix + "-tcol-wisp"
+	issueTarget := fixture.IssuePrefix + "-tcol-issuetgt"
+	wispTarget := fixture.IssuePrefix + "-tcol-wisptgt"
+	const external = "external:https://example.invalid/tracker/61"
+	const foreign = "othertcol-9001"
+	seedDependencyEditorIssue(t, ctx, fixture, issue)
+	seedDependencyEditorIssue(t, ctx, fixture, issueTarget)
+	seedDependencyEditorWisp(t, ctx, fixture, wisp)
+	seedDependencyEditorWisp(t, ctx, fixture, wispTarget)
+
+	if _, err := fixture.Editor.AddDependencies(ctx, publicops.AddDependenciesRequest{
+		Actor: "writer",
+		Edges: []publicops.DependencyEdge{
+			{IssueID: issue, DependsOnID: issueTarget, Type: publicops.DepBlocks},
+			{IssueID: issue, DependsOnID: wispTarget, Type: publicops.DepRelated},
+			{IssueID: issue, DependsOnID: external, Type: publicops.DepRelated},
+			{IssueID: issue, DependsOnID: foreign, Type: publicops.DepRelated},
+			{IssueID: wisp, DependsOnID: wispTarget, Type: publicops.DepBlocks},
+			{IssueID: wisp, DependsOnID: issueTarget, Type: publicops.DepRelated},
+		},
+	}); err != nil {
+		t.Fatalf("AddDependencies over the four target classes: %v", err)
+	}
+
+	for _, want := range []struct {
+		table  string
+		source string
+		target string
+		column string
+		why    string
+	}{
+		{"dependencies", issue, issueTarget, "depends_on_issue_id",
+			"a local issue is the one target class the foreign key can hold"},
+		{"dependencies", issue, wispTarget, "depends_on_wisp_id",
+			"a wisp has no row in issues, so the issue-keyed column would fail its foreign key"},
+		{"dependencies", issue, external, "depends_on_external",
+			"an external: reference names something outside this database entirely"},
+		{"dependencies", issue, foreign, "depends_on_external",
+			"another repository's id lives in that rig's database, not this one"},
+		{"wisp_dependencies", wisp, wispTarget, "depends_on_wisp_id",
+			"the ephemeral plane classifies its targets by the same rule"},
+		{"wisp_dependencies", wisp, issueTarget, "depends_on_issue_id",
+			"a wisp-sourced edge onto a durable issue still files the target as an issue"},
+	} {
+		assertDependencyEditorTargetColumn(t, ctx, fixture, want.table, want.source, want.target, want.column, want.why)
+	}
+}
+
+// RunDependencyEditorRefusesBlockingEdgeAcrossAWispHierarchy is the EPHEMERAL
+// half of dependencyeditor.go:146-148.
+//
+// RunDependencyEditorRefusesBlockingEdgeAcrossItsOwnHierarchy seeds durable
+// issues, and the hierarchy walk it exercises reads a UNION of both dependency
+// tables. A body that read only the durable one passes that case and fails this
+// one, and the deadlock it lets through is real: a wisp gated on its own
+// ancestor never becomes ready, because the ancestor inherits the descendant's
+// blocked state.
+//
+// The last arm is the boundary the walk deliberately does not cross. It climbs
+// child → parent only, so two children of one wisp parent share a hierarchy
+// COMPONENT but not a hierarchy LINE, and an ordering edge between them stays
+// legal.
+func RunDependencyEditorRefusesBlockingEdgeAcrossAWispHierarchy(t *testing.T, ctx context.Context, fixture DependencyEditorFixture) {
+	t.Helper()
+	parent := fixture.IssuePrefix + "-whier-parent"
+	child := fixture.IssuePrefix + "-whier-child"
+	sibling := fixture.IssuePrefix + "-whier-sibling"
+	for _, id := range []string{parent, child, sibling} {
+		seedDependencyEditorWisp(t, ctx, fixture, id)
+	}
+	if _, err := fixture.Editor.AddDependencies(ctx, publicops.AddDependenciesRequest{
+		Actor: "writer",
+		Edges: []publicops.DependencyEdge{
+			{IssueID: child, DependsOnID: parent, Type: publicops.DepParentChild},
+			{IssueID: sibling, DependsOnID: parent, Type: publicops.DepParentChild},
+		},
+	}); err != nil {
+		t.Fatalf("seed the wisp hierarchy: %v", err)
+	}
+
+	_, err := fixture.Editor.AddDependencies(ctx, publicops.AddDependenciesRequest{
+		Actor: "writer",
+		Edges: []publicops.DependencyEdge{{IssueID: parent, DependsOnID: child, Type: publicops.DepBlocks}},
+	})
+	var descendant *publicops.DependencyHierarchyConflictError
+	if !errors.As(err, &descendant) {
+		t.Fatalf("gating a wisp parent on its own child: error = %v, want *DependencyHierarchyConflictError", err)
+	}
+	if descendant.BlockerIsAncestor {
+		t.Errorf("conflict = %#v, want BlockerIsAncestor false: the blocker is the DESCENDANT here", descendant)
+	}
+
+	_, err = fixture.Editor.AddDependencies(ctx, publicops.AddDependenciesRequest{
+		Actor: "writer",
+		// conditional-blocks rather than blocks: the guard covers the whole
+		// scheduling set, and this type has no constant in the public sample.
+		Edges: []publicops.DependencyEdge{{IssueID: child, DependsOnID: parent, Type: types.DepConditionalBlocks}},
+	})
+	var ancestor *publicops.DependencyHierarchyConflictError
+	if !errors.As(err, &ancestor) {
+		t.Fatalf("gating a wisp child on its own parent: error = %v, want *DependencyHierarchyConflictError", err)
+	}
+	if !ancestor.BlockerIsAncestor {
+		t.Errorf("conflict = %#v, want BlockerIsAncestor true", ancestor)
+	}
+	// The hierarchy refusal beats the type conflict the pair already carries:
+	// the pair has a parent-child row, and a body checking the existing edge
+	// first would report the wrong reason for the right refusal.
+	var conflict *publicops.DependencyTypeConflictError
+	if errors.As(err, &conflict) {
+		t.Errorf("error = %#v, want the hierarchy conflict: the deadlock is the reason, not the pre-existing row", conflict)
+	}
+
+	if _, err := fixture.Editor.AddDependencies(ctx, publicops.AddDependenciesRequest{
+		Actor: "writer",
+		Edges: []publicops.DependencyEdge{{IssueID: sibling, DependsOnID: child, Type: publicops.DepBlocks}},
+	}); err != nil {
+		t.Fatalf("ordering two children of one wisp parent: %v — siblings share a component, not a line", err)
+	}
+	assertDependencyEdgeTypedCount(t, ctx, fixture, "wisp_dependencies", sibling, child, string(publicops.DepBlocks), 1)
+}
+
+// RunDependencyEditorRefusesACycleThroughAParentChildHop pins the edge set the
+// ADD-TIME gate walks, which is NOT the set DetectCycles walks.
+// cycle_detector_contract.go says so from the other side — `parent-child` is
+// outside the report's walk, "which the ADD-time gate does walk" — and nothing
+// pinned the half that sentence asserts.
+//
+// It matters because a blocked parent propagates its blocked state to its
+// children, so a loop alternating `blocks` and `parent-child` hops is a
+// livelock in which nothing ever becomes ready, even though no `blocks` cycle
+// exists anywhere in it. Every other cycle case in this file closes a loop made
+// of blocking edges only, so a body narrowed to those passes all of them.
+//
+// Both closing orientations are asserted because they enter the gate
+// differently: a blocking closing edge is checked by the per-edge probe on its
+// own type, and a parent-child closing edge is one whose OWN type the walk has
+// to include to see the loop at all.
+//
+// The last arm is the false-positive guard, and it is the reason this is one
+// case rather than two: a body that treated every parent-child hop as a cycle
+// would pass both refusals and refuse the ordinary shape — a chain of tasks
+// each gating an epic it does not belong to — that the refusals exist to
+// distinguish from.
+func RunDependencyEditorRefusesACycleThroughAParentChildHop(t *testing.T, ctx context.Context, fixture DependencyEditorFixture) {
+	t.Helper()
+	// A closing BLOCKS edge: parentA -> childA -> parentB -> childB -> parentA,
+	// alternating parent-child and blocks hops.
+	parentA := fixture.IssuePrefix + "-pchop-b-pa"
+	parentB := fixture.IssuePrefix + "-pchop-b-pb"
+	childA := fixture.IssuePrefix + "-pchop-b-ca"
+	childB := fixture.IssuePrefix + "-pchop-b-cb"
+	for _, id := range []string{parentA, parentB, childA, childB} {
+		seedDependencyEditorIssue(t, ctx, fixture, id)
+	}
+	if _, err := fixture.Editor.AddDependencies(ctx, publicops.AddDependenciesRequest{
+		Actor: "writer",
+		Edges: []publicops.DependencyEdge{
+			{IssueID: childA, DependsOnID: parentA, Type: publicops.DepParentChild},
+			{IssueID: childB, DependsOnID: parentB, Type: publicops.DepParentChild},
+			{IssueID: parentB, DependsOnID: childA, Type: publicops.DepBlocks},
+		},
+	}); err != nil {
+		t.Fatalf("seed the combined graph: %v", err)
+	}
+	_, err := fixture.Editor.AddDependencies(ctx, publicops.AddDependenciesRequest{
+		Actor: "writer",
+		Edges: []publicops.DependencyEdge{{IssueID: parentA, DependsOnID: childB, Type: publicops.DepBlocks}},
+	})
+	if !errors.Is(err, publicops.ErrDependencyCycle) {
+		t.Fatalf("a blocking edge closing a loop through parent-child hops: error = %v, want ErrDependencyCycle", err)
+	}
+	assertDependencyEditorNoEdgesFrom(t, ctx, fixture, parentA)
+
+	// The same loop, with the PARENT-CHILD edge as the one that closes it.
+	pcParentA := fixture.IssuePrefix + "-pchop-p-pa"
+	pcParentB := fixture.IssuePrefix + "-pchop-p-pb"
+	pcChildA := fixture.IssuePrefix + "-pchop-p-ca"
+	pcChildB := fixture.IssuePrefix + "-pchop-p-cb"
+	for _, id := range []string{pcParentA, pcParentB, pcChildA, pcChildB} {
+		seedDependencyEditorIssue(t, ctx, fixture, id)
+	}
+	if _, err := fixture.Editor.AddDependencies(ctx, publicops.AddDependenciesRequest{
+		Actor: "writer",
+		Edges: []publicops.DependencyEdge{
+			{IssueID: pcChildA, DependsOnID: pcParentA, Type: publicops.DepParentChild},
+			{IssueID: pcParentB, DependsOnID: pcChildA, Type: publicops.DepBlocks},
+			{IssueID: pcParentA, DependsOnID: pcChildB, Type: publicops.DepBlocks},
+		},
+	}); err != nil {
+		t.Fatalf("seed the combined graph for the parent-child closing edge: %v", err)
+	}
+	_, err = fixture.Editor.AddDependencies(ctx, publicops.AddDependenciesRequest{
+		Actor: "writer",
+		Edges: []publicops.DependencyEdge{{IssueID: pcChildB, DependsOnID: pcParentB, Type: publicops.DepParentChild}},
+	})
+	if !errors.Is(err, publicops.ErrDependencyCycle) {
+		t.Fatalf("a parent-child edge closing a loop through blocking hops: error = %v, want ErrDependencyCycle", err)
+	}
+	assertDependencyEditorNoEdgesFrom(t, ctx, fixture, pcChildB)
+
+	// The acyclic shape the two refusals must not also refuse: each child gates
+	// an epic it does not belong to, and belongs to the next one along.
+	const levels = 4
+	chain := make([]publicops.DependencyEdge, 0, 2*levels)
+	for i := 0; i < levels; i++ {
+		parent := fmt.Sprintf("%s-pchop-chain-p%d", fixture.IssuePrefix, i)
+		child := fmt.Sprintf("%s-pchop-chain-c%d", fixture.IssuePrefix, i)
+		seedDependencyEditorIssue(t, ctx, fixture, parent)
+		seedDependencyEditorIssue(t, ctx, fixture, child)
+		chain = append(chain, publicops.DependencyEdge{IssueID: parent, DependsOnID: child, Type: publicops.DepBlocks})
+		if i > 0 {
+			previous := fmt.Sprintf("%s-pchop-chain-c%d", fixture.IssuePrefix, i-1)
+			chain = append(chain, publicops.DependencyEdge{IssueID: previous, DependsOnID: parent, Type: publicops.DepParentChild})
+		}
+	}
+	if _, err := fixture.Editor.AddDependencies(ctx, publicops.AddDependenciesRequest{Actor: "writer", Edges: chain}); err != nil {
+		t.Fatalf("an acyclic chain alternating blocking and parent-child hops: %v — the walk must not read every hierarchy as a loop", err)
+	}
+}
+
+// RunDependencyEditorRefusesASamePlaneEdgeClosingACrossPlaneCycle is the half
+// of bd-xe27 that RunDependencyEditorRefusesCrossPlaneCycle cannot reach.
+//
+// There, the edge under test CROSSES the planes itself, so a gate that decided
+// to merge the two tables from the edge in front of it still refuses. Here both
+// endpoints of the new edge live in ONE plane and only the INTERIOR of the loop
+// leaves it — so the gate has to merge the tables unconditionally, from the
+// graph rather than from the edge. That distinction was a real defect: the
+// merged two-session check ran only when the closing edge crossed tiers, and a
+// same-tier closing edge saw one session and let the cycle commit.
+//
+// Both orientations are asserted, because "the plane the endpoints share" and
+// "the plane the interior visits" swap between them and the two tables are not
+// symmetric — only one of them is versioned.
+func RunDependencyEditorRefusesASamePlaneEdgeClosingACrossPlaneCycle(t *testing.T, ctx context.Context, fixture DependencyEditorFixture) {
+	t.Helper()
+	// Durable endpoints, the interior hop through the ephemeral plane:
+	// issueA -> issueB (new) with issueB -> wisp -> issueA already stored.
+	issueA := fixture.IssuePrefix + "-splane-issue-a"
+	issueB := fixture.IssuePrefix + "-splane-issue-b"
+	throughWisp := fixture.IssuePrefix + "-splane-via-wisp"
+	seedDependencyEditorIssue(t, ctx, fixture, issueA)
+	seedDependencyEditorIssue(t, ctx, fixture, issueB)
+	seedDependencyEditorWisp(t, ctx, fixture, throughWisp)
+	if _, err := fixture.Editor.AddDependencies(ctx, publicops.AddDependenciesRequest{
+		Actor: "writer",
+		Edges: []publicops.DependencyEdge{
+			{IssueID: issueB, DependsOnID: throughWisp, Type: publicops.DepBlocks},
+			{IssueID: throughWisp, DependsOnID: issueA, Type: publicops.DepBlocks},
+		},
+	}); err != nil {
+		t.Fatalf("seed the path that leaves the durable plane and comes back: %v", err)
+	}
+	_, err := fixture.Editor.AddDependencies(ctx, publicops.AddDependenciesRequest{
+		Actor: "writer",
+		Edges: []publicops.DependencyEdge{{IssueID: issueA, DependsOnID: issueB, Type: publicops.DepBlocks}},
+	})
+	if !errors.Is(err, publicops.ErrDependencyCycle) {
+		t.Fatalf("a durable edge closing a loop whose interior runs through the wisp plane: error = %v, want ErrDependencyCycle", err)
+	}
+	assertDependencyEditorNoEdgesFrom(t, ctx, fixture, issueA)
+
+	// Ephemeral endpoints, the interior hop through the durable plane.
+	wispA := fixture.IssuePrefix + "-splane-wisp-a"
+	wispB := fixture.IssuePrefix + "-splane-wisp-b"
+	throughIssue := fixture.IssuePrefix + "-splane-via-issue"
+	seedDependencyEditorWisp(t, ctx, fixture, wispA)
+	seedDependencyEditorWisp(t, ctx, fixture, wispB)
+	seedDependencyEditorIssue(t, ctx, fixture, throughIssue)
+	if _, err := fixture.Editor.AddDependencies(ctx, publicops.AddDependenciesRequest{
+		Actor: "writer",
+		Edges: []publicops.DependencyEdge{
+			{IssueID: wispB, DependsOnID: throughIssue, Type: publicops.DepBlocks},
+			{IssueID: throughIssue, DependsOnID: wispA, Type: publicops.DepBlocks},
+		},
+	}); err != nil {
+		t.Fatalf("seed the path that leaves the ephemeral plane and comes back: %v", err)
+	}
+	_, err = fixture.Editor.AddDependencies(ctx, publicops.AddDependenciesRequest{
+		Actor: "writer",
+		Edges: []publicops.DependencyEdge{{IssueID: wispA, DependsOnID: wispB, Type: publicops.DepBlocks}},
+	})
+	if !errors.Is(err, publicops.ErrDependencyCycle) {
+		t.Fatalf("an ephemeral edge closing a loop whose interior runs through the durable plane: error = %v, want ErrDependencyCycle", err)
+	}
+	assertDependencyEditorNoEdgesFrom(t, ctx, fixture, wispA)
+}
+
 func seedDependencyEditorIssue(t *testing.T, ctx context.Context, fixture DependencyEditorFixture, id string) {
 	t.Helper()
 	if err := fixture.CreateIssue(ctx, dependencyEditorSeed(id, false), "seed"); err != nil {
@@ -1167,6 +1479,31 @@ func assertDependencyEdgeTypedCount(t *testing.T, ctx context.Context, fixture D
 	}
 	if got != want {
 		t.Errorf("%s %s edges %s -> %s = %d, want %d", table, depType, source, target, got, want)
+	}
+}
+
+// assertDependencyEditorTargetColumn checks WHICH typed target column holds an
+// edge's target, which assertDependencyEdgeCount's COALESCE deliberately cannot
+// see. It asserts the whole triple rather than the wanted column alone: a body
+// that wrote the id into two columns would satisfy the positive check and still
+// hold a row no reader can classify.
+func assertDependencyEditorTargetColumn(t *testing.T, ctx context.Context, fixture DependencyEditorFixture, table, source, target, wantColumn, why string) {
+	t.Helper()
+	for _, column := range []string{"depends_on_issue_id", "depends_on_wisp_id", "depends_on_external"} {
+		want := 0
+		if column == wantColumn {
+			want = 1
+		}
+		var got int
+		//nolint:gosec // G201: table is one of the contract's two hardcoded names, column one of the three above.
+		query := "SELECT COUNT(*) FROM " + table + " WHERE issue_id = ? AND " + column + " = ?"
+		if err := fixture.QueryScalar(ctx, query, []any{source, target}, &got); err != nil {
+			t.Fatalf("count %s.%s rows %s -> %s: %v", table, column, source, target, err)
+		}
+		if got != want {
+			t.Errorf("%s.%s rows %s -> %s = %d, want %d: the target belongs in %s — %s",
+				table, column, source, target, got, want, wantColumn, why)
+		}
 	}
 }
 

--- a/internal/storage/dolt/dependencies_extended_test.go
+++ b/internal/storage/dolt/dependencies_extended_test.go
@@ -11,13 +11,13 @@ import (
 // =============================================================================
 // GetDependenciesWithMetadata Tests
 // =============================================================================
-
-func TestGetDependenciesWithMetadata(t *testing.T) {
-	// Note: This test is skipped in embedded Dolt mode because GetDependenciesWithMetadata
-	// makes nested GetIssue calls inside a rows cursor, which can cause connection issues.
-	// This is a known limitation of the current implementation (see bd-tdgo.3).
-	t.Skip("Skipping: GetDependenciesWithMetadata has nested query issue in embedded Dolt mode")
-}
+//
+// GetDependenciesWithMetadata and GetDependentsWithMetadata make nested GetIssue
+// calls inside a rows cursor, which the embedded engine cannot serve on one
+// connection (bd-tdgo.3). The populated-graph tests for both were unconditional
+// t.Skip bodies with no assertion in them at all — green forever, including
+// against the limitation they were named for — so they were removed rather than
+// left reading as coverage. The empty-graph case below runs for real.
 
 func TestGetDependenciesWithMetadata_NoResults(t *testing.T) {
 	store, cleanup := setupTestStore(t)
@@ -46,17 +46,6 @@ func TestGetDependenciesWithMetadata_NoResults(t *testing.T) {
 	if len(deps) != 0 {
 		t.Errorf("expected 0 dependencies, got %d", len(deps))
 	}
-}
-
-// =============================================================================
-// GetDependentsWithMetadata Tests
-// =============================================================================
-
-func TestGetDependentsWithMetadata(t *testing.T) {
-	// Note: This test is skipped in embedded Dolt mode because GetDependentsWithMetadata
-	// makes nested GetIssue calls inside a rows cursor, which can cause connection issues.
-	// This is a known limitation of the current implementation (see bd-tdgo.3).
-	t.Skip("Skipping: GetDependentsWithMetadata has nested query issue in embedded Dolt mode")
 }
 
 // =============================================================================
@@ -1193,6 +1182,14 @@ func TestAddDependency_Blocks_DeepCrossTypeChain(t *testing.T) {
 		}
 	}
 }
+
+// The combined-graph RULE the next two pin — the ADD-time gate walks
+// parent-child hops, which DetectCycles deliberately does not — now runs at all
+// three backends as
+// conformance.RunDependencyEditorRefusesACycleThroughAParentChildHop, together
+// with the acyclic chain TestAddDependency_Blocks_DeepCrossTypeChain guards.
+// They stay for the route: the contract drives the DependencyEditor role, these
+// drive DoltStore.AddDependency, and the seam recomputes its own routing.
 
 func TestAddDependency_CombinedGraphCycle_BlocksClosesLoop(t *testing.T) {
 	// Cycle detection now walks both blocks and parent-child edges so a

--- a/internal/storage/dolt/dependency_editor_contract_test.go
+++ b/internal/storage/dolt/dependency_editor_contract_test.go
@@ -169,6 +169,30 @@ func TestDependencyEditorRecordsOneHistoryEntryForAMixedPlaneRequest(t *testing.
 	conformance.RunDependencyEditorRecordsOneHistoryEntryForAMixedPlaneRequest(t, ctx, fixture)
 }
 
+func TestDependencyEditorWritesTheTargetIntoItsTypedColumn(t *testing.T) {
+	fixture, ctx, cleanup := newDoltDependencyEditorFixture(t, "tcol")
+	defer cleanup()
+	conformance.RunDependencyEditorWritesTheTargetIntoItsTypedColumn(t, ctx, fixture)
+}
+
+func TestDependencyEditorRefusesBlockingEdgeAcrossAWispHierarchy(t *testing.T) {
+	fixture, ctx, cleanup := newDoltDependencyEditorFixture(t, "whier")
+	defer cleanup()
+	conformance.RunDependencyEditorRefusesBlockingEdgeAcrossAWispHierarchy(t, ctx, fixture)
+}
+
+func TestDependencyEditorRefusesACycleThroughAParentChildHop(t *testing.T) {
+	fixture, ctx, cleanup := newDoltDependencyEditorFixture(t, "pchop")
+	defer cleanup()
+	conformance.RunDependencyEditorRefusesACycleThroughAParentChildHop(t, ctx, fixture)
+}
+
+func TestDependencyEditorRefusesASamePlaneEdgeClosingACrossPlaneCycle(t *testing.T) {
+	fixture, ctx, cleanup := newDoltDependencyEditorFixture(t, "splane")
+	defer cleanup()
+	conformance.RunDependencyEditorRefusesASamePlaneEdgeClosingACrossPlaneCycle(t, ctx, fixture)
+}
+
 // newDoltDependencyEditorFixture composes the backend's role fixture kit with
 // the accessor under test. Every hook but the accessor comes from the kit, so
 // the seeding and scalar-query plumbing stays identical to the other roles'.

--- a/internal/storage/dolt/wisp_infra_dep_test.go
+++ b/internal/storage/dolt/wisp_infra_dep_test.go
@@ -253,6 +253,22 @@ func TestDemoteToWisp_InfraDepToExternalUsesExternalColumn(t *testing.T) {
 	}
 }
 
+// The typed-target-column RULE the two AddWispDep tests below pin — a wisp
+// target lands in depends_on_wisp_id, an issue target in depends_on_issue_id —
+// now runs at all three backends as
+// conformance.RunDependencyEditorWritesTheTargetIntoItsTypedColumn, which also
+// covers the external and foreign-repository classes. That case exists because
+// every other contract assertion reads the target through
+// COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external) and so
+// cannot see which column holds it.
+//
+// These stay for the route: they drive DoltStore.AddDependency, whose own
+// routing computation no contract case exercises, and they drive it with INFRA
+// issue types, whose automatic wisp routing (IsInfraTypeCtx over the
+// types.infra / types.custom config) is a classification step ahead of the one
+// the contract pins. The contract's fixture seeds the two planes explicitly and
+// never goes through that config.
+
 // TestAddWispDep_InfraWispToInfraWisp verifies that when an infra-type wisp
 // depends on another infra-type wisp, the dependency row in wisp_dependencies
 // uses depends_on_wisp_id (not depends_on_issue_id or a physical depends_on_id).

--- a/internal/storage/dolt/wisps_cycle_test.go
+++ b/internal/storage/dolt/wisps_cycle_test.go
@@ -8,6 +8,20 @@ import (
 	"github.com/steveyegge/beads/internal/types"
 )
 
+// The RULE these two pin — a same-plane edge is refused when the loop it closes
+// only exists by leaving the plane and coming back — now lives at all three
+// backends as
+// conformance.RunDependencyEditorRefusesASamePlaneEdgeClosingACrossPlaneCycle.
+//
+// They stay because they are not the same route. That case reaches the shared
+// gate through issueops.ExecuteAddDependencies, which computes its own routing;
+// these reach it through DoltStore.AddDependency, which computes routing again
+// with its own pre-transaction wisp cache and is what ~15 cmd/bd files call
+// directly (state.go, swarm.go, gate.go, duplicates.go, the tx variants in
+// create_atomic.go and graph_apply.go, …). Breaking that wrapper's own routing
+// leaves every DependencyEditor case green, so nothing in the contract layer
+// covers the seam these run.
+
 func TestAddDependencyRejectsPermanentEndpointCycleThroughWisp(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()

--- a/internal/storage/embeddeddolt/dependencies_test.go
+++ b/internal/storage/embeddeddolt/dependencies_test.go
@@ -9,6 +9,21 @@ import (
 	"github.com/steveyegge/beads/internal/types"
 )
 
+// Four of the state classes below were, until recently, held ONLY here, and
+// they now have three-backend cases in backend/conformance/
+// dependency_editor_contract.go:
+//
+//	wisp_parent_child_shadow_rejected  -> RunDependencyEditorRefusesBlockingEdgeAcrossAWispHierarchy
+//	mixed_table_cycle_*                -> RunDependencyEditorRefusesASamePlaneEdgeClosingACrossPlaneCycle
+//	combined_graph_cycle_*             -> RunDependencyEditorRefusesACycleThroughAParentChildHop
+//	deep_linear_chain_allowed          -> the acyclic arm of the same case
+//
+// The subtests stay because the contract does not run the route they run.
+// Every case here drives store.AddDependency, the seam ~15 cmd/bd files call
+// directly; the contract drives the DependencyEditor role, which computes its
+// routing separately. Blanking the seam's own cross-prefix decision leaves the
+// whole DependencyEditor contract green at this backend, so these are the only
+// tests standing over that wrapper.
 func TestAddDependency(t *testing.T) {
 	skipUnlessEmbeddedDolt(t)
 

--- a/internal/storage/embeddeddolt/dependency_editor_contract_test.go
+++ b/internal/storage/embeddeddolt/dependency_editor_contract_test.go
@@ -171,6 +171,30 @@ func TestEmbeddedDependencyEditorRecordsOneHistoryEntryForAMixedPlaneRequest(t *
 	conformance.RunDependencyEditorRecordsOneHistoryEntryForAMixedPlaneRequest(t, ctx, newEmbeddedDependencyEditorFixture(t, ctx, "mixhist"))
 }
 
+func TestEmbeddedDependencyEditorWritesTheTargetIntoItsTypedColumn(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	ctx := t.Context()
+	conformance.RunDependencyEditorWritesTheTargetIntoItsTypedColumn(t, ctx, newEmbeddedDependencyEditorFixture(t, ctx, "tcol"))
+}
+
+func TestEmbeddedDependencyEditorRefusesBlockingEdgeAcrossAWispHierarchy(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	ctx := t.Context()
+	conformance.RunDependencyEditorRefusesBlockingEdgeAcrossAWispHierarchy(t, ctx, newEmbeddedDependencyEditorFixture(t, ctx, "whier"))
+}
+
+func TestEmbeddedDependencyEditorRefusesACycleThroughAParentChildHop(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	ctx := t.Context()
+	conformance.RunDependencyEditorRefusesACycleThroughAParentChildHop(t, ctx, newEmbeddedDependencyEditorFixture(t, ctx, "pchop"))
+}
+
+func TestEmbeddedDependencyEditorRefusesASamePlaneEdgeClosingACrossPlaneCycle(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	ctx := t.Context()
+	conformance.RunDependencyEditorRefusesASamePlaneEdgeClosingACrossPlaneCycle(t, ctx, newEmbeddedDependencyEditorFixture(t, ctx, "splane"))
+}
+
 // newEmbeddedDependencyEditorFixture composes the backend's role fixture kit
 // with the accessor under test. Every hook but the accessor comes from the kit,
 // so the seeding and scalar-query plumbing stays identical to the other roles'.

--- a/internal/storage/uow/dependency_editor_contract_test.go
+++ b/internal/storage/uow/dependency_editor_contract_test.go
@@ -50,6 +50,10 @@ func TestUOWDependencyEditorContract(t *testing.T) {
 		{name: "RemovesOnlyTheNamedEdge", run: conformance.RunDependencyEditorRemovesOnlyTheNamedEdge},
 		{name: "SkipPerEdgeCycleCheckDropsOnlyTheProbe", run: conformance.RunDependencyEditorSkipPerEdgeCycleCheckDropsOnlyTheProbe},
 		{name: "RecordsOneHistoryEntryForAMixedPlaneRequest", run: conformance.RunDependencyEditorRecordsOneHistoryEntryForAMixedPlaneRequest},
+		{name: "WritesTheTargetIntoItsTypedColumn", run: conformance.RunDependencyEditorWritesTheTargetIntoItsTypedColumn},
+		{name: "RefusesBlockingEdgeAcrossAWispHierarchy", run: conformance.RunDependencyEditorRefusesBlockingEdgeAcrossAWispHierarchy},
+		{name: "RefusesACycleThroughAParentChildHop", run: conformance.RunDependencyEditorRefusesACycleThroughAParentChildHop},
+		{name: "RefusesASamePlaneEdgeClosingACrossPlaneCycle", run: conformance.RunDependencyEditorRefusesASamePlaneEdgeClosingACrossPlaneCycle},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			test.run(t, ctx, fixture)


### PR DESCRIPTION
Slice 3 of a test-deduplication pass against the conformance contracts. **It deduplicated almost nothing, and that is the finding.**

## Why there was nothing to delete

`DoltStore.AddDependency` is still a **live production seam outside the DependencyEditor role** — 15 non-test `cmd/bd` files call it directly (`state.go`, `swarm.go`, `gate.go`, `duplicates.go`, `mol_bond.go`, the tx variants in `create_atomic.go`/`graph_apply.go`, …) — and it is a *different body for the routing half*, computing `isCrossPrefix` and wisp routing itself before reaching the shared `issueops` code.

Probe: blank the routing condition at `dolt/dependencies.go:38`. The ad-hoc test **fails**; all 31 `TestDependencyEditor` contract cases **pass**. None of the 14 candidate files calls a role accessor at all.

So these tests are not duplicates of the contract. They are the only coverage a path with 15 live callers has. Deletion here waits on those callers converging onto the role; that is not this PR.

## What the slice produced instead — 4 cases × 3 legs

Each closes a gap found by a seeded-state audit, and each was verified twice: before, the ad-hoc failed while the contract passed; after, the contract fails the mutant.

- **`WritesTheTargetIntoItsTypedColumn`** — every existing case reads the target through `COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external)`, so **no case could see which column held it**. Only `depends_on_issue_id` carries `fk_dep_issue_target`. A wisp target filed as external was invisible to all 27. Reads all three columns and asserts the whole 0/0/1 triple, so a double-write fails too.
- **`RefusesBlockingEdgeAcrossAWispHierarchy`** — the guard reads a UNION of both dependency tables; every seeded case used issues only. A wisp gated on its own ancestor never becomes ready.
- **`RefusesACycleThroughAParentChildHop`** — `cycle_detector_contract.go` states parent-child is outside the report's walk "which the ADD-time gate does walk". Nothing pinned that half. Carries an acyclic control, so a body rejecting every hierarchy also fails.
- **`RefusesASamePlaneEdgeClosingACrossPlaneCycle`** — the existing cross-plane case's own edge crosses planes; here only the loop's interior does. That distinction was a shipped defect.

## Deleted: 2 functions

`TestGetDependenciesWithMetadata` and `TestGetDependentsWithMetadata` were unconditional `t.Skip` bodies with no assertions — green forever, including against the limitation they were named for.

## Kept, deliberately

- **All 13 `is_blocked` tests.** `is_blocked` is a derived *and persisted* column and no contract reads it. Deleting those raw-row assertions because "BlockingAnnotator covers blocking" is the corrupted-table trap: reading back through the role is exactly the check that passes on a corrupted table.
- **The GH#1495 type matrix.** Three reject rows are individually weaker than the contract, but every contract seed is `TypeTask`, so the matrix's "the guard is structural, not type-based" claim cannot port without reshaping a helper 31 cases share.
- **`GetDependentRecords`.** The inbound direction is deliberately not EdgeReader's, and is public API with no role.

## Review

Three adversarial review agents ran over this branch — coverage-loss, port-integrity, and structural-residue lenses. All three cleared it: no coverage lost, no dead helpers, no orphaned citations, shard manifest consistent. Port integrity found the slice's mutation evidence had covered only 2 of 3 legs for two cases (uow runs different bodies — `pickDepTargetColumn`, and a second `CycleThroughEdges` gate); it closed both gaps itself with uow-specific mutants that turn those legs red.

## Verification

`go build ./...`, `go vet`, `golangci-lint run` clean. `DependencyEditor` contract green on dolt, uow and embeddeddolt; all four new cases confirmed executing on all three legs (uow as subtests of the table-driven runner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)