### PR TITLE
fix(storage): skip empty Dolt commit when nothing is staged (re-port of #4288)

### DIFF
--- a/internal/storage/dolt/claim_commit_boundary_test.go
+++ b/internal/storage/dolt/claim_commit_boundary_test.go
@@ -125,6 +125,10 @@ func (c *claimCommitBoundaryConn) QueryContext(_ context.Context, query string, 
 		return &claimCommitBoundaryRows{columns: []string{"name", "category"}}, nil
 	case strings.Contains(query, "SELECT value FROM config"):
 		return &claimCommitBoundaryRows{columns: []string{"value"}}, nil
+	case strings.Contains(query, "FROM dolt_status"):
+		// Empty-commit guard (GH#4288 re-port): report one staged row so the
+		// commit paths under test still reach DOLT_COMMIT.
+		return &claimCommitBoundaryRows{columns: []string{"count"}, values: [][]driver.Value{{int64(1)}}}, nil
 	case strings.Contains(query, "CALL DOLT_ADD"):
 		c.driver.stageCalls++
 		if c.driver.stageErr != nil {

--- a/internal/storage/dolt/draincall_regression_test.go
+++ b/internal/storage/dolt/draincall_regression_test.go
@@ -38,6 +38,8 @@ func TestDoltAddAndCommitDrainsCallResultSets(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_ADD(?)")).
 		WithArgs("issues").
 		WillReturnRows(sqlmock.NewRows([]string{"status"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) FROM dolt_status WHERE staged = 1")).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
 	mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_COMMIT('-m', ?, '--author', ?)")).
 		WithArgs("bd: test commit", " <>").
 		WillReturnRows(sqlmock.NewRows([]string{"hash"}))
@@ -84,6 +86,8 @@ func TestDoltAddAndCommitPostSQLFailuresAreIndeterminate(t *testing.T) {
 				mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_ADD(?)")).
 					WithArgs("issues").
 					WillReturnRows(sqlmock.NewRows([]string{"status"}))
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) FROM dolt_status WHERE staged = 1")).
+					WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
 				mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_COMMIT('-m', ?, '--author', ?)")).
 					WithArgs("bd: test commit", " <>").
 					WillReturnError(testConnectionLoss)
@@ -97,6 +101,8 @@ func TestDoltAddAndCommitPostSQLFailuresAreIndeterminate(t *testing.T) {
 				mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_ADD(?)")).
 					WithArgs("issues").
 					WillReturnRows(sqlmock.NewRows([]string{"status"}))
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) FROM dolt_status WHERE staged = 1")).
+					WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
 				mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_COMMIT('-m', ?, '--author', ?)")).
 					WithArgs("bd: test commit", " <>").
 					WillReturnError(&mysql.MySQLError{Number: 1213, Message: "deadlock"})
@@ -110,6 +116,8 @@ func TestDoltAddAndCommitPostSQLFailuresAreIndeterminate(t *testing.T) {
 				mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_ADD(?)")).
 					WithArgs("issues").
 					WillReturnRows(sqlmock.NewRows([]string{"status"}))
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) FROM dolt_status WHERE staged = 1")).
+					WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
 				mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_COMMIT('-m', ?, '--author', ?)")).
 					WithArgs("bd: test commit", " <>").
 					WillReturnError(&mysql.MySQLError{Number: 1205, Message: "lock wait timeout"})
@@ -199,6 +207,8 @@ func TestDoltAddAndCommitTreatsNothingToCommitAsSuccess(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_ADD(?)")).
 		WithArgs("issues").
 		WillReturnRows(sqlmock.NewRows([]string{"status"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) FROM dolt_status WHERE staged = 1")).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
 	mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_COMMIT('-m', ?, '--author', ?)")).
 		WithArgs("bd: test commit", " <>").
 		WillReturnError(errors.New("nothing to commit"))
@@ -407,6 +417,8 @@ func TestDoltAddAndCommitInTxClassifiesCommitResponses(t *testing.T) {
 			mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_ADD(?)")).
 				WithArgs("issues").
 				WillReturnRows(sqlmock.NewRows([]string{"status"}))
+			mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) FROM dolt_status WHERE staged = 1")).
+				WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
 			mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_COMMIT('-m', ?, '--author', ?)")).
 				WithArgs("bd: test commit", " <>").
 				WillReturnError(tc.commitErr)

--- a/internal/storage/dolt/empty_commit_test.go
+++ b/internal/storage/dolt/empty_commit_test.go
@@ -1,0 +1,252 @@
+//go:build cgo
+
+package dolt
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestDoltAddAndCommitSkipsEmptyCommitWithUnrelatedDirtyTable is a regression
+// test for the high-frequency "nothing to commit" Dolt warning spam.
+//
+// Root cause: doltAddAndCommit / doltAddAndCommitInTx stage only a FIXED table
+// list (e.g. ["dependencies"]) and then issue DOLT_COMMIT('-m', ...). An
+// idempotent no-op write (re-adding an existing dependency via INSERT IGNORE, or
+// removing a non-existent one) leaves that table clean, so the DOLT_ADD stages
+// nothing and the '-m' commit fails server-side with "nothing to commit" —
+// logged as a warning on every call. At reconcile cadence this floods dolt.log.
+//
+// Crucially, a *global* "any pending changes" check (issueops.HasPendingChanges,
+// as used by StageAndCommit which stages ALL dirty tables) is NOT sufficient
+// here: when an UNRELATED table (config, issues, …) is dirty in the working set,
+// the global check reports "pending" yet the selective DOLT_ADD still stages
+// nothing, so the empty '-m' commit fires anyway. The fix checks the STAGED set
+// (hasStagedChanges) after staging the target tables.
+//
+// This test reproduces that exact condition: it leaves `config` dirty, then
+// asserts no-op dependency writes neither error nor advance HEAD, while real
+// writes still commit (no over-suppression).
+func TestDoltAddAndCommitSkipsEmptyCommitWithUnrelatedDirtyTable(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	a := &types.Issue{ID: "pc-a", Title: "A", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	b := &types.Issue{ID: "pc-b", Title: "B", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	c := &types.Issue{ID: "pc-c", Title: "C", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	for _, iss := range []*types.Issue{a, b, c} {
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create %s: %v", iss.ID, err)
+		}
+	}
+
+	dep := &types.Dependency{IssueID: a.ID, DependsOnID: b.ID, Type: types.DepBlocks}
+
+	// Real add: must commit (HEAD advances).
+	head0 := headCommit(t, store)
+	if err := store.AddDependency(ctx, dep, "tester"); err != nil {
+		t.Fatalf("real AddDependency: %v", err)
+	}
+	head1 := headCommit(t, store)
+	if head1 == head0 {
+		t.Fatalf("real AddDependency did not advance HEAD (%s)", head1)
+	}
+
+	// Dirty an UNRELATED table without committing it. This is the working-set
+	// state that defeats a naive global-pending guard: `config` shows up in
+	// dolt_status, so "any pending changes" is true, but the dependencies table
+	// is clean for the idempotent calls below.
+	dirtyConfigUncommitted(t, store)
+
+	// Idempotent add (same edge, INSERT IGNORE no-op): must NOT error and must
+	// NOT advance HEAD — and (the bug) must NOT issue an empty '-m' commit.
+	headBefore := headCommit(t, store)
+	if err := store.AddDependency(ctx, dep, "tester"); err != nil {
+		t.Fatalf("idempotent AddDependency returned error (the bug): %v", err)
+	}
+	if got := headCommit(t, store); got != headBefore {
+		t.Errorf("idempotent AddDependency advanced HEAD %s -> %s (empty commit)", headBefore, got)
+	}
+
+	// No-op remove (edge that does not exist): same expectations.
+	headBefore = headCommit(t, store)
+	if err := store.RemoveDependency(ctx, a.ID, c.ID, "tester"); err != nil {
+		t.Fatalf("no-op RemoveDependency returned error (the bug): %v", err)
+	}
+	if got := headCommit(t, store); got != headBefore {
+		t.Errorf("no-op RemoveDependency advanced HEAD %s -> %s (empty commit)", headBefore, got)
+	}
+
+	// Regression guard against over-suppression: a REAL remove must still commit
+	// even though config is dirty in the working set.
+	headBefore = headCommit(t, store)
+	if err := store.RemoveDependency(ctx, a.ID, b.ID, "tester"); err != nil {
+		t.Fatalf("real RemoveDependency: %v", err)
+	}
+	if got := headCommit(t, store); got == headBefore {
+		t.Errorf("real RemoveDependency did not advance HEAD (%s) — guard over-suppressed a real change", got)
+	}
+}
+
+// TestClaimAndCloseNoRegressionWithUnrelatedDirtyTable guards the issues.go
+// commit sites that were consolidated onto the guarded doltAddAndCommitInTx
+// helper (UpdateIssue/ClaimIssue/ClaimReadyIssue/CloseIssue/Delete*).
+//
+// IMPORTANT — what this test does and does NOT prove. The empty-commit BUG is a
+// server-side "nothing to commit" WARNING, not a HEAD movement: an empty
+// DOLT_COMMIT('-m') with nothing staged ERRORS (and is swallowed), so it never
+// creates a commit and HEAD never advances WHETHER OR NOT the guard is present.
+// A HEAD-based integration test therefore cannot discriminate the warning. The
+// discriminating coverage lives in the sqlmock unit tests
+// (versioncontrolops.TestStageAndCommit* and dolt.TestHasStagedChanges), which
+// assert DOLT_COMMIT is NOT issued on an empty staged set and FAIL if the guard
+// is reverted. The issues.go sites merely ROUTE to that already-tested helper.
+//
+// This test's job is the COMPLEMENTARY half: prove the consolidation introduced
+// no REGRESSION / over-suppression — idempotent re-claim is a clean no-op (no
+// error, no spurious commit), and real claim/close still commit (HEAD advances),
+// even with an unrelated table (config) dirty in the working set. The true
+// warning-rate proof is the live-city measurement at deploy time.
+func TestClaimAndCloseNoRegressionWithUnrelatedDirtyTable(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	mk := func(id string) *types.Issue {
+		return &types.Issue{ID: id, Title: id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	}
+	for _, id := range []string{"pc-claim", "pc-close"} {
+		if err := store.CreateIssue(ctx, mk(id), "tester"); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+
+	// Real claim must commit (HEAD advances).
+	head0 := headCommit(t, store)
+	if err := store.ClaimIssue(ctx, "pc-claim", "actorX"); err != nil {
+		t.Fatalf("real ClaimIssue: %v", err)
+	}
+	if headCommit(t, store) == head0 {
+		t.Fatal("real ClaimIssue did not advance HEAD")
+	}
+
+	// Defeat a naive global-pending guard: leave config dirty in the working set,
+	// so dolt_status is non-empty for the idempotent no-op below.
+	dirtyConfigUncommitted(t, store)
+
+	// Idempotent re-claim by the SAME actor (already in_progress): no write, no
+	// events row — must NOT error and must NOT advance HEAD (the residual bug was
+	// an empty '-m' commit firing here because config was dirty).
+	headBefore := headCommit(t, store)
+	if err := store.ClaimIssue(ctx, "pc-claim", "actorX"); err != nil {
+		t.Fatalf("idempotent re-claim returned error (the bug): %v", err)
+	}
+	if got := headCommit(t, store); got != headBefore {
+		t.Errorf("idempotent re-claim advanced HEAD %s -> %s (empty commit)", headBefore, got)
+	}
+
+	// Over-suppression guard: a REAL close still rewrites closed_at/updated_at, so
+	// it MUST advance HEAD even with config dirty in the working set.
+	headBefore = headCommit(t, store)
+	if err := store.CloseIssue(ctx, "pc-close", "done", "tester", ""); err != nil {
+		t.Fatalf("real CloseIssue (config dirty): %v", err)
+	}
+	if got := headCommit(t, store); got == headBefore {
+		t.Error("real CloseIssue did not advance HEAD — guard over-suppressed a real change")
+	}
+}
+
+// headCommit returns the current HEAD commit hash via dolt_log.
+func headCommit(t *testing.T, store *DoltStore) string {
+	t.Helper()
+	ctx, cancel := testContext(t)
+	defer cancel()
+	hash, err := store.GetCurrentCommit(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentCommit: %v", err)
+	}
+	return hash
+}
+
+// dirtyConfigUncommitted writes a row to the (non-ignored) config table on the
+// store's pool and leaves it uncommitted, so dolt_status reports config dirty.
+func dirtyConfigUncommitted(t *testing.T, store *DoltStore) {
+	t.Helper()
+	ctx, cancel := testContext(t)
+	defer cancel()
+	if _, err := store.db.ExecContext(ctx,
+		"INSERT INTO config (`key`, value) VALUES ('empty_commit_test', 'x') "+
+			"ON DUPLICATE KEY UPDATE value = VALUES(value)"); err != nil {
+		t.Fatalf("dirty config: %v", err)
+	}
+	var n int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM dolt_status WHERE table_name = 'config'").Scan(&n); err != nil {
+		t.Fatalf("verify config dirty: %v", err)
+	}
+	if n == 0 {
+		t.Fatalf("precondition failed: config not dirty in working set")
+	}
+}
+
+// TestHasStagedChanges is a fast, server-free unit test of the guard predicate
+// (issueops.HasStagedChanges) used by StageAndCommit, doltAddAndCommit and
+// doltAddAndCommitInTx. It asserts the helper returns false on an empty staged
+// set (so the caller skips the empty '-m' commit) and true when something is
+// staged (so a real change still commits). Mirrors the sqlmock style of
+// versioncontrolops.TestStageAndCommit*.
+func TestHasStagedChanges(t *testing.T) {
+	matchStaged := regexp.MustCompile(`SELECT COUNT\(\*\) FROM dolt_status WHERE staged = 1`)
+
+	t.Run("empty staged set -> false", func(t *testing.T) {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+		if err != nil {
+			t.Fatalf("sqlmock.New: %v", err)
+		}
+		defer db.Close()
+		mock.ExpectQuery(matchStaged.String()).
+			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+		staged, err := issueops.HasStagedChanges(context.Background(), db)
+		if err != nil {
+			t.Fatalf("HasStagedChanges: %v", err)
+		}
+		if staged {
+			t.Error("expected staged=false for an empty staged set")
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Errorf("unmet expectations: %v", err)
+		}
+	})
+
+	t.Run("non-empty staged set -> true", func(t *testing.T) {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+		if err != nil {
+			t.Fatalf("sqlmock.New: %v", err)
+		}
+		defer db.Close()
+		mock.ExpectQuery(matchStaged.String()).
+			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
+
+		staged, err := issueops.HasStagedChanges(context.Background(), db)
+		if err != nil {
+			t.Fatalf("HasStagedChanges: %v", err)
+		}
+		if !staged {
+			t.Error("expected staged=true when rows are staged")
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Errorf("unmet expectations: %v", err)
+		}
+	})
+}

--- a/internal/storage/dolt/ephemeral_routing.go
+++ b/internal/storage/dolt/ephemeral_routing.go
@@ -331,6 +331,27 @@ func (s *DoltStore) doltAddAndCommitInTx(ctx context.Context, tx *sql.Tx, tables
 			return fmt.Errorf("dolt add %s: %w", table, err)
 		}
 	}
+
+	// Skip the commit when nothing was actually staged. A caller can reach here
+	// after an idempotent no-op write (e.g. re-adding an existing dependency via
+	// INSERT IGNORE, or removing a non-existent one), in which case the DOLT_ADDs
+	// above stage nothing and DOLT_COMMIT('-m') fails with a server-side "nothing
+	// to commit" warning that floods the Dolt log at reconcile cadence.
+	//
+	// Unlike StageAndCommit's fast-path (a global HasPendingChanges check), this
+	// helper stages only a FIXED table list. Other tables may be dirty
+	// concurrently, so the guard must test the STAGED set, not the whole working
+	// set — otherwise we would still fire an empty `-m` commit whenever an
+	// unrelated table is dirty. issueops.HasStagedChanges checks exactly what
+	// '-m' will commit; *sql.Tx satisfies issueops.SQLQuerier.
+	staged, err := issueops.HasStagedChanges(ctx, tx)
+	if err != nil {
+		return fmt.Errorf("check staged changes before commit: %w", err)
+	}
+	if !staged {
+		return nil
+	}
+
 	if err := schema.DrainCall(ctx, tx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
 		commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
 		return wrapSQLCommitError("dolt commit", err)

--- a/internal/storage/dolt/reopen_routing_test.go
+++ b/internal/storage/dolt/reopen_routing_test.go
@@ -69,6 +69,11 @@ func (c *reopenPromotionConn) QueryContext(_ context.Context, query string, args
 			values:  [][]driver.Value{{string("closed")}},
 		}, nil
 	}
+	if strings.Contains(query, "FROM dolt_status") {
+		// Empty-commit guard (GH#4288 re-port): report one staged row so the
+		// commit path under test still reaches DOLT_COMMIT.
+		return &reopenPromotionRows{columns: []string{"count"}, values: [][]driver.Value{{int64(1)}}}, nil
+	}
 	if strings.Contains(query, "CALL DOLT_ADD") && len(args) == 1 {
 		if table, ok := args[0].Value.(string); ok {
 			c.driver.doltAddTables = append(c.driver.doltAddTables, table)

--- a/internal/storage/dolt/slot_commit_boundary_test.go
+++ b/internal/storage/dolt/slot_commit_boundary_test.go
@@ -94,6 +94,10 @@ func (c *slotCommitBoundaryConn) QueryContext(_ context.Context, query string, _
 		return &claimCommitBoundaryRows{columns: []string{"label"}}, nil
 	case strings.Contains(query, "SELECT id FROM events"), strings.Contains(query, "SELECT id FROM wisp_events"):
 		return &claimCommitBoundaryRows{columns: []string{"id"}}, nil
+	case strings.Contains(query, "FROM dolt_status"):
+		// Empty-commit guard (GH#4288 re-port): report one staged row so the
+		// commit paths under test still reach DOLT_COMMIT.
+		return &claimCommitBoundaryRows{columns: []string{"count"}, values: [][]driver.Value{{int64(1)}}}, nil
 	case strings.Contains(query, "CALL DOLT_ADD"):
 		c.driver.stageCalls++
 		if c.driver.stageErr != nil {

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -3122,6 +3122,22 @@ func (s *DoltStore) doltAddAndCommit(ctx context.Context, tables []string, commi
 					fmt.Errorf("dolt add %s after SQL mutation: %w: %w", table, err, ErrCommitIndeterminate))
 			}
 		}
+
+		// Skip the commit when nothing was actually staged (idempotent no-op
+		// write), so Dolt does not log a server-side "nothing to commit" warning
+		// on every reconcile-cadence call. The guard tests the STAGED set rather
+		// than the whole working set because this helper stages only a fixed
+		// table list — an unrelated dirty table must not trigger an empty '-m'
+		// commit. A guard-read failure is NOT a publication failure: nothing has
+		// been committed and nothing is indeterminate, so plain error return.
+		staged, err := issueops.HasStagedChanges(ctx, conn)
+		if err != nil {
+			return fmt.Errorf("check staged changes before commit: %w", err)
+		}
+		if !staged {
+			return nil
+		}
+
 		if err := schema.DrainCall(ctx, conn, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
 			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
 			return s.recordDoltPublicationFailure(ctx,

--- a/internal/storage/dolt/transaction_phase_test.go
+++ b/internal/storage/dolt/transaction_phase_test.go
@@ -63,6 +63,8 @@ func TestRunInTransactionStageFailureAfterRegularCommitIsIndeterminateAndNotRepl
 	store, conn, tx, regularMock, ignoredMock := newTransactionPhaseFixture(t)
 	tx.dirty.MarkDirty("issues")
 	regularMock.ExpectCommit()
+	regularMock.ExpectQuery("SELECT COUNT\\(\\*\\) FROM dolt_status s").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
 	regularMock.ExpectExec("CALL DOLT_ADD\\(\\?\\)").WithArgs("issues").
 		WillReturnError(errors.New("invalid connection"))
 	ignoredMock.ExpectRollback()

--- a/internal/storage/embeddeddolt/post_sql_commit_test.go
+++ b/internal/storage/embeddeddolt/post_sql_commit_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/steveyegge/beads/internal/storage"
 )
 
@@ -25,7 +26,7 @@ func TestStageAndCommitAfterSQLCommitResponseLossIsIndeterminateAndNotReplayed(t
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			responseLoss := errors.New(tc.name + " response lost after SQL commit")
-			conn := &postSQLCommitFailureConn{failCall: tc.failCall, err: responseLoss}
+			conn := &postSQLCommitFailureConn{failCall: tc.failCall, err: responseLoss, status: newDoltStatusStub(t)}
 
 			err := stageAndCommitAfterSQLCommit(t.Context(), conn,
 				map[string]bool{"issues": true}, "bd: commit derived state", "tester <tester@example.com>")
@@ -45,10 +46,30 @@ func TestStageAndCommitAfterSQLCommitResponseLossIsIndeterminateAndNotReplayed(t
 	}
 }
 
+// newDoltStatusStub returns a *sql.DB whose dolt_status queries each yield a
+// single-row count of 1, standing in for the pending/staged empty-commit guard
+// reads (GH#4288 re-port) that StageAndCommit issues around its Exec calls.
+// The version-control call counting below deliberately tracks only Exec calls,
+// so the guard reads stay invisible to the assertions.
+func newDoltStatusStub(t *testing.T) *sql.DB {
+	t.Helper()
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	for i := 0; i < 4; i++ {
+		mock.ExpectQuery(`FROM dolt_status`).
+			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
 type postSQLCommitFailureConn struct {
 	failCall int
 	err      error
 	calls    []string
+	status   *sql.DB
 }
 
 func (c *postSQLCommitFailureConn) ExecContext(_ context.Context, query string, _ ...any) (sql.Result, error) {
@@ -63,6 +84,6 @@ func (*postSQLCommitFailureConn) QueryContext(context.Context, string, ...any) (
 	return nil, errors.New("unexpected QueryContext")
 }
 
-func (*postSQLCommitFailureConn) QueryRowContext(context.Context, string, ...any) *sql.Row {
-	return nil
+func (c *postSQLCommitFailureConn) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	return c.status.QueryRowContext(ctx, query, args...)
 }

--- a/internal/storage/issueops/commit_pending.go
+++ b/internal/storage/issueops/commit_pending.go
@@ -30,6 +30,29 @@ func HasPendingChanges(ctx context.Context, db SQLQuerier) (bool, error) {
 	return count > 0, nil
 }
 
+// HasStagedChanges reports whether the Dolt working set has any STAGED changes,
+// i.e. rows that a subsequent DOLT_COMMIT('-m', …) would actually commit.
+//
+// This is the correct pre-commit check for selective-staging commit helpers
+// (StageAndCommit, doltAddAndCommit, doltAddAndCommitInTx) that DOLT_ADD only a
+// fixed/dirty-tracked set of tables. A global HasPendingChanges check is NOT
+// sufficient for them: a table can be marked dirty by a write statement yet have
+// no real row change (idempotent INSERT IGNORE / ON DUPLICATE KEY no-op, or an
+// UPDATE matching nothing). When some OTHER table is concurrently dirty in the
+// working set, HasPendingChanges is true, but staging only the (clean) target
+// tables stages nothing — and DOLT_COMMIT('-m') then fails server-side with a
+// "nothing to commit" warning that floods the Dolt log at reconcile cadence.
+// Checking the staged set AFTER DOLT_ADD captures exactly what '-m' will commit.
+func HasStagedChanges(ctx context.Context, db SQLQuerier) (bool, error) {
+	var count int
+	err := db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM dolt_status WHERE staged = 1").Scan(&count)
+	if err != nil {
+		return false, fmt.Errorf("failed to check staged status: %w", err)
+	}
+	return count > 0, nil
+}
+
 // BuildBatchCommitMessage generates a descriptive commit message summarizing
 // what changed since the last commit by querying dolt_diff against HEAD.
 // It reports issue-level create/update/delete counts and lists any other

--- a/internal/storage/versioncontrolops/commit.go
+++ b/internal/storage/versioncontrolops/commit.go
@@ -49,13 +49,47 @@ func StageAndCommit(ctx context.Context, conn DBConn, dirtyTables map[string]boo
 		return nil
 	}
 
+	// dirtyTables tracks tables touched by a write statement, but a statement
+	// can succeed without changing any rows (e.g. an idempotent
+	// "INSERT ... ON DUPLICATE KEY UPDATE value = VALUES(value)" re-writing the
+	// same value, an INSERT IGNORE that hit a duplicate, or an UPDATE whose WHERE
+	// matched nothing). Staging + committing in that case is a no-op that Dolt
+	// rejects with a "nothing to commit" warning logged server-side on every call
+	// — at high-frequency callers (config/metadata heartbeats, reconcile counters,
+	// idempotent label/dependency writes) this floods the Dolt log.
+	//
+	// Cheap fast-path: if NOTHING is pending in the whole working set (excluding
+	// dolt-ignored tables, which cannot be staged), skip without touching Dolt's
+	// staging machinery. Note: callers like Update/Close also write an events row,
+	// so a zero-rows main-table write can still be a real change — dolt_status
+	// captures that correctly where a rows-affected check would not.
+	pending, err := issueops.HasPendingChanges(ctx, conn)
+	if err != nil {
+		return fmt.Errorf("check pending changes before commit: %w", err)
+	}
+	if !pending {
+		return nil
+	}
+
 	for table := range dirtyTables {
 		if _, err := conn.ExecContext(ctx, "CALL DOLT_ADD(?)", table); err != nil {
 			return fmt.Errorf("dolt add %s: %w", table, err)
 		}
 	}
 
-	var err error
+	// Precise guard: HasPendingChanges above is global, but we only DOLT_ADD the
+	// dirty-tracked tables. When those specific tables turn out clean (idempotent
+	// no-op) while some UNRELATED table is concurrently dirty, the fast-path does
+	// not fire yet staging stages nothing — so DOLT_COMMIT('-m') would still emit
+	// the "nothing to commit" warning. Check the STAGED set (exactly what '-m'
+	// will commit) and skip the empty commit.
+	staged, err := issueops.HasStagedChanges(ctx, conn)
+	if err != nil {
+		return fmt.Errorf("check staged changes before commit: %w", err)
+	}
+	if !staged {
+		return nil
+	}
 	if author == "" {
 		_, err = conn.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?)", commitMsg)
 	} else {

--- a/internal/storage/versioncontrolops/commit_empty_test.go
+++ b/internal/storage/versioncontrolops/commit_empty_test.go
@@ -1,0 +1,124 @@
+package versioncontrolops
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+// TestStageAndCommitSkipsWhenNothingPending is a regression test for the
+// high-frequency "nothing to commit" Dolt warning spam.
+//
+// Root cause: a write statement can succeed and mark its table dirty without
+// changing any rows (e.g. SetMetadata's "INSERT ... ON DUPLICATE KEY UPDATE
+// value = VALUES(value)" re-writing the same value). The old StageAndCommit
+// guarded only on len(dirtyTables)==0, so it still issued DOLT_ADD + DOLT_COMMIT
+// for such no-op transactions; Dolt rejected each with a server-side
+// "nothing to commit" warning that floods the log at heartbeat cadence.
+//
+// The fix consults Dolt's authoritative working-set status (HasPendingChanges,
+// which queries dolt_status) and skips staging + commit when nothing is pending.
+// These tests assert on whether DOLT_COMMIT is issued — the actual discriminator
+// (HEAD never advances on an empty commit either way, so HEAD is not a valid
+// signal; the bug is the wasted commit attempt and its warning).
+
+// matchPendingQuery matches the dolt_status query used by HasPendingChanges
+// (the global "anything pending?" fast-path check, which joins dolt_ignore).
+var matchPendingQuery = regexp.MustCompile(`SELECT COUNT\(\*\) FROM dolt_status s`)
+
+// matchStagedQuery matches the dolt_status query used by HasStagedChanges (the
+// precise "anything actually staged?" check issued after DOLT_ADD).
+var matchStagedQuery = regexp.MustCompile(`SELECT COUNT\(\*\) FROM dolt_status WHERE staged = 1`)
+
+func TestStageAndCommitSkipsWhenNothingPending(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	// dolt_status reports ZERO committable changes — the idempotent no-op case.
+	mock.ExpectQuery(matchPendingQuery.String()).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	// No ExpectExec for DOLT_ADD / DOLT_COMMIT: if StageAndCommit issues either,
+	// sqlmock fails the test with "call not expected".
+
+	err = StageAndCommit(context.Background(), db, map[string]bool{"metadata": true}, "idempotent heartbeat", "tester")
+	if err != nil {
+		t.Fatalf("StageAndCommit returned error on a clean no-op: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("StageAndCommit issued a commit when nothing was pending (the bug): %v", err)
+	}
+}
+
+func TestStageAndCommitCommitsWhenPending(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	// dolt_status reports a committable change — a real write.
+	mock.ExpectQuery(matchPendingQuery.String()).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	// The real path must stage the dirty table...
+	mock.ExpectExec(`CALL DOLT_ADD\(\?\)`).
+		WithArgs("metadata").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	// ...confirm something is actually staged...
+	mock.ExpectQuery(matchStagedQuery.String()).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	// ...and commit.
+	mock.ExpectExec(`CALL DOLT_COMMIT`).
+		WithArgs("real change", "tester").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err = StageAndCommit(context.Background(), db, map[string]bool{"metadata": true}, "real change", "tester")
+	if err != nil {
+		t.Fatalf("StageAndCommit returned error on a real change: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("StageAndCommit failed to stage+commit a real change: %v", err)
+	}
+}
+
+// TestStageAndCommitSkipsWhenOnlyUnrelatedTableDirty is a regression test for
+// the second, subtler half of the empty-commit bug: the dirty-tracked tables
+// turn out clean (idempotent INSERT IGNORE label/dependency write) while some
+// UNRELATED table (config, issues, …) is concurrently dirty in the working set.
+//
+// The global HasPendingChanges fast-path returns true (the unrelated table is
+// pending), so StageAndCommit proceeds to DOLT_ADD its dirty-tracked table — but
+// that stages nothing, and without the post-staging HasStagedChanges guard the
+// '-m' commit would fire and Dolt would log "nothing to commit". The fix must
+// detect the empty staged set and skip the commit.
+func TestStageAndCommitSkipsWhenOnlyUnrelatedTableDirty(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	// Global status: something IS pending (an unrelated table like config).
+	mock.ExpectQuery(matchPendingQuery.String()).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	// We stage only the dirty-tracked table ("labels"), which is clean here.
+	mock.ExpectExec(`CALL DOLT_ADD\(\?\)`).
+		WithArgs("labels").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	// Staged set is EMPTY — the guard must skip the commit. No ExpectExec for
+	// DOLT_COMMIT: if StageAndCommit issues it, sqlmock fails with "not expected".
+	mock.ExpectQuery(matchStagedQuery.String()).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+	err = StageAndCommit(context.Background(), db, map[string]bool{"labels": true}, "idempotent label add", "tester")
+	if err != nil {
+		t.Fatalf("StageAndCommit returned error on a no-op with unrelated dirty table: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("StageAndCommit issued an empty commit when only an unrelated table was dirty (the bug): %v", err)
+	}
+}


### PR DESCRIPTION
Maintainer-side re-port of #4288 (@realies, substance-approved by maphew 2026-07-27), redone against current main per bd-oibnz. The original PR had two halves; the **consolidation half** (issues.go hand-rolled DOLT_ADD/DOLT_COMMIT sites onto `doltAddAndCommitInTx`) already landed independently via #5341 — main also settled the add-error semantics question (strict adds via `schema.DrainCall`) that the re-port bead flagged. This PR carries the remaining **guard half**, plus the original's tests.

## The bug

An idempotent no-op write (INSERT IGNORE hitting a duplicate, ON DUPLICATE KEY re-writing the same value, an UPDATE matching nothing) marks its table dirty without changing rows. The selective DOLT_ADD then stages nothing and `DOLT_COMMIT('-m')` fails server-side with a "nothing to commit" warning — flooding dolt.log at reconcile cadence.

## What lands

- **`issueops.HasStagedChanges`** — reports whether `dolt_status` has staged rows, i.e. exactly what a `'-m'` commit would include.
- **`versioncontrolops.StageAndCommit`** — global `HasPendingChanges` fast-path before staging, plus the precise `HasStagedChanges` guard before commit (the subtle case: the dirty-tracked tables are clean while an UNRELATED table is dirty — the global check passes but staging stages nothing).
- **`DoltStore.doltAddAndCommit` / `doltAddAndCommitInTx`** — staged-set guard before commit (fixed table lists, so only the staged check applies). Composes with the existing `VersionCommitDeferred` (bd-4wamg) early-out, which remains first. In `doltAddAndCommit` a guard-read failure returns a plain error, not a publication failure: nothing committed, nothing indeterminate.
- **Tests**: the original's sqlmock discriminators (assert DOLT_COMMIT is NOT issued on an empty staged set — they fail if a guard is reverted; HEAD is deliberately not the signal, since an empty '-m' errors and never advances HEAD either way), the cgo integration regressions (no-op dependency writes, claim/close over-suppression with an unrelated dirty table), and `TestHasStagedChanges`.
- **Harness updates**: existing commit-boundary/draincall/phase/post-SQL stub drivers taught to serve the two new `dolt_status` guard reads (the embeddeddolt stub previously returned a nil `*sql.Row`, which the new guard would dereference). `Commit()`-path tests (stage-all flow) are untouched — that path doesn't use these helpers.

Relationship to #5401: complementary — that covered the proxied-server (uow) commit path; this covers the classic-store paths.

## Verification

Local: build/vet/gofmt clean; every touched package green in full (`dolt`, `embeddeddolt`, `versioncontrolops`, `issueops`). A first whole-`internal/storage/...` sweep surfaced the two harness gaps fixed above (plus ambient Docker-dependent skips); the post-fix full-sweep re-run was still in flight at posting time — CI is the gate. Attribution preserved via `Co-authored-by`.

Closes #4288.

_claude-fable-5 on behalf of bee (beads-lane steward); tracking bead bd-oibnz_
