### PR TITLE
fix(dolt): borrow ignored-tx connection from the warm pool (FIX 1 of #4581)

### DIFF
--- a/internal/storage/dolt/connection_pool_test.go
+++ b/internal/storage/dolt/connection_pool_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -36,6 +37,50 @@ type mockDriver struct {
 	opens  atomic.Int64 // total Open() calls (NewConnection events)
 	closes atomic.Int64 // total Close() calls (ConnectionClosed events)
 	live   atomic.Int64 // currently-open connections
+
+	qmu     sync.Mutex // guards queries
+	queries []string   // every query string passed to Prepare (borrow-path assertions)
+
+	// failCheckout makes Prepare of a DOLT_CHECKOUT statement fail, so borrow-path
+	// tests can force beginTxOnConn to error and fall through to the fallback.
+	failCheckout atomic.Bool
+
+	// activeBranch is what a SELECT active_branch() query reports; empty means
+	// "main". Borrow-path tests set it to another branch to prove the borrow
+	// refuses to switch a pooled session's branch and falls back instead.
+	activeBranch atomic.Value // string
+
+	// failActiveBranch makes a SELECT active_branch() query fail, modeling a
+	// stale borrowed connection.
+	failActiveBranch atomic.Bool
+}
+
+// reportedBranch returns the branch active_branch() queries report.
+func (d *mockDriver) reportedBranch() string {
+	if v, ok := d.activeBranch.Load().(string); ok && v != "" {
+		return v
+	}
+	return "main"
+}
+
+// recordQuery appends a prepared query for later assertion.
+func (d *mockDriver) recordQuery(query string) {
+	d.qmu.Lock()
+	d.queries = append(d.queries, query)
+	d.qmu.Unlock()
+}
+
+// countQuery returns how many recorded queries contain substr.
+func (d *mockDriver) countQuery(substr string) int {
+	d.qmu.Lock()
+	defer d.qmu.Unlock()
+	n := 0
+	for _, q := range d.queries {
+		if strings.Contains(q, substr) {
+			n++
+		}
+	}
+	return n
 }
 
 func (d *mockDriver) Open(name string) (driver.Conn, error) {
@@ -52,6 +97,10 @@ type mockConn struct {
 }
 
 func (c *mockConn) Prepare(query string) (driver.Stmt, error) {
+	c.drv.recordQuery(query)
+	if c.drv.failCheckout.Load() && strings.Contains(query, "DOLT_CHECKOUT") {
+		return nil, fmt.Errorf("mock: forced DOLT_CHECKOUT failure")
+	}
 	return &mockStmt{}, nil
 }
 
@@ -71,6 +120,13 @@ func (c *mockConn) Begin() (driver.Tx, error) {
 // We simulate a small amount of work so the concurrency test can observe
 // SetMaxOpenConns back-pressure.
 func (c *mockConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	if strings.Contains(query, "active_branch") {
+		c.drv.recordQuery(query)
+		if c.drv.failActiveBranch.Load() {
+			return nil, fmt.Errorf("mock: forced active_branch failure")
+		}
+		return &mockRows{val: c.drv.reportedBranch()}, nil
+	}
 	time.Sleep(20 * time.Millisecond)
 	return &mockRows{}, nil
 }
@@ -89,6 +145,7 @@ func (mockStmt) Query(args []driver.Value) (driver.Rows, error)  { return &mockR
 
 type mockRows struct {
 	done bool
+	val  driver.Value // value for the single row; nil means int64(1)
 }
 
 func (r *mockRows) Columns() []string { return []string{"x"} }
@@ -99,7 +156,11 @@ func (r *mockRows) Next(dest []driver.Value) error {
 	}
 	r.done = true
 	if len(dest) > 0 {
-		dest[0] = int64(1)
+		if r.val != nil {
+			dest[0] = r.val
+		} else {
+			dest[0] = int64(1)
+		}
 	}
 	return nil
 }

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -865,6 +865,7 @@ var doltMetrics struct {
 	poolWaitMs           metric.Float64Histogram
 	claimVerifyLost      metric.Int64Counter
 	claimVerifyRecovered metric.Int64Counter
+	ignoredTxFreshPool   metric.Int64Counter
 }
 
 func init() {
@@ -912,6 +913,10 @@ func init() {
 	doltMetrics.claimVerifyRecovered, _ = m.Int64Counter("bd.claim_verify_recovered_total",
 		metric.WithDescription("Indeterminate claim-family commits resolved by re-read (label: op, outcome=applied|replayed)"),
 		metric.WithUnit("{write}"),
+	)
+	doltMetrics.ignoredTxFreshPool, _ = m.Int64Counter("bd.db.ignored_tx_fresh_pool",
+		metric.WithDescription("ignored-tx transactions that fell back to a dedicated single-connection pool instead of borrowing from the main pool"),
+		metric.WithUnit("{tx}"),
 	)
 }
 

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -192,13 +192,17 @@ func (s *DoltStore) runDoltTransaction(ctx context.Context, commitMsg string, fn
 		return fmt.Errorf("failed to begin regular tx: %w", err)
 	}
 
-	ignoredDB, ignoredConn, ignoredTx, err := s.beginIgnoredTxOnBranch(ctx, currentBranch)
+	// NOTE (GH#3140 metrics skew): the pool-wait bracket above measures only the
+	// FIRST acquisition (the regular conn). A borrow inside beginIgnoredTxOnBranch
+	// that has to wait increments the pool's global WaitCount, which the NEXT
+	// transaction's delta then misattributes. Rare given the InUse pre-check in
+	// borrowConnForIgnoredTx; not worth restructuring the metrics for.
+	ignoredCleanup, ignoredTx, err := s.beginIgnoredTxOnBranch(ctx, currentBranch)
 	if err != nil {
 		_ = regularTx.Rollback()
 		return err
 	}
-	defer ignoredDB.Close()
-	defer ignoredConn.Close()
+	defer ignoredCleanup()
 
 	tx := &doltTransaction{regularTx: regularTx, ignoredTx: ignoredTx, store: s}
 
@@ -239,38 +243,137 @@ func (s *DoltStore) finishDoltTransaction(ctx context.Context, conn *sql.Conn, t
 	return nil
 }
 
-func (s *DoltStore) beginIgnoredTxOnBranch(ctx context.Context, branch string) (*sql.DB, *sql.Conn, *sql.Tx, error) {
-	// Use an independent single-connection pool for ignored tables. Reusing the
-	// main pool can deadlock when MaxOpenConns=1, and each Dolt SQL session has
-	// its own active branch. This intentionally pays one extra connection setup
-	// for mixed regular/ignored writes so the ignored transaction can be checked
-	// out to the regular transaction's branch before writes.
+// ignoredTxBorrowTimeout bounds how long a borrow of a second warm connection
+// from the main pool may wait before falling back to a dedicated fresh dial. It
+// keeps the second acquisition from ever waiting unboundedly while the caller
+// already holds the first (regular-tx) connection, which is what makes deadlock
+// impossible by construction on the borrow path.
+const ignoredTxBorrowTimeout = 250 * time.Millisecond
+
+// beginIgnoredTxOnBranch starts the ignored-tables transaction, checked out to
+// the regular transaction's branch. It borrows a second warm connection from the
+// main pool when one is safely available — the hosted-gateway churn fix: once the
+// pool is warm this costs zero new MySQL handshakes and zero Dolt session-setup
+// round-trips per write. It falls back to a dedicated single-connection pool when
+// borrowing could deadlock (MaxOpenConns==1, the documented case that every
+// branch-isolated test exercises) or when the pool is exhausted or a borrowed
+// connection turns out to be stale.
+//
+// The returned cleanup closure releases whichever acquisition path was taken, so
+// the caller does not need to know which one ran.
+func (s *DoltStore) beginIgnoredTxOnBranch(ctx context.Context, branch string) (cleanup func(), tx *sql.Tx, err error) {
+	// Borrow fast path: reuse an already-open pooled connection. Unlike the
+	// fallback below, this path never switches the session's branch — see
+	// beginBorrowedTx for the pool invariant it preserves.
+	if conn := s.borrowConnForIgnoredTx(ctx); conn != nil {
+		tx, err := beginBorrowedTx(ctx, conn, branch)
+		if err == nil {
+			return func() { _ = conn.Close() }, tx, nil
+		}
+		// A stale pooled connection or a session on another branch: a fresh
+		// dial always worked before, so discard this one (its session state is
+		// untouched) and fall through to the fallback.
+		_ = conn.Close()
+	}
+
+	// Fallback: a dedicated single-connection pool, paying the fresh dial the
+	// borrow path exists to avoid.
+	doltMetrics.ignoredTxFreshPool.Add(ctx, 1)
 	db, err := sql.Open("mysql", s.connStr)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to open ignored tx connection: %w", err)
+		return nil, nil, fmt.Errorf("failed to open ignored tx connection: %w", err)
 	}
 	db.SetMaxOpenConns(1)
 
 	conn, err := db.Conn(ctx)
 	if err != nil {
 		_ = db.Close()
-		return nil, nil, nil, fmt.Errorf("failed to acquire ignored tx connection: %w", err)
+		return nil, nil, fmt.Errorf("failed to acquire ignored tx connection: %w", err)
 	}
 
-	if _, err := conn.ExecContext(ctx, "CALL DOLT_CHECKOUT(?)", branch); err != nil {
-		_ = conn.Close()
-		_ = db.Close()
-		return nil, nil, nil, fmt.Errorf("failed to checkout ignored tx branch %s: %w", branch, err)
-	}
-
-	tx, err := conn.BeginTx(ctx, nil)
+	tx, err = beginTxOnConn(ctx, conn, branch)
 	if err != nil {
 		_ = conn.Close()
 		_ = db.Close()
-		return nil, nil, nil, fmt.Errorf("failed to begin ignored tx: %w", err)
+		return nil, nil, err
 	}
 
-	return db, conn, tx, nil
+	return func() { _ = conn.Close(); _ = db.Close() }, tx, nil
+}
+
+// borrowConnForIgnoredTx returns a second connection borrowed from the main pool
+// for the ignored-tables transaction, or nil if borrowing is unsafe or would
+// block. The caller falls back to a dedicated single-connection pool on nil.
+func (s *DoltStore) borrowConnForIgnoredTx(ctx context.Context) *sql.Conn {
+	st := s.db.Stats()
+	// MaxOpenConns==1: the caller already pinned the pool's only connection for
+	// the regular tx, so a borrow would deadlock. Preserve today's behavior.
+	if st.MaxOpenConnections == 1 {
+		return nil
+	}
+	// Exhausted pool: skip the wait and go straight to the fallback.
+	// MaxOpenConnections==0 means unlimited — always safe to grow.
+	if st.MaxOpenConnections > 0 && st.InUse >= st.MaxOpenConnections {
+		return nil
+	}
+
+	bctx, cancel := context.WithTimeout(ctx, ignoredTxBorrowTimeout)
+	defer cancel()
+	conn, err := s.db.Conn(bctx)
+	if err != nil {
+		// Lost a stats/Conn race, parent ctx canceled, or a slow dial exceeded
+		// the borrow timeout — fall back to a fresh dial.
+		return nil
+	}
+	return conn
+}
+
+// beginBorrowedTx begins the ignored-tables transaction on a connection
+// borrowed from the main pool, without ever changing that session's branch.
+//
+// Pool invariant: DOLT_CHECKOUT is session-level, and the borrow cleanup
+// returns the connection to the pool as-is — so switching its branch here
+// would leak a foreign branch into the pool for an unrelated later caller.
+// Every other production checkout site (federation staging, compact, flatten)
+// restores the branch before releasing the connection; the borrow path
+// preserves the same invariant by refusing instead of switching. Today no
+// shipped flow diverges a pool session's branch from the regular tx's branch
+// (DoltStore.Checkout has no non-test callers), so this is defense in depth
+// for future Checkout callers and for multi-connection tests.
+//
+// Instead of an unconditional checkout it verifies the session is already on
+// the requested branch — the overwhelmingly common case — and sends the
+// caller to the fresh-dial fallback otherwise. Same round-trip count as the
+// checkout it replaces (one statement), so the borrow fast path stays free.
+func beginBorrowedTx(ctx context.Context, conn *sql.Conn, branch string) (*sql.Tx, error) {
+	var active string
+	if err := conn.QueryRowContext(ctx, "SELECT active_branch()").Scan(&active); err != nil {
+		return nil, fmt.Errorf("failed to read borrowed conn's active branch: %w", err)
+	}
+	if active != branch {
+		return nil, fmt.Errorf("borrowed conn is on branch %q, want %q: refusing to switch a pooled session's branch", active, branch)
+	}
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to begin ignored tx: %w", err)
+	}
+	return tx, nil
+}
+
+// beginTxOnConn checks a connection out to branch and begins a transaction on
+// it. Only the fallback path uses it: the fallback owns a dedicated
+// single-connection pool, so checking its session out is safe. Every Dolt SQL
+// session has its own active branch, so the explicit checkout is required on
+// a fresh dial.
+func beginTxOnConn(ctx context.Context, conn *sql.Conn, branch string) (*sql.Tx, error) {
+	if _, err := conn.ExecContext(ctx, "CALL DOLT_CHECKOUT(?)", branch); err != nil {
+		return nil, fmt.Errorf("failed to checkout ignored tx branch %s: %w", branch, err)
+	}
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to begin ignored tx: %w", err)
+	}
+	return tx, nil
 }
 
 // isDoltNothingToCommit returns true if the error indicates there were no

--- a/internal/storage/dolt/transaction_borrow_test.go
+++ b/internal/storage/dolt/transaction_borrow_test.go
@@ -1,0 +1,194 @@
+package dolt
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// These pure-Go unit tests exercise the FIX #1 ignored-tx borrow path using the
+// in-process mock driver from connection_pool_test.go. No Dolt sql-server is
+// needed. An unroutable connStr makes the fresh-pool fallback fail fast and
+// observably, so tests can distinguish a borrow (mock-backed, succeeds) from a
+// fallback (real "mysql" driver, dial error).
+
+const unroutableConnStr = "root@tcp(127.0.0.1:1)/x"
+
+func newMockStore(t *testing.T, maxOpen int) (*DoltStore, *mockDriver) {
+	t.Helper()
+	db, drv := openMockDB(t)
+	db.SetMaxOpenConns(maxOpen)
+	db.SetMaxIdleConns(5)
+	s := &DoltStore{db: db, connStr: unroutableConnStr}
+	t.Cleanup(func() { _ = db.Close() })
+	return s, drv
+}
+
+func TestBorrowConnForIgnoredTxGuards(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("MaxOpenConns==1 never touches the pool", func(t *testing.T) {
+		s, drv := newMockStore(t, 1)
+		if conn := s.borrowConnForIgnoredTx(ctx); conn != nil {
+			_ = conn.Close()
+			t.Fatal("borrow should return nil when MaxOpenConns==1")
+		}
+		if got := drv.opens.Load(); got != 0 {
+			t.Fatalf("drv.opens = %d, want 0 (guard fires before any dial)", got)
+		}
+	})
+
+	t.Run("exhausted pool falls back without waiting", func(t *testing.T) {
+		s, _ := newMockStore(t, 2)
+		c1, err := s.db.Conn(ctx)
+		if err != nil {
+			t.Fatalf("hold conn 1: %v", err)
+		}
+		defer c1.Close()
+		c2, err := s.db.Conn(ctx)
+		if err != nil {
+			t.Fatalf("hold conn 2: %v", err)
+		}
+		defer c2.Close()
+
+		start := time.Now()
+		conn := s.borrowConnForIgnoredTx(ctx)
+		elapsed := time.Since(start)
+		if conn != nil {
+			_ = conn.Close()
+			t.Fatal("borrow should return nil when the pool is exhausted")
+		}
+		if elapsed >= ignoredTxBorrowTimeout {
+			t.Fatalf("borrow took %v, want the InUse pre-check to return well under %v", elapsed, ignoredTxBorrowTimeout)
+		}
+	})
+
+	t.Run("spare capacity borrows a conn", func(t *testing.T) {
+		s, _ := newMockStore(t, 2)
+		c1, err := s.db.Conn(ctx)
+		if err != nil {
+			t.Fatalf("hold conn 1: %v", err)
+		}
+		defer c1.Close()
+
+		conn := s.borrowConnForIgnoredTx(ctx)
+		if conn == nil {
+			t.Fatal("borrow should succeed with spare capacity")
+		}
+		_ = conn.Close()
+	})
+
+	t.Run("unlimited pool always borrows", func(t *testing.T) {
+		s, _ := newMockStore(t, 0)
+		conn := s.borrowConnForIgnoredTx(ctx)
+		if conn == nil {
+			t.Fatal("borrow should succeed on an unlimited pool")
+		}
+		_ = conn.Close()
+	})
+}
+
+func TestIgnoredTxBorrowReusesPooledConn(t *testing.T) {
+	ctx := context.Background()
+	s, drv := newMockStore(t, 10)
+
+	const iterations = 5
+	for i := 0; i < iterations; i++ {
+		cleanup, tx, err := s.beginIgnoredTxOnBranch(ctx, "main")
+		if err != nil {
+			t.Fatalf("iter %d: beginIgnoredTxOnBranch: %v", i, err)
+		}
+		if tx == nil {
+			t.Fatalf("iter %d: nil tx", i)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatalf("iter %d: commit: %v", i, err)
+		}
+		cleanup()
+	}
+
+	if got := drv.opens.Load(); got != 1 {
+		t.Fatalf("drv.opens = %d after %d borrows, want 1 (pooled conn reused, no per-write churn)", got, iterations)
+	}
+	if got := drv.countQuery("active_branch"); got != iterations {
+		t.Fatalf("active_branch ran %d times, want %d (branch verified on the borrowed conn each write)", got, iterations)
+	}
+	if got := drv.countQuery("DOLT_CHECKOUT"); got != 0 {
+		t.Fatalf("DOLT_CHECKOUT ran %d times on the pool, want 0 (a borrow must never switch a pooled session's branch)", got)
+	}
+}
+
+// TestIgnoredTxBorrowRefusesForeignBranch is the pool-invariant teeth test: a
+// pooled session sitting on a branch other than the regular tx's must NOT be
+// checked out to it (the cleanup returns the conn to the pool without a
+// restore, so a checkout would leak the branch switch to an unrelated later
+// caller). The borrow must refuse and fall back to the fresh dial instead.
+func TestIgnoredTxBorrowRefusesForeignBranch(t *testing.T) {
+	ctx := context.Background()
+	s, drv := newMockStore(t, 10)
+	drv.activeBranch.Store("feature-x") // pool sessions report a foreign branch
+
+	cleanup, tx, err := s.beginIgnoredTxOnBranch(ctx, "main")
+	if err == nil {
+		if tx != nil {
+			_ = tx.Rollback()
+		}
+		cleanup()
+		t.Fatal("expected the fallback dial to fail after the borrow refused the foreign branch")
+	}
+	if !strings.Contains(err.Error(), "failed to acquire ignored tx connection") {
+		t.Fatalf("error = %q, want the fallback's %q (proves the borrow refused and fell through)", err.Error(), "failed to acquire ignored tx connection")
+	}
+	if got := drv.countQuery("DOLT_CHECKOUT"); got != 0 {
+		t.Fatalf("DOLT_CHECKOUT ran %d times on the pool, want 0 (borrow must refuse, not switch, a foreign-branch session)", got)
+	}
+	if inUse := s.db.Stats().InUse; inUse != 0 {
+		t.Fatalf("s.db InUse = %d after refusal, want 0 (borrowed conn returned to pool untouched)", inUse)
+	}
+}
+
+func TestIgnoredTxFallsBackWhenPoolPinned(t *testing.T) {
+	ctx := context.Background()
+	s, drv := newMockStore(t, 1) // MaxOpenConns==1 → borrow guard forces the fallback
+
+	cleanup, tx, err := s.beginIgnoredTxOnBranch(ctx, "main")
+	if err == nil {
+		// Resolve the tx BEFORE cleanup: cleanup closes the sql.Conn, which blocks
+		// on closemu until an open Tx is committed/rolled back — a discarded open tx
+		// would hang the package instead of failing this assertion cleanly.
+		if tx != nil {
+			_ = tx.Rollback()
+		}
+		cleanup()
+		t.Fatal("expected the fallback dial to fail against the unroutable connStr")
+	}
+	if !strings.Contains(err.Error(), "failed to acquire ignored tx connection") {
+		t.Fatalf("error = %q, want the fallback's %q", err.Error(), "failed to acquire ignored tx connection")
+	}
+	if got := drv.opens.Load(); got != 0 {
+		t.Fatalf("drv.opens = %d, want 0 (fallback dials the real mysql driver, not the mock)", got)
+	}
+}
+
+func TestIgnoredTxBorrowFallsThroughOnBadConn(t *testing.T) {
+	ctx := context.Background()
+	s, drv := newMockStore(t, 10)
+	drv.failActiveBranch.Store(true) // borrow succeeds, but the conn is stale (branch read fails)
+
+	cleanup, tx, err := s.beginIgnoredTxOnBranch(ctx, "main")
+	if err == nil {
+		if tx != nil {
+			_ = tx.Rollback()
+		}
+		cleanup()
+		t.Fatal("expected the fallback dial to fail after the borrowed conn turned out stale")
+	}
+	if !strings.Contains(err.Error(), "failed to acquire ignored tx connection") {
+		t.Fatalf("error = %q, want the fallback's %q (proves it fell through)", err.Error(), "failed to acquire ignored tx connection")
+	}
+	// The borrowed conn must have been closed back to the pool, not leaked.
+	if inUse := s.db.Stats().InUse; inUse != 0 {
+		t.Fatalf("s.db InUse = %d after fall-through, want 0 (borrowed conn returned to pool)", inUse)
+	}
+}


### PR DESCRIPTION
Standalone extraction of **FIX 1** from #4581, executing the path-1 split maphew proposed there on 2026-07-26 ("land FIX 1 now — it's independent, reviewed, and the measured 2× win stands"); the author's stated one-week window has lapsed (12+ days silent), so proceeding maintainer-side with the original work attributed via `Co-authored-by` (@julianknutsen for the borrow design and tests, @maphew for the branch-refusal hardening he pushed as 9c769896b).

## What lands

- **Ignored-tx pool borrow** (`transaction.go`): mixed regular/ignored writes previously paid a full fresh dial (TLS + MySQL auth + Dolt session setup) for the ignored-tables transaction on every write. `beginIgnoredTxOnBranch` now borrows a second warm connection from the main pool when safely available; the old dedicated single-connection pool remains as the fallback (MaxOpenConns==1, exhausted pool, stale borrow, foreign-branch session). Zero new handshakes per write once the pool is warm — the measured 2× hosted-gateway win from #4581.
- **Pool invariant preserved** (maphew's review finding 1 + his fix): the borrow path never switches a pooled session's branch — it verifies `active_branch()` and refuses to the fallback otherwise, matching the restore-before-release invariant every production checkout site keeps. `TestIgnoredTxBorrowRefusesForeignBranch` proves refusal, untouched pool return, and completion via fallback.
- **Observability**: new `bd.db.ignored_tx_fresh_pool` counter for fallback frequency.
- **Teeth tests**: the #4581 mock-driver suite (`transaction_borrow_test.go` + `connection_pool_test.go` extensions), pure-Go, no live server needed.

## What deliberately does NOT land (FIX 2 territory → bd-5osca)

Main independently grew `internal/creds` + `ApplyGatewayCredential` (mint-once-at-open) while #4581 sat; per maphew's fold attempt the per-dial `BeforeConnect` connector collides with it and needs *unification*, not co-landing. Excluded here: `connector.go`/`credcmd.go`, the `openSQLDB` dial sites, `Config.CredentialCommand` plumbing, the credential-token invalidation follow-ups (branch commits 5c2b9bad8/99bb19bb8/d13434282 — they invalidate a per-dial cache that doesn't exist on main, so they'd be semantically dead until FIX 2 lands), and the FIX1→FIX2 seam test `TestIgnoredTxFallbackUsesCredentialCommand`. All tracked in **bd-5osca** with the unification requirements from maphew's 7/26 analysis. The problem FIX 2 solves is still real on main; nothing is being dropped.

## Review status & verification

FIX 1 was reviewed in #4581 (maphew, 7/7: findings addressed or tracked; his 7/26 fold attempt confirmed "FIX 1 came through untouched — nothing main landed overlaps it"). I re-verified that against today's main: `beginIgnoredTxOnBranch` and the mock-driver harness are byte-identical to the PR base, so the port is mechanical; the only adaptation is the fallback dialing `sql.Open("mysql", s.connStr)` (main's current form) instead of FIX 2's `openSQLDB`.

Local: `go build` / `go vet` / `gofmt` clean; full pure-Go `internal/storage/dolt` suite green including all borrow teeth tests.

Closes the FIX-1 half of the #4581 arc; #4581 itself stays open pending the bd-5osca decision on FIX 2.

_claude-fable-5 on behalf of bee (beads-lane steward); tracking bead bd-sk7xe_