### PR TITLE
fix(list): stop claiming Total when the page is truncated (GH#5362)

### DIFF
--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -307,7 +307,8 @@ func runListCore(cmd *cobra.Command, _ []string) error {
 			if depErr != nil && in.depsMode != "" {
 				return HandleError("loading dependencies for --deps: %v", depErr)
 			}
-			displayPrettyListWithDepsMode(treeIssues, false, allDeps, in.depsMode)
+			// Hierarchical --parent walks use an unlimited per-level query, so the tree is never page-truncated.
+			displayPrettyListWithDepsMode(treeIssues, false, allDeps, in.depsMode, false)
 			printSkipLabelsFooter(in.SkipLabels)
 			return nil
 		}
@@ -316,7 +317,7 @@ func runListCore(cmd *cobra.Command, _ []string) error {
 		if depErr != nil && in.depsMode != "" {
 			return HandleError("loading dependencies for --deps: %v", depErr)
 		}
-		displayPrettyListWithDepsMode(issues, false, allDeps, in.depsMode)
+		displayPrettyListWithDepsMode(issues, false, allDeps, in.depsMode, truncated)
 		printTruncationHint(truncated, in.effectiveLimit)
 		printSkipLabelsFooter(in.SkipLabels)
 		return nil

--- a/cmd/bd/list_helpers_test.go
+++ b/cmd/bd/list_helpers_test.go
@@ -304,6 +304,31 @@ func TestListDisplayPrettyList(t *testing.T) {
 	if !strings.Contains(out, "bd-1") || !strings.Contains(out, "bd-1.1") || !strings.Contains(out, "Total:") {
 		t.Fatalf("unexpected output: %q", out)
 	}
+	if strings.Contains(out, "Showing ") {
+		t.Fatalf("untruncated list must keep Total: wording, got: %q", out)
+	}
+}
+
+// GH#5362: a page cut by --limit must not label the page size as Total.
+func TestListDisplayPrettyList_TruncatedSummary(t *testing.T) {
+	issues := []*types.Issue{
+		{ID: "bd-1", Title: "A", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+		{ID: "bd-2", Title: "B", Status: types.StatusInProgress, Priority: 1, IssueType: types.TypeFeature},
+	}
+
+	out := captureStdout(t, func() error {
+		displayPrettyListWithDepsMode(issues, false, nil, "", true)
+		return nil
+	})
+	if !strings.Contains(out, "Showing 2 issues") {
+		t.Fatalf("expected honest Showing N summary when truncated, got: %q", out)
+	}
+	if !strings.Contains(out, "truncated by --limit") {
+		t.Fatalf("expected truncation notice in summary, got: %q", out)
+	}
+	if strings.Contains(out, "Total:") {
+		t.Fatalf("truncated summary must not claim Total:, got: %q", out)
+	}
 }
 
 func TestDisplayWatchedIssueList_UsesDependencyHierarchy(t *testing.T) {
@@ -318,7 +343,7 @@ func TestDisplayWatchedIssueList_UsesDependencyHierarchy(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() error {
-		displayWatchedIssueList(context.Background(), store, []*types.Issue{child, parent})
+		displayWatchedIssueList(context.Background(), store, []*types.Issue{child, parent}, false)
 		return nil
 	})
 

--- a/cmd/bd/list_proxied_server.go
+++ b/cmd/bd/list_proxied_server.go
@@ -155,7 +155,7 @@ func runListProxiedWatch(_ *cobra.Command, ctx context.Context, in listInput) er
 	if err != nil {
 		return fmt.Errorf("initial query: %w", err)
 	}
-	displayPrettyListWithDeps(issues, true, deps)
+	displayPrettyListWithDeps(issues, true, deps, hasMore)
 	printTruncationHint(hasMore, in.effectiveLimit)
 	lastSnapshot := issueSnapshot(issues)
 
@@ -182,7 +182,7 @@ func runListProxiedWatch(_ *cobra.Command, ctx context.Context, in listInput) er
 			snap := issueSnapshot(issues)
 			if snap != lastSnapshot {
 				lastSnapshot = snap
-				displayPrettyListWithDeps(issues, true, deps)
+				displayPrettyListWithDeps(issues, true, deps, hasMore)
 				printTruncationHint(hasMore, in.effectiveLimit)
 				fmt.Fprintf(os.Stderr, "\nWatching for changes... (Press Ctrl+C to exit)\n")
 			}
@@ -238,7 +238,7 @@ func renderProxiedListText(ctx context.Context, issues []*types.Issue, in listIn
 			printTruncationHint(truncated, in.effectiveLimit)
 			return nil
 		}
-		displayPrettyListWithDepsMode(issues, false, depsByIssueID, in.depsMode)
+		displayPrettyListWithDepsMode(issues, false, depsByIssueID, in.depsMode, truncated)
 		printTruncationHint(truncated, in.effectiveLimit)
 		printSkipLabelsFooter(in.SkipLabels)
 		return nil

--- a/cmd/bd/list_show_filter_modes.go
+++ b/cmd/bd/list_show_filter_modes.go
@@ -152,7 +152,7 @@ func loadWatchedIssues(ctx context.Context, store storage.DoltStorage, filter ty
 	return issues, nil
 }
 
-func displayWatchedIssueList(ctx context.Context, store watchListDependencyStore, issues []*types.Issue) {
+func displayWatchedIssueList(ctx context.Context, store watchListDependencyStore, issues []*types.Issue, truncated bool) {
 	var allDeps map[string][]*types.Dependency
 	if store != nil {
 		deps, err := store.GetAllDependencyRecords(ctx)
@@ -160,7 +160,7 @@ func displayWatchedIssueList(ctx context.Context, store watchListDependencyStore
 			allDeps = deps
 		}
 	}
-	displayPrettyListWithDeps(issues, true, allDeps)
+	displayPrettyListWithDeps(issues, true, allDeps, truncated)
 }
 
 // watchIssues returns an error only for the initial query — a failure there
@@ -180,7 +180,7 @@ func watchIssues(ctx context.Context, store storage.DoltStorage, filter types.Is
 	// below depends on; what is left is the cut and its verdict, and those are
 	// the shared epilogue's on every other listing this command has.
 	issues, truncated := workapi.FinishPage(issues, "", false, effectiveLimit, false)
-	displayWatchedIssueList(ctx, store, issues)
+	displayWatchedIssueList(ctx, store, issues, truncated)
 	printTruncationHint(truncated, effectiveLimit)
 	lastSnapshot := issueSnapshot(issues)
 
@@ -210,7 +210,7 @@ func watchIssues(ctx context.Context, store storage.DoltStorage, filter types.Is
 			snap := issueSnapshot(issues)
 			if snap != lastSnapshot {
 				lastSnapshot = snap
-				displayWatchedIssueList(ctx, store, issues)
+				displayWatchedIssueList(ctx, store, issues, truncated)
 				printTruncationHint(truncated, effectiveLimit)
 				fmt.Fprintf(os.Stderr, "\nWatching for changes... (Press Ctrl+C to exit)\n")
 			}
@@ -251,7 +251,8 @@ func runListProxiedHierarchicalParent(ctx context.Context, uw uow.UnitOfWork, in
 		return err
 	}
 
-	displayPrettyListWithDepsMode(treeIssues, false, depsByIssueID, in.depsMode)
+	// Hierarchical --parent walks use an unlimited per-level query; never page-truncated.
+	displayPrettyListWithDepsMode(treeIssues, false, depsByIssueID, in.depsMode, false)
 	printSkipLabelsFooter(in.SkipLabels)
 	return nil
 }

--- a/cmd/bd/list_tree.go
+++ b/cmd/bd/list_tree.go
@@ -145,19 +145,20 @@ func printPrettyTree(childrenMap map[string][]*types.Issue, parentID string, pre
 // displayPrettyList displays issues in pretty tree format (GH#654)
 // Uses buildIssueTree which only supports dotted ID hierarchy
 func displayPrettyList(issues []*types.Issue, showHeader bool) {
-	displayPrettyListWithDeps(issues, showHeader, nil)
+	displayPrettyListWithDeps(issues, showHeader, nil, false)
 }
 
 // displayPrettyListWithDeps displays issues in tree format using dependency data.
-func displayPrettyListWithDeps(issues []*types.Issue, showHeader bool, allDeps map[string][]*types.Dependency) {
-	displayPrettyListWithDepsMode(issues, showHeader, allDeps, "")
+func displayPrettyListWithDeps(issues []*types.Issue, showHeader bool, allDeps map[string][]*types.Dependency, truncated bool) {
+	displayPrettyListWithDepsMode(issues, showHeader, allDeps, "", truncated)
 }
 
 // displayPrettyListWithDepsMode displays issues in tree format. When depsMode is
 // "scheduling" or "all", the tree also annotates each node's dependency edges and
 // orders siblings by their scheduling dependencies (see orderSiblingsByDeps). An
-// empty depsMode is the plain parent-child tree.
-func displayPrettyListWithDepsMode(issues []*types.Issue, showHeader bool, allDeps map[string][]*types.Dependency, depsMode string) {
+// empty depsMode is the plain parent-child tree. truncated means the page was cut
+// by --limit; the summary then says "Showing N" instead of "Total: N" (GH#5362).
+func displayPrettyListWithDepsMode(issues []*types.Issue, showHeader bool, allDeps map[string][]*types.Dependency, depsMode string, truncated bool) {
 	if showHeader {
 		// Clear screen and show header
 		fmt.Print("\033[2J\033[H")
@@ -190,7 +191,7 @@ func displayPrettyListWithDepsMode(issues []*types.Issue, showHeader bool, allDe
 		printPrettyTree(childrenMap, issue.ID, "", dr)
 	}
 
-	// Summary
+	// Summary — counts describe the shown page; never label a truncated page "Total".
 	fmt.Println()
 	fmt.Println(strings.Repeat("-", 80))
 	openCount := 0
@@ -203,7 +204,12 @@ func displayPrettyListWithDepsMode(issues []*types.Issue, showHeader bool, allDe
 			inProgressCount++
 		}
 	}
-	fmt.Printf("Total: %d issues (%d open, %d in progress)\n", len(issues), openCount, inProgressCount)
+	if truncated {
+		fmt.Printf("Showing %d issues (%d open, %d in progress); more match (truncated by --limit). Use --limit 0 for all.\n",
+			len(issues), openCount, inProgressCount)
+	} else {
+		fmt.Printf("Total: %d issues (%d open, %d in progress)\n", len(issues), openCount, inProgressCount)
+	}
 	fmt.Println()
 	fmt.Println("Status: ○ open  ◐ in_progress  ● blocked  ✓ closed  ❄ deferred")
 	if dr != nil {


### PR DESCRIPTION
## What

Stop `bd list`'s pretty-tree summary from labeling a page-capped row count as
`Total: N`. When the page was truncated by `--limit`, the footer now says
`Showing N issues …; more match (truncated by --limit)` so a partial queue
cannot be mistaken for the full set.

## Why

Fixes #5362.

Reported by @AgentMonocle: with the default limit of 50,
`bd list` printed `Total: 50 issues` even when hundreds matched. Multi-agent
workflows treated that as a complete queue and missed remaining work
(production incident cited in the issue).

`bd ready` already distinguishes page size from the full set; this brings the
list pretty footer in line with that honesty contract. The existing stderr
truncation hint (GH#3212) remains; this fix is about the stdout summary that
asserted completeness.

### Out of scope (issue secondary items)

1. **`--json` silently ignored without `--flat`** — already fixed on current
   `main`: the JSON branch runs before the tree renderer, and `--json`
   clears pretty/tree selection. Verified by code inspection of `runListCore`
   / `gatherListInput`. Not changed here.
2. **`--limit 0` undocumented on `bd ready`** — already fixed on current
   `main`: help text is `Maximum issues to show (use 0 for unlimited)`. Not
   changed here.

## Verification

```bash
# Unit: truncated vs untruncated pretty summary
go test ./cmd/bd/ -count=1 -run 'TestListDisplayPrettyList'

# Manual: create >50 matching closed issues, then:
bd list --status closed --closed-after <recent>          # footer: Showing 50…truncated
bd list --status closed --closed-after <recent> --limit 0  # footer: Total: N
```

Local: `go test ./cmd/bd/ -count=1 -run 'TestListDisplayPrettyList|TestDisplayWatchedIssueList'` → pass.

## Notes for reviewers

- No new flags / surface.
- On an interactive TTY with a truncated page you'll now see two similar
  sentences: this new stdout footer and the existing stderr truncation hint
  (GH#3212). They're on different streams by design — the stderr hint is
  TTY-only and invisible to piping agents, which is exactly the audience #5362
  is about, so the stdout footer is the one that fixes the bug. Happy to fold
  them together if you'd rather.
- True cardinality (`Showing N of M`) would need a list-predicate Counter
  that mirrors Reader.List defaults (Counter's default exclusions differ from
  list's); left for a follow-up if desired. HasMore is enough to refuse a
  false Total without an extra count query.
