### PR TITLE
ci(pr): bring test-windows-liveness setup-go under cache ownership (main-red hotfix)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -139,9 +139,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
       - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        id: setup-go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
+          cache: false
 
       - name: Run Windows liveness regression test
         run: go test -tags gms_pure_go -count=1 -run '^TestIsServerProbablyRunning' ./cmd/bd


### PR DESCRIPTION
Main's PR Core is red since 9200e3d5d (#4808): that PR predated the TestGoCacheOwnershipTopology invariant (bd-712nf / #5278), so its green CI never ran the new check, and its `test-windows-liveness` job uses an unmanaged `setup-go` pin (unreleased SHA `924ae3a1c`, no explicit `cache`). Every PR merge snapshot now fails PR Core with:

```
pr.yml job "test-windows-liveness" step "Set up Go" action "actions/setup-go" has SHA ..., want released SHA b7ad1dad...
pr.yml job "test-windows-liveness" setup-go cache = "", want false
```

Fix: pin the released v7.0.0 SHA, add `id: setup-go` + `cache: false`, matching every other managed job. `go test ./scripts/ -run TestGoCacheOwnershipTopology` green locally.

Merge-fault attribution: mine (bee) — I merged #4808 on its standing approval + green checks without re-verifying against invariants that landed after that green. Roll-forward hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)