### PR TITLE
feat(httpapi): add include_comments and include_dependents to getIssue

### DIFF
--- a/internal/httpapi/apigen/types.gen.go
+++ b/internal/httpapi/apigen/types.gen.go
@@ -758,6 +758,15 @@ type ListIssuesParams struct {
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
 }
 
+// GetIssueParams defines parameters for GetIssue.
+type GetIssueParams struct {
+	// IncludeComments Populate `comments` with the issue's full comment bodies. When it is honored `comments_omitted` is false, so a client is never left to guess whether an absent list means "no comments" or "not asked for".
+	IncludeComments *bool `form:"include_comments,omitempty" json:"include_comments,omitempty"`
+
+	// IncludeDependents Populate `dependents` with the issues that depend on this one, each carrying its edge type — the shape `dependencies` already carries. Default false, for `include_comments`'s reason.
+	IncludeDependents *bool `form:"include_dependents,omitempty" json:"include_dependents,omitempty"`
+}
+
 // QueryIssuesParams defines parameters for QueryIssues.
 type QueryIssuesParams struct {
 	// Q The query expression, e.g. `status=open AND priority>1` or `type=bug OR label=urgent`. Blank, unparseable, or naming a field or operator the language does not have is a 400 `invalid_argument` with `param: "q"` and `reason: "invalid_value"`.

--- a/internal/httpapi/apigen/types.gen.go
+++ b/internal/httpapi/apigen/types.gen.go
@@ -184,7 +184,9 @@ type BondRef = types.BondRef
 
 // ClaimRequest defines model for ClaimRequest.
 type ClaimRequest struct {
-	// Actor Who is claiming the issue. The server trims it, then refuses an empty result, anything longer than 256 BYTES (the `maxLength` above counts characters — the byte limit is the binding one), and any control character including newline. The value is persisted as the assignee and interpolated into the storage commit message, so an unvalidated newline would forge audit-trail lines.
+	// Actor Who is claiming the issue. The server trims it, then refuses an empty result, anything longer than 256 BYTES (the `maxLength` above counts characters — the byte limit is the binding one), and any control character including newline: Unicode category Cc — C0, DEL and the C1 block — plus the U+2028/U+2029 line separators, which is the set the `pattern` above spells.
+	//
+	// The value is persisted as the assignee and interpolated into the storage commit message, so an unvalidated newline would forge audit-trail lines. C1 is refused for that same reason and not for tidiness: U+0085 is a line break on a VT-conformant terminal, and U+009B is the one-byte CSI introducer, which would make an actor an escape-sequence payload in anything that prints an assignee.
 	Actor string `json:"actor"`
 }
 

--- a/internal/httpapi/claim.go
+++ b/internal/httpapi/claim.go
@@ -149,13 +149,9 @@ func (s *Server) claimTarget(w http.ResponseWriter, r *http.Request) (string, bo
 // header name for exactly this kind of refusal — it is what the Host middleware
 // already does.
 //
-// SPEC GAP, deliberate and to be closed at the next revision window: the frozen
-// document does not mention Content-Type anywhere, so this refusal is the one
-// 400 on this route a client generated from the schema cannot predict. It is
-// unreachable for a conformant client — requestBody already declares
-// application/json — and the status/code/param/reason are all in the documented
-// vocabulary, so the fix is prose describing the CSRF control, not a behavior
-// change.
+// The document states this rule once, at the document level, beside the
+// Host-header and unknown-query-parameter rules, because it holds for every
+// body-carrying operation rather than for this one.
 func (s *Server) requireJSONContent(w http.ResponseWriter, r *http.Request) bool {
 	got := r.Header.Get("Content-Type")
 	if media, _, err := mime.ParseMediaType(got); err == nil && media == claimContentType {

--- a/internal/httpapi/claim.go
+++ b/internal/httpapi/claim.go
@@ -294,16 +294,15 @@ func validateActor(actor string) (string, *Result) {
 // control character (category Cc — C0, DEL, and the C1 block) plus the
 // U+2028/U+2029 line separators.
 //
-// This is deliberately WIDER than the schema's pattern, which excludes only C0
-// and DEL. The document's prose is what governs here — it promises refusal of
-// "any control character including newline" — and C1 qualifies: U+0085 is NEL,
-// a line break on a VT-conformant terminal, so "alice<U+0085>bd: claim bd-9
-// by mallory" forges exactly the audit-trail line the C0 check exists to
-// prevent once the actor reaches the storage commit message. U+009B is the
-// one-byte CSI introducer, which makes an unfiltered actor an escape-sequence
-// payload in anything that prints an assignee. Widening refuses more than the
-// pattern advertises and can therefore never persist a value the document
-// forbids; the pattern is what should move at the next spec window.
+// C1 is refused for the reason C0 is, not for tidiness: U+0085 is NEL, a line
+// break on a VT-conformant terminal, so "alice<U+0085>bd: claim bd-9 by
+// mallory" forges exactly the audit-trail line the C0 check exists to prevent
+// once the actor reaches the storage commit message. U+009B is the one-byte CSI
+// introducer, which makes an unfiltered actor an escape-sequence payload in
+// anything that prints an assignee.
+//
+// The schema's `actor` pattern spells this same set, so what the document
+// advertises and what the server refuses are one statement.
 func isControlChar(r rune) bool {
 	return unicode.IsControl(r) || r == '\u2028' || r == '\u2029'
 }

--- a/internal/httpapi/get_issue_test.go
+++ b/internal/httpapi/get_issue_test.go
@@ -1,0 +1,258 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/issueops"
+)
+
+// The pins for the two include parameters on GET /v0/beads/issues/{id}.
+//
+// The handler is a decoder and nothing else — the row lists are the ROLE's to
+// populate — so the property under test is that each parameter reaches
+// issueops.GetRequest and that neither is set when the caller did not ask.
+// Both halves are asserted: the request the role received, and the body the
+// client got, because a flag forwarded to a role whose answer nobody reads
+// would satisfy the first alone.
+
+// includeAwareReader answers a detail view the way the role contract says a
+// reader answers one: the two expensive row lists are present when the request
+// asked for them and absent when it did not — the contract
+// backend/conformance/reader_contract.go holds the real implementations to. It
+// models that and nothing else, because that is exactly what these parameters
+// select.
+type includeAwareReader struct {
+	roleReader
+}
+
+func (r *includeAwareReader) Get(ctx context.Context, req issueops.GetRequest) (*issueops.IssueDetails, error) {
+	if _, err := r.roleReader.Get(ctx, req); err != nil {
+		return nil, err
+	}
+	one := int64(1)
+	omitted := true
+	details := &issueops.IssueDetails{
+		Issue:           *seededIssue(req.ID, "", types.StatusOpen),
+		CommentCount:    &one,
+		DependentCount:  &one,
+		CommentsOmitted: &omitted,
+	}
+	if req.IncludeComments {
+		details.Comments = []*types.Comment{{
+			ID:        "c-1",
+			IssueID:   req.ID,
+			Author:    "alice",
+			Text:      "the comment body",
+			CreatedAt: time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC),
+		}}
+		// Never set alongside a populated list: the flag exists to tell "no
+		// comments" from "not asked for", and a caller that asked has neither
+		// question.
+		details.CommentsOmitted = nil
+	}
+	if req.IncludeDependents {
+		details.Dependents = []*types.IssueWithDependencyMetadata{{
+			Issue:          *seededIssue("bd-2", "", types.StatusOpen),
+			DependencyType: types.DepBlocks,
+		}}
+	}
+	return details, nil
+}
+
+func newGetIssueServer(t *testing.T) (*testServer, *includeAwareReader) {
+	t.Helper()
+	rd := &includeAwareReader{}
+	return newTestServer(t, rolesConfig(Config{Reader: rd})), rd
+}
+
+// TestGetIssueWithoutTheIncludeParametersIsUnchanged is the no-regression half
+// of adding them: a caller that sends neither gets the request the role saw
+// before this operation had parameters at all, so nothing about the response
+// can have moved.
+//
+// The second half asserts the DEFAULT rather than the decode. Spelling both
+// parameters `false` must answer the same body as omitting them; a default
+// that drifted to true would still satisfy the explicit-spelling cases below.
+func TestGetIssueWithoutTheIncludeParametersIsUnchanged(t *testing.T) {
+	ts, rd := newGetIssueServer(t)
+
+	resp := ts.get(t, "/v0/beads/issues/bd-1")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	omitted := decodeBody(t, resp)
+
+	reqs := rd.getRequests()
+	if len(reqs) != 1 {
+		t.Fatalf("%d detail reads, want 1", len(reqs))
+	}
+	if want := (issueops.GetRequest{ID: "bd-1"}); reqs[0] != want {
+		t.Errorf("GetRequest = %+v, want %+v — a caller that asks for neither row list must not pay for either", reqs[0], want)
+	}
+	if _, ok := omitted["comments"]; ok {
+		t.Error("`comments` is populated without include_comments")
+	}
+	if _, ok := omitted["dependents"]; ok {
+		t.Error("`dependents` is populated without include_dependents")
+	}
+
+	explicit := ts.get(t, "/v0/beads/issues/bd-1?include_comments=false&include_dependents=false")
+	if explicit.StatusCode != http.StatusOK {
+		t.Fatalf("explicit false: status = %d, want 200: %s", explicit.StatusCode, readAll(t, explicit))
+	}
+	if got := decodeBody(t, explicit); !reflect.DeepEqual(got, omitted) {
+		t.Errorf("spelling both parameters false answered %v, want the body an omitted parameter answers: %v", got, omitted)
+	}
+}
+
+// TestGetIssueIncludeParametersReachTheRole drives each parameter alone and
+// both together. Alone matters: the two row lists are independent reads, and a
+// handler that decoded one into the other's field would answer every
+// single-parameter request with the wrong list and still look correct on the
+// both-parameters case.
+//
+// The values exercise strconv.ParseBool's vocabulary rather than "true" three
+// times, because that vocabulary is what the shared decoder publishes.
+func TestGetIssueIncludeParametersReachTheRole(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		query string
+		want  issueops.GetRequest
+	}{
+		{
+			name:  "comments alone",
+			query: "?include_comments=true",
+			want:  issueops.GetRequest{ID: "bd-1", IncludeComments: true},
+		},
+		{
+			name:  "dependents alone",
+			query: "?include_dependents=1",
+			want:  issueops.GetRequest{ID: "bd-1", IncludeDependents: true},
+		},
+		{
+			name:  "both",
+			query: "?include_comments=TRUE&include_dependents=t",
+			want:  issueops.GetRequest{ID: "bd-1", IncludeComments: true, IncludeDependents: true},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ts, rd := newGetIssueServer(t)
+
+			resp := ts.get(t, "/v0/beads/issues/bd-1"+tc.query)
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+			}
+
+			reqs := rd.getRequests()
+			if len(reqs) != 1 {
+				t.Fatalf("%d detail reads, want 1", len(reqs))
+			}
+			if reqs[0] != tc.want {
+				t.Errorf("GetRequest = %+v, want %+v", reqs[0], tc.want)
+			}
+
+			body := decodeBody(t, resp)
+			if _, ok := body["comments"]; ok != tc.want.IncludeComments {
+				t.Errorf("`comments` present = %v, want %v", ok, tc.want.IncludeComments)
+			}
+			if _, ok := body["dependents"]; ok != tc.want.IncludeDependents {
+				t.Errorf("`dependents` present = %v, want %v", ok, tc.want.IncludeDependents)
+			}
+			if tc.want.IncludeComments {
+				if _, ok := body["comments_omitted"]; ok {
+					t.Error("`comments_omitted` is set on a response that carries the comment bodies")
+				}
+			}
+		})
+	}
+}
+
+// TestGetIssueRefusesAMalformedIncludeParameter: a bad boolean is now this
+// operation's OWN 400, not the document-level unknown-parameter rule, and the
+// two carry opposite client recoveries — `invalid_value` says "send something
+// else", `unknown_parameter` says "this server is older than you think".
+func TestGetIssueRefusesAMalformedIncludeParameter(t *testing.T) {
+	for _, param := range []string{"include_comments", "include_dependents"} {
+		t.Run(param, func(t *testing.T) {
+			ts, rd := newGetIssueServer(t)
+
+			resp := ts.get(t, "/v0/beads/issues/bd-1?"+param+"=maybe")
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
+			}
+			body := decodeBody(t, resp)
+			if body["code"] != string(CodeInvalidArgument) || body["param"] != param || body["reason"] != string(ReasonInvalidValue) {
+				t.Errorf("body = %v, want invalid_argument on param %s with reason invalid_value", body, param)
+			}
+			if n := len(rd.getRequests()); n != 0 {
+				t.Errorf("%d detail reads ran; a refused request must not reach the database", n)
+			}
+		})
+	}
+}
+
+// TestGetIssueStaysStrictAboutUnknownParameters is the guard on what having a
+// parameter table could have cost. This operation used to reject every query
+// key outright; now the table is the whole allowlist, and a key outside it must
+// still be refused by name — silently ignoring one would hand a client the
+// count-only body it believed it had asked to have filled in.
+//
+// The last case is the interaction: a request carrying BOTH a malformed known
+// parameter and an unknown one is reported as the malformed value, because
+// reporting it as version skew would send the client to degrade a parameter
+// this server does in fact have.
+func TestGetIssueStaysStrictAboutUnknownParameters(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		query  string
+		param  string
+		reason Reason
+	}{
+		{"an unknown key alone", "?bogus=1", "bogus", ReasonUnknownParameter},
+		{"an unknown key beside a known one", "?include_comments=true&bogus=1", "bogus", ReasonUnknownParameter},
+		{"a near miss on a real parameter", "?include_comment=true", "include_comment", ReasonUnknownParameter},
+		{"a malformed known key beside an unknown one", "?include_comments=maybe&bogus=1", "include_comments", ReasonInvalidValue},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ts, rd := newGetIssueServer(t)
+
+			resp := ts.get(t, "/v0/beads/issues/bd-1"+tc.query)
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
+			}
+			body := decodeBody(t, resp)
+			if body["code"] != string(CodeInvalidArgument) || body["param"] != tc.param || body["reason"] != string(tc.reason) {
+				t.Errorf("body = %v, want invalid_argument on param %s with reason %s", body, tc.param, tc.reason)
+			}
+			if n := len(rd.getRequests()); n != 0 {
+				t.Errorf("%d detail reads ran; a refused request must not reach the database", n)
+			}
+		})
+	}
+}
+
+// TestGetIssueAnswersAQueryRefusalBeforeTheIDBound pins the order the operation
+// already had. When it took no parameters, the query string was refused first,
+// so an unknown key on an id no row could hold was a 400 — and a client that
+// sends one gets the answer that tells it what to fix. Deciding the id first
+// would turn that request into a 404 and lose the refusal.
+func TestGetIssueAnswersAQueryRefusalBeforeTheIDBound(t *testing.T) {
+	ts, rd := newGetIssueServer(t)
+
+	resp := ts.get(t, "/v0/beads/issues/bd-%01?bogus=1")
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
+	}
+	body := decodeBody(t, resp)
+	if body["param"] != "bogus" || body["reason"] != string(ReasonUnknownParameter) {
+		t.Errorf("body = %v, want param=bogus reason=unknown_parameter", body)
+	}
+	if n := len(rd.getRequests()); n != 0 {
+		t.Errorf("%d detail reads ran for a refused request", n)
+	}
+}

--- a/internal/httpapi/problem.go
+++ b/internal/httpapi/problem.go
@@ -225,7 +225,11 @@ var operationCodes = map[string][]Code{
 	OpGetContext:    {CodeInternal},
 	OpListReadyWork: {CodeInvalidArgument, CodeBusy, CodeDBUnavailable, CodeInternal},
 	OpListIssues:    {CodeInvalidArgument, CodeInvalidCursor, CodeBusy, CodeDBUnavailable, CodeInternal},
-	OpGetIssue:      {CodeNotFound, CodeBusy, CodeDBUnavailable, CodeInternal},
+	// The 400 is this operation's own, the getStats precedent: a malformed
+	// `include_comments` or `include_dependents` is a bad value on a parameter
+	// this server knows, not the document-level unknown-key rule this table
+	// omits.
+	OpGetIssue: {CodeInvalidArgument, CodeNotFound, CodeBusy, CodeDBUnavailable, CodeInternal},
 	// No 400 of its own: the operation takes no parameters, so the only
 	// invalid_argument it can raise is the document-level unknown-query-key
 	// rule this table deliberately omits.

--- a/internal/httpapi/reads.go
+++ b/internal/httpapi/reads.go
@@ -296,7 +296,19 @@ var querySorts = []string{"priority", "created", "updated", "closed", "status", 
 
 // handleGetIssue answers GET /v0/beads/issues/{id}.
 func (s *Server) handleGetIssue(w http.ResponseWriter, r *http.Request) {
-	if !s.requireNoQuery(w, r) {
+	q := newQuery(r.URL.Query())
+
+	// Both default off, so a request that names neither builds the request this
+	// handler built when the operation had no parameters at all.
+	req := issueops.GetRequest{
+		IncludeComments:   q.boolean("include_comments"),
+		IncludeDependents: q.boolean("include_dependents"),
+	}
+
+	// Before the id bound, which is the order this operation had when
+	// requireNoQuery ran first: a refused query string is a 400 that names what
+	// to fix, and deciding the id first would answer it with a 404 instead.
+	if !s.acceptQuery(w, r, q) {
 		return
 	}
 	id := r.PathValue("id")
@@ -314,15 +326,14 @@ func (s *Server) handleGetIssue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	req.ID = id
+
 	rd, err := s.reader(r)
 	if err != nil {
 		s.failErr(w, r, err)
 		return
 	}
-	// IncludeDependents and IncludeComments stay at their zero values: v0
-	// takes no parameter that asks for those rows, so `dependents` and
-	// `comments` are always absent and `comments_omitted` says so.
-	details, err := rd.Get(r.Context(), issueops.GetRequest{ID: id})
+	details, err := rd.Get(r.Context(), req)
 	if err != nil {
 		s.failReadErr(w, r, err)
 		return

--- a/internal/httpapi/spec/openapi.v0.yaml
+++ b/internal/httpapi/spec/openapi.v0.yaml
@@ -56,9 +56,8 @@ info:
       `reason: "unknown_parameter"` and `param` naming the offending key.
       Operations with no parameters at all (`GET /healthz`,
       `GET /v0/beads/context`, `GET /v0/beads/dependencies/cycles`,
-      `GET /v0/beads/issues/{id}`, `POST /v0/beads/issues/{id}:claim`,
-      `POST /v0/beads/issues:sweep`, `POST /v0/beads/issues:delete`,
-      `GET /v0/beads/config`,
+      `POST /v0/beads/issues/{id}:claim`, `POST /v0/beads/issues:sweep`,
+      `POST /v0/beads/issues:delete`, `GET /v0/beads/config`,
       `GET /v0/beads/config/{key}`) reject every query key the same way.
 
     * **Request media type.** Every operation that carries a request body
@@ -1204,16 +1203,34 @@ paths:
         fallback when no issue matches.
 
 
-        COMMENT BODIES AND DEPENDENTS ARE NOT REACHABLE OVER v0. This operation
-        takes no query parameters, and every query key is rejected, so there is
-        no way to ask for them: `comments` and `dependents` are always absent,
-        and `comment_count`, `dependent_count` and `comments_omitted` are what
-        this surface reports about them. A workflow that must read comment text
-        keeps using `bd show --json --include-comments` for now. Adding
-        `include_comments` / `include_dependents` parameters later is additive
-        and needs no schema change — the fields are already specified.
+        COMMENT BODIES AND DEPENDENTS ARE ASKED FOR, NEVER VOLUNTEERED. They
+        are the two expensive row lists on this read, so each is absent unless
+        the request sets the parameter that populates it, and a caller that
+        wants only the cardinalities reads `comment_count`, `dependent_count`
+        and `comments_omitted` and pays for neither. A request that sets
+        neither parameter is answered exactly as this operation answered it
+        before the parameters existed.
       parameters:
         - $ref: '#/components/parameters/IssueID'
+        - name: include_comments
+          in: query
+          description: >-
+            Populate `comments` with the issue's full comment bodies. When it
+            is honored `comments_omitted` is false, so a client is never left
+            to guess whether an absent list means "no comments" or "not asked
+            for".
+          schema:
+            type: boolean
+            default: false
+        - name: include_dependents
+          in: query
+          description: >-
+            Populate `dependents` with the issues that depend on this one, each
+            carrying its edge type — the shape `dependencies` already carries.
+            Default false, for `include_comments`'s reason.
+          schema:
+            type: boolean
+            default: false
       responses:
         '200':
           description: The issue.
@@ -1221,6 +1238,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/IssueDetails'
+        '400':
+          $ref: '#/components/responses/InvalidArgument'
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
@@ -2610,19 +2629,18 @@ components:
         comments:
           type: array
           description: >-
-            NOT POPULATED IN v0 — `getIssue` has no parameter that requests
-            comment bodies and rejects every query key, so this is always
-            absent. Use `comment_count` and `comments_omitted`. Documented
-            because the struct carries the field and a later version may add
-            the parameter that fills it.
+            The issue's comment bodies. Populated only when the request sets
+            `getIssue`'s `include_comments`; absent otherwise, which is what
+            `comment_count` and `comments_omitted` report about.
           items: { $ref: '#/components/schemas/Comment' }
         # --- added by IssueDetails ---
         dependents:
           type: array
           description: >-
-            Issues that depend on this one, each carrying its edge type. NOT
-            POPULATED IN v0, for the same reason as `comments`: use
-            `dependent_count`.
+            Issues that depend on this one, each carrying its edge type.
+            Populated only when the request sets `getIssue`'s
+            `include_dependents`; absent otherwise, where `dependent_count` is
+            the cardinality.
           items: { $ref: '#/components/schemas/IssueWithDependencyMetadata' }
         parent:
           type: string
@@ -2640,10 +2658,9 @@ components:
           type: boolean
           description: >-
             True when `comment_count` is nonzero and `comments` was left out —
-            which over v0 HTTP is every such issue, since bodies cannot be
-            requested. Without it, an absent `comments` key is ambiguous
-            between "no comments" and "comments not included in this
-            response".
+            every such issue on a request that did not set `include_comments`.
+            Without it, an absent `comments` key is ambiguous between "no
+            comments" and "comments not included in this response".
         epic_total_children:
           type: integer
         epic_closed_children:

--- a/internal/httpapi/spec/openapi.v0.yaml
+++ b/internal/httpapi/spec/openapi.v0.yaml
@@ -3237,7 +3237,7 @@ components:
           type: string
           minLength: 1
           maxLength: 256
-          pattern: '^[^\u0000-\u001F\u007F]+$'
+          pattern: '^[^\u0000-\u001F\u007F-\u009F\u2028\u2029]+$'
           description: >-
             Caller-asserted attribution, under the same rules as
             `SweepRequest`'s `actor`: trimmed, refused when empty after
@@ -3365,7 +3365,7 @@ components:
           type: string
           minLength: 1
           maxLength: 256
-          pattern: '^[^\u0000-\u001F\u007F]+$'
+          pattern: '^[^\u0000-\u001F\u007F-\u009F\u2028\u2029]+$'
           description: >-
             Caller-asserted attribution for wherever the backend records it,
             under the same rules and for the same reasons as `ClaimRequest`'s
@@ -3904,7 +3904,7 @@ components:
           type: string
           minLength: 1
           maxLength: 256
-          pattern: '^[^\u0000-\u001F\u007F]+$'
+          pattern: '^[^\u0000-\u001F\u007F-\u009F\u2028\u2029]+$'
           description: >-
             Who is creating the issues, under `ClaimRequest.actor`'s rules and
             for the same reasons: the server trims it, refuses an empty result,
@@ -4025,14 +4025,22 @@ components:
           type: string
           minLength: 1
           maxLength: 256
-          pattern: '^[^\u0000-\u001F\u007F]+$'
+          pattern: '^[^\u0000-\u001F\u007F-\u009F\u2028\u2029]+$'
           description: >-
             Who is claiming the issue. The server trims it, then refuses an
             empty result, anything longer than 256 BYTES (the `maxLength` above
             counts characters — the byte limit is the binding one), and any
-            control character including newline. The value is persisted as the
-            assignee and interpolated into the storage commit message, so an
-            unvalidated newline would forge audit-trail lines.
+            control character including newline: Unicode category Cc — C0, DEL
+            and the C1 block — plus the U+2028/U+2029 line separators, which is
+            the set the `pattern` above spells.
+
+
+            The value is persisted as the assignee and interpolated into the
+            storage commit message, so an unvalidated newline would forge
+            audit-trail lines. C1 is refused for that same reason and not for
+            tidiness: U+0085 is a line break on a VT-conformant terminal, and
+            U+009B is the one-byte CSI introducer, which would make an actor an
+            escape-sequence payload in anything that prints an assignee.
 
     ClaimResponse:
       type: object

--- a/internal/httpapi/spec/openapi.v0.yaml
+++ b/internal/httpapi/spec/openapi.v0.yaml
@@ -44,7 +44,7 @@ info:
     one error shape on this surface.
 
 
-    ## Two 400s apply to every route, and are documented here once
+    ## Three 400s cut across operations, and are documented here once
 
 
     * **Host header.** A request whose `Host` header is not in the server's
@@ -61,11 +61,26 @@ info:
       `GET /v0/beads/config`,
       `GET /v0/beads/config/{key}`) reject every query key the same way.
 
+    * **Request media type.** Every operation that carries a request body
+      requires `Content-Type: application/json` and refuses anything else with
+      `400` / `code: invalid_argument` / `param: "Content-Type"` /
+      `reason: "invalid_value"`. The refusal is a CSRF control rather than
+      pedantry: a JSON content type is not CORS-simple, so a cross-origin write
+      always triggers a preflight this server never approves, and accepting
+      `text/plain` or a form encoding would let an attacker's page skip that
+      preflight and drive a write from any browser on the host. It is
+      unreachable for a client generated from this document — every
+      `requestBody` here declares `application/json` — and is stated so that
+      the one 400 such a client could not otherwise predict is predictable.
+      `415` is deliberately not used: it is not in this surface's status
+      vocabulary, and adding one for this would be permanent wire surface.
 
-    Both are uniform rules, reachable on EVERY route including `GET /healthz`,
-    and are stated here instead of being repeated on every operation. The
+
+    The first two are uniform rules reachable on EVERY route including
+    `GET /healthz`; the third holds on every body-carrying operation. All three
+    are stated here instead of being repeated on every operation. The
     per-operation `responses` below therefore list what an operation produces
-    BEYOND these two: a generated client must treat `400 invalid_argument` as
+    BEYOND them: a generated client must treat `400 invalid_argument` as
     possible everywhere, including on the operations whose documented statuses
     are only `404`/`500`/`503`.
 


### PR DESCRIPTION
## What

Adds the two additive query parameters `GET /v0/beads/issues/{id}` reserved for itself — `include_comments` and `include_dependents` — and closes the two document-level gaps the same revision window owes.

Today the operation documents comment bodies and dependents as unreachable over v0: it takes no query parameters, so `comments` and `dependents` are always absent and a workflow that needs comment text has to fork `bd show --json --include-comments`. The document names this exact pair as the additive way out ("Adding `include_comments` / `include_dependents` parameters later is additive and needs no schema change — the fields are already specified"), and `issueops.GetRequest` has carried the flags all along. This is the wire half; no role, storage or schema change is involved.

## Commits

Three, each independently reviewable:

1. **`docs(httpapi): document the JSON media-type requirement in the v0 spec`** — prose only. `requireJSONContent` refuses a body-carrying request whose `Content-Type` is not `application/json`, and the frozen document mentioned `Content-Type` nowhere, so that was the one 400 on those routes a generated client could not predict. `claim.go` has carried a note since it was written that this is prose owed at the next revision window. Stated once at the document level, beside the Host-header and unknown-query-parameter rules, because it holds for every body-carrying operation rather than any one of them. No behavior change.

2. **`docs(httpapi): widen the actor pattern to the set the server refuses`** — `validateActor` refuses every Unicode Cc control character (C0, DEL and the C1 block) plus U+2028/U+2029; the schema's `pattern` excluded only C0 and DEL, so the document advertised a narrower rule than the server enforces. `isControlChar` has carried the matching note that the pattern is the half that should move. All four schemas move together — claim, sweep, delete and batchCreate share `validateActor`, so widening one and leaving three would make the document disagree with itself about a single validator. A tightening of the published contract only: no request that used to succeed now fails.

3. **`feat(httpapi): add include_comments and include_dependents to getIssue`** — the operation itself.

## The parameters

Both optional, both `default: false`, decoded by the shared `query.boolean` (so `strconv.ParseBool`'s vocabulary). The defaults are the role's own: the two row lists are the expensive half of this read, and a caller that wants only the cardinalities keeps paying for neither.

**A request that names neither builds the same `GetRequest` the handler built before**, so existing callers see byte-identical responses. That is the property the first test asserts, and it is why this change is the safe one to land first.

`invalid_argument` joins `getIssue`'s `operationCodes` row: a malformed boolean is now this operation's own 400 — the `getStats`/`skip_blocked` precedent — rather than the document-level unknown-key rule that table deliberately omits. Adding a status+code pair to an operation is additive; clients default-branch. Against an older server these parameters earn `400` / `reason: "unknown_parameter"`, which is the documented per-parameter capability probe working as intended.

Route, path and capability (`issues.get`) are untouched: capabilities gate operations, parameters are probed.

`IssueDetails`' `comments`, `dependents` and `comments_omitted` descriptions now name the parameters that populate them. No schema changes — the fields were already specified.

## Handler ordering

The handler decodes the query **before** bounding the id, which is the order it already had when `requireNoQuery` ran first. An unknown key on an id no row could hold stays the 400 that names what to fix, instead of becoming a 404 that tells the caller nothing. `TestGetIssueAnswersAQueryRefusalBeforeTheIDBound` pins it.

## Tests

New `internal/httpapi/get_issue_test.go`, following the per-operation precedent (`ready_count_test.go`, `stats_test.go`). The seam is the role: the handler is a decoder, so the `issueops.GetRequest` it built is where the behavior is observable, and the response body is asserted alongside it so a flag forwarded to an answer nobody reads cannot pass.

| Case | Asserts |
|---|---|
| Both parameters omitted | `GetRequest{ID}` exactly — the pre-change request; `comments`/`dependents` absent |
| Both spelled `false` | Byte-identical body to omitting them — pins the default, not just the decode |
| `include_comments` alone | Flag reaches the role alone; `comments` present, `dependents` absent |
| `include_dependents` alone | The mirror — catches a handler that decoded one into the other's field |
| Both together | Both flags; both lists; `comments_omitted` cleared |
| `include_comments=maybe`, `include_dependents=maybe` | 400 `invalid_argument` / `param` naming it / `reason: invalid_value`; storage untouched |
| `?bogus=1`, and beside a known key, and a near miss (`include_comment`) | Still `unknown_parameter` — the parameter table is the whole allowlist |
| `include_comments=maybe&bogus=1` | Reported as the malformed known value, not as version skew |
| Impossible id with a refused query | The 400, not the 404 |

The values exercise `ParseBool`'s vocabulary (`true`, `1`, `TRUE`, `t`) rather than `true` three times, since that vocabulary is what the shared decoder publishes.

## Gates

All green:

- `go test ./internal/httpapi/` — including `TestSpecRouteParity`, `TestSpecStatusCodesMatchHandlerTable`, `TestSpecGovernance`, `TestSpecCapabilityVocabularyMatchesTheRouteTable`, `TestDefaultsMatchCLIFlags`, `TestWireTagBijection`, `TestClaimRequestMembersMatchTheHandler`
- `make api-check` — `types.gen.go` regenerated and committed (`GetIssueParams`, plus the `ClaimRequest.actor` doc comment)
- `make ci-pr-lint` — 0 issues, both passes
- `make ci-pr-policy`
- `make test` — full suite, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
