### PR TITLE
Four ordering contract cases for sort behavior no shared proof owns

### DIFF
--- a/backend/conformance/audit_search-counts-stats.go
+++ b/backend/conformance/audit_search-counts-stats.go
@@ -35,6 +35,7 @@ func RunAudit_search_counts_stats(t *testing.T, f Factory) {
 	t.Run("SearchDefaultOrderTieBreak", func(t *testing.T) { testAuditSearchDefaultOrderTieBreak(t, f) })
 	t.Run("SearchIdenticalTimestampIDOrder", func(t *testing.T) { testAuditSearchIdenticalTimestampIDOrder(t, f) })
 	t.Run("SearchSortByClosedNullsLast", func(t *testing.T) { testAuditSearchSortByClosedNullsLast(t, f) })
+	t.Run("SearchSortByTitleCaseFolded", func(t *testing.T) { testAuditSearchSortByTitleCaseFolded(t, f) })
 	t.Run("SearchTextIDBranchExternalRef", func(t *testing.T) { testAuditSearchTextIDBranchExternalRef(t, f) })
 	t.Run("SearchIDPrefixCaseSensitive", func(t *testing.T) { testAuditSearchIDPrefixCaseSensitive(t, f) })
 	t.Run("SearchParentDescendantCaseSensitive", func(t *testing.T) { testAuditSearchParentDescendantCaseSensitive(t, f) })
@@ -398,6 +399,39 @@ func testAuditSearchSortByClosedNullsLast(t *testing.T, f Factory) {
 	want := []string{"cs-closed-new", "cs-closed-old", "cs-open-a", "cs-open-b"}
 	if got := orderedIDs(results); !reflect.DeepEqual(got, want) {
 		t.Errorf("closed-sort order = %v, want %v (NULLs last on DESC)", got, want)
+	}
+}
+
+// A search sorted by title and cut to a limit keeps the first N rows under
+// case-folded title order — "apple" before "Zebra" — with case-folded ties broken
+// by id ASC, on every backend and database collation. sqlbuild/sort.go renders
+// LOWER(title) for both the SQL ORDER BY and the Go-side merge, but an engine whose
+// default text collation is byte-wise or linguistic satisfies every other ordering
+// case in this slice while reordering this one, silently changing which rows survive
+// the cut with no error and no other signal.
+func testAuditSearchSortByTitleCaseFolded(t *testing.T, f Factory) {
+	s := f(t)
+	c := ctx()
+	// Byte order (APPLE2, Apple, Zebra, apple, banana) and priority order both
+	// disagree with the case-folded order asserted below.
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "ti-1", Title: "Zebra", Priority: 0}), "a"))
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "ti-2", Title: "apple", Priority: 3}), "a"))
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "ti-3", Title: "APPLE2", Priority: 2}), "a"))
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "ti-4", Title: "banana", Priority: 1}), "a"))
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "ti-5", Title: "Apple", Priority: 3}), "a"))
+
+	// ti-2/ti-5 fold to the same title, so they pin the id-ASC tie leg.
+	want := []string{"ti-2", "ti-5", "ti-3", "ti-4", "ti-1"}
+	results, err := s.SearchIssues(c, "", types.IssueFilter{SortBy: "title"})
+	must(t, err)
+	if got := orderedIDs(results); !reflect.DeepEqual(got, want) {
+		t.Errorf("title-sort order = %v, want %v (LOWER(title) ASC, id ASC)", got, want)
+	}
+
+	page, err := s.SearchIssues(c, "", types.IssueFilter{SortBy: "title", Limit: 2})
+	must(t, err)
+	if got := orderedIDs(page); !reflect.DeepEqual(got, want[:2]) {
+		t.Errorf("title-sort page = %v, want %v (first 2 rows of the case-folded order)", got, want[:2])
 	}
 }
 

--- a/backend/conformance/audit_search-counts-stats.go
+++ b/backend/conformance/audit_search-counts-stats.go
@@ -37,6 +37,7 @@ func RunAudit_search_counts_stats(t *testing.T, f Factory) {
 	t.Run("SearchSortByClosedNullsLast", func(t *testing.T) { testAuditSearchSortByClosedNullsLast(t, f) })
 	t.Run("SearchSortByTitleCaseFolded", func(t *testing.T) { testAuditSearchSortByTitleCaseFolded(t, f) })
 	t.Run("SearchSortTieBreakSurvivesReversal", func(t *testing.T) { testAuditSearchSortTieBreakSurvivesReversal(t, f) })
+	t.Run("SearchSortNullsDirectional", func(t *testing.T) { testAuditSearchSortNullsDirectional(t, f) })
 	t.Run("SearchTextIDBranchExternalRef", func(t *testing.T) { testAuditSearchTextIDBranchExternalRef(t, f) })
 	t.Run("SearchIDPrefixCaseSensitive", func(t *testing.T) { testAuditSearchIDPrefixCaseSensitive(t, f) })
 	t.Run("SearchParentDescendantCaseSensitive", func(t *testing.T) { testAuditSearchParentDescendantCaseSensitive(t, f) })
@@ -477,6 +478,44 @@ func testAuditSearchSortTieBreakSurvivesReversal(t *testing.T, f Factory) {
 	want = []string{"tb-a", "tb-b", "tb-new", "tb-c"}
 	if got := orderedIDs(results); !reflect.DeepEqual(got, want) {
 		t.Errorf("reversed status-sort order = %v, want %v (the tied open group is STILL id ASC)", got, want)
+	}
+}
+
+// Rows with no value for a nullable sort key (closed_at, assignee) sort first on
+// ascending order and last on descending order, regardless of the engine's native
+// NULL ordering. sqlbuild/sort.go leads those keys with an explicit (col IS NULL)
+// term precisely "so the contract does not depend on a driver's default NULL
+// ordering", but the slice pins only the closed sort in its default direction.
+// The unassigned rows are created exactly as `bd create` leaves them, so the case
+// pins the observable order without prescribing a NULL-vs-empty-string encoding.
+func testAuditSearchSortNullsDirectional(t *testing.T, f Factory) {
+	s := f(t)
+	c := ctx()
+	tNew, tOld := auditWholeSec(2022), auditWholeSec(2021)
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "nl-open-a", Title: "oa", Status: types.StatusOpen}), "a"))
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "nl-open-b", Title: "ob", Status: types.StatusOpen}), "a"))
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "nl-closed-new", Title: "cn", Status: types.StatusClosed, ClosedAt: &tNew, Assignee: "alice"}), "a"))
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "nl-closed-old", Title: "co", Status: types.StatusClosed, ClosedAt: &tOld, Assignee: "bob"}), "a"))
+
+	results, err := s.SearchIssues(c, "", types.IssueFilter{SortBy: "closed", SortDesc: true})
+	must(t, err)
+	want := []string{"nl-open-a", "nl-open-b", "nl-closed-old", "nl-closed-new"}
+	if got := orderedIDs(results); !reflect.DeepEqual(got, want) {
+		t.Errorf("reversed closed-sort order = %v, want %v (NULLs first on ASC, then oldest closed)", got, want)
+	}
+
+	results, err = s.SearchIssues(c, "", types.IssueFilter{SortBy: "assignee"})
+	must(t, err)
+	want = []string{"nl-open-a", "nl-open-b", "nl-closed-new", "nl-closed-old"}
+	if got := orderedIDs(results); !reflect.DeepEqual(got, want) {
+		t.Errorf("assignee-sort order = %v, want %v (unassigned first on ASC, id ASC among them)", got, want)
+	}
+
+	results, err = s.SearchIssues(c, "", types.IssueFilter{SortBy: "assignee", SortDesc: true})
+	must(t, err)
+	want = []string{"nl-closed-old", "nl-closed-new", "nl-open-a", "nl-open-b"}
+	if got := orderedIDs(results); !reflect.DeepEqual(got, want) {
+		t.Errorf("reversed assignee-sort order = %v, want %v (unassigned last on DESC)", got, want)
 	}
 }
 

