### PR TITLE
feat(httpapi): serve reopenIssue over v0

### DIFF
--- a/cmd/bd/serve_close_proxied_integration_test.go
+++ b/cmd/bd/serve_close_proxied_integration_test.go
@@ -48,6 +48,32 @@ func (sp *serveProcess) closeIssue(t *testing.T, id, body string) (int, map[stri
 	return resp.StatusCode, m
 }
 
+// reopenIssue posts a reopen for id and returns the status and decoded body.
+func (sp *serveProcess) reopenIssue(t *testing.T, id, body string) (int, map[string]any) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, sp.url("/v0/beads/issues/"+id+":reopen"), strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("new reopen request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := sp.client.Do(req)
+	if err != nil {
+		t.Fatalf("POST reopen %s: %v\nstderr:\n%s", id, err, sp.stderr.String())
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read reopen body: %v", err)
+	}
+	var m map[string]any
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &m); err != nil {
+			t.Fatalf("decode reopen body %q: %v", raw, err)
+		}
+	}
+	return resp.StatusCode, m
+}
+
 func TestProxiedServerServeClose(t *testing.T) {
 	requireSharedProxiedServer(t)
 	t.Parallel()
@@ -180,6 +206,80 @@ func TestProxiedServerServeClose(t *testing.T) {
 		// a real divergence and belongs in review, not in this list.
 		if diff := diffJSONObjects(fromHTTP, fromCLI, nil); diff != "" {
 			t.Errorf("CloseIssueResponse.issue and `bd close --json`[0] disagree:\n%s", diff)
+		}
+	})
+
+	// THE ROUND-TRIP PROOF for reopenIssue. A fake role can report Changed; only
+	// a real store can show that the reopen CLEARED the close record — which is
+	// what makes the close's first-close-wins rule survivable, since the way to
+	// write a new reason is to reopen and close again.
+	t.Run("a close and reopen round trip clears the close record", func(t *testing.T) {
+		issue := bdProxiedCreate(t, bd, p.dir, "round trip", "-p", "1")
+
+		if status, body := sp.closeIssue(t, issue.ID, `{"actor":"http-agent","reason":"shipped","session":"session-x"}`); status != http.StatusOK {
+			t.Fatalf("close: status = %d, want 200: %v", status, body)
+		}
+		closed := bdProxiedShow(t, bd, p.dir, issue.ID)
+		if closed.CloseReason != "shipped" || closed.ClosedBySession != "session-x" {
+			t.Fatalf("the close did not record its reason/session: %q/%q", closed.CloseReason, closed.ClosedBySession)
+		}
+
+		status, body := sp.reopenIssue(t, issue.ID, `{"actor":"http-agent","reason":"the fix regressed"}`)
+		if status != http.StatusOK {
+			t.Fatalf("reopen: status = %d, want 200: %v", status, body)
+		}
+		if body["already_open"] != false {
+			t.Errorf("already_open = %v, want false on a reopen that changed the row", body["already_open"])
+		}
+		reopened, ok := body["issue"].(map[string]any)
+		if !ok {
+			t.Fatalf("issue = %#v, want an object", body["issue"])
+		}
+		if reopened["status"] != "open" {
+			t.Errorf("the response reports status %v, want open", reopened["status"])
+		}
+
+		after := bdProxiedShow(t, bd, p.dir, issue.ID)
+		if string(after.Status) != "open" {
+			t.Fatalf("bd show reports status %q; the HTTP reopen did not land", after.Status)
+		}
+		if after.CloseReason != "" || after.ClosedBySession != "" {
+			t.Errorf("the reopen left close_reason %q and closed_by_session %q; both describe a closure that no longer holds",
+				after.CloseReason, after.ClosedBySession)
+		}
+
+		// The reason is recorded on the EVENT, which is where the document tells
+		// a client to read it back — not on a field of the issue, and not in the
+		// response.
+		events, err := bdProxiedRun(t, bd, p.dir, "history", issue.ID, "--events")
+		if err != nil {
+			t.Fatalf("bd history --events: %v\n%s", err, events)
+		}
+		if !strings.Contains(string(events), "the fix regressed") {
+			t.Errorf("the reopen reason is not on the issue's event stream:\n%s", events)
+		}
+
+		// And the round trip really is a round trip: the issue is claimable
+		// again, which is the recovery flow this pair exists to serve.
+		if status, claim := sp.claim(t, issue.ID, "http-agent"); status != http.StatusOK {
+			t.Errorf("claim after reopen: status = %d, want 200: %v", status, claim)
+		}
+	})
+
+	// The idempotent half, against the real store: a reopen of an issue that was
+	// never done changes nothing and succeeds.
+	t.Run("reopening an issue that was never done is idempotent", func(t *testing.T) {
+		issue := bdProxiedCreate(t, bd, p.dir, "never closed", "-p", "2")
+
+		status, body := sp.reopenIssue(t, issue.ID, `{"actor":"http-agent"}`)
+		if status != http.StatusOK {
+			t.Fatalf("status = %d, want 200: %v", status, body)
+		}
+		if body["already_open"] != true {
+			t.Errorf("already_open = %v, want true for an issue that was never done", body["already_open"])
+		}
+		if shown := bdProxiedShow(t, bd, p.dir, issue.ID); string(shown.Status) != "open" {
+			t.Errorf("bd show reports status %q after an idempotent reopen", shown.Status)
 		}
 	})
 

--- a/cmd/bd/serve_proxied_integration_test.go
+++ b/cmd/bd/serve_proxied_integration_test.go
@@ -146,7 +146,7 @@ var servedCapabilities = []any{
 	"config.get", "config.list",
 	"dependencies.blocking", "dependencies.cycles", "dependencies.list", "dependencies.tree",
 	"issues.batchCreate", "issues.claim", "issues.close", "issues.delete",
-	"issues.get", "issues.list", "issues.query", "issues.sweep",
+	"issues.get", "issues.list", "issues.query", "issues.reopen", "issues.sweep",
 	"memories.forget", "memories.get", "memories.list", "memories.remember",
 	"ready.count", "ready.list", "stats.get",
 }

