### PR TITLE
fix: roll main forward to green — #5136 init regression + serve-test cache isolation

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -1286,7 +1286,21 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 					return err
 				}
 				if bootstrap {
-					syncFromRemote = true
+					if probeErr != nil {
+						// The fail-closed UNKNOWN kept the refusal gate shut
+						// above, but reaching here means no override flag was
+						// passed and there is no local history to protect —
+						// and the bootstrap clone would run against the same
+						// origin the probe could not reach, turning every
+						// credential-less clone of a private repo into a hard
+						// init failure. Fall back to a fresh local database,
+						// which is what init did here before the probe existed.
+						if !quiet {
+							fmt.Printf("  %s Could not verify the git origin's Dolt history; initialized a fresh local database\n", ui.RenderWarn("!"))
+						}
+					} else {
+						syncFromRemote = true
+					}
 				}
 			}
 		}

--- a/cmd/bd/init_safety_test.go
+++ b/cmd/bd/init_safety_test.go
@@ -69,6 +69,48 @@ func TestInitReinitLocalConfiguredRemoteWithoutDoltDataSucceeds(t *testing.T) {
 	}
 }
 
+// TestInitFreshWithUnreachableGitOriginSucceeds pins the plain-init arm of
+// the tri-state probe: a git origin the probe cannot reach at all (exit 128 —
+// the credential-less private-remote shape every CI container has) resolves
+// to UNKNOWN, which fails closed for the refusal gate but must NOT convert a
+// plain `bd init` into a bootstrap clone against that same unreachable
+// origin. There is no local history to protect here, and the clone can only
+// fail the same way the probe did, so init falls back to a fresh local
+// database — the behavior this path always had before the probe existed.
+// Regression: #5136 broke TestE2E_InitDoltMetadataRoundtrip (Main-lane only,
+// so its PR ran green) exactly this way.
+func TestInitFreshWithUnreachableGitOriginSucceeds(t *testing.T) {
+	bdBin := buildBDForInitTests(t)
+
+	workDir := t.TempDir()
+	runGitForBootstrapTest(t, workDir, "init", "-b", "main")
+	runGitForBootstrapTest(t, workDir, "config", "core.hooksPath", ".git/hooks")
+	// An origin whose probe errors (missing path -> git ls-remote exit 128),
+	// not one that answers "no refs/dolt/data".
+	runGitForBootstrapTest(t, workDir, "remote", "add", "origin",
+		filepath.Join(t.TempDir(), "does-not-exist.git"))
+
+	homeDir := t.TempDir() // must differ from workDir: metrics.go caches to $HOME/.beads
+
+	cmd := exec.Command(bdBin, "init", "--backend", "dolt", "--prefix", "org", "--quiet", "--non-interactive", "--skip-hooks", "--skip-agents")
+	cmd.Dir = workDir
+	cmd.Env = hermeticInitEnv(homeDir)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		lower := strings.ToLower(out.String())
+		if strings.Contains(lower, "dolt") && (strings.Contains(lower, "not supported") || strings.Contains(lower, "not available") || strings.Contains(lower, "unknown")) {
+			t.Skipf("dolt backend not available: %s", out.String())
+		}
+		t.Fatalf("bd init with an unreachable git origin failed: %v\noutput:\n%s", err, out.String())
+	}
+
+	if _, err := os.Stat(filepath.Join(workDir, ".beads")); err != nil {
+		t.Fatalf(".beads should have been created by a successful init: %v", err)
+	}
+}
+
 // TestInitReinitLocalConfiguredRemoteWithDoltDataRefuses is the sibling case:
 // sync.remote (again via BD_SYNC_REMOTE, not --remote) points at a bare repo
 // that DOES have refs/dolt/data pushed to it. `bd init --reinit-local` must

--- a/cmd/bd/serve_registered_backend_test.go
+++ b/cmd/bd/serve_registered_backend_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/git"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/backends"
 	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
