### PR TITLE
fix(uow): skip empty Dolt commit on the proxied-server commit path (relands #4348 fix 2)

### DIFF
--- a/internal/storage/uow/doltserver_tx.go
+++ b/internal/storage/uow/doltserver_tx.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 
 	"github.com/steveyegge/beads/internal/storage/domain/db"
+	"github.com/steveyegge/beads/internal/storage/issueops"
 )
 
 type doltServerTx struct {
@@ -34,6 +35,53 @@ func (t *doltServerTx) Commit(ctx context.Context, message string) error {
 	stmt, args := "CALL DOLT_COMMIT('-Am', ?);", []interface{}{message}
 	if message == "" {
 		stmt, args = "COMMIT;", nil
+	} else {
+		// Skip the guaranteed-empty DOLT_COMMIT when an idempotent write staged
+		// nothing — e.g. a same-value REPLACE INTO metadata, or a re-claim whose
+		// CAS UPDATE matched 0 rows, re-applied per-tick by orchestrators
+		// converging desired state. Dolt rejects such empty commits server-side
+		// with "nothing to commit", flooding the server log (observed ~99% of
+		// log lines on a busy coordination DB) and burning CPU evaluating them.
+		//
+		// DOLT_COMMIT('-Am') stages-and-commits the whole working set, so
+		// nothing is pre-staged at this point: the correct gate is the global
+		// working-set check (HasPendingChanges, which mirrors what '-Am' sweeps
+		// up and excludes dolt_ignore'd tables), NOT a staged-set count — that
+		// would always read 0 here and wrongly skip every real write. This
+		// connection is pinned to a single Dolt session (BeginTx pins t.conn
+		// and runs START TRANSACTION), so dolt_status reflects only this UOW's
+		// changes.
+		//
+		// The skip must still CLOSE the open transaction before the pinned
+		// connection is released — releasing with START TRANSACTION open hands
+		// the next borrower an implicit commit of orphaned state — so it
+		// demotes the statement to the plain-COMMIT (ephemeral) form above
+		// rather than returning early: the SQL transaction commits, persisting
+		// any dolt_ignored writes into the working set, without minting a Dolt
+		// commit.
+		//
+		// Deliberately NOT ported from the original fix (#4348, 3bd52c27f): the
+		// swallow of a residual "nothing to commit" error from DOLT_COMMIT
+		// itself. RunTx already swallows that at the call site (tx.go), and the
+		// uow layer lets it surface as a lost-update signal
+		// (lostupdate_dolt_test.go) — swallowing it a layer down could mask a
+		// silently lost write.
+		pending, perr := issueops.HasPendingChanges(ctx, t.conn)
+		if perr != nil {
+			if isSerializationError(perr) {
+				// As below: the server already rolled the transaction back and
+				// the caller retries the whole unit of work, so leave the
+				// pinned session in place for the retry.
+				return perr
+			}
+			// A failed status check leaves the transaction open on the pinned
+			// session, exactly like a failed DOLT_COMMIT below: roll back
+			// before release, or poison the connection.
+			return t.closeOpenTxAfterFailure(ctx, perr)
+		}
+		if !pending {
+			stmt, args = "COMMIT;", nil
+		}
 	}
 	_, err := t.conn.ExecContext(ctx, stmt, args...)
 	if err == nil {
@@ -52,6 +100,17 @@ func (t *doltServerTx) Commit(ctx context.Context, message string) error {
 	// borrower cannot inherit and implicitly commit the orphaned writes. If the
 	// rollback also fails the session state is unknown, so poison the connection
 	// and let the pool discard it instead of handing it out again.
+	return t.closeOpenTxAfterFailure(ctx, err)
+}
+
+// closeOpenTxAfterFailure finishes a Commit attempt that failed with the
+// transaction still open on the pinned session: roll it back before releasing
+// the connection so the next borrower cannot inherit and implicitly commit the
+// orphaned writes, and poison the connection (pool discard) when even the
+// rollback fails and the session state is unknown. Serialization failures are
+// the caller's to handle first — those guarantee a server-side rollback and
+// must leave the pinned session in place for the retry.
+func (t *doltServerTx) closeOpenTxAfterFailure(ctx context.Context, err error) error {
 	t.done = true
 	if rbErr := t.rollbackConn(ctx); rbErr != nil {
 		t.poisonConn()

--- a/internal/storage/uow/doltserver_tx_test.go
+++ b/internal/storage/uow/doltserver_tx_test.go
@@ -32,9 +32,22 @@ func newMockTxProvider(t *testing.T) (*doltSQLProvider, sqlmock.Sqlmock) {
 	return &doltSQLProvider{defaultBranch: defaultBranch, db: mockDB}, mock
 }
 
+// matchHasPending matches the dolt_status working-set check issued by
+// issueops.HasPendingChanges — the guard Commit runs before deciding whether
+// to mint a Dolt commit (#4348 re-port).
+const matchHasPending = `SELECT COUNT\(\*\) FROM dolt_status`
+
+// expectPendingChanges arms the HasPendingChanges guard to report a dirty
+// (count > 0) working set, letting Commit proceed to DOLT_COMMIT.
+func expectPendingChanges(mock sqlmock.Sqlmock, count int) {
+	mock.ExpectQuery(matchHasPending).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(count))
+}
+
 func TestDoltServerTxCommitFailureRollsBackBeforeRelease(t *testing.T) {
 	p, mock := newMockTxProvider(t)
 	mock.ExpectExec("START TRANSACTION").WillReturnResult(sqlmock.NewResult(0, 0))
+	expectPendingChanges(mock, 1)
 	mock.ExpectExec("DOLT_COMMIT").WillReturnError(errors.New("commit exploded"))
 	mock.ExpectExec("ROLLBACK").WillReturnResult(sqlmock.NewResult(0, 0))
 
@@ -50,6 +63,7 @@ func TestDoltServerTxCommitFailureRollsBackBeforeRelease(t *testing.T) {
 func TestDoltServerTxCommitAndRollbackFailurePoisonsConn(t *testing.T) {
 	p, mock := newMockTxProvider(t)
 	mock.ExpectExec("START TRANSACTION").WillReturnResult(sqlmock.NewResult(0, 0))
+	expectPendingChanges(mock, 1)
 	mock.ExpectExec("DOLT_COMMIT").WillReturnError(errors.New("commit exploded"))
 	mock.ExpectExec("ROLLBACK").WillReturnError(errors.New("rollback exploded too"))
 
@@ -81,4 +95,110 @@ func TestBeginTxStartTransactionFailureReleasesConn(t *testing.T) {
 	_, err := p.BeginTx(context.Background())
 	require.ErrorContains(t, err, "no tx for you")
 	assert.Equal(t, 0, p.db.Stats().InUse, "pinned conn must not leak when START TRANSACTION fails")
+}
+
+// The tests below pin the #4348 re-port (original commit 3bd52c27f): Commit
+// gates DOLT_COMMIT('-Am') on issueops.HasPendingChanges so an idempotent
+// write that staged nothing (same-value REPLACE INTO metadata, 0-row CAS
+// re-claim, per-tick orchestrator reconciles) no longer issues a
+// guaranteed-empty commit that Dolt rejects server-side with "nothing to
+// commit" — flooding the server log and burning CPU. The skip path must still
+// CLOSE the open SQL transaction (plain COMMIT) before the pinned connection
+// is released; releasing with START TRANSACTION open would hand the next
+// borrower an implicit commit of orphaned state.
+
+// matchPlainCommit matches ONLY the plain SQL COMMIT (the ephemeral/skip
+// form), never CALL DOLT_COMMIT(...).
+const matchPlainCommit = `^COMMIT;$`
+
+func TestDoltServerTxCommitSkipsEmptyDoltCommit(t *testing.T) {
+	p, mock := newMockTxProvider(t)
+	mock.ExpectExec("START TRANSACTION").WillReturnResult(sqlmock.NewResult(0, 0))
+	// Clean working set: the guard reports nothing pending…
+	expectPendingChanges(mock, 0)
+	// …so the tx must close with a plain COMMIT. Deliberately NO expectation
+	// for DOLT_COMMIT: if the guard is reverted, the unconditional
+	// CALL DOLT_COMMIT('-Am', ?) fails to match matchPlainCommit and this test
+	// fails.
+	mock.ExpectExec(matchPlainCommit).WillReturnResult(sqlmock.NewResult(0, 0))
+
+	tx, err := p.BeginTx(context.Background())
+	require.NoError(t, err)
+
+	err = tx.Commit(context.Background(), "bd: noop")
+	require.NoError(t, err, "Commit on a clean working set must skip DOLT_COMMIT and succeed")
+	require.NoError(t, mock.ExpectationsWereMet(), "skip path must still close the SQL transaction with a plain COMMIT")
+	assert.Equal(t, 1, p.db.Stats().OpenConnections, "cleanly closed session may return to the pool")
+
+	err = tx.Commit(context.Background(), "bd: again")
+	require.ErrorContains(t, err, "already done", "skip path must still mark the tx done")
+}
+
+func TestDoltServerTxCommitIssuesDoltCommitWhenPending(t *testing.T) {
+	p, mock := newMockTxProvider(t)
+	mock.ExpectExec("START TRANSACTION").WillReturnResult(sqlmock.NewResult(0, 0))
+	expectPendingChanges(mock, 3)
+	mock.ExpectExec("DOLT_COMMIT").WithArgs("bd: real write").WillReturnResult(sqlmock.NewResult(0, 1))
+
+	tx, err := p.BeginTx(context.Background())
+	require.NoError(t, err)
+
+	err = tx.Commit(context.Background(), "bd: real write")
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet(), "a dirty working set must be committed via DOLT_COMMIT")
+}
+
+func TestDoltServerTxCommitPendingCheckFailureRollsBackBeforeRelease(t *testing.T) {
+	p, mock := newMockTxProvider(t)
+	mock.ExpectExec("START TRANSACTION").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(matchHasPending).WillReturnError(errors.New("status check exploded"))
+	mock.ExpectExec("ROLLBACK").WillReturnResult(sqlmock.NewResult(0, 0))
+
+	tx, err := p.BeginTx(context.Background())
+	require.NoError(t, err)
+
+	err = tx.Commit(context.Background(), "msg")
+	require.ErrorContains(t, err, "status check exploded")
+	require.NoError(t, mock.ExpectationsWereMet(), "a failed pending check leaves the tx open and must ROLLBACK before release")
+	assert.Equal(t, 1, p.db.Stats().OpenConnections, "rolled-back session is clean and may return to the pool")
+}
+
+// TestDoltServerTxCommitPropagatesNothingToCommit pins the deliberate
+// deviation from the original #4348 commit: a residual "nothing to commit"
+// from DOLT_COMMIT itself is NOT swallowed here. RunTx already swallows it at
+// the call site (tx.go), and the uow layer lets it surface as a lost-update
+// signal (lostupdate_dolt_test.go) — swallowing it a layer down could mask a
+// silently lost write.
+func TestDoltServerTxCommitPropagatesNothingToCommit(t *testing.T) {
+	p, mock := newMockTxProvider(t)
+	mock.ExpectExec("START TRANSACTION").WillReturnResult(sqlmock.NewResult(0, 0))
+	expectPendingChanges(mock, 1)
+	mock.ExpectExec("DOLT_COMMIT").WillReturnError(errors.New("nothing to commit"))
+	mock.ExpectExec("ROLLBACK").WillReturnResult(sqlmock.NewResult(0, 0))
+
+	tx, err := p.BeginTx(context.Background())
+	require.NoError(t, err)
+
+	err = tx.Commit(context.Background(), "msg")
+	require.ErrorContains(t, err, "nothing to commit", "the lost-update signal must surface to the caller, not be swallowed here")
+	require.NoError(t, mock.ExpectationsWereMet(), "the failed DOLT_COMMIT leaves the tx open and must ROLLBACK before release")
+}
+
+// TestDoltServerTxEphemeralCommitSkipsPendingCheck pins that the empty-message
+// EPHEMERAL form (bd-aq0ql) bypasses the HasPendingChanges guard entirely: it
+// already never mints a Dolt commit, so a dolt_status round-trip would be pure
+// overhead on the lease-heartbeat path.
+func TestDoltServerTxEphemeralCommitSkipsPendingCheck(t *testing.T) {
+	p, mock := newMockTxProvider(t)
+	mock.ExpectExec("START TRANSACTION").WillReturnResult(sqlmock.NewResult(0, 0))
+	// No dolt_status query expected: an added guard round-trip would surface
+	// as an unexpected query and fail Commit.
+	mock.ExpectExec(matchPlainCommit).WillReturnResult(sqlmock.NewResult(0, 0))
+
+	tx, err := p.BeginTx(context.Background())
+	require.NoError(t, err)
+
+	err = tx.Commit(context.Background(), "")
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
 }


### PR DESCRIPTION
Maintainer-side re-port of #4348's uow fix (author: @realies), per the offer in the review there; tracked as bd-ga8p7. Co-authorship recorded on the commit; the rewrite was substantial because main's `doltServerTx.Commit` invariants changed under the original (794ff0790: never release a pinned connection with an open transaction).

**What this does:** gates `DOLT_COMMIT('-Am')` on `HasPendingChanges` (the global working-set check that mirrors what '-Am' sweeps and excludes dolt_ignore'd tables — a staged-set count would always read 0 here and skip every real write). When nothing is pending, the commit **demotes to the plain-COMMIT ephemeral form instead of returning early**, so the open SQL transaction closes (persisting any dolt_ignored wisp writes into the working set) and the pinned connection is never released mid-transaction. Failure of the status check itself takes the same rollback-before-release/poison tail as a failed DOLT_COMMIT (factored as `closeOpenTxAfterFailure`; behavior unchanged).

**Deliberately not ported** from the original: the swallow of a residual "nothing to commit" from DOLT_COMMIT — `RunTx` already swallows it at the call site and the uow layer uses it as a lost-update signal (`lostupdate_dolt_test.go`); a new regression test (`TestDoltServerTxCommitPropagatesNothingToCommit`) pins the propagation.

**Note on #4348's other half:** the store.go fix (dolt_ignore filter in `commitWorkingSet`) landed independently on main the day before this re-port — #5341 (`af45955aa`) applied the identical predicate with its own discriminating test (`TestCommitToleratesDirtyIgnoredWisp`), which runs green on this branch. A cherry-pick of the original produced a zero-length diff, so this PR carries only the uow half.

**Verification** (real exit codes; Dolt-backed suites run with `BEADS_TEST_ENV_RUN_DOLT=1` and a pinned `DOCKER_HOST` — see bd-84kos for why that matters on OrbStack): build + vet clean; all 9 `TestDoltServerTx|TestBeginTx` tests green (4 pre-existing + 5 new, re-cut onto the `newMockTxProvider` harness); full `./scripts/test.sh -count=1 ./internal/storage/uow/...` green in 398s with real Dolt testcontainers including `TestUOW_ConcurrentMergeOps_NoLostUpdate` end-to-end. Two failures in the wider dolt-store real-Dolt sweep are pre-existing on origin/main with an empty FAIL-set diff (beads being filed separately).

Closes #4348.

_claude-fable-5 on behalf of the beads maintainers (bee)_