### PR TITLE
Pin the two partial-id resolver reads and the fresh-workspace vocabulary reads

### DIFF
--- a/backend/conformance/audit_config_metadata_slots_repomtime.go
+++ b/backend/conformance/audit_config_metadata_slots_repomtime.go
@@ -1,6 +1,7 @@
 package conformance
 
 import (
+	"maps"
 	"slices"
 	"sort"
 	"strings"
@@ -147,6 +148,70 @@ func testAuditDeleteConfigLeavesNormalizedTable(t *testing.T, f Factory) {
 	}
 }
 
+// testAuditUnconfiguredVocabulary pins the success path a fresh workspace takes
+// on its very first list-shaped command: with no custom vocabulary configured,
+// GetCustomStatuses, GetCustomStatusesDetailed and GetCustomTypes answer empty
+// with a nil error, and GetInfraTypes answers the default infra set.
+//
+// Every existing vocabulary case configures the vocabulary first, so the
+// unconfigured path had no owning proof and GetInfraTypes had none at all.
+// The consumption is a hard failure edge: internal/workapi/list.go LoadListConfig
+// loads all four up front and wraps any error, so a backend that answers a scan
+// error or a nil-map surprise for an unconfigured workspace bricks `bd list`,
+// `bd ready` and every other list-shaped command rather than degrading.
+//
+// The infra set is spelled out rather than compared against the production
+// constant: this suite is the contract, and reading the answer from the same
+// place the implementation reads it would assert nothing.
+func testAuditUnconfiguredVocabulary(t *testing.T, f Factory) {
+	s := f(t)
+	c := ctx()
+
+	names, err := s.GetCustomStatuses(c)
+	must(t, err)
+	if len(names) != 0 {
+		t.Errorf("GetCustomStatuses on an unconfigured workspace = %v, want empty", names)
+	}
+
+	detailed, err := s.GetCustomStatusesDetailed(c)
+	must(t, err)
+	if len(detailed) != 0 {
+		t.Errorf("GetCustomStatusesDetailed on an unconfigured workspace = %v, want empty", auditDetailedPairs(detailed))
+	}
+
+	custom, err := s.GetCustomTypes(c)
+	must(t, err)
+	if len(custom) != 0 {
+		t.Errorf("GetCustomTypes on an unconfigured workspace = %v, want empty", custom)
+	}
+
+	infra := s.GetInfraTypes(c)
+	if !maps.Equal(infra, map[string]bool{"agent": true, "role": true, "message": true}) {
+		t.Errorf("GetInfraTypes on an unconfigured workspace = %v, want the default agent/role/message set", infra)
+	}
+}
+
+// testAuditConfiguredInfraTypes pins the other half: a configured types.infra
+// key replaces the default set outright, and the answer is exactly the
+// configured names. Infra types decide which issue types route to the wisps
+// table instead of the versioned issues table, so a backend that ignores the
+// key silently versions rows the workspace asked to keep ephemeral.
+//
+// Subject: SetConfig. A backend whose allowlist refuses it does not run this
+// case. The assertion is the value, not the cache: invalidation is a per-store
+// concern this suite declines to pin, which is why the read happens on a store
+// that has not read the key before.
+func testAuditConfiguredInfraTypes(t *testing.T, f Factory) {
+	s := f(t)
+	c := ctx()
+	must(t, s.SetConfig(c, "types.infra", "gate,probe"))
+
+	infra := s.GetInfraTypes(c)
+	if !maps.Equal(infra, map[string]bool{"gate": true, "probe": true}) {
+		t.Errorf("GetInfraTypes after types.infra=gate,probe = %v, want exactly gate/probe", infra)
+	}
+}
+
 // testAuditRepoMtimeClearKeyAsymmetry pins the verbatim-key vs abs-normalized-key
 // asymmetry: SetRepoMtime/GetRepoMtime use the path argument verbatim, but
 // ClearRepoMtime first resolves it to an absolute path before the DELETE. So
@@ -204,6 +269,8 @@ func RunAudit_config_metadata_slots_repomtime(t *testing.T, f Factory) {
 	t.Run("SetConfigInvalidStatusRollsBack", func(t *testing.T) { testAuditSetConfigInvalidStatusRollsBack(t, f) })
 	t.Run("CustomTypesOrder", func(t *testing.T) { testAuditCustomTypesOrder(t, f) })
 	t.Run("DeleteConfigLeavesNormalizedTable", func(t *testing.T) { testAuditDeleteConfigLeavesNormalizedTable(t, f) })
+	t.Run("UnconfiguredVocabulary", func(t *testing.T) { testAuditUnconfiguredVocabulary(t, f) })
+	t.Run("ConfiguredInfraTypes", func(t *testing.T) { testAuditConfiguredInfraTypes(t, f) })
 	t.Run("RepoMtimeClearKeyAsymmetry", func(t *testing.T) { testAuditRepoMtimeClearKeyAsymmetry(t, f) })
 	t.Run("SlotGetNonStringValues", func(t *testing.T) { testAuditSlotGetNonStringValues(t, f) })
 }

--- a/backend/conformance/conformance.go
+++ b/backend/conformance/conformance.go
@@ -140,6 +140,8 @@ func RunAll(t *testing.T, factory Factory) {
 	t.Run("SearchStatusFilter", func(t *testing.T) { testSearchStatusFilter(t, factory) })
 	t.Run("SearchPriorityFilter", func(t *testing.T) { testSearchPriorityFilter(t, factory) })
 	t.Run("SearchLimit", func(t *testing.T) { testSearchLimit(t, factory) })
+	t.Run("SearchByIDsFilter", func(t *testing.T) { testSearchByIDsFilter(t, factory) })
+	t.Run("SearchIssueIDsProjection", func(t *testing.T) { testSearchIssueIDsProjection(t, factory) })
 	t.Run("CountIssues", func(t *testing.T) { testCountIssues(t, factory) })
 	t.Run("CountByGroup", func(t *testing.T) { testCountByGroup(t, factory) })
 	t.Run("CountByGroupIsBlockedFilter", func(t *testing.T) { testCountByGroupIsBlockedFilter(t, factory) })
@@ -490,6 +492,76 @@ func testSearchLimit(t *testing.T, f Factory) {
 	results, _ := s.SearchIssues(ctx(), "", types.IssueFilter{Limit: 2})
 	if len(results) != 2 {
 		t.Errorf("limit=2: len = %d", len(results))
+	}
+}
+
+// testSearchByIDsFilter pins the exact-id read the partial-id resolver takes as
+// its fast path: IssueFilter.IDs answers exactly the named row, and an id nobody
+// holds answers an EMPTY result with a NIL error.
+//
+// The nil-error half is the load-bearing one. internal/utils/id_parser.go
+// branches on `err == nil && len(results) > 0` (GH#942), so a backend that
+// reports a miss as an error silently pushes every user-typed `bd show`,
+// `bd update` and `bd close` argument onto the slow substring path. The pinned
+// testGetByIDs covers the different GetIssuesByIDs method; no case sends
+// IssueFilter.IDs to SearchIssues.
+//
+// Subject: SearchIssues with IssueFilter.IDs. A backend whose allowlist refuses
+// that filter does not run this case.
+func testSearchByIDsFilter(t *testing.T, f Factory) {
+	s := f(t)
+	c := ctx()
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "test-idf1", Title: "One"}), "a"))
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "test-idf2", Title: "Two"}), "a"))
+
+	hit, err := s.SearchIssues(c, "", types.IssueFilter{IDs: []string{"test-idf1"}})
+	must(t, err)
+	if !slices.Equal(issueIDs(hit), []string{"test-idf1"}) {
+		t.Errorf("SearchIssues(IDs=[test-idf1]) = %v, want [test-idf1]", issueIDs(hit))
+	}
+
+	miss, err := s.SearchIssues(c, "", types.IssueFilter{IDs: []string{"test-nobody"}})
+	if err != nil {
+		t.Fatalf("SearchIssues(IDs=[test-nobody]) = %v, want a nil error — the resolver's fast path branches on it", err)
+	}
+	if len(miss) != 0 {
+		t.Errorf("SearchIssues(IDs=[test-nobody]) = %v, want no rows", issueIDs(miss))
+	}
+}
+
+// testSearchIssueIDsProjection pins the narrow projection the partial-id
+// resolver walks when the exact-id fast path misses
+// (internal/utils/id_parser.go): SearchIssueIDs answers the bare ids of every
+// issue carrying the hash token, and its Ephemeral leg answers wisp ids so a
+// wisp stays resolvable by partial id.
+//
+// SearchIssueIDs appears nowhere else in this suite, and the id arm of the
+// query is unpinned: the audit's SearchTextIDBranchExternalRef covers the
+// adjacent SearchIssues text branch only. Assert ids, never issues — not
+// hydrating 45 columns to read one is the whole point of the method.
+//
+// Subject: SearchIssueIDs. A backend whose allowlist refuses it does not run
+// this case.
+func testSearchIssueIDsProjection(t *testing.T, f Factory) {
+	s := f(t)
+	c := ctx()
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "test-a3f8e9", Title: "One"}), "a"))
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "test-a3f8aa", Title: "Two"}), "a"))
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "test-b111", Title: "Three"}), "a"))
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "test-wisp-b7c2", Title: "Wisp", Ephemeral: true}), "a"))
+
+	ids, err := s.SearchIssueIDs(c, "a3f8", types.IssueFilter{})
+	must(t, err)
+	sort.Strings(ids)
+	if !slices.Equal(ids, []string{"test-a3f8aa", "test-a3f8e9"}) {
+		t.Errorf("SearchIssueIDs(%q) = %v, want [test-a3f8aa test-a3f8e9]", "a3f8", ids)
+	}
+
+	ephemeral := true
+	wispIDs, err := s.SearchIssueIDs(c, "b7c2", types.IssueFilter{Ephemeral: &ephemeral})
+	must(t, err)
+	if !slices.Equal(wispIDs, []string{"test-wisp-b7c2"}) {
+		t.Errorf("SearchIssueIDs(%q, Ephemeral=true) = %v, want [test-wisp-b7c2]", "b7c2", wispIDs)
 	}
 }
 


### PR DESCRIPTION
## What

Two conformance blocks over reads that CLI behavior observably depends on and
that the shared suite did not own:

- **`SearchByIDsFilter` / `SearchIssueIDsProjection`** — the two store reads the
  partial-id resolver walks (`internal/utils/id_parser.go`).
- **`Audit/config-metadata-slots-repomtime/UnconfiguredVocabulary` and
  `.../ConfiguredInfraTypes`** — the vocabulary reads every list-shaped command
  makes before it does anything else (`internal/workapi/list.go`
  `LoadListConfig`).

## Why

Both are behaviors a single backend never notices are unpinned, because its own
backend-local tests catch its regressions. A second storage backend has no
shared proof telling it what "correct" is here, and every one of these reads is
load-bearing for a user-visible path.

**Id resolution.** `bd show`, `bd update` and `bd close` all resolve their
user-typed argument through `ResolvePartialID`. Its fast path branches on
`err == nil && len(results) > 0` (#942), so a backend that reports an unknown id
as an *error* rather than an empty result silently pushes every exact lookup
onto the slow substring path — no error, no other signal. `IssueFilter.IDs`
never reached `SearchIssues` anywhere in the suite (the pinned `testGetByIDs`
covers the different `GetIssuesByIDs` method), and `SearchIssueIDs` appeared
**zero** times in `backend/conformance`. The audit's
`SearchTextIDBranchExternalRef` pins the adjacent text branch but neither the
id arm nor the id projection.

**Vocabulary.** `GetInfraTypes` appeared nowhere in the suite, and every
existing vocabulary case configures the vocabulary before reading it — so the
path a brand-new workspace actually takes, all four reads against an
unconfigured store, had no owning proof. `LoadListConfig` wraps and returns any
error from those reads, so a backend that answers a scan error or a nil-map
surprise there bricks `bd list` and `bd ready` on a fresh workspace instead of
degrading. `ConfiguredInfraTypes` pins the other half: infra types decide which
issue types route to the wisps table instead of the versioned issues table, so a
backend that ignores `types.infra` silently versions rows the workspace asked to
keep ephemeral.

## Red/green

Every case was driven red by perturbing the production behavior it pins, then
green with the perturbation reverted, against the embedded-Dolt oracle:

| Case | RED reason | Observed |
| --- | --- | --- |
| SearchByIDsFilter | `IssueFilter.IDs` clause dropped from the filter builder | `SearchIssues(IDs=[test-idf1]) = [test-idf1 test-idf2], want [test-idf1]` |
| SearchIssueIDsProjection (token) | `SearchIssueIDsInTx` ignores its query | `SearchIssueIDs("a3f8") = [test-a3f8aa test-a3f8e9 test-b111 test-wisp-b7c2], want [test-a3f8aa test-a3f8e9]` |
| SearchIssueIDsProjection (wisp) | the projection stops reading the wisp plane | `SearchIssueIDs("b7c2", Ephemeral=true) = [], want [test-wisp-b7c2]` |
| UnconfiguredVocabulary (infra) | `defaultInfraTypes` drops `message` | `GetInfraTypes ... = map[agent:true role:true], want the default agent/role/message set` |
| UnconfiguredVocabulary (statuses) | `GetCustomStatuses` errors on an empty vocabulary | `unexpected error: scan custom_statuses: no rows` |
| ConfiguredInfraTypes | `ResolveInfraTypesInTx` ignores the config value | `GetInfraTypes after types.infra=gate,probe = map[agent:true message:true role:true], want exactly gate/probe` |

## Test results

Both behaviorally distinct in-tree implementations wired to `RunAll` run every
new case green:

- `internal/storage/embeddeddolt` (the reference oracle) — new cases pass
- `internal/storage/dolt` (server-backed) — new cases pass
- `./scripts/conformance.sh` tier 1 (full embedded `TestConformance`) and tier 2
  (`./test/conformance/`, 35.6s) both green
- `./backend/... ./issueops/... . ./internal/storage/issueops/... ./internal/utils/... ./internal/workapi/...` green

Timing (the suite's budget, measured rather than assumed): the four new cases
cost ~0.4s focused. Full embedded `TestConformance` went 63.07s before → 64.47s
after for the whole series including the sibling claim-role PR; this PR is the
smaller half of that.

## Notes

Each case names the subject it binds — `SearchIssues` with `IssueFilter.IDs`,
`SearchIssueIDs`, `SetConfig` — so a partial backend whose declared unsupported
allowlist refuses that subject knows to leave the case out of its
supported-subset gate rather than discovering it unrunnable inside `RunAll`.

The claim-role block from the same design lands separately in
`conformance-claim-role`: it is a new file with no dependency on this one, and
splitting keeps both diffs reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