--- a/backend/conformance/audit_search-counts-stats.go
+++ b/backend/conformance/audit_search-counts-stats.go
@@ -36,6 +36,7 @@ func RunAudit_search_counts_stats(t *testing.T, f Factory) {
 	t.Run("SearchIdenticalTimestampIDOrder", func(t *testing.T) { testAuditSearchIdenticalTimestampIDOrder(t, f) })
 	t.Run("SearchSortByClosedNullsLast", func(t *testing.T) { testAuditSearchSortByClosedNullsLast(t, f) })
 	t.Run("SearchSortByTitleCaseFolded", func(t *testing.T) { testAuditSearchSortByTitleCaseFolded(t, f) })
+	t.Run("SearchSortTieBreakSurvivesReversal", func(t *testing.T) { testAuditSearchSortTieBreakSurvivesReversal(t, f) })
 	t.Run("SearchTextIDBranchExternalRef", func(t *testing.T) { testAuditSearchTextIDBranchExternalRef(t, f) })
 	t.Run("SearchIDPrefixCaseSensitive", func(t *testing.T) { testAuditSearchIDPrefixCaseSensitive(t, f) })
 	t.Run("SearchParentDescendantCaseSensitive", func(t *testing.T) { testAuditSearchParentDescendantCaseSensitive(t, f) })
@@ -432,6 +433,50 @@ func testAuditSearchSortByTitleCaseFolded(t *testing.T, f Factory) {
 	must(t, err)
 	if got := orderedIDs(page); !reflect.DeepEqual(got, want[:2]) {
 		t.Errorf("title-sort page = %v, want %v (first 2 rows of the case-folded order)", got, want[:2])
+	}
+}
+
+// Every non-default sort breaks exact ties by id ASC, and reversing the sort flips
+// the primary key only — the id tie-break never flips. sqlbuild/sort.go emits
+// ORDER BY <col> <dir>, id ASC for every non-default key and runs flipDir over the
+// primary direction alone, so a tied group's internal order is identical in both
+// directions. The slice pins tie-breaking for the default and closed sorts only;
+// this case covers a timestamp key and a vocabulary key below the same seam.
+func testAuditSearchSortTieBreakSurvivesReversal(t *testing.T, f Factory) {
+	s := f(t)
+	c := ctx()
+	tied, newer := auditWholeSec(2020), auditWholeSec(2022)
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "tb-a", Title: "a", Status: types.StatusOpen, CreatedAt: tied, UpdatedAt: tied}), "a"))
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "tb-b", Title: "b", Status: types.StatusOpen, CreatedAt: tied, UpdatedAt: tied}), "a"))
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "tb-c", Title: "c", Status: types.StatusClosed, CreatedAt: tied, UpdatedAt: tied}), "a"))
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "tb-new", Title: "n", Status: types.StatusInProgress, CreatedAt: newer, UpdatedAt: newer}), "a"))
+
+	results, err := s.SearchIssues(c, "", types.IssueFilter{SortBy: "updated"})
+	must(t, err)
+	want := []string{"tb-new", "tb-a", "tb-b", "tb-c"}
+	if got := orderedIDs(results); !reflect.DeepEqual(got, want) {
+		t.Errorf("updated-sort order = %v, want %v (updated_at DESC, id ASC)", got, want)
+	}
+
+	results, err = s.SearchIssues(c, "", types.IssueFilter{SortBy: "updated", SortDesc: true})
+	must(t, err)
+	want = []string{"tb-a", "tb-b", "tb-c", "tb-new"}
+	if got := orderedIDs(results); !reflect.DeepEqual(got, want) {
+		t.Errorf("reversed updated-sort order = %v, want %v (oldest first; the tied group is STILL id ASC)", got, want)
+	}
+
+	results, err = s.SearchIssues(c, "", types.IssueFilter{SortBy: "status"})
+	must(t, err)
+	want = []string{"tb-c", "tb-new", "tb-a", "tb-b"}
+	if got := orderedIDs(results); !reflect.DeepEqual(got, want) {
+		t.Errorf("status-sort order = %v, want %v (status ASC, id ASC)", got, want)
+	}
+
+	results, err = s.SearchIssues(c, "", types.IssueFilter{SortBy: "status", SortDesc: true})
+	must(t, err)
+	want = []string{"tb-a", "tb-b", "tb-new", "tb-c"}
+	if got := orderedIDs(results); !reflect.DeepEqual(got, want) {
+		t.Errorf("reversed status-sort order = %v, want %v (the tied open group is STILL id ASC)", got, want)
 	}
 }
 

--- a/backend/conformance/audit_search-counts-stats.go
+++ b/backend/conformance/audit_search-counts-stats.go
@@ -38,6 +38,7 @@ func RunAudit_search_counts_stats(t *testing.T, f Factory) {
 	t.Run("SearchSortByTitleCaseFolded", func(t *testing.T) { testAuditSearchSortByTitleCaseFolded(t, f) })
 	t.Run("SearchSortTieBreakSurvivesReversal", func(t *testing.T) { testAuditSearchSortTieBreakSurvivesReversal(t, f) })
 	t.Run("SearchSortNullsDirectional", func(t *testing.T) { testAuditSearchSortNullsDirectional(t, f) })
+	t.Run("SearchSortByIDCompleteSet", func(t *testing.T) { testAuditSearchSortByIDCompleteSet(t, f) })
 	t.Run("SearchTextIDBranchExternalRef", func(t *testing.T) { testAuditSearchTextIDBranchExternalRef(t, f) })
 	t.Run("SearchIDPrefixCaseSensitive", func(t *testing.T) { testAuditSearchIDPrefixCaseSensitive(t, f) })
 	t.Run("SearchParentDescendantCaseSensitive", func(t *testing.T) { testAuditSearchParentDescendantCaseSensitive(t, f) })
@@ -516,6 +517,29 @@ func testAuditSearchSortNullsDirectional(t *testing.T, f Factory) {
 	want = []string{"nl-closed-old", "nl-closed-new", "nl-open-a", "nl-open-b"}
 	if got := orderedIDs(results); !reflect.DeepEqual(got, want) {
 		t.Errorf("reversed assignee-sort order = %v, want %v (unassigned last on DESC)", got, want)
+	}
+}
+
+// A search with SortBy="id" succeeds and answers the complete matching set. "id" is
+// the one key sqlbuild renders no ORDER BY for at all — IsGoSideSort suppresses the
+// clause and "id" is deliberately absent from SortDefs — so a store that validated
+// the key against SortDefs would refuse it, and a store that trimmed the set in its
+// own byte order would break the id sort for every caller. Sequence is not asserted:
+// the natural-numeric display order is owned above the store (internal/workapi/sort.go
+// CompareIssuesBy via utils.NaturalCompareIDs), which is why callers push Limit 0 here.
+func testAuditSearchSortByIDCompleteSet(t *testing.T, f Factory) {
+	s := f(t)
+	c := ctx()
+	// Natural order (test-2, test-9, test-10) and byte order (test-10, test-2, test-9) differ.
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "test-9", Title: "nine"}), "a"))
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "test-10", Title: "ten"}), "a"))
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "test-2", Title: "two"}), "a"))
+
+	results, err := s.SearchIssues(c, "", types.IssueFilter{SortBy: "id", Limit: 0})
+	must(t, err)
+	want := []string{"test-10", "test-2", "test-9"}
+	if got := issueIDs(results); !reflect.DeepEqual(got, want) {
+		t.Errorf("SortBy=id set = %v, want %v (complete matching set)", got, want)
 	}
 }
 


### PR DESCRIPTION
Four ordering cases for `backend/conformance`, all in the existing
`search-counts-stats` audit slice whose charter already names `sqlbuild/sort.go`
as its grounding. Test-only: no production code changes, one file, +142/-0.

## Why

`sqlbuild/sort.go` makes four promises that the shared suite never asked a
backend to keep. A single backend never notices — its own tests cover it — but
the conformance suite is the proof obligation a *second* storage backend
carries, and today it would have to reproduce these behaviors with no shared
proof telling it what "correct" is.

Each case closes one such gap, and each is grounded in a specific rendering
decision in `sqlbuild/sort.go`:

| Case | Contract | Why it was unowned |
| --- | --- | --- |
| `SearchSortByTitleCaseFolded` | A bounded page sorted by title keeps the first N rows under `LOWER(title)` order, ties by id ASC | The slice had no title sort; the querier-role case titles every row with its lowercase id, so a byte-collated backend passes it |
| `SearchSortTieBreakSurvivesReversal` | Non-default sorts break ties by id ASC, and `SortDesc` flips the primary key only | The audit pinned the tie-break for the default and closed sorts only; the querier's reversed legs run above the role epilogue, on title/priority, never on a tie |
| `SearchSortNullsDirectional` | Nullable keys (closed_at, assignee) put valueless rows first on ASC, last on DESC | Only the closed sort in its default direction was pinned; the flipped direction and the assignee key had none |
| `SearchSortByIDCompleteSet` | `SortBy: "id"` is accepted and answers the complete matching set | No conformance search case ever sent `SortBy: "id"` to `SearchIssues`; the reader-role id-sort cases run above the epilogue that hides it |

The regression sentence for each case is in its commit message and its doc
comment.

## Red/green

These pin reference behavior, so they pass against the oracle as written.
To show each assertion is load-bearing rather than decorative, each case was
run against a deliberately diverged `sqlbuild/sort.go` modelling the exact
failure class it exists to catch, then reverted:

| Injected divergence | Result |
| --- | --- |
| `ORDER BY title` instead of `LOWER(title)` (byte collation) | Only `SearchSortByTitleCaseFolded` fails — both the full order and the `Limit 2` page |
| `id <dir>` tie-break, so reversal flips it too | Only `SearchSortTieBreakSurvivesReversal` fails |
| `(col IS NULL)` lead term inverted (models NULLs-last-on-ASC engines) | `SearchSortNullsDirectional` fails on all three legs |
| Go-side key pushed into SQL as an unresolvable column (models a store that refuses what it cannot render) | Only `SearchSortByIDCompleteSet` fails |

In every run the pre-existing ordering cases stayed green, which is the
residue claim these four cases rest on.

One result is worth recording. Removing the `(col IS NULL)` term outright is a
**no-op** on Dolt — its native NULL ordering already matches the contract — so
the divergence only shows against an engine whose native placement is the
opposite. That is precisely why the term is written explicitly "so the contract
does not depend on a driver's default NULL ordering", and why the proof belongs
in the shared suite rather than at one backend that cannot observe it.

The same run answers a fixture question: because inverting the term (rather
than removing it) is what moves the assignee legs, unassigned is stored as SQL
NULL here. The assertions are written not to depend on that — the asserted
order is identical under a NULL or an empty-string encoding, since the rows are
seeded through the public create path exactly as `bd create` leaves them.

## Verification

Run against both behaviorally distinct in-tree implementations wired to
`RunAudit_search_counts_stats`:

```
BEADS_TEST_EMBEDDED_DOLT=1 CGO_ENABLED=1 go test -tags gms_pure_go -timeout 30m \
  ./internal/storage/embeddeddolt/ -run '^TestConformance$/^Audit$/^search-counts-stats$'
ok  github.com/steveyegge/beads/internal/storage/embeddeddolt  9.96s

CGO_ENABLED=1 go test -tags=integration,gms_pure_go -timeout 20m -count=1 \
  ./internal/storage/dolt/ -run '^TestConformance$/^Audit$/^search-counts-stats$'
ok  github.com/steveyegge/beads/internal/storage/dolt  17.12s
```

Plus `./scripts/ci/pr-lint.sh` (gofmt + golangci-lint, both passes: 0 issues)
and the full `./scripts/conformance.sh` lane:

```
Tier 1  embedded-Dolt RunAll   64.76s
Tier 2  e2e bd init + CLI      35.84s
==> conformance OK             1m50s wall
```

Timing: the four new cases add **1.12s** on embedded Dolt (0.32 + 0.29 + 0.31 +
0.20), taking the `search-counts-stats` slice from 8.74s to 9.86s. Each case is
an independent leaf with its own fresh store, so the delta is additive against
the lane total above.

## Notes

- No production code is touched, so nothing here changes backend behavior — it
  only states behavior the backends already have.
- Cases land in the existing `RunAudit_search_counts_stats` entry point, so the
  in-tree Dolt and embedded-Dolt suites pick them up with zero new wiring.
- Sequence is deliberately **not** asserted for `SortBy: "id"`: the
  natural-numeric display order is owned above the store
  (`internal/workapi/sort.go` `CompareIssuesBy` via `utils.NaturalCompareIDs`).
  The store owes acceptance and completeness only, which is why that case
  passes `Limit: 0` the way its callers do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