--- a/internal/httpapi/apigen/types.gen.go
+++ b/internal/httpapi/apigen/types.gen.go
@@ -243,7 +243,7 @@ type ContextResponse struct {
 	// BeadsDir Absolute path of the served workspace's `.beads` directory. A host path, kept because it is the single-workspace server's only workspace-identity handshake; disclosing it to network peers is part of what an operator accepts when binding beyond loopback.
 	BeadsDir string `json:"beads_dir"`
 
-	// Capabilities The operations this server actually implements, derived from its route table. v0's vocabulary is `ready.list`, `ready.count`, `issues.list`, `issues.query`, `issues.get`, `issues.claim`, `issues.close`, `issues.sweep`, `issues.delete`, `issues.batchCreate`, `stats.get`, `config.list`, `config.get`, `dependencies.cycles`, `dependencies.list`, `dependencies.blocking`, `dependencies.tree`, `memories.list`, `memories.get`, `memories.remember`, `memories.forget`; it grows additively, and an operation never appears here unless it is fully implemented. This is how a client checks for an operation — never the version string.
+	// Capabilities The operations this server actually implements, derived from its route table. v0's vocabulary is `ready.list`, `ready.count`, `issues.list`, `issues.query`, `issues.get`, `issues.claim`, `issues.close`, `issues.reopen`, `issues.sweep`, `issues.delete`, `issues.batchCreate`, `stats.get`, `config.list`, `config.get`, `dependencies.cycles`, `dependencies.list`, `dependencies.blocking`, `dependencies.tree`, `memories.list`, `memories.get`, `memories.remember`, `memories.forget`; it grows additively, and an operation never appears here unless it is fully implemented. This is how a client checks for an operation — never the version string.
 	Capabilities []string `json:"capabilities"`
 
 	// Database Logical database name (not a host or a DSN).
@@ -516,6 +516,24 @@ type RememberedMemory struct {
 
 	// Value The stored content, echoed verbatim. Always present, and never withheld — this plane has no redaction; see the operation description.
 	Value string `json:"value"`
+}
+
+// ReopenIssueRequest defines model for ReopenIssueRequest.
+type ReopenIssueRequest struct {
+	// Actor Who is reopening the issue. `ClaimRequest.actor`'s rules exactly: the server trims it, then refuses an empty result, anything longer than 256 BYTES (the `maxLength` above counts characters — the byte limit is the binding one), and any control character including newline. The value reaches the `reopened` event's attribution and the storage commit message, so an unvalidated newline would forge audit-trail lines.
+	Actor string `json:"actor"`
+
+	// Reason Why the issue is being reopened. Recorded on the `reopened` EVENT this move records — not on a field of the issue, and not carried in the response, so a caller that wants it back reads the issue's events. Refused for control characters, and bounded by what the column holds rather than by the number above.
+	Reason *string `json:"reason,omitempty"`
+}
+
+// ReopenIssueResponse defines model for ReopenIssueResponse.
+type ReopenIssueResponse struct {
+	// AlreadyOpen True when the issue was not in a done status and this call changed nothing — idempotent, mirroring `CloseIssueResponse.already_closed` and `ClaimResponse.already_claimed`. The response still carries the row.
+	AlreadyOpen bool `json:"already_open"`
+
+	// Issue A tracked work item. Property semantics documented here apply to every schema that repeats them below.
+	Issue Issue `json:"issue"`
 }
 
 // Setting One entry of the workspace's stored settings plane.
@@ -971,6 +989,9 @@ type ClaimIssueJSONRequestBody = ClaimRequest
 
 // CloseIssueJSONRequestBody defines body for CloseIssue for application/json ContentType.
 type CloseIssueJSONRequestBody = CloseIssueRequest
+
+// ReopenIssueJSONRequestBody defines body for ReopenIssue for application/json ContentType.
+type ReopenIssueJSONRequestBody = ReopenIssueRequest
 
 // BatchCreateIssuesJSONRequestBody defines body for BatchCreateIssues for application/json ContentType.
 type BatchCreateIssuesJSONRequestBody = BatchCreateRequest

--- a/internal/httpapi/claim_test.go
+++ b/internal/httpapi/claim_test.go
@@ -651,8 +651,10 @@ func TestCustomMethodsNarrowThePOSTSurface(t *testing.T) {
 		"/v0/beads/issues/bd-1:claim-not", // a suffix that merely starts the same
 		"/v0/beads/issues/bd-1:close-not",
 		"/v0/beads/issues/bd-1:unclaim",
-		"/v0/beads/issues/bd-1:reopen", // a verb this build does not serve
-		"/v0/beads/issues/bd-1:delete",
+		"/v0/beads/issues/:reopen",
+		"/v0/beads/issues/bd-1:Reopen",
+		"/v0/beads/issues/bd-1:reopened",
+		"/v0/beads/issues/bd-1:delete", // a verb this build does not serve
 	} {
 		t.Run(path, func(t *testing.T) {
 			issues := &fakeIssues{issue: seededIssue("bd-1", "alice", types.StatusInProgress)}

--- a/internal/httpapi/problem.go
+++ b/internal/httpapi/problem.go
@@ -168,7 +168,11 @@ const (
 	// status patch because Close carries semantics a patch has nowhere to put —
 	// the reason and session under first-close-wins, the done-status
 	// normalization, and the close policy vocabulary.
-	OpCloseIssue           = "closeIssue"
+	OpCloseIssue = "closeIssue"
+	// OpReopenIssue is the close's mirror, and it completes the lifecycle pair
+	// so a recovery flow works end to end over this surface. It is the one
+	// write here with no conflict code: reopen has no policy guard.
+	OpReopenIssue          = "reopenIssue"
 	OpListSettings         = "listSettings"
 	OpGetSetting           = "getSetting"
 	OpListDependencyCycles = "listDependencyCycles"
@@ -309,6 +313,15 @@ var operationCodes = map[string][]Code{
 	// `already_closed`, the claim's answer to the same question.
 	OpCloseIssue: {
 		CodeInvalidArgument, CodeNotFound, CodeNotClosable,
+		CodeBusy, CodeDBUnavailable, CodeInternal,
+	},
+	// NO 409, and the absence is the point. Close has a policy guard — open
+	// children, a live blocker — and reopen is the direction that takes an issue
+	// OUT of the done category rather than putting it in, so there is no state
+	// of the graph that can refuse it and nothing to name. The idempotent case
+	// is a 200 carrying `already_open`, not a conflict.
+	OpReopenIssue: {
+		CodeInvalidArgument, CodeNotFound,
 		CodeBusy, CodeDBUnavailable, CodeInternal,
 	},
 	// No not_found. The role refuses an edge whose target names nothing, and

--- a/internal/httpapi/reopen.go
+++ b/internal/httpapi/reopen.go
@@ -1,0 +1,114 @@
+package httpapi
+
+import (
+	"net/http"
+
+	"github.com/steveyegge/beads/internal/httpapi/apigen"
+	"github.com/steveyegge/beads/issueops"
+)
+
+// reopenRequestMembers is the document's member list for ReopenIssueRequest,
+// read as raw members for the reason closeRequestMembers is.
+var reopenRequestMembers = []string{"actor", "reason"}
+
+// reopenProvenance labels the version-control history entry a reopen records,
+// naming the surface it came from.
+//
+// The role's own default is not good enough for this: the implementations do
+// not agree on it — the store-backed ones write "bd: reopen issue" and the
+// unit-of-work one "reopen issue" — so a workspace served by one backend today
+// and another tomorrow would grow two spellings of the same event. Spelling it
+// here makes the entry read the same whichever backend answered, which is the
+// field's own recommendation.
+//
+// It never changes WHETHER history is recorded, only how the entry reads, and
+// it is not wire-visible.
+const reopenProvenance = "bd serve: reopen issue"
+
+// handleReopen reopens one issue: the close's mirror, and the half that makes a
+// recovery flow work end to end over this surface.
+//
+// It carries the claim's posture verbatim. The actor is caller-ASSERTED
+// provenance for the audit trail and not authenticated identity; hooks do not
+// fire and the per-command auto-commit machinery does not run, exactly as for
+// POST /v0/beads/issues/{id}:claim. The only durable effect is the single
+// storage commit the role makes inside its own transaction.
+//
+// Everything above the role is argument validation. The move itself — which
+// statuses count as done, clearing the close reason and session, and the
+// `reopened` event the reason is recorded on — belongs to issueops.Lifecycle.
+//
+// PLANES, as for the close: the id resolves across both, so a reopen whose
+// target is a wisp lands on the unversioned plane and records no durable
+// history entry.
+func (s *Server) handleReopen(w http.ResponseWriter, r *http.Request) {
+	// The custom-method dispatcher split the id off the segment and bounded it
+	// before this handler was chosen at all; see customMethodTarget.
+	id := r.PathValue(customMethodIDValue)
+	if !s.requireNoQuery(w, r) {
+		return
+	}
+	if !s.requireJSONContent(w, r) {
+		return
+	}
+	request, ok := s.reopenRequest(w, r, id)
+	if !ok {
+		return
+	}
+
+	lifecycle, err := s.lifecycle(r)
+	if err != nil {
+		s.failErr(w, r, err)
+		return
+	}
+	result, err := lifecycle.Reopen(r.Context(), request)
+	if err != nil {
+		// No failReopen sibling, deliberately: this operation has no conflict
+		// code and therefore no typed refusal to read extension members out of.
+		// The shared mapping is the whole of its error vocabulary, and adding a
+		// pass-through wrapper would suggest otherwise.
+		s.failErr(w, r, err)
+		return
+	}
+	// `already_open` is the wire's name for the role's unchanged result: a
+	// reopen of an issue that was never done. Idempotent, like the re-claim and
+	// the re-close, and for the same reason.
+	writeJSON(w, apigen.ReopenIssueResponse{
+		Issue:       *result.Issue,
+		AlreadyOpen: !result.Changed,
+	})
+}
+
+// reopenRequest decodes and validates the body, and reports whether the request
+// may proceed.
+func (s *Server) reopenRequest(w http.ResponseWriter, r *http.Request, id string) (issueops.ReopenRequest, bool) {
+	members, res := decodeJSONObjectBody(w, r)
+	if res != nil {
+		s.fail(w, r, *res)
+		return issueops.ReopenRequest{}, false
+	}
+	if offender, unknown := unknownMember(members, reopenRequestMembers); unknown {
+		s.failUnknownMember(w, r, offender, reopenRequestMembers)
+		return issueops.ReopenRequest{}, false
+	}
+
+	actor, ok := s.bodyActor(w, r, members)
+	if !ok {
+		return issueops.ReopenRequest{}, false
+	}
+	// The close's bounds, shared rather than restated: this value reaches the
+	// `reopened` event rather than a column, and an event stream is printed by
+	// the same renderers a close reason is.
+	reason, ok := s.storedTextMember(w, r, members, "reason")
+	if !ok {
+		return issueops.ReopenRequest{}, false
+	}
+
+	// ExpectedVersion stays unpublished on this surface, as for the close.
+	return issueops.ReopenRequest{
+		Actor:      actor,
+		IssueID:    id,
+		Reason:     reason,
+		Provenance: reopenProvenance,
+	}, true
+}

--- a/internal/httpapi/reopen_test.go
+++ b/internal/httpapi/reopen_test.go
@@ -1,0 +1,323 @@
+package httpapi
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/issueops"
+)
+
+// The close's test header applies unchanged: these are pure, they run the
+// reopen path end to end over a real listener against a fake ROLE, and what a
+// fake cannot prove — the close→reopen round trip clearing close_reason and
+// closed_by_session, and the reason landing on the issue's event stream — lives
+// in cmd/bd's TestProxiedServerServeClose against real Dolt.
+
+const reopenPath = "/v0/beads/issues/bd-1:reopen"
+
+func (ts *testServer) reopenIssue(t *testing.T, path, body string) *http.Response {
+	t.Helper()
+	return ts.postBody(t, path, "application/json", body)
+}
+
+func newReopenServer(t *testing.T, lifecycle *roleLifecycle) *testServer {
+	t.Helper()
+	return newTestServer(t, rolesConfig(Config{Lifecycle: lifecycle}))
+}
+
+func reopenedIssue(id string) *types.Issue {
+	return seededIssue(id, "alice", types.StatusOpen)
+}
+
+// TestReopenWritesOnceAndAnswersWithTheRowItWrote is the happy path, plus the
+// one thing this operation adds that the close does not: the handler names the
+// history entry, so an entry reads the same whichever backend served it.
+func TestReopenWritesOnceAndAnswersWithTheRowItWrote(t *testing.T) {
+	lifecycle := &roleLifecycle{reopenResult: issueops.ReopenResult{Issue: reopenedIssue("bd-1"), Changed: true}}
+	ts := newReopenServer(t, lifecycle)
+
+	resp := ts.reopenIssue(t, reopenPath, `{"actor":"alice","reason":"the fix regressed"}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+
+	want := issueops.ReopenRequest{
+		Actor: "alice", IssueID: "bd-1", Reason: "the fix regressed", Provenance: reopenProvenance,
+	}
+	if got := lifecycle.reopenRequests(); len(got) != 1 || got[0] != want {
+		t.Fatalf("the role received %+v, want exactly one %+v", got, want)
+	}
+
+	body := decodeBody(t, resp)
+	if body["already_open"] != false {
+		t.Errorf("already_open = %v, want false on a reopen that changed the row", body["already_open"])
+	}
+	issue, ok := body["issue"].(map[string]any)
+	if !ok {
+		t.Fatalf("issue = %#v, want an object", body["issue"])
+	}
+	if issue["status"] != string(types.StatusOpen) {
+		t.Errorf("the response does not carry the reopened row: %v", issue)
+	}
+	// The reason is recorded on the EVENT, not on a field of the issue, and the
+	// document says so — publishing it here would tell a client to read it back
+	// from the wrong place.
+	if _, present := body["reason"]; present {
+		t.Errorf("the response carries the reopen reason; it belongs on the event stream: %v", body)
+	}
+}
+
+// TestReopenNamesItsHistoryEntry pins the provenance label as a value rather
+// than leaving it to the role's default. The implementations do not agree on
+// that default — "bd: reopen issue" against "reopen issue" — so a workspace
+// served by one backend today and another tomorrow would grow two spellings of
+// one event.
+func TestReopenNamesItsHistoryEntry(t *testing.T) {
+	lifecycle := &roleLifecycle{reopenResult: issueops.ReopenResult{Issue: reopenedIssue("bd-1"), Changed: true}}
+	ts := newReopenServer(t, lifecycle)
+
+	if resp := ts.reopenIssue(t, reopenPath, `{"actor":"alice"}`); resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	got := lifecycle.reopenRequests()
+	if len(got) != 1 {
+		t.Fatalf("the role was called %d times, want 1", len(got))
+	}
+	if got[0].Provenance == "" {
+		t.Fatal("the reopen carries no provenance, so the history entry reads differently per backend")
+	}
+	if !strings.Contains(got[0].Provenance, "serve") {
+		t.Errorf("provenance = %q; it is meant to name THIS surface", got[0].Provenance)
+	}
+}
+
+// TestReopenIsIdempotentForAnIssueThatWasNeverDone is the operation's whole
+// idempotency story, and the reason it has no 409: a reopen of a non-done issue
+// changes nothing and SUCCEEDS.
+func TestReopenIsIdempotentForAnIssueThatWasNeverDone(t *testing.T) {
+	lifecycle := &roleLifecycle{reopenResult: issueops.ReopenResult{Issue: reopenedIssue("bd-1"), Changed: false}}
+	ts := newReopenServer(t, lifecycle)
+
+	resp := ts.reopenIssue(t, reopenPath, `{"actor":"alice"}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	body := decodeBody(t, resp)
+	if body["already_open"] != true {
+		t.Errorf("already_open = %v, want true for an issue that was never done", body["already_open"])
+	}
+	if _, ok := body["issue"].(map[string]any); !ok {
+		t.Errorf("the idempotent answer dropped the row: %v", body)
+	}
+}
+
+// TestReopenPublishesNoConflictCode is the absence, asserted. The operation's
+// row says it has no 409 and the spec documents none; this is the third leg —
+// nothing in the frozen set for this operation is a conflict, so a future
+// change that gave reopen a policy guard has to land its code deliberately.
+func TestReopenPublishesNoConflictCode(t *testing.T) {
+	codes, ok := operationCodes[OpReopenIssue]
+	if !ok {
+		t.Fatalf("no %s row in the handler table", OpReopenIssue)
+	}
+	for _, c := range codes {
+		if c.Status() == http.StatusConflict {
+			t.Errorf("reopen publishes the conflict code %q; it has no policy guard, so there is nothing to refuse", c)
+		}
+	}
+}
+
+// TestReopenUnknownIDIs404 keeps the miss on the shape the document already
+// describes.
+func TestReopenUnknownIDIs404(t *testing.T) {
+	lifecycle := &roleLifecycle{reopenErr: fmt.Errorf("reopen bd-9: %w", issueops.ErrNotFound)}
+	ts := newReopenServer(t, lifecycle)
+
+	resp := ts.reopenIssue(t, "/v0/beads/issues/bd-9:reopen", `{"actor":"alice"}`)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if body := decodeBody(t, resp); body["code"] != string(CodeNotFound) {
+		t.Errorf("code = %v, want %s", body["code"], CodeNotFound)
+	}
+}
+
+// TestReopenRejectsTheShapesTheDocumentRefuses is the body vocabulary, refused
+// at the wire edge with nothing reaching the role. `session` and `force` are
+// here as REFUSALS: they are the close's members, and a client that sends them
+// to this operation is told so by name rather than having them ignored.
+func TestReopenRejectsTheShapesTheDocumentRefuses(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		body  string
+		param string
+	}{
+		{"no actor", `{"reason":"x"}`, "actor"},
+		{"blank actor", `{"actor":"   "}`, "actor"},
+		{"actor with a newline", "{\"actor\":\"alice\\nbd: reopen bd-1 by mallory\"}", "actor"},
+		{"null actor", `{"actor":null}`, "actor"},
+		{"oversize actor", `{"actor":"` + strings.Repeat("x", 300) + `"}`, "actor"},
+		{"the close's session member", `{"actor":"alice","session":"s"}`, "session"},
+		{"the close's force member", `{"actor":"alice","force":true}`, "force"},
+		{"unknown member", `{"actor":"alice","cascade":true}`, "cascade"},
+		{"reason is not a string", `{"actor":"alice","reason":7}`, "reason"},
+		{"null reason", `{"actor":"alice","reason":null}`, "reason"},
+		{"oversize reason", `{"actor":"alice","reason":"` + strings.Repeat("x", 300) + `"}`, "reason"},
+		{"reason with a control character", "{\"actor\":\"alice\",\"reason\":\"why\\nbd: forged\"}", "reason"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lifecycle := &roleLifecycle{reopenResult: issueops.ReopenResult{Issue: reopenedIssue("bd-1")}}
+			ts := newReopenServer(t, lifecycle)
+
+			resp := ts.reopenIssue(t, reopenPath, tc.body)
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
+			}
+			body := decodeBody(t, resp)
+			if body["code"] != string(CodeInvalidArgument) {
+				t.Errorf("code = %v, want %s", body["code"], CodeInvalidArgument)
+			}
+			if body["param"] != tc.param {
+				t.Errorf("param = %v, want %q", body["param"], tc.param)
+			}
+			if got := lifecycle.reopenRequests(); len(got) != 0 {
+				t.Errorf("a refused body reached the role: %+v", got)
+			}
+		})
+	}
+}
+
+// TestReopenRefusesAForeignMediaType and TestReopenRefusesAQueryParameter: the
+// two document-level rules, on the newest write.
+func TestReopenRefusesAForeignMediaType(t *testing.T) {
+	lifecycle := &roleLifecycle{}
+	ts := newReopenServer(t, lifecycle)
+
+	resp := ts.postBody(t, reopenPath, "text/plain", `{"actor":"alice"}`)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if body := decodeBody(t, resp); body["param"] != "Content-Type" {
+		t.Errorf("param = %v, want Content-Type", body["param"])
+	}
+	if got := lifecycle.reopenRequests(); len(got) != 0 {
+		t.Errorf("a foreign media type reached the role: %+v", got)
+	}
+}
+
+func TestReopenRefusesAQueryParameter(t *testing.T) {
+	lifecycle := &roleLifecycle{}
+	ts := newReopenServer(t, lifecycle)
+
+	resp := ts.reopenIssue(t, reopenPath+"?reason=x", `{"actor":"alice"}`)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if body := decodeBody(t, resp); body["reason"] != string(ReasonUnknownParameter) {
+		t.Errorf("reason = %v, want %s", body["reason"], ReasonUnknownParameter)
+	}
+	if got := lifecycle.reopenRequests(); len(got) != 0 {
+		t.Errorf("a query string reached the role: %+v", got)
+	}
+}
+
+// TestReopenRefusesALifecycleThatAnswersWithNothing is checkedLifecycle.Reopen's
+// reason for existing, the close's hazard on the mirror operation.
+func TestReopenRefusesALifecycleThatAnswersWithNothing(t *testing.T) {
+	lifecycle := &roleLifecycle{reopenResult: issueops.ReopenResult{Changed: true}}
+	ts := newReopenServer(t, lifecycle)
+
+	resp := ts.reopenIssue(t, reopenPath, `{"actor":"alice"}`)
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if body := decodeBody(t, resp); body["code"] != string(CodeInternal) {
+		t.Errorf("code = %v, want %s", body["code"], CodeInternal)
+	}
+	if !strings.Contains(ts.stderr.String(), "request_error") {
+		t.Errorf("a broken role produced no request_error line:\n%s", ts.stderr.String())
+	}
+}
+
+// TestReopenPathReachesItsHandler drives the path the DOCUMENT spells, and
+// proves the dispatcher hands it to THIS operation rather than to one of the
+// two rows already sharing the pattern.
+func TestReopenPathReachesItsHandler(t *testing.T) {
+	lifecycle := &roleLifecycle{reopenResult: issueops.ReopenResult{Issue: reopenedIssue("bd-1"), Changed: true}}
+	ts := newReopenServer(t, lifecycle)
+
+	if resp := ts.reopenIssue(t, reopenPath, `{"actor":"alice"}`); resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST the documented reopen path: status = %d, want 200", resp.StatusCode)
+	}
+	line := findLogLine(t, ts.stderr.String(), "path="+reopenPath)
+	if !strings.Contains(line, "op="+OpReopenIssue) {
+		t.Errorf("the documented reopen path is served by another operation:\n%s", line)
+	}
+	// And it reached the reopen verb, not the close's — the dispatcher chooses
+	// by suffix, and a mis-set customMethod would land here silently.
+	if got := lifecycle.closeRequests(); len(got) != 0 {
+		t.Errorf("the reopen path reached the close verb: %+v", got)
+	}
+}
+
+// TestReopenTakesADatabaseSlot: no write on this surface is exempt.
+func TestReopenTakesADatabaseSlot(t *testing.T) {
+	for _, rt := range routeTable {
+		if rt.op != OpReopenIssue {
+			continue
+		}
+		if rt.bypassSemaphore {
+			t.Error("the reopen route bypasses the database semaphore; only handlers that touch no database may")
+		}
+		if !rt.implemented {
+			t.Error("the reopen route is still marked unimplemented, so capabilities will not advertise it")
+		}
+		return
+	}
+	t.Fatalf("no %s row in the route table", OpReopenIssue)
+}
+
+// TestCloseAndReopenAreDistinctOnOnePattern is the pair test the dispatcher
+// makes possible and therefore has to earn: three rows now share one ServeMux
+// registration, and each documented path must reach its own verb.
+func TestCloseAndReopenAreDistinctOnOnePattern(t *testing.T) {
+	lifecycle := &roleLifecycle{
+		closeResult:  issueops.CloseResult{Issue: closedIssue("bd-1"), Changed: true},
+		reopenResult: issueops.ReopenResult{Issue: reopenedIssue("bd-1"), Changed: true},
+	}
+	ts := newReopenServer(t, lifecycle)
+
+	if resp := ts.closeIssue(t, closePath, `{"actor":"alice","reason":"done"}`); resp.StatusCode != http.StatusOK {
+		t.Fatalf("close: status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if resp := ts.reopenIssue(t, reopenPath, `{"actor":"alice","reason":"not done"}`); resp.StatusCode != http.StatusOK {
+		t.Fatalf("reopen: status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+
+	closes, reopens := lifecycle.closeRequests(), lifecycle.reopenRequests()
+	if len(closes) != 1 || closes[0].Reason != "done" {
+		t.Errorf("the close verb received %+v, want exactly the close's body", closes)
+	}
+	if len(reopens) != 1 || reopens[0].Reason != "not done" {
+		t.Errorf("the reopen verb received %+v, want exactly the reopen's body", reopens)
+	}
+}
+
+// TestReopenResolvesAcrossBothPlanes, as the close does and the claim
+// deliberately does not.
+func TestReopenResolvesAcrossBothPlanes(t *testing.T) {
+	wisp := seededIssue("bd-w1", "alice", types.StatusOpen)
+	lifecycle := &roleLifecycle{reopenResult: issueops.ReopenResult{Issue: wisp, Changed: true}}
+	ts := newReopenServer(t, lifecycle)
+
+	resp := ts.reopenIssue(t, "/v0/beads/issues/bd-w1:reopen", `{"actor":"alice"}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("reopening a wisp id: status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if got := lifecycle.reopenRequests(); len(got) != 1 || got[0].IssueID != "bd-w1" {
+		t.Fatalf("the role received %+v, want the wisp id unchanged", got)
+	}
+}

--- a/internal/httpapi/roles.go
+++ b/internal/httpapi/roles.go
@@ -93,11 +93,11 @@ func (c checkedBatchCreator) CreateBatch(ctx context.Context, req issueops.Creat
 
 // checkedLifecycle is the lifecycle role every mutation handler is handed.
 //
-// Close is the whole reason the type exists on this slice: handleClose writes
-// *result.Issue, which is checkedClaimer's hazard exactly. Create, Update and
-// Reopen pass through because no handler on this surface reaches them yet; each
-// grows a guard in the change that publishes its operation, rather than one
-// written speculatively against a body nobody marshals.
+// Close and Reopen are why it exists: both handlers write *result.Issue, which
+// is checkedClaimer's hazard exactly. Create and Update pass through because no
+// handler on this surface reaches them yet; each grows a guard in the change
+// that publishes its operation, rather than one written speculatively against a
+// body nobody marshals.
 type checkedLifecycle struct{ inner issueops.Lifecycle }
 
 // Create passes the request through unchanged: this surface publishes no
@@ -129,10 +129,16 @@ func (c checkedLifecycle) Close(ctx context.Context, req issueops.CloseRequest) 
 	return result, err
 }
 
-// Reopen passes the request through unchanged; reopenIssue is not published on
-// this surface yet.
+// Reopen refuses a result that reports success without the row the response
+// body is built from, for Close's reason: handleReopen dereferences it, and a
+// broken implementation should be the generic 500 with the fault in the log
+// rather than a panic on a live server.
 func (c checkedLifecycle) Reopen(ctx context.Context, req issueops.ReopenRequest) (issueops.ReopenResult, error) {
-	return c.inner.Reopen(ctx, req)
+	result, err := c.inner.Reopen(ctx, req)
+	if err == nil && result.Issue == nil {
+		return issueops.ReopenResult{}, fmt.Errorf("reopen %q: the lifecycle reported success without an issue", req.IssueID)
+	}
+	return result, err
 }
 
 // checkedClaimer is the claimer the claim handler is handed.

--- a/internal/httpapi/roles_test.go
+++ b/internal/httpapi/roles_test.go
@@ -368,11 +368,14 @@ func (c *roleClaimer) claimRequests() []issueops.ClaimRequest {
 // rules and the problem shapes, with the transaction and the policy left to the
 // integration test against real Dolt.
 type roleLifecycle struct {
-	closeResult issueops.CloseResult
-	closeErr    error
+	closeResult  issueops.CloseResult
+	closeErr     error
+	reopenResult issueops.ReopenResult
+	reopenErr    error
 
-	mu     sync.Mutex
-	closes []issueops.CloseRequest
+	mu      sync.Mutex
+	closes  []issueops.CloseRequest
+	reopens []issueops.ReopenRequest
 }
 
 func (l *roleLifecycle) Create(_ context.Context, _ issueops.CreateRequest) (issueops.CreateResult, error) {
@@ -393,8 +396,22 @@ func (l *roleLifecycle) Close(_ context.Context, req issueops.CloseRequest) (iss
 	return l.closeResult, nil
 }
 
-func (l *roleLifecycle) Reopen(_ context.Context, _ issueops.ReopenRequest) (issueops.ReopenResult, error) {
-	return issueops.ReopenResult{}, errors.New("reopen is not published on this surface")
+func (l *roleLifecycle) Reopen(_ context.Context, req issueops.ReopenRequest) (issueops.ReopenResult, error) {
+	l.mu.Lock()
+	l.reopens = append(l.reopens, req)
+	l.mu.Unlock()
+	if l.reopenErr != nil {
+		return issueops.ReopenResult{}, l.reopenErr
+	}
+	return l.reopenResult, nil
+}
+
+// reopenRequests is closeRequests' twin: an empty list means nothing reached
+// the role.
+func (l *roleLifecycle) reopenRequests() []issueops.ReopenRequest {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]issueops.ReopenRequest(nil), l.reopens...)
 }
 
 // closeRequests is how a case asserts that a refusal happened at the wire edge:

--- a/internal/httpapi/routes.go
+++ b/internal/httpapi/routes.go
@@ -305,6 +305,18 @@ var routeTable = []route{
 		handler:      (*Server).handleClose,
 	},
 	{
+		op:     OpReopenIssue,
+		method: http.MethodPost,
+		// The close's mirror, on the dispatcher the close built. Nothing new is
+		// needed here: a third row on this pattern is a row.
+		pattern:      customMethodPattern,
+		specPath:     "/v0/beads/issues/{id}:reopen",
+		customMethod: ":reopen",
+		capability:   "issues.reopen",
+		implemented:  true,
+		handler:      (*Server).handleReopen,
+	},
+	{
 		op:     OpSweepIssues,
 		method: http.MethodPost,
 		// A collection-level custom method, spelled the way countReadyWork's is.

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -589,7 +589,7 @@ func TestCapabilitiesAdvertiseEveryImplementedOperation(t *testing.T) {
 		"config.get", "config.list", "dependencies.blocking", "dependencies.cycles",
 		"dependencies.list", "dependencies.tree", "issues.batchCreate",
 		"issues.claim", "issues.close", "issues.delete", "issues.get", "issues.list",
-		"issues.query", "issues.sweep", "memories.forget", "memories.get",
+		"issues.query", "issues.reopen", "issues.sweep", "memories.forget", "memories.get",
 		"memories.list", "memories.remember", "ready.count", "ready.list",
 		"stats.get",
 	}

--- a/internal/httpapi/spec/openapi.v0.yaml
+++ b/internal/httpapi/spec/openapi.v0.yaml
@@ -57,7 +57,8 @@ info:
       Operations with no parameters at all (`GET /healthz`,
       `GET /v0/beads/context`, `GET /v0/beads/dependencies/cycles`,
       `POST /v0/beads/issues/{id}:claim`,
-      `POST /v0/beads/issues/{id}:close`, `POST /v0/beads/issues:sweep`,
+      `POST /v0/beads/issues/{id}:close`,
+      `POST /v0/beads/issues/{id}:reopen`, `POST /v0/beads/issues:sweep`,
       `POST /v0/beads/issues:delete`, `GET /v0/beads/config`,
       `GET /v0/beads/config/{key}`) reject every query key the same way.
 
@@ -1398,6 +1399,98 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        '500':
+          $ref: '#/components/responses/InternalError'
+        '503':
+          $ref: '#/components/responses/Unavailable'
+
+  /v0/beads/issues/{id}:reopen:
+    post:
+      operationId: reopenIssue
+      summary: Reopen one issue
+      description: >-
+        Moves the literal `closed` status and every configured done status back
+        to `open`. It is `POST /v0/beads/issues/{id}:close`'s mirror, and it
+        completes the lifecycle pair so a recovery flow works end to end over
+        this surface.
+
+
+        A reopen of an issue that is NOT done changes nothing and succeeds —
+        200 with `already_open: true`, the re-claim's and the re-close's answer
+        to the same question. An agent replaying its own recovery should not
+        have to classify an error to learn it already ran.
+
+
+        Reopening CLEARS `close_reason` and `closed_by_session`, because they
+        describe a closure that no longer holds. That is what makes the close's
+        first-close-wins rule survivable: the way to write a new reason is to
+        reopen and close again, not to re-close.
+
+
+        ## Where the reason is recorded
+
+
+        On the `reopened` EVENT this move records, not on a field of the issue,
+        and the response does not carry it. A caller that wants it back reads
+        the issue's events — the same place the actor attribution for the
+        reopen lives. A reopen with no reason still records that entry; it
+        simply carries none.
+
+
+        ## No conflict to name
+
+
+        This operation documents no `409`, and the absence is deliberate:
+        reopen has no policy guard. Close has one — open children, a live
+        blocker — and reopen is the direction that removes an issue from the
+        done category rather than adding it, so there is nothing for a policy
+        to refuse.
+
+
+        ## Planes
+
+
+        The id resolves across BOTH planes, as the close does. A reopen whose
+        target is a wisp lands on the unversioned plane and records no durable
+        history entry.
+
+
+        ## Hooks and auto-commit
+
+
+        Hooks do not fire and the per-command auto-commit machinery does not
+        run, exactly as for `POST /v0/beads/issues/{id}:claim`. The only
+        durable effect is the single storage commit the role makes in its own
+        transaction.
+      parameters:
+        - $ref: '#/components/parameters/IssueID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReopenIssueRequest'
+      responses:
+        '200':
+          description: The issue is open.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReopenIssueResponse'
+        '400':
+          description: >-
+            Invalid request: an unknown query parameter, an unparseable or
+            oversized body, an unknown body member, an `actor` that is empty
+            after trimming, longer than 256 bytes, or carrying control
+            characters — or a `reason` longer than the column holds or carrying
+            control characters.
+          x-bd-codes: [invalid_argument]
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalError'
         '503':
@@ -3277,7 +3370,7 @@ components:
             The operations this server actually implements, derived from its
             route table. v0's vocabulary is `ready.list`, `ready.count`,
             `issues.list`, `issues.query`, `issues.get`, `issues.claim`,
-            `issues.close`,
+            `issues.close`, `issues.reopen`,
             `issues.sweep`, `issues.delete`, `issues.batchCreate`,
             `stats.get`, `config.list`, `config.get`, `dependencies.cycles`,
             `dependencies.list`, `dependencies.blocking`, `dependencies.tree`,
@@ -4233,6 +4326,48 @@ components:
             close — including an idempotent re-close — because a caller that
             bypassed the guard is exactly the caller that wants the number. An
             unforced close that got this far had none, so it reports 0.
+
+    ReopenIssueRequest:
+      type: object
+      additionalProperties: false
+      required: [actor]
+      properties:
+        actor:
+          type: string
+          minLength: 1
+          maxLength: 256
+          pattern: '^[^\u0000-\u001F\u007F-\u009F\u2028\u2029]+$'
+          description: >-
+            Who is reopening the issue. `ClaimRequest.actor`'s rules exactly:
+            the server trims it, then refuses an empty result, anything longer
+            than 256 BYTES (the `maxLength` above counts characters — the byte
+            limit is the binding one), and any control character including
+            newline. The value reaches the `reopened` event's attribution and
+            the storage commit message, so an unvalidated newline would forge
+            audit-trail lines.
+        reason:
+          type: string
+          maxLength: 255
+          description: >-
+            Why the issue is being reopened. Recorded on the `reopened` EVENT
+            this move records — not on a field of the issue, and not carried in
+            the response, so a caller that wants it back reads the issue's
+            events. Refused for control characters, and bounded by what the
+            column holds rather than by the number above.
+
+    ReopenIssueResponse:
+      type: object
+      required: [issue, already_open]
+      properties:
+        issue:
+          $ref: '#/components/schemas/Issue'
+        already_open:
+          type: boolean
+          description: >-
+            True when the issue was not in a done status and this call changed
+            nothing — idempotent, mirroring `CloseIssueResponse.already_closed`
+            and `ClaimResponse.already_claimed`. The response still carries the
+            row.
 
     Problem:
       type: object


### PR DESCRIPTION
## Stack position

**PR 2 of 3** in the v0 write-lifecycle series. Base: `lifecycle-close`.

```
main
└── lifecycle-close (#5423)
    └── lifecycle-reopen (#5417)   ← this PR
        └── lifecycle-update (#5422)
```

#5410 has merged, so the stack now sits on `main`; the close PR was recreated as #5423 when GitHub closed #5416 along with its deleted base branch.

`reopenIssue` goes third overall and second among the writes, because it is **near-trivial on the dispatcher the close just built** — a third row on the shared wildcard is a row — and because it **completes the lifecycle pair** the document describes it as ("it is `POST /v0/beads/issues/{id}:close`'s mirror, and it completes the lifecycle pair so a recovery flow works end to end over this surface"). Landing it immediately after close is what keeps the dispatcher's second consumer honest while the design is still fresh: `TestCloseAndReopenAreDistinctOnOnePattern` is a test that could not exist before this PR.

> Review only the top commit; the parent is #5423.

## What lands

`POST /v0/beads/issues/{id}:reopen` — spec, `routeTable` row, `operationCodes` row, handler and tests together. No new routing machinery and no new codes.

### The absence of a 409 is the design statement

Close has a policy guard — open children, a live blocker — because it moves an issue **into** the done category. Reopen moves it **out**, so there is no state of the graph that can refuse it and nothing to name.

`TestReopenPublishesNoConflictCode` asserts that as an invariant rather than leaving it as the incidental current shape of a table, so a future change that gives reopen a guard has to land its code deliberately rather than discovering it needs one.

### Idempotency, and where the reason lives

`already_open` is `!result.Changed`, mirroring `already_closed` and `already_claimed`: a reopen of a non-done issue changes nothing and succeeds, because an agent replaying its own recovery should not have to classify an error to learn it already ran.

The `reason` is recorded on the `reopened` **event** rather than on a field of the issue — the role's own contract — and the response deliberately does not carry it, so a client reads it back from the place it actually lives. A test asserts the response does *not* publish it, because publishing it would tell clients to read it from the wrong place.

The body refuses the close's `session` and `force` **by name**. They are the neighbouring operation's members, and a client that sends them here is told so rather than having them silently ignored.

### Provenance

The handler names the history entry (`ReopenRequest.Provenance`) instead of taking the role's default. The implementations disagree about that default — the store-backed ones write `bd: reopen issue`, the unit-of-work one writes `reopen issue` — so a workspace served by one backend today and another tomorrow would grow two spellings of one event. Not wire-visible.

## Gates

- `go test ./internal/httpapi/` — green, including all parity tests
- `TestProxiedServerServeLifecycle` and `TestServerModeServe` — green (`BEADS_TEST_PROXIED_SERVER=1`). This commit adds `issues.reopen` to the single `servedCapabilities` list #5423 introduces, so the commit stays self-contained.
- `make api-check` — green (types regenerated from the spec in the same commit)
- `make ci-pr-lint` — green (gofmt, golangci-lint, golangci-lint windows: 0 issues)
- Red/green observed. The initial run of this branch failed `TestCustomMethodsNarrowThePOSTSurface//v0/beads/issues/bd-1:reopen` — that path was a *negative* case in PR 1 ("a verb this build does not serve") and is now served, which is the surface-widening this PR performs, caught by the test written to catch it. Two mutations confirm the new tests bite: blanking the provenance fails `TestReopenNamesItsHistoryEntry`, and setting the reopen row's `customMethod` to `:close` fails the whole reopen suite plus `TestCustomMethodRowsDeclareTheirDocumentedPath`.

## Retained real-dependency proof

`TestProxiedServerServeClose` grows the round trip the close operation's own description promises — "the stored pair keeps what the first close gave it until a reopen clears both" — against real Dolt:

- **close → reopen**: `close_reason` and `closed_by_session` are **cleared** — which is what makes the close's first-close-wins rule survivable, since the way to write a new reason is to reopen and close again
- the reopen **reason read back off the issue's event stream** via `bd history --events`, proving the document's claim about where it lands
- the issue is **claimable again**, which is the recovery flow the pair exists to serve
- the idempotent reopen of an issue that was never done

## Deviations from the published spec

None. `internal/httpapi/spec/openapi.v0.yaml` and the handler land in the same commit, and `make api-check` plus the parity tests hold them together.

`ExpectedVersion` stays unpublished here for the reason #5423 gives: `issueops.ErrVersionMismatch` has no entry in `problem.go`'s classification, so an `expected_version` member would render its own refusal as `500 internal`, and the status+code pair it needs is a one-way door (`bd-serve-v0.md`, "The error-code vocabulary") that `TestSpecStatusCodesMatchHandlerTable` forces to be admitted deliberately. Reopen publishing nothing new here is the same restraint `TestReopenPublishesNoConflictCode` pins above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