@@ -223,6 +224,15 @@ func TestServeRefusesAnEmbeddedWorkspaceEndToEnd(t *testing.T) {
 	setRootContext(ctx, cancel)
 	t.Chdir(dir)
 	t.Setenv("BEADS_DIR", beadsDir)
+	// Same cached-workspace hazard as startServeInProcess: runServe resolves
+	// the workspace through GetRepoContext, which caches a prior test's
+	// verdict — including its error — for the whole process.
+	beads.ResetCaches()
+	git.ResetCaches()
+	t.Cleanup(func() {
+		beads.ResetCaches()
+		git.ResetCaches()
+	})
 
 	// runServe surfaces the refusal through HandleError, which writes the
 	// message to stderr and returns an opaque exit error, so the message is
@@ -313,6 +323,19 @@ func startServeInProcess(t *testing.T, dir, beadsDir string) (string, <-chan err
 	t.Setenv("BD_NON_INTERACTIVE", "1")
 	t.Setenv("BD_DISABLE_METRICS", "1")
 	t.Setenv("BD_DISABLE_EVENT_FLUSH", "1")
+
+	// GetRepoContext caches per process — the context AND the error. A prior
+	// in-process test that resolved (or failed to resolve) a workspace leaves
+	// that verdict cached, and this command would serve it instead of the
+	// tempdir above ("no .beads directory found", deterministic in Main's
+	// cmd/bd shard 8 ordering). Reset on the way out too, so this test's
+	// soon-to-be-deleted tempdir isn't the next test's cached workspace.
+	beads.ResetCaches()
+	git.ResetCaches()
+	t.Cleanup(func() {
+		beads.ResetCaches()
+		git.ResetCaches()
+	})
 
 	lines, stopCapture := captureStdoutLines(t)
 	done := make(chan error, 1)


### PR DESCRIPTION
Main has been red on two independent breaks; this rolls both forward.

## Shard 1/8: `TestE2E_InitDoltMetadataRoundtrip` (since 5ff61baef, #5136 — red 17:41Z today)

#5136's tri-state probe resolves a probe *error* (git ls-remote exit 128 — the credential-less private-origin shape every CI container has) as UNKNOWN → has-data. Fail-closed is right for the ADR-0002 **refusal gate**, but on a plain fresh init — no override flags, no local history to protect — `CheckRemoteSafety` then answers `ActionBootstrap`, and the bootstrap clone hard-fails against the same origin the probe couldn't reach.

**Fix:** when the decision is bootstrap but the probe errored, skip the clone and initialize a fresh local database (the behavior this path always had before the probe existed). Override flows keep #5136's fail-closed refusal unchanged — both #5136 regression tests still pass.

Also adds a **PR-lane** regression test: the E2E test that caught this runs only in the Main lane, which is why #5136's own PR ran green. Verified the new test fails on main without the fix (exact CI failure shape) and passes with it. Tracked as bd-97nv7.

## Shard 8/8: `TestServeAnswersFromARegisteredBackendStore` (since a867d98f3, #5352 — red on **every** main run since 8/5, including its own merge run)

`runServe` resolves the workspace through `beads.GetRepoContext`, a process-wide `sync.Once` that caches a prior test's verdict — **including its error**. The in-process serve tests never reset it, so whichever earlier shard-8 test leaves the cache poisoned makes this fail deterministically with 'no .beads directory found' (and the same shape hit PR Core on #4959, filed as bd-xlfu1). The sibling readonly test already resets; this brings the other two in line, plus a cleanup reset so the test's deleted tempdir isn't the *next* test's cached workspace.

cc @julianknutsen (#5352) @vishnujayvel (#5136) — FYI, no action needed; happy to adjust if either fix direction conflicts with your intent.

Targeted runs green locally (`-race -tags=integration,gms_pure_go`): both #5136 regression tests, the E2E roundtrip, all three serve tests.