### PR TITLE
feat(httpapi): serve updateIssue over v0

### DIFF
--- a/cmd/bd/serve_proxied_integration_test.go
+++ b/cmd/bd/serve_proxied_integration_test.go
@@ -147,6 +147,7 @@ var servedCapabilities = []any{
 	"dependencies.blocking", "dependencies.cycles", "dependencies.list", "dependencies.tree",
 	"issues.batchCreate", "issues.claim", "issues.close", "issues.delete",
 	"issues.get", "issues.list", "issues.query", "issues.reopen", "issues.sweep",
+	"issues.update",
 	"memories.forget", "memories.get", "memories.list", "memories.remember",
 	"ready.count", "ready.list", "stats.get",
 }

--- a/cmd/bd/serve_update_proxied_integration_test.go
+++ b/cmd/bd/serve_update_proxied_integration_test.go
@@ -1,0 +1,250 @@
+//go:build cgo
+
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// End-to-end for the field update, against real Dolt through a real `bd serve`
+// subprocess. The pure tests in internal/httpapi cover the wire edge on a fake
+// role and assert the projection onto issueops.IssuePatch field by field; what
+// only this level can prove is that the projection LANDS — that a set member, a
+// null-cleared member and an untouched member all end up in the row the way the
+// document says, and that a same-value resend really is a no-op against a store
+// rather than against a fake's bookkeeping.
+
+// updateIssue patches id and returns the status and decoded body.
+func (sp *serveProcess) updateIssue(t *testing.T, id, body string) (int, map[string]any) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPatch, sp.url("/v0/beads/issues/"+id), strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("new update request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := sp.client.Do(req)
+	if err != nil {
+		t.Fatalf("PATCH %s: %v\nstderr:\n%s", id, err, sp.stderr.String())
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read update body: %v", err)
+	}
+	var m map[string]any
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &m); err != nil {
+			t.Fatalf("decode update body %q: %v", raw, err)
+		}
+	}
+	return resp.StatusCode, m
+}
+
+func TestProxiedServerServeUpdate(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+	p := newSharedProxiedProject(t, bd, "srvupd")
+	sp := startServe(t, bd, p.dir, bdProxiedEnv(p.dir))
+
+	// THE THREE-WAY PROOF the spec names: one issue carrying a SET member, a
+	// NULL-CLEARED member and an UNTOUCHED member, read back after the PATCH.
+	// A fake role can report what it was handed; only a real row can show that
+	// "absent means untouched" is a property of the write rather than of the
+	// handler's bookkeeping.
+	t.Run("a set member, a cleared member and an untouched member", func(t *testing.T) {
+		issue := bdProxiedCreate(t, bd, p.dir, "before", "-p", "3",
+			"-d", "the original description", "--acceptance", "the original criteria")
+
+		// Give it something to clear and something to leave alone.
+		if _, err := bdProxiedRun(t, bd, p.dir, "update", issue.ID, "--external-ref", "JIRA-1"); err != nil {
+			t.Fatalf("bd update --external-ref: %v", err)
+		}
+		seeded := bdProxiedShow(t, bd, p.dir, issue.ID)
+		if seeded.ExternalRef == nil || *seeded.ExternalRef != "JIRA-1" {
+			t.Fatalf("external_ref did not seed: %v", seeded.ExternalRef)
+		}
+
+		status, body := sp.updateIssue(t, issue.ID, `{"actor":"http-agent","patch":{
+			"title":"after",
+			"priority":1,
+			"external_ref":null
+		}}`)
+		if status != http.StatusOK {
+			t.Fatalf("status = %d, want 200: %v", status, body)
+		}
+		if body["changed"] != true {
+			t.Errorf("changed = %v, want true", body["changed"])
+		}
+
+		after := bdProxiedShow(t, bd, p.dir, issue.ID)
+		// SET: the two members the patch carried.
+		if after.Title != "after" {
+			t.Errorf("title = %q, want the patched value", after.Title)
+		}
+		if after.Priority != 1 {
+			t.Errorf("priority = %d, want the patched 1", after.Priority)
+		}
+		// NULL-CLEARED: the member the patch sent as null.
+		if after.ExternalRef != nil && *after.ExternalRef != "" {
+			t.Errorf("external_ref = %q, want it cleared by the explicit null", *after.ExternalRef)
+		}
+		// UNTOUCHED: the members the patch never mentioned. This is the half a
+		// handler that filled the whole struct from a decoded body would blank.
+		if after.Description != "the original description" {
+			t.Errorf("description = %q; an absent member must leave the field untouched", after.Description)
+		}
+		if after.AcceptanceCriteria != "the original criteria" {
+			t.Errorf("acceptance_criteria = %q; an absent member must leave the field untouched", after.AcceptanceCriteria)
+		}
+		if string(after.Status) != "open" {
+			t.Errorf("status = %q; this operation cannot edit status at all", after.Status)
+		}
+	})
+
+	// The idempotency half: a same-value resend is a 200 with changed:false, and
+	// the row is unchanged.
+	t.Run("a same-value resend reports changed false", func(t *testing.T) {
+		issue := bdProxiedCreate(t, bd, p.dir, "idempotent", "-p", "2")
+
+		status, body := sp.updateIssue(t, issue.ID, `{"actor":"http-agent","patch":{"title":"renamed"}}`)
+		if status != http.StatusOK {
+			t.Fatalf("first update: status = %d, want 200: %v", status, body)
+		}
+		if body["changed"] != true {
+			t.Errorf("changed = %v, want true on the first write", body["changed"])
+		}
+
+		status, body = sp.updateIssue(t, issue.ID, `{"actor":"http-agent","patch":{"title":"renamed"}}`)
+		if status != http.StatusOK {
+			t.Fatalf("resend: status = %d, want 200: %v", status, body)
+		}
+		if body["changed"] != false {
+			t.Errorf("changed = %v, want false for a same-value patch", body["changed"])
+		}
+		if shown := bdProxiedShow(t, bd, p.dir, issue.ID); shown.Title != "renamed" {
+			t.Errorf("title = %q after the resend", shown.Title)
+		}
+	})
+
+	// Labels are COMPLETE REPLACEMENT, which is the one member whose semantics a
+	// client cannot infer from the field name.
+	t.Run("labels are replaced wholesale", func(t *testing.T) {
+		issue := bdProxiedCreate(t, bd, p.dir, "labelled", "-p", "2", "--label", "keep", "--label", "drop")
+
+		status, body := sp.updateIssue(t, issue.ID, `{"actor":"http-agent","patch":{"labels":["keep","added"]}}`)
+		if status != http.StatusOK {
+			t.Fatalf("status = %d, want 200: %v", status, body)
+		}
+		after := bdProxiedShow(t, bd, p.dir, issue.ID)
+		got := map[string]bool{}
+		for _, l := range after.Labels {
+			got[l] = true
+		}
+		if !got["keep"] || !got["added"] {
+			t.Errorf("labels = %v, want the replacement set", after.Labels)
+		}
+		if got["drop"] {
+			t.Errorf("labels = %v; replacement must remove a label the request omitted", after.Labels)
+		}
+	})
+
+	// The rule-8 oracle against `bd update --json`[0], the claim's device: both
+	// surfaces marshal the same canonical struct, so the allowlist is empty.
+	t.Run("the updated issue matches bd update --json element 0", func(t *testing.T) {
+		issue := bdProxiedCreate(t, bd, p.dir, "parity oracle", "-p", "1",
+			"-d", "described", "--acceptance", "accepted", "--label", "oracle")
+
+		status, body := sp.updateIssue(t, issue.ID, `{"actor":"parity-agent","patch":{"title":"patched by http"}}`)
+		if status != http.StatusOK {
+			t.Fatalf("status = %d, want 200: %v", status, body)
+		}
+		fromHTTP, ok := body["issue"].(map[string]any)
+		if !ok {
+			t.Fatalf("issue = %#v, want an object", body["issue"])
+		}
+
+		// A same-value update through the CLI writes nothing and reports the
+		// same row, so both sides describe one post-state snapshot.
+		fromCLI := bdProxiedUpdateOneRaw(t, bd, p.dir, issue.ID, "--title", "patched by http")
+		if diff := diffJSONObjects(fromHTTP, fromCLI, nil); diff != "" {
+			t.Errorf("UpdateIssueResponse.issue and `bd update --json`[0] disagree:\n%s", diff)
+		}
+	})
+
+	t.Run("unknown ids are 404 and refused bodies write nothing", func(t *testing.T) {
+		status, body := sp.updateIssue(t, "bd-nosuchissue", `{"actor":"http-agent","patch":{"title":"t"}}`)
+		if status != http.StatusNotFound {
+			t.Fatalf("unknown id: status = %d, want 404: %v", status, body)
+		}
+		if body["code"] != "not_found" {
+			t.Errorf("code = %v, want not_found", body["code"])
+		}
+
+		issue := bdProxiedCreate(t, bd, p.dir, "never patched", "-p", "2", "-d", "untouched")
+		for _, refused := range []string{
+			`{"actor":"   ","patch":{"title":"t"}}`,
+			`{"actor":"agent","patch":{}}`,
+			`{"actor":"agent","patch":{"status":"closed"}}`,
+			`{"actor":"agent","patch":{"assignee":"mallory"}}`,
+			`{"actor":"agent","patch":{"title":null}}`,
+			`{"actor":"agent","patch":{"priority":9}}`,
+			`{"actor":"agent","patch":{"notes":"a","append_notes":"b"}}`,
+		} {
+			status, problem := sp.updateIssue(t, issue.ID, refused)
+			if status != http.StatusBadRequest {
+				t.Fatalf("body %.50q: status = %d, want 400: %v", refused, status, problem)
+			}
+			if problem["code"] != "invalid_argument" {
+				t.Errorf("body %.50q: code = %v, want invalid_argument", refused, problem["code"])
+			}
+		}
+
+		// The refusals are wire-edge refusals: nothing reached the database.
+		after := bdProxiedShow(t, bd, p.dir, issue.ID)
+		if after.Title != "never patched" || after.Description != "untouched" ||
+			string(after.Status) != "open" || after.Assignee != "" {
+			t.Errorf("a refused update wrote to the row: %+v", after)
+		}
+	})
+
+	// The workspace's own vocabulary is the role's question, and the document
+	// promises its refusal as a 400 rather than letting it fall through to a 500.
+	t.Run("a value this workspace refuses is a 400", func(t *testing.T) {
+		issue := bdProxiedCreate(t, bd, p.dir, "typed", "-p", "2")
+
+		status, body := sp.updateIssue(t, issue.ID,
+			`{"actor":"http-agent","patch":{"issue_type":"not-a-configured-type"}}`)
+		if status != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400: %v", status, body)
+		}
+		if body["code"] != "invalid_argument" {
+			t.Errorf("code = %v, want invalid_argument", body["code"])
+		}
+		if shown := bdProxiedShow(t, bd, p.dir, issue.ID); string(shown.IssueType) == "not-a-configured-type" {
+			t.Error("the refused issue_type was written anyway")
+		}
+	})
+
+	// The lifecycle operations and the patch share one path under different
+	// methods. A PATCH must never execute as one of them.
+	t.Run("a patch is never a lifecycle verb", func(t *testing.T) {
+		issue := bdProxiedCreate(t, bd, p.dir, "not a close", "-p", "2")
+
+		// The custom-method segment under PATCH addresses an issue whose id is
+		// literally "<id>:close", which no row holds.
+		status, body := sp.updateIssue(t, issue.ID+":close", `{"actor":"http-agent","patch":{"title":"t"}}`)
+		if status != http.StatusNotFound {
+			t.Fatalf("PATCH a custom-method segment: status = %d, want 404: %v", status, body)
+		}
+		if shown := bdProxiedShow(t, bd, p.dir, issue.ID); string(shown.Status) != "open" {
+			t.Errorf("a PATCH executed as a close: status %q", shown.Status)
+		}
+	})
+
+	sp.shutdown(t)
+}

--- a/internal/httpapi/apigen/types.gen.go
+++ b/internal/httpapi/apigen/types.gen.go
@@ -243,7 +243,7 @@ type ContextResponse struct {
 	// BeadsDir Absolute path of the served workspace's `.beads` directory. A host path, kept because it is the single-workspace server's only workspace-identity handshake; disclosing it to network peers is part of what an operator accepts when binding beyond loopback.
 	BeadsDir string `json:"beads_dir"`
 
-	// Capabilities The operations this server actually implements, derived from its route table. v0's vocabulary is `ready.list`, `ready.count`, `issues.list`, `issues.query`, `issues.get`, `issues.claim`, `issues.close`, `issues.reopen`, `issues.sweep`, `issues.delete`, `issues.batchCreate`, `stats.get`, `config.list`, `config.get`, `dependencies.cycles`, `dependencies.list`, `dependencies.blocking`, `dependencies.tree`, `memories.list`, `memories.get`, `memories.remember`, `memories.forget`; it grows additively, and an operation never appears here unless it is fully implemented. This is how a client checks for an operation — never the version string.
+	// Capabilities The operations this server actually implements, derived from its route table. v0's vocabulary is `ready.list`, `ready.count`, `issues.list`, `issues.query`, `issues.get`, `issues.claim`, `issues.close`, `issues.reopen`, `issues.update`, `issues.sweep`, `issues.delete`, `issues.batchCreate`, `stats.get`, `config.list`, `config.get`, `dependencies.cycles`, `dependencies.list`, `dependencies.blocking`, `dependencies.tree`, `memories.list`, `memories.get`, `memories.remember`, `memories.forget`; it grows additively, and an operation never appears here unless it is fully implemented. This is how a client checks for an operation — never the version string.
 	Capabilities []string `json:"capabilities"`
 
 	// Database Logical database name (not a host or a DSN).
@@ -380,6 +380,43 @@ type IssueBlocking = issueops.IssueBlocking
 
 // IssueDetails An `Issue` with its labels, dependency edges and cardinalities — the body of `GET /v0/beads/issues/{id}`. `dependencies` and `dependents` carry FULL issue objects plus the edge type, not bare edges. Property semantics are documented on `Issue`.
 type IssueDetails = types.IssueDetails
+
+// IssuePatchBody The fields to write. Every member is optional and PRESENCE is the signal: a member present is written, a member absent is untouched. An empty object is a `400` — a write that writes nothing is a client bug.
+//
+// This is a deliberate SUBSET of the fields an issue carries; the members it does not spell are future surface rather than oversights, and `updateIssue`'s own description says which and why.
+type IssuePatchBody struct {
+	AcceptanceCriteria *string `json:"acceptance_criteria,omitempty"`
+
+	// AppendNotes Appends to the notes rather than replacing them. Mutually exclusive with `notes`.
+	AppendNotes *string `json:"append_notes,omitempty"`
+
+	// DeferUntil RFC 3339. Explicit `null` CLEARS the deferral.
+	DeferUntil  *time.Time `json:"defer_until,omitempty"`
+	Description *string    `json:"description,omitempty"`
+	Design      *string    `json:"design,omitempty"`
+
+	// DueAt RFC 3339. Explicit `null` CLEARS the due date.
+	DueAt *time.Time `json:"due_at,omitempty"`
+
+	// EstimatedMinutes Explicit `null` CLEARS the estimate.
+	EstimatedMinutes *int `json:"estimated_minutes,omitempty"`
+
+	// ExternalRef Explicit `null` CLEARS the reference.
+	ExternalRef *string `json:"external_ref,omitempty"`
+
+	// IssueType The issue type, from this workspace's own configured vocabulary. A type outside it is refused by the ROLE and reaches the client as a `400` — this server cannot read the vocabulary without a transaction, so it checks only what this schema declares.
+	IssueType *string `json:"issue_type,omitempty"`
+
+	// Labels COMPLETE REPLACEMENT of the label set. An empty array clears every label. Incremental add/remove is deferred: replacement is the only shape whose result the client already knows without a read-back.
+	Labels *[]string `json:"labels,omitempty"`
+
+	// Notes Replaces the notes. Mutually exclusive with `append_notes`; sending both is a `400`.
+	Notes    *string `json:"notes,omitempty"`
+	Priority *int    `json:"priority,omitempty"`
+
+	// Title The issue's title. Must not be blank after trimming; the length bound is what the column holds.
+	Title *string `json:"title,omitempty"`
+}
 
 // IssueWithCounts An `Issue` plus relationship cardinalities. This is the element type of both `/v0/beads/ready` and `/v0/beads/issues`, matching what `bd ready --json` and `bd list --json` emit. Property semantics are documented on `Issue`.
 type IssueWithCounts = types.IssueWithCounts
@@ -667,6 +704,26 @@ type SweepSkips struct {
 //
 // The tree is FLAT. A node's place in it is read from `depth` and `parent_id`, not from nesting, and a subtree is contiguous in `items`.
 type TreeNode = types.TreeNode
+
+// UpdateIssueRequest defines model for UpdateIssueRequest.
+type UpdateIssueRequest struct {
+	// Actor Who is editing the issue. `ClaimRequest.actor`'s rules exactly: the server trims it, then refuses an empty result, anything longer than 256 BYTES (the `maxLength` above counts characters — the byte limit is the binding one), and any control character including newline. The value reaches the history entry's attribution and the storage commit message, so an unvalidated newline would forge audit-trail lines.
+	Actor string `json:"actor"`
+
+	// Patch The fields to write. Every member is optional and PRESENCE is the signal: a member present is written, a member absent is untouched. An empty object is a `400` — a write that writes nothing is a client bug.
+	//
+	// This is a deliberate SUBSET of the fields an issue carries; the members it does not spell are future surface rather than oversights, and `updateIssue`'s own description says which and why.
+	Patch IssuePatchBody `json:"patch"`
+}
+
+// UpdateIssueResponse defines model for UpdateIssueResponse.
+type UpdateIssueResponse struct {
+	// Changed Whether the request persisted a semantic mutation. A same-value patch is a 200 with `changed: false` rather than an error — idempotent, like every replay answer on this surface.
+	Changed bool `json:"changed"`
+
+	// Issue A tracked work item. Property semantics documented here apply to every schema that repeats them below.
+	Issue Issue `json:"issue"`
+}
 
 // IssueID defines model for IssueID.
 type IssueID = string
@@ -983,6 +1040,9 @@ type GetStatsParams struct {
 	// IGNORED when `assignee` is set: that answer computes both numbers by a route with no fast path, and it is not an error to ask.
 	SkipBlocked *bool `form:"skip_blocked,omitempty" json:"skip_blocked,omitempty"`
 }
+
+// UpdateIssueJSONRequestBody defines body for UpdateIssue for application/json ContentType.
+type UpdateIssueJSONRequestBody = UpdateIssueRequest
 
 // ClaimIssueJSONRequestBody defines body for ClaimIssue for application/json ContentType.
 type ClaimIssueJSONRequestBody = ClaimRequest

--- a/internal/httpapi/close_test.go
+++ b/internal/httpapi/close_test.go
@@ -426,10 +426,16 @@ func TestCloseErrorsMapThroughTheSharedClassification(t *testing.T) {
 
 // TestCloseIsNotReachableByOtherMethods: the dispatcher is registered for POST
 // alone, so the documented path under any other method is an unrouted path.
+//
+// PATCH is excluded and has its own test below. `PATCH /v0/beads/issues/{id}`
+// is a documented operation on a single-segment wildcard, so it MATCHES this
+// path — as an update of an issue whose id happens to be "bd-1:close". That is
+// the detail path's long-standing behavior (GET has always answered the same
+// way), and what matters is that it never executes as a close.
 func TestCloseIsNotReachableByOtherMethods(t *testing.T) {
 	ts := newCloseServer(t, &roleLifecycle{})
 
-	for _, method := range []string{http.MethodGet, http.MethodPut, http.MethodPatch, http.MethodDelete} {
+	for _, method := range []string{http.MethodGet, http.MethodPut, http.MethodDelete} {
 		req, err := http.NewRequest(method, ts.base+closePath, strings.NewReader(`{"actor":"alice"}`))
 		if err != nil {
 			t.Fatalf("new %s request: %v", method, err)

--- a/internal/httpapi/problem.go
+++ b/internal/httpapi/problem.go
@@ -172,7 +172,12 @@ const (
 	// OpReopenIssue is the close's mirror, and it completes the lifecycle pair
 	// so a recovery flow works end to end over this surface. It is the one
 	// write here with no conflict code: reopen has no policy guard.
-	OpReopenIssue          = "reopenIssue"
+	OpReopenIssue = "reopenIssue"
+	// OpUpdateIssue edits the FIELDS of one issue. Lifecycle is deliberately not
+	// among them: status belongs to close/reopen/claim, which carry the policy
+	// and conflict vocabulary, and assignee belongs to the claim's
+	// compare-and-set. Keeping both out is why this operation has no 409.
+	OpUpdateIssue          = "updateIssue"
 	OpListSettings         = "listSettings"
 	OpGetSetting           = "getSetting"
 	OpListDependencyCycles = "listDependencyCycles"
@@ -321,6 +326,15 @@ var operationCodes = map[string][]Code{
 	// of the graph that can refuse it and nothing to name. The idempotent case
 	// is a 200 carrying `already_open`, not a conflict.
 	OpReopenIssue: {
+		CodeInvalidArgument, CodeNotFound,
+		CodeBusy, CodeDBUnavailable, CodeInternal,
+	},
+	// No conflict code, and the excluded members are exactly where one would
+	// have entered: `status` would drag in close policy, `assignee` the claim
+	// fence, `parent_id` the graph vocabulary. The 400 is the body vocabulary
+	// plus the ROLE's ErrValidation — a workspace-vocabulary issue_type, a
+	// field-length refusal that slipped the edge check — through failUpdate.
+	OpUpdateIssue: {
 		CodeInvalidArgument, CodeNotFound,
 		CodeBusy, CodeDBUnavailable, CodeInternal,
 	},

--- a/internal/httpapi/roles.go
+++ b/internal/httpapi/roles.go
@@ -93,11 +93,10 @@ func (c checkedBatchCreator) CreateBatch(ctx context.Context, req issueops.Creat
 
 // checkedLifecycle is the lifecycle role every mutation handler is handed.
 //
-// Close and Reopen are why it exists: both handlers write *result.Issue, which
-// is checkedClaimer's hazard exactly. Create and Update pass through because no
-// handler on this surface reaches them yet; each grows a guard in the change
-// that publishes its operation, rather than one written speculatively against a
-// body nobody marshals.
+// Update, Close and Reopen are why it exists: all three handlers write
+// *result.Issue, which is checkedClaimer's hazard exactly. Create passes
+// through because no handler on this surface reaches it — a single create is
+// unpublished here, and batchCreateIssues goes to issueops.BatchCreator.
 type checkedLifecycle struct{ inner issueops.Lifecycle }
 
 // Create passes the request through unchanged: this surface publishes no
@@ -106,10 +105,14 @@ func (c checkedLifecycle) Create(ctx context.Context, req issueops.CreateRequest
 	return c.inner.Create(ctx, req)
 }
 
-// Update passes the request through unchanged; updateIssue is not published on
-// this surface yet.
+// Update refuses a result that reports success without the row the response
+// body is built from, for Close's reason.
 func (c checkedLifecycle) Update(ctx context.Context, req issueops.UpdateRequest) (issueops.UpdateResult, error) {
-	return c.inner.Update(ctx, req)
+	result, err := c.inner.Update(ctx, req)
+	if err == nil && result.Issue == nil {
+		return issueops.UpdateResult{}, fmt.Errorf("update %q: the lifecycle reported success without an issue", req.IssueID)
+	}
+	return result, err
 }
 
 // Close refuses a result that reports success without the row the response body

--- a/internal/httpapi/roles_test.go
+++ b/internal/httpapi/roles_test.go
@@ -372,18 +372,35 @@ type roleLifecycle struct {
 	closeErr     error
 	reopenResult issueops.ReopenResult
 	reopenErr    error
+	updateResult issueops.UpdateResult
+	updateErr    error
 
 	mu      sync.Mutex
 	closes  []issueops.CloseRequest
 	reopens []issueops.ReopenRequest
+	updates []issueops.UpdateRequest
 }
 
 func (l *roleLifecycle) Create(_ context.Context, _ issueops.CreateRequest) (issueops.CreateResult, error) {
 	return issueops.CreateResult{}, errors.New("create is not published on this surface")
 }
 
-func (l *roleLifecycle) Update(_ context.Context, _ issueops.UpdateRequest) (issueops.UpdateResult, error) {
-	return issueops.UpdateResult{}, errors.New("update is not published on this surface")
+func (l *roleLifecycle) Update(_ context.Context, req issueops.UpdateRequest) (issueops.UpdateResult, error) {
+	l.mu.Lock()
+	l.updates = append(l.updates, req)
+	l.mu.Unlock()
+	if l.updateErr != nil {
+		return issueops.UpdateResult{}, l.updateErr
+	}
+	return l.updateResult, nil
+}
+
+// updateRequests is closeRequests' twin, and the one the patch tests read the
+// whole projection off: an empty list means nothing reached the role.
+func (l *roleLifecycle) updateRequests() []issueops.UpdateRequest {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]issueops.UpdateRequest(nil), l.updates...)
 }
 
 func (l *roleLifecycle) Close(_ context.Context, req issueops.CloseRequest) (issueops.CloseResult, error) {

--- a/internal/httpapi/routes.go
+++ b/internal/httpapi/routes.go
@@ -204,6 +204,22 @@ var routeTable = []route{
 		handler:     (*Server).handleGetIssue,
 	},
 	{
+		op:     OpUpdateIssue,
+		method: http.MethodPatch,
+		// A PLAIN METHOD on the issue-detail path, not a custom method: partial
+		// update of one named resource is what PATCH already means, exactly as
+		// one named resource with no body is what DELETE means for forgetMemory.
+		//
+		// It therefore registers directly and keeps pattern == specPath. It
+		// cannot collide with the POST dispatcher above — ServeMux registers
+		// method and pattern together — and it leaves the custom-method
+		// namespace for the operations that are not CRUD.
+		pattern:     "/v0/beads/issues/{id}",
+		capability:  "issues.update",
+		implemented: true,
+		handler:     (*Server).handleUpdate,
+	},
+	{
 		op:          OpListSettings,
 		method:      http.MethodGet,
 		pattern:     "/v0/beads/config",
@@ -280,11 +296,12 @@ var routeTable = []route{
 		// drives the documented path.
 		//
 		// The wildcard therefore matches every POST under /v0/beads/issues/,
-		// including the issue-detail path the document declares GET-only.
-		// The dispatcher answers 404 — the same answer the catch-all gives any
-		// other unrouted path — for a segment that ends in no registered
-		// suffix, so the wide pattern stays a routing detail rather than
-		// undocumented surface. TestCustomMethodsNarrowThePOSTSurface pins it.
+		// including the issue-detail path, which this document publishes under
+		// GET and PATCH and under no other method. The dispatcher answers 404 —
+		// the same answer the catch-all gives any other unrouted path — for a
+		// segment that ends in no registered suffix, so the wide pattern stays a
+		// routing detail rather than undocumented surface.
+		// TestCustomMethodsNarrowThePOSTSurface pins it.
 		specPath:     "/v0/beads/issues/{id}:claim",
 		customMethod: ":claim",
 		capability:   "issues.claim",

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -589,7 +589,8 @@ func TestCapabilitiesAdvertiseEveryImplementedOperation(t *testing.T) {
 		"config.get", "config.list", "dependencies.blocking", "dependencies.cycles",
 		"dependencies.list", "dependencies.tree", "issues.batchCreate",
 		"issues.claim", "issues.close", "issues.delete", "issues.get", "issues.list",
-		"issues.query", "issues.reopen", "issues.sweep", "memories.forget", "memories.get",
+		"issues.query", "issues.reopen", "issues.sweep", "issues.update",
+		"memories.forget", "memories.get",
 		"memories.list", "memories.remember", "ready.count", "ready.list",
 		"stats.get",
 	}

--- a/internal/httpapi/spec/openapi.v0.yaml
+++ b/internal/httpapi/spec/openapi.v0.yaml
@@ -1249,6 +1249,130 @@ paths:
         '503':
           $ref: '#/components/responses/Unavailable'
 
+    patch:
+      operationId: updateIssue
+      summary: Edit the fields of one issue
+      description: >-
+        Partial update of one named issue. A plain `PATCH` rather than a custom
+        method, because partial update of one named resource is what `PATCH`
+        already means — exactly as one named resource with no body is what
+        `DELETE` means for `forgetMemory`. The custom-method namespace is left
+        for the operations that are not CRUD.
+
+
+        ## Member presence is the signal
+
+
+        A member PRESENT in `patch` is written; a member ABSENT is left
+        untouched. That is the whole partial-update rule, and it is why an
+        absent member and a member set to its current value are different
+        requests with the same outcome.
+
+
+        Explicit `null` is defined per member. On the four NULLABLE members —
+        `estimated_minutes`, `external_ref`, `due_at`, `defer_until` — it
+        CLEARS the value, because `null` is the only wire spelling a clear has.
+        On every other member it is a `400` naming the member, so a null is
+        never quietly recorded as an empty string.
+
+
+        An EMPTY `patch` object is a `400`: a write that writes nothing is a
+        client bug, the same judgement `issues:batchCreate` makes about an
+        empty `items`.
+
+
+        `labels` is COMPLETE REPLACEMENT. It is the only shape whose result the
+        client already knows without a read-back; an additive
+        `labels_add`/`labels_remove` pair can join the vocabulary later without
+        disturbing it.
+
+
+        `notes` and `append_notes` are mutually exclusive; sending both is a
+        `400`.
+
+
+        ## What this operation deliberately cannot edit
+
+
+        `status` — lifecycle is `{id}:close`, `{id}:reopen` and `{id}:claim`,
+        the operations that carry the policy and conflict vocabulary. A status
+        member here would smuggle close policy into this operation's code set
+        and publish two ways to do one thing.
+
+
+        `assignee` — assignment is the claim's compare-and-set territory, and a
+        raw assignee write would need the claim's conflict vocabulary on this
+        operation too. An unclaim/transfer operation is future surface.
+
+
+        `metadata` — its replace/merge/set/unset algebra deserves its own
+        design pass, not a corner of this one.
+
+
+        Also absent, and additive to publish later: `parent_id` (a set value
+        atomically replaces ALL parents — a graph edit in patch clothing),
+        `persistence` (a plane move is an atomic aggregate migration),
+        `owner` (`assignee`'s argument), `closed_by_session` (written under
+        first-close-wins by `{id}:close`, which a patch write would bypass),
+        and `spec_id`/`await_id` (workflow plumbing this surface publishes
+        nowhere yet). Keeping the first three out is half the reason this
+        operation documents no `409` at all.
+
+
+        ## Planes
+
+
+        The id resolves across BOTH planes, as the close and reopen do. An
+        update whose target is a wisp lands on the unversioned plane and
+        records no durable history entry.
+
+
+        ## Hooks and auto-commit
+
+
+        Hooks do not fire and the per-command auto-commit machinery does not
+        run, exactly as for `POST /v0/beads/issues/{id}:claim`. The only
+        durable effect is the single storage commit the role makes in its own
+        transaction.
+      parameters:
+        - $ref: '#/components/parameters/IssueID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateIssueRequest'
+      responses:
+        '200':
+          description: >-
+            The update was applied. A same-value patch is a 200 with
+            `changed: false`, not an error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateIssueResponse'
+        '400':
+          description: >-
+            Invalid request: an unknown query parameter, an unparseable or
+            oversized body, an unknown body member at either level, an `actor`
+            that is empty after trimming, longer than 256 bytes, or carrying
+            control characters, an empty `patch`, a member carrying the wrong
+            JSON type, an explicit `null` on a member that is not nullable, a
+            value outside its documented bounds, `notes` together with
+            `append_notes` — or a value this workspace's own validation
+            refuses, such as an `issue_type` outside its configured vocabulary.
+          x-bd-codes: [invalid_argument]
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+        '503':
+          $ref: '#/components/responses/Unavailable'
+
   /v0/beads/issues/{id}:claim:
     post:
       operationId: claimIssue
@@ -3370,7 +3494,7 @@ components:
             The operations this server actually implements, derived from its
             route table. v0's vocabulary is `ready.list`, `ready.count`,
             `issues.list`, `issues.query`, `issues.get`, `issues.claim`,
-            `issues.close`, `issues.reopen`,
+            `issues.close`, `issues.reopen`, `issues.update`,
             `issues.sweep`, `issues.delete`, `issues.batchCreate`,
             `stats.get`, `config.list`, `config.get`, `dependencies.cycles`,
             `dependencies.list`, `dependencies.blocking`, `dependencies.tree`,
@@ -4368,6 +4492,117 @@ components:
             nothing — idempotent, mirroring `CloseIssueResponse.already_closed`
             and `ClaimResponse.already_claimed`. The response still carries the
             row.
+
+    UpdateIssueRequest:
+      type: object
+      additionalProperties: false
+      required: [actor, patch]
+      properties:
+        actor:
+          type: string
+          minLength: 1
+          maxLength: 256
+          pattern: '^[^\u0000-\u001F\u007F-\u009F\u2028\u2029]+$'
+          description: >-
+            Who is editing the issue. `ClaimRequest.actor`'s rules exactly: the
+            server trims it, then refuses an empty result, anything longer than
+            256 BYTES (the `maxLength` above counts characters — the byte limit
+            is the binding one), and any control character including newline.
+            The value reaches the history entry's attribution and the storage
+            commit message, so an unvalidated newline would forge audit-trail
+            lines.
+        patch:
+          $ref: '#/components/schemas/IssuePatchBody'
+
+    IssuePatchBody:
+      type: object
+      additionalProperties: false
+      description: >-
+        The fields to write. Every member is optional and PRESENCE is the
+        signal: a member present is written, a member absent is untouched. An
+        empty object is a `400` — a write that writes nothing is a client bug.
+
+
+        This is a deliberate SUBSET of the fields an issue carries; the members
+        it does not spell are future surface rather than oversights, and
+        `updateIssue`'s own description says which and why.
+      properties:
+        title:
+          type: string
+          minLength: 1
+          maxLength: 255
+          description: >-
+            The issue's title. Must not be blank after trimming; the length
+            bound is what the column holds.
+        description:
+          type: string
+        design:
+          type: string
+        acceptance_criteria:
+          type: string
+        notes:
+          type: string
+          description: >-
+            Replaces the notes. Mutually exclusive with `append_notes`; sending
+            both is a `400`.
+        append_notes:
+          type: string
+          description: >-
+            Appends to the notes rather than replacing them. Mutually exclusive
+            with `notes`.
+        priority:
+          type: integer
+          minimum: 0
+          maximum: 4
+        issue_type:
+          type: string
+          maxLength: 255
+          description: >-
+            The issue type, from this workspace's own configured vocabulary. A
+            type outside it is refused by the ROLE and reaches the client as a
+            `400` — this server cannot read the vocabulary without a
+            transaction, so it checks only what this schema declares.
+        labels:
+          type: array
+          items:
+            type: string
+            maxLength: 255
+          description: >-
+            COMPLETE REPLACEMENT of the label set. An empty array clears every
+            label. Incremental add/remove is deferred: replacement is the only
+            shape whose result the client already knows without a read-back.
+        estimated_minutes:
+          type: integer
+          nullable: true
+          description: 'Explicit `null` CLEARS the estimate.'
+        external_ref:
+          type: string
+          nullable: true
+          maxLength: 255
+          description: 'Explicit `null` CLEARS the reference.'
+        due_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: 'RFC 3339. Explicit `null` CLEARS the due date.'
+        defer_until:
+          type: string
+          format: date-time
+          nullable: true
+          description: 'RFC 3339. Explicit `null` CLEARS the deferral.'
+
+    UpdateIssueResponse:
+      type: object
+      required: [issue, changed]
+      properties:
+        issue:
+          $ref: '#/components/schemas/Issue'
+        changed:
+          type: boolean
+          description: >-
+            Whether the request persisted a semantic mutation. A same-value
+            patch is a 200 with `changed: false` rather than an error —
+            idempotent, like every replay answer on this surface.
 
     Problem:
       type: object

--- a/internal/httpapi/spec_parity_test.go
+++ b/internal/httpapi/spec_parity_test.go
@@ -699,6 +699,87 @@ func TestCloseRequestMembersMatchTheHandler(t *testing.T) {
 	}
 }
 
+// TestUpdateRequestMembersMatchTheHandler is the claim's and the close's gate
+// for the update body, at BOTH of its levels.
+//
+// It matters more here than anywhere else on the surface: `patch` is the widest
+// member list published, and the handler's accepted set is a hand-rolled copy
+// of it because presence has to be observable. A spec revision adding an
+// optional patch member would otherwise leave `make api-check` and every other
+// spec test green while the server refused the newly documented member as
+// unknown_parameter — and the reverse, a member the handler honors that the
+// document never promised, is undisclosed write surface on a mutation.
+func TestUpdateRequestMembersMatchTheHandler(t *testing.T) {
+	doc := loadSpec(t)
+	schemas := mapAt(t, mapAt(t, doc, "components"), "schemas")
+
+	for _, tc := range []struct {
+		schema   string
+		accepted []string
+		goType   reflect.Type
+	}{
+		{"UpdateIssueRequest", updateRequestMembers, reflect.TypeOf(apigen.UpdateIssueRequest{})},
+		{"IssuePatchBody", issuePatchMembers, reflect.TypeOf(apigen.IssuePatchBody{})},
+	} {
+		t.Run(tc.schema, func(t *testing.T) {
+			accepted := map[string]bool{}
+			for _, name := range tc.accepted {
+				accepted[name] = true
+			}
+
+			goFields := jsonTagNames(t, tc.goType)
+			if extra := diff(goFields, accepted); len(extra) > 0 {
+				t.Errorf("generated %s declares members the update handler refuses as unknown: %v\n"+
+					"teach the handler to honor them, or the document promises a member the server turns down", tc.schema, extra)
+			}
+			if missing := diff(accepted, goFields); len(missing) > 0 {
+				t.Errorf("the update handler accepts members %s does not declare: %v", tc.schema, missing)
+			}
+
+			specProps := schemaProperties(t, doc, mapAt(t, schemas, tc.schema))
+			if extra := diff(specProps, accepted); len(extra) > 0 {
+				t.Errorf("the %s schema documents members the update handler refuses: %v", tc.schema, extra)
+			}
+			if missing := diff(accepted, specProps); len(missing) > 0 {
+				t.Errorf("the update handler accepts members the %s schema does not document: %v", tc.schema, missing)
+			}
+		})
+	}
+}
+
+// TestNullablePatchMembersAreExactlyTheDocumentsNullableOnes pins the closed set
+// on which explicit `null` CLEARS rather than refuses.
+//
+// The two sides can drift silently and in the worst direction: a member the
+// document marks nullable but the handler does not would refuse a clear the
+// contract promises, and a member the handler treats as nullable but the
+// document does not would let a null through as an unannounced clear on a field
+// nobody agreed could be cleared.
+func TestNullablePatchMembersAreExactlyTheDocumentsNullableOnes(t *testing.T) {
+	doc := loadSpec(t)
+	schema := mapAt(t, mapAt(t, mapAt(t, doc, "components"), "schemas"), "IssuePatchBody")
+
+	documented := map[string]bool{}
+	for name, raw := range mapAt(t, schema, "properties") {
+		prop, ok := raw.(map[string]any)
+		if !ok {
+			t.Fatalf("property %q is %T, want a mapping", name, raw)
+		}
+		if nullable, _ := prop["nullable"].(bool); nullable {
+			documented[name] = true
+		}
+	}
+
+	if missing := diff(documented, nullablePatchMembers); len(missing) > 0 {
+		t.Errorf("the document marks these patch members nullable and the handler refuses a null on them: %v\n"+
+			"a clear the contract promises would be answered with a 400", missing)
+	}
+	if extra := diff(nullablePatchMembers, documented); len(extra) > 0 {
+		t.Errorf("the handler clears these patch members on an explicit null and the document does not declare them nullable: %v\n"+
+			"that is an unannounced clear on a field nobody agreed could be cleared", extra)
+	}
+}
+
 // TestCustomMethodRowsDeclareTheirDocumentedPath bounds the routing exception
 // from the side TestSpecRouteParity cannot see. That test compares DECLARED
 // spec paths, so it stays green whatever the customMethod field says; the

--- a/internal/httpapi/update.go
+++ b/internal/httpapi/update.go
@@ -1,0 +1,332 @@
+package httpapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/steveyegge/beads/internal/httpapi/apigen"
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/issueops"
+)
+
+const (
+	// updatePatchMember is the member carrying the fields to write. Nesting them
+	// rather than spreading them beside `actor` keeps the patch vocabulary a
+	// closed set that can grow without ever colliding with a request-level
+	// member.
+	updatePatchMember = "patch"
+	// maxUpdateBodyBytes bounds the request body. A patch can carry a
+	// description, a design and acceptance criteria at once, so the claim's
+	// megabyte is too tight and the batch's four is the right order.
+	maxUpdateBodyBytes = 4 << 20
+)
+
+// updateRequestMembers and issuePatchMembers are the document's member lists at
+// each level, refused BY NAME for the reason every other body on this surface
+// is: encoding/json's DisallowUnknownFields reports the offender only inside an
+// error string.
+var (
+	updateRequestMembers = []string{"actor", updatePatchMember}
+	issuePatchMembers    = []string{
+		"title", "description", "design", "acceptance_criteria",
+		"notes", "append_notes", "priority", "issue_type", "labels",
+		"estimated_minutes", "external_ref", "due_at", "defer_until",
+	}
+	// nullablePatchMembers is the closed set on which explicit `null` CLEARS
+	// rather than refuses. They are exactly the members the role models as
+	// Field[*T], because a pointer is the only thing a clear has to write.
+	nullablePatchMembers = map[string]bool{
+		"estimated_minutes": true,
+		"external_ref":      true,
+		"due_at":            true,
+		"defer_until":       true,
+	}
+)
+
+// handleUpdate edits the fields of one issue.
+//
+// It carries the claim's posture verbatim. The actor is caller-ASSERTED
+// provenance for the audit trail and not authenticated identity; hooks do not
+// fire and the per-command auto-commit machinery does not run, exactly as for
+// POST /v0/beads/issues/{id}:claim. The only durable effect is the single
+// storage commit the role makes inside its own transaction.
+//
+// A PLAIN PATCH on the issue-detail path rather than a custom method, so the id
+// arrives from the router's own wildcard and there is no suffix to split. The
+// id bound is this handler's, because it is not on the dispatcher's pattern.
+//
+// PLANES, as for close and reopen: the id resolves across both.
+func (s *Server) handleUpdate(w http.ResponseWriter, r *http.Request) {
+	id, ok := s.updateTarget(w, r)
+	if !ok {
+		return
+	}
+	if !s.requireNoQuery(w, r) {
+		return
+	}
+	if !s.requireJSONContent(w, r) {
+		return
+	}
+	request, ok := s.updateRequest(w, r, id)
+	if !ok {
+		return
+	}
+
+	lifecycle, err := s.lifecycle(r)
+	if err != nil {
+		s.failUpdate(w, r, err)
+		return
+	}
+	result, err := lifecycle.Update(r.Context(), request)
+	if err != nil {
+		s.failUpdate(w, r, err)
+		return
+	}
+	// `changed` is the role's own verbatim: a same-value patch is a 200 with
+	// false, not an error — idempotent, like every replay answer here.
+	writeJSON(w, apigen.UpdateIssueResponse{Issue: *result.Issue, Changed: result.Changed})
+}
+
+// updateTarget reads and bounds the id this operation addresses.
+//
+// The bound is the dispatcher's, applied here because this route is not on the
+// dispatcher's pattern: an id longer than the column, or carrying a control
+// character a percent-escape decoded to, names no row that can exist, and it
+// gets the SAME 404 a real miss gets so a caller cannot map the server's notion
+// of a well-formed id.
+func (s *Server) updateTarget(w http.ResponseWriter, r *http.Request) (string, bool) {
+	id := r.PathValue("id")
+	if id == "" || types.CheckFieldLen("id", id) != nil || strings.ContainsFunc(id, isControlChar) {
+		s.fail(w, r, NotFound())
+		return "", false
+	}
+	return id, true
+}
+
+// updateRequest decodes and validates the body, and reports whether the request
+// may proceed. Every refusal here happens BEFORE any database work.
+func (s *Server) updateRequest(w http.ResponseWriter, r *http.Request, id string) (issueops.UpdateRequest, bool) {
+	members, res := decodeJSONObject(w, r, maxUpdateBodyBytes)
+	if res != nil {
+		s.fail(w, r, *res)
+		return issueops.UpdateRequest{}, false
+	}
+	if offender, unknown := unknownMember(members, updateRequestMembers); unknown {
+		s.failUnknownMember(w, r, offender, updateRequestMembers)
+		return issueops.UpdateRequest{}, false
+	}
+
+	actor, ok := s.bodyActor(w, r, members)
+	if !ok {
+		return issueops.UpdateRequest{}, false
+	}
+	patch, ok := s.issuePatch(w, r, members)
+	if !ok {
+		return issueops.UpdateRequest{}, false
+	}
+
+	// Claim, the force flags and every Expected* precondition stay ZERO:
+	// unpublished on this surface. Publishing a precondition means minting a
+	// frozen conflict code and putting `row_version` on the issue body for
+	// clients to echo, which is its own decision rather than a rider on this.
+	return issueops.UpdateRequest{
+		Actor:      actor,
+		IssueID:    id,
+		Patch:      patch,
+		Provenance: updateProvenance,
+	}, true
+}
+
+// updateProvenance labels the history entry an update records, naming this
+// surface for reopenProvenance's reason: the role's implementations disagree
+// about their own default, so a spelled label is what makes an entry read the
+// same whichever backend answered. Not wire-visible.
+const updateProvenance = "bd serve: update issue"
+
+// issuePatch projects the decoded `patch` member onto the role's IssuePatch.
+//
+// MEMBER PRESENCE IS THE SIGNAL, which is the whole reason the body is decoded
+// as raw members: a member present sets the role's Field, a member absent
+// leaves the field untouched, and the generated struct cannot tell those apart
+// because it models both as a nil pointer. Explicit `null` is a third state
+// this reads directly off the raw bytes — a clear on the four nullable members,
+// and a 400 naming the member everywhere else.
+func (s *Server) issuePatch(w http.ResponseWriter, r *http.Request, members map[string]json.RawMessage) (issueops.IssuePatch, bool) {
+	refuse := func(member, detail string) (issueops.IssuePatch, bool) {
+		s.fail(w, r, InvalidArgument(patchParam(member), ReasonInvalidValue, detail))
+		return issueops.IssuePatch{}, false
+	}
+
+	raw, ok := members[updatePatchMember]
+	if !ok {
+		return refuse("", "`"+updatePatchMember+"` is required")
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil || fields == nil {
+		return refuse("", "`"+updatePatchMember+"` must be a JSON object")
+	}
+	if len(fields) == 0 {
+		// A write that writes nothing is a client bug, not a no-op to answer —
+		// the batch-create empty-items judgement, applied to a patch.
+		return refuse("", "`"+updatePatchMember+"` must carry at least one field; an update that updates nothing is refused rather than answered")
+	}
+	if offender, unknown := unknownMember(fields, issuePatchMembers); unknown {
+		s.failUnknownMember(w, r, patchParam(offender), issuePatchMembers)
+		return issueops.IssuePatch{}, false
+	}
+
+	// Explicit null, before any typed decode: unmarshaling null into *T yields
+	// nil, which is indistinguishable from the member being absent, so a null on
+	// a non-nullable member would otherwise slide through as "untouched" — a
+	// write the client asked for and the server silently dropped.
+	for name, value := range fields {
+		if isJSONNull(value) && !nullablePatchMembers[name] {
+			return refuse(name, "`"+name+"` is not nullable; omit it to leave the field unchanged")
+		}
+	}
+
+	// The typed decode, which is what makes a member's type the DOCUMENT's
+	// type: `priority: "high"` is refused here rather than reaching a role that
+	// would have to guess what the caller meant.
+	var wire apigen.IssuePatchBody
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		return refuse("", "a `"+updatePatchMember+"` member carries the wrong JSON type")
+	}
+
+	patch := issueops.IssuePatch{}
+	set := func(name string) bool { _, present := fields[name]; return present }
+
+	if set("title") {
+		title := *wire.Title
+		if strings.TrimSpace(title) == "" {
+			return refuse("title", "`title` must not be blank")
+		}
+		if types.CheckFieldLen("title", title) != nil {
+			return refuse("title", fmt.Sprintf("`title` is %d characters; storage holds at most %d",
+				utf8.RuneCountInString(title), types.MaxFieldLen))
+		}
+		patch.Title = issueops.Field[string]{Set: true, Value: title}
+	}
+	if set("description") {
+		patch.Description = issueops.Field[string]{Set: true, Value: *wire.Description}
+	}
+	if set("design") {
+		patch.Design = issueops.Field[string]{Set: true, Value: *wire.Design}
+	}
+	if set("acceptance_criteria") {
+		patch.AcceptanceCriteria = issueops.Field[string]{Set: true, Value: *wire.AcceptanceCriteria}
+	}
+	// The role refuses both together too, but refusing here keeps the 400 a
+	// statement about the request rather than a translated storage error.
+	if set("notes") && set("append_notes") {
+		return refuse("append_notes", "`notes` replaces the notes and `append_notes` adds to them; send one")
+	}
+	if set("notes") {
+		patch.Notes = issueops.Field[string]{Set: true, Value: *wire.Notes}
+	}
+	if set("append_notes") {
+		patch.AppendNotes = issueops.Field[string]{Set: true, Value: *wire.AppendNotes}
+	}
+	if set("priority") {
+		priority := *wire.Priority
+		if priority < 0 || priority > 4 {
+			return refuse("priority", fmt.Sprintf("`priority` is %d; the range is 0 to 4", priority))
+		}
+		patch.Priority = issueops.Field[int]{Set: true, Value: priority}
+	}
+	if set("issue_type") {
+		issueType := *wire.IssueType
+		// Only what the SCHEMA declares is checked here. Whether the value is in
+		// this workspace's configured vocabulary is the role's question, and it
+		// cannot be asked without a transaction; failUpdate answers that one.
+		if types.CheckFieldLen("issue_type", issueType) != nil {
+			return refuse("issue_type", fmt.Sprintf("`issue_type` is %d characters; storage holds at most %d",
+				utf8.RuneCountInString(issueType), types.MaxFieldLen))
+		}
+		patch.IssueType = issueops.Field[issueops.IssueType]{Set: true, Value: issueops.IssueType(issueType)}
+	}
+	if set("labels") {
+		labels := *wire.Labels
+		for i, label := range labels {
+			if types.CheckFieldLen("label", label) != nil {
+				return refuse("labels", fmt.Sprintf("`labels[%d]` is %d characters; storage holds at most %d",
+					i, utf8.RuneCountInString(label), types.MaxFieldLen))
+			}
+		}
+		// COMPLETE REPLACEMENT, and an empty array clears every label — which is
+		// why this sets Replace rather than Add.
+		patch.Labels = issueops.LabelPatch{Replace: issueops.Field[[]string]{Set: true, Value: labels}}
+	}
+
+	// The four nullable members. Set is true whenever the member is present;
+	// the VALUE is a nil pointer for an explicit null, which is how a clear
+	// reaches the role.
+	if set("estimated_minutes") {
+		patch.EstimatedMinutes = issueops.Field[*int]{Set: true, Value: wire.EstimatedMinutes}
+	}
+	if set("external_ref") {
+		if ref := wire.ExternalRef; ref != nil && types.CheckFieldLen("external_ref", *ref) != nil {
+			return refuse("external_ref", fmt.Sprintf("`external_ref` is %d characters; storage holds at most %d",
+				utf8.RuneCountInString(*ref), types.MaxFieldLen))
+		}
+		patch.ExternalRef = issueops.Field[*string]{Set: true, Value: wire.ExternalRef}
+	}
+	if set("due_at") {
+		patch.DueAt = issueops.Field[*time.Time]{Set: true, Value: wire.DueAt}
+	}
+	if set("defer_until") {
+		patch.DeferUntil = issueops.Field[*time.Time]{Set: true, Value: wire.DeferUntil}
+	}
+	return patch, true
+}
+
+// isJSONNull reports whether a raw member is the literal `null`.
+func isJSONNull(raw json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(raw), []byte("null"))
+}
+
+// patchParam names a patch member the way a client reads it back off `param`:
+// qualified by the member that carries it, so `patch.title` is unambiguous
+// against a request-level member of the same name.
+func patchParam(member string) string {
+	if member == "" {
+		return updatePatchMember
+	}
+	return updatePatchMember + "." + member
+}
+
+// failUpdate answers a failed update, mapping the role's own validation refusal
+// onto the 400 the document promises.
+//
+// It is failBatchCreate's sibling and follows its rule exactly: the role's
+// ErrValidation is answered HERE rather than in ClassifyError, and NEITHER
+// BRANCH QUOTES THE ROLE'S MESSAGE. A refusal from the workspace's configured
+// vocabulary arrives as prose about statuses and types, and 4xx details on this
+// surface reflect the caller's own input back rather than server internals. The
+// real error goes to the log with the request id.
+//
+// The ErrNotFound check runs FIRST and is the divergence from failBatchCreate:
+// this operation DOES address a resource by path, so an id that names nothing
+// is a genuine 404 rather than a statement about the body.
+func (s *Server) failUpdate(w http.ResponseWriter, r *http.Request, err error) {
+	if errors.Is(err, storage.ErrNotFound) {
+		s.fail(w, r, NotFound())
+		return
+	}
+	if !errors.Is(err, storage.ErrValidation) {
+		s.failErr(w, r, err)
+		return
+	}
+	// The 4xx path does not log by default, so this is the one place the real
+	// refusal is recorded for the operator.
+	s.event("request_refused", "request_id", requestInfo(r.Context()).id, "error", err.Error())
+	s.fail(w, r, InvalidArgument(updatePatchMember, ReasonInvalidValue,
+		"a patch value was refused by this workspace's own validation; nothing was written"))
+}

--- a/internal/httpapi/update_test.go
+++ b/internal/httpapi/update_test.go
@@ -1,0 +1,566 @@
+package httpapi
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/issueops"
+)
+
+// Pure, on a fake ROLE, like the close's and the reopen's. What a fake cannot
+// prove is that a set member, a null-cleared member and an untouched member all
+// land the way this handler says they do in a real row; that is
+// TestProxiedServerServeUpdate against real Dolt.
+
+const updatePath = "/v0/beads/issues/bd-1"
+
+func (ts *testServer) updateIssue(t *testing.T, path, body string) *http.Response {
+	t.Helper()
+	return ts.patchBody(t, path, "application/json", body)
+}
+
+// patchBody is postBody's PATCH twin: this is the first operation on the
+// surface that uses the method, so the helper is new rather than shared.
+func (ts *testServer) patchBody(t *testing.T, path, contentType, body string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPatch, ts.base+path, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	resp, err := ts.client.Do(req)
+	if err != nil {
+		t.Fatalf("PATCH %s: %v", path, err)
+	}
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	return resp
+}
+
+func newUpdateServer(t *testing.T, lifecycle *roleLifecycle) *testServer {
+	t.Helper()
+	return newTestServer(t, rolesConfig(Config{Lifecycle: lifecycle}))
+}
+
+func updatedIssue(id string) *types.Issue {
+	return seededIssue(id, "alice", types.StatusOpen)
+}
+
+// TestUpdateForwardsEveryDocumentedMember walks the whole patch vocabulary in
+// one request and asserts the projection onto the role's IssuePatch field by
+// field. It is the widest body on this surface, and the mapping is where a
+// silent mis-wiring would live.
+func TestUpdateForwardsEveryDocumentedMember(t *testing.T) {
+	lifecycle := &roleLifecycle{updateResult: issueops.UpdateResult{Issue: updatedIssue("bd-1"), Changed: true}}
+	ts := newUpdateServer(t, lifecycle)
+
+	resp := ts.updateIssue(t, updatePath, `{"actor":"alice","patch":{
+		"title":"new title",
+		"description":"new description",
+		"design":"new design",
+		"acceptance_criteria":"new criteria",
+		"notes":"new notes",
+		"priority":3,
+		"issue_type":"bug",
+		"labels":["one","two"],
+		"estimated_minutes":45,
+		"external_ref":"JIRA-7",
+		"due_at":"2026-09-01T12:00:00Z",
+		"defer_until":"2026-08-20T09:30:00Z"
+	}}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+
+	got := lifecycle.updateRequests()
+	if len(got) != 1 {
+		t.Fatalf("the role was called %d times, want 1", len(got))
+	}
+	req := got[0]
+	if req.Actor != "alice" || req.IssueID != "bd-1" {
+		t.Errorf("the role received actor %q id %q", req.Actor, req.IssueID)
+	}
+	// Every precondition and force flag stays zero: unpublished on this surface.
+	if req.Claim || req.ForceAssigneeTransfer || req.ForceClosePolicy ||
+		req.ExpectedVersion != nil || req.ExpectedAssignee != nil || req.ExpectedStatus != nil {
+		t.Errorf("the handler published a precondition or force flag: %+v", req)
+	}
+	if req.IssuePlaneOnly {
+		t.Error("the update narrowed itself to the issue plane; this operation resolves across both")
+	}
+
+	p := req.Patch
+	for _, tc := range []struct {
+		name string
+		set  bool
+		got  any
+		want any
+	}{
+		{"title", p.Title.Set, p.Title.Value, "new title"},
+		{"description", p.Description.Set, p.Description.Value, "new description"},
+		{"design", p.Design.Set, p.Design.Value, "new design"},
+		{"acceptance_criteria", p.AcceptanceCriteria.Set, p.AcceptanceCriteria.Value, "new criteria"},
+		{"notes", p.Notes.Set, p.Notes.Value, "new notes"},
+		{"priority", p.Priority.Set, p.Priority.Value, 3},
+		{"issue_type", p.IssueType.Set, p.IssueType.Value, issueops.IssueType("bug")},
+	} {
+		if !tc.set {
+			t.Errorf("%s: Set is false though the member was present", tc.name)
+			continue
+		}
+		if tc.got != tc.want {
+			t.Errorf("%s = %v, want %v", tc.name, tc.got, tc.want)
+		}
+	}
+
+	// labels is COMPLETE REPLACEMENT, so it must reach Replace and never Add.
+	if !p.Labels.Replace.Set || len(p.Labels.Replace.Value) != 2 {
+		t.Errorf("labels reached Replace as %+v, want the two-element set", p.Labels.Replace)
+	}
+	if len(p.Labels.Add) != 0 || len(p.Labels.Remove) != 0 {
+		t.Errorf("labels reached the incremental edits (%v/%v); the document publishes replacement only", p.Labels.Add, p.Labels.Remove)
+	}
+
+	if !p.EstimatedMinutes.Set || p.EstimatedMinutes.Value == nil || *p.EstimatedMinutes.Value != 45 {
+		t.Errorf("estimated_minutes = %+v, want a set 45", p.EstimatedMinutes)
+	}
+	if !p.ExternalRef.Set || p.ExternalRef.Value == nil || *p.ExternalRef.Value != "JIRA-7" {
+		t.Errorf("external_ref = %+v, want a set JIRA-7", p.ExternalRef)
+	}
+	wantDue := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	if !p.DueAt.Set || p.DueAt.Value == nil || !p.DueAt.Value.Equal(wantDue) {
+		t.Errorf("due_at = %+v, want %v", p.DueAt, wantDue)
+	}
+	wantDefer := time.Date(2026, 8, 20, 9, 30, 0, 0, time.UTC)
+	if !p.DeferUntil.Set || p.DeferUntil.Value == nil || !p.DeferUntil.Value.Equal(wantDefer) {
+		t.Errorf("defer_until = %+v, want %v", p.DeferUntil, wantDefer)
+	}
+}
+
+// TestUpdateLeavesAbsentMembersUntouched is the partial-update rule itself:
+// PRESENCE is the signal, so every member the body did not carry must arrive
+// with Set false. A handler that filled the whole struct from a decoded body
+// would pass every other test in this file and silently blank twelve fields.
+func TestUpdateLeavesAbsentMembersUntouched(t *testing.T) {
+	lifecycle := &roleLifecycle{updateResult: issueops.UpdateResult{Issue: updatedIssue("bd-1"), Changed: true}}
+	ts := newUpdateServer(t, lifecycle)
+
+	resp := ts.updateIssue(t, updatePath, `{"actor":"alice","patch":{"title":"only this"}}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	p := lifecycle.updateRequests()[0].Patch
+	if !p.Title.Set {
+		t.Fatal("title was not set")
+	}
+	for _, tc := range []struct {
+		name string
+		set  bool
+	}{
+		{"description", p.Description.Set},
+		{"design", p.Design.Set},
+		{"acceptance_criteria", p.AcceptanceCriteria.Set},
+		{"notes", p.Notes.Set},
+		{"append_notes", p.AppendNotes.Set},
+		{"priority", p.Priority.Set},
+		{"issue_type", p.IssueType.Set},
+		{"labels", p.Labels.Replace.Set},
+		{"estimated_minutes", p.EstimatedMinutes.Set},
+		{"external_ref", p.ExternalRef.Set},
+		{"due_at", p.DueAt.Set},
+		{"defer_until", p.DeferUntil.Set},
+	} {
+		if tc.set {
+			t.Errorf("%s: Set is true though the member was absent; an absent member must leave the field untouched", tc.name)
+		}
+	}
+	// And the fields this operation does not publish at all stay zero, whatever
+	// the body said — they are not in the accepted set, so they cannot be
+	// reached even by name.
+	if p.Status.Set || p.Assignee.Set || p.Owner.Set || p.ParentID.Set ||
+		p.Persistence.Set || p.ClosedBySession.Set || p.SpecID.Set || p.AwaitID.Set {
+		t.Errorf("an unpublished patch member was set: %+v", p)
+	}
+	if p.Metadata.Replace.Set || p.Metadata.Merge.Set || len(p.Metadata.Set) > 0 || len(p.Metadata.Unset) > 0 {
+		t.Errorf("metadata was reached: %+v", p.Metadata)
+	}
+}
+
+// TestUpdateClearsTheNullableMembers is the other half of the presence rule:
+// explicit null on the four Field[*T] members CLEARS, which on the wire is a
+// SET field carrying a nil pointer. Set false would mean "untouched" and the
+// clear would be silently dropped.
+func TestUpdateClearsTheNullableMembers(t *testing.T) {
+	lifecycle := &roleLifecycle{updateResult: issueops.UpdateResult{Issue: updatedIssue("bd-1"), Changed: true}}
+	ts := newUpdateServer(t, lifecycle)
+
+	resp := ts.updateIssue(t, updatePath, `{"actor":"alice","patch":{
+		"estimated_minutes":null,"external_ref":null,"due_at":null,"defer_until":null
+	}}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	p := lifecycle.updateRequests()[0].Patch
+	if !p.EstimatedMinutes.Set || p.EstimatedMinutes.Value != nil {
+		t.Errorf("estimated_minutes = %+v, want set with a nil value (a clear)", p.EstimatedMinutes)
+	}
+	if !p.ExternalRef.Set || p.ExternalRef.Value != nil {
+		t.Errorf("external_ref = %+v, want set with a nil value (a clear)", p.ExternalRef)
+	}
+	if !p.DueAt.Set || p.DueAt.Value != nil {
+		t.Errorf("due_at = %+v, want set with a nil value (a clear)", p.DueAt)
+	}
+	if !p.DeferUntil.Set || p.DeferUntil.Value != nil {
+		t.Errorf("defer_until = %+v, want set with a nil value (a clear)", p.DeferUntil)
+	}
+}
+
+// TestUpdateRefusesNullOnEveryOtherMember is the claim's null-through-a-pointer
+// rule generalized. Without it, `"title":null` unmarshals to a nil pointer that
+// is indistinguishable from an absent member — a write the client asked for and
+// the server silently dropped.
+func TestUpdateRefusesNullOnEveryOtherMember(t *testing.T) {
+	for _, member := range []string{
+		"title", "description", "design", "acceptance_criteria",
+		"notes", "append_notes", "priority", "issue_type", "labels",
+	} {
+		t.Run(member, func(t *testing.T) {
+			lifecycle := &roleLifecycle{updateResult: issueops.UpdateResult{Issue: updatedIssue("bd-1")}}
+			ts := newUpdateServer(t, lifecycle)
+
+			resp := ts.updateIssue(t, updatePath, fmt.Sprintf(`{"actor":"alice","patch":{%q:null}}`, member))
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
+			}
+			body := decodeBody(t, resp)
+			if body["param"] != "patch."+member {
+				t.Errorf("param = %v, want patch.%s", body["param"], member)
+			}
+			if got := lifecycle.updateRequests(); len(got) != 0 {
+				t.Errorf("a null reached the role: %+v", got)
+			}
+		})
+	}
+}
+
+// TestUpdateIsIdempotentForASameValuePatch: the role's Changed, verbatim. A
+// same-value patch is a 200 with changed:false, not an error.
+func TestUpdateIsIdempotentForASameValuePatch(t *testing.T) {
+	lifecycle := &roleLifecycle{updateResult: issueops.UpdateResult{Issue: updatedIssue("bd-1"), Changed: false}}
+	ts := newUpdateServer(t, lifecycle)
+
+	resp := ts.updateIssue(t, updatePath, `{"actor":"alice","patch":{"title":"claim me"}}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if body := decodeBody(t, resp); body["changed"] != false {
+		t.Errorf("changed = %v, want false for a same-value patch", body["changed"])
+	}
+}
+
+// TestUpdateNamesItsHistoryEntry: the reopen's rule, for the same reason.
+func TestUpdateNamesItsHistoryEntry(t *testing.T) {
+	lifecycle := &roleLifecycle{updateResult: issueops.UpdateResult{Issue: updatedIssue("bd-1"), Changed: true}}
+	ts := newUpdateServer(t, lifecycle)
+
+	if resp := ts.updateIssue(t, updatePath, `{"actor":"alice","patch":{"title":"t"}}`); resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	got := lifecycle.updateRequests()[0]
+	if got.Provenance == "" {
+		t.Fatal("the update carries no provenance, so the history entry reads differently per backend")
+	}
+	if !strings.Contains(got.Provenance, "serve") {
+		t.Errorf("provenance = %q; it is meant to name THIS surface", got.Provenance)
+	}
+}
+
+// TestUpdateRejectsTheShapesTheDocumentRefuses is the body vocabulary. The
+// EXCLUDED members are the important half: status, assignee and metadata are
+// refused by NAME, so a client that tries to smuggle lifecycle through a patch
+// is told what happened rather than having it ignored.
+func TestUpdateRejectsTheShapesTheDocumentRefuses(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		body  string
+		param string
+	}{
+		{"no actor", `{"patch":{"title":"t"}}`, "actor"},
+		{"blank actor", `{"actor":"  ","patch":{"title":"t"}}`, "actor"},
+		{"actor with a newline", "{\"actor\":\"a\\nbd: update\",\"patch\":{\"title\":\"t\"}}", "actor"},
+		{"null actor", `{"actor":null,"patch":{"title":"t"}}`, "actor"},
+		{"no patch", `{"actor":"alice"}`, "patch"},
+		{"null patch", `{"actor":"alice","patch":null}`, "patch"},
+		{"patch is not an object", `{"actor":"alice","patch":["title"]}`, "patch"},
+		{"empty patch", `{"actor":"alice","patch":{}}`, "patch"},
+		{"unknown request member", `{"actor":"alice","patch":{"title":"t"},"force":true}`, "force"},
+		// The three the spec argues out of the vocabulary, refused by name.
+		{"status is not a patch member", `{"actor":"alice","patch":{"status":"closed"}}`, "patch.status"},
+		{"assignee is not a patch member", `{"actor":"alice","patch":{"assignee":"bob"}}`, "patch.assignee"},
+		{"metadata is not a patch member", `{"actor":"alice","patch":{"metadata":{}}}`, "patch.metadata"},
+		{"parent_id is not a patch member", `{"actor":"alice","patch":{"parent_id":"bd-2"}}`, "patch.parent_id"},
+		{"blank title", `{"actor":"alice","patch":{"title":"   "}}`, "patch.title"},
+		{"oversize title", `{"actor":"alice","patch":{"title":"` + strings.Repeat("x", 300) + `"}}`, "patch.title"},
+		{"title is not a string", `{"actor":"alice","patch":{"title":7}}`, "patch"},
+		{"priority below the range", `{"actor":"alice","patch":{"priority":-1}}`, "patch.priority"},
+		{"priority above the range", `{"actor":"alice","patch":{"priority":5}}`, "patch.priority"},
+		{"priority is not a number", `{"actor":"alice","patch":{"priority":"high"}}`, "patch"},
+		{"oversize issue_type", `{"actor":"alice","patch":{"issue_type":"` + strings.Repeat("x", 300) + `"}}`, "patch.issue_type"},
+		{"oversize label", `{"actor":"alice","patch":{"labels":["` + strings.Repeat("x", 300) + `"]}}`, "patch.labels"},
+		{"labels is not an array", `{"actor":"alice","patch":{"labels":"one"}}`, "patch"},
+		{"oversize external_ref", `{"actor":"alice","patch":{"external_ref":"` + strings.Repeat("x", 300) + `"}}`, "patch.external_ref"},
+		{"malformed due_at", `{"actor":"alice","patch":{"due_at":"not a time"}}`, "patch"},
+		{"notes and append_notes together", `{"actor":"alice","patch":{"notes":"a","append_notes":"b"}}`, "patch.append_notes"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lifecycle := &roleLifecycle{updateResult: issueops.UpdateResult{Issue: updatedIssue("bd-1")}}
+			ts := newUpdateServer(t, lifecycle)
+
+			resp := ts.updateIssue(t, updatePath, tc.body)
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
+			}
+			body := decodeBody(t, resp)
+			if body["code"] != string(CodeInvalidArgument) {
+				t.Errorf("code = %v, want %s", body["code"], CodeInvalidArgument)
+			}
+			if body["param"] != tc.param {
+				t.Errorf("param = %v, want %q", body["param"], tc.param)
+			}
+			if got := lifecycle.updateRequests(); len(got) != 0 {
+				t.Errorf("a refused body reached the role: %+v", got)
+			}
+		})
+	}
+}
+
+// TestUpdateAcceptsAnEmptyLabelArrayAsAClear: an empty array is not an empty
+// patch. It is a complete replacement with nothing in it, which is how a client
+// removes every label — so it must reach the role rather than being refused
+// alongside the empty-object case.
+func TestUpdateAcceptsAnEmptyLabelArrayAsAClear(t *testing.T) {
+	lifecycle := &roleLifecycle{updateResult: issueops.UpdateResult{Issue: updatedIssue("bd-1"), Changed: true}}
+	ts := newUpdateServer(t, lifecycle)
+
+	resp := ts.updateIssue(t, updatePath, `{"actor":"alice","patch":{"labels":[]}}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	p := lifecycle.updateRequests()[0].Patch
+	if !p.Labels.Replace.Set || len(p.Labels.Replace.Value) != 0 {
+		t.Errorf("labels = %+v, want a set replacement carrying nothing", p.Labels.Replace)
+	}
+}
+
+// TestUpdateMapsARoleValidationRefusalToTheDocumented400 is failUpdate's
+// reason for existing: the workspace's configured vocabulary is a question this
+// server cannot ask without a transaction, so the role answers it and the 400
+// the document promises has to come from the mapping.
+func TestUpdateMapsARoleValidationRefusalToTheDocumented400(t *testing.T) {
+	lifecycle := &roleLifecycle{updateErr: fmt.Errorf(
+		"%w: issue_type \"epic\" is not configured for this workspace", storage.ErrValidation)}
+	ts := newUpdateServer(t, lifecycle)
+
+	resp := ts.updateIssue(t, updatePath, `{"actor":"alice","patch":{"issue_type":"epic"}}`)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
+	}
+	body := decodeBody(t, resp)
+	if body["code"] != string(CodeInvalidArgument) {
+		t.Errorf("code = %v, want %s", body["code"], CodeInvalidArgument)
+	}
+	// The role's own prose never reaches the client — 4xx details reflect the
+	// caller's input back, not server internals — but the operator gets it.
+	if detail, _ := body["detail"].(string); strings.Contains(detail, "not configured for this workspace") {
+		t.Errorf("the role's message was quoted into the response: %q", detail)
+	}
+	if !strings.Contains(ts.stderr.String(), "request_refused") {
+		t.Errorf("the real refusal was not logged for the operator:\n%s", ts.stderr.String())
+	}
+}
+
+// TestUpdateOfAnAbsentIssueIs404 is failUpdate's other branch, and the
+// divergence from failBatchCreate: this operation DOES address a resource by
+// path, so an id that names nothing is a genuine 404 rather than a statement
+// about the body.
+func TestUpdateOfAnAbsentIssueIs404(t *testing.T) {
+	lifecycle := &roleLifecycle{updateErr: fmt.Errorf("update bd-9: %w", issueops.ErrNotFound)}
+	ts := newUpdateServer(t, lifecycle)
+
+	resp := ts.updateIssue(t, "/v0/beads/issues/bd-9", `{"actor":"alice","patch":{"title":"t"}}`)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if body := decodeBody(t, resp); body["code"] != string(CodeNotFound) {
+		t.Errorf("code = %v, want %s", body["code"], CodeNotFound)
+	}
+}
+
+// TestUpdateRefusesAForeignMediaType and TestUpdateRefusesAQueryParameter: the
+// two document-level rules hold on a PATCH exactly as on a POST.
+func TestUpdateRefusesAForeignMediaType(t *testing.T) {
+	lifecycle := &roleLifecycle{}
+	ts := newUpdateServer(t, lifecycle)
+
+	resp := ts.patchBody(t, updatePath, "text/plain", `{"actor":"alice","patch":{"title":"t"}}`)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if body := decodeBody(t, resp); body["param"] != "Content-Type" {
+		t.Errorf("param = %v, want Content-Type", body["param"])
+	}
+	if got := lifecycle.updateRequests(); len(got) != 0 {
+		t.Errorf("a foreign media type reached the role: %+v", got)
+	}
+}
+
+func TestUpdateRefusesAQueryParameter(t *testing.T) {
+	lifecycle := &roleLifecycle{}
+	ts := newUpdateServer(t, lifecycle)
+
+	resp := ts.updateIssue(t, updatePath+"?force=true", `{"actor":"alice","patch":{"title":"t"}}`)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if body := decodeBody(t, resp); body["reason"] != string(ReasonUnknownParameter) {
+		t.Errorf("reason = %v, want %s", body["reason"], ReasonUnknownParameter)
+	}
+	if got := lifecycle.updateRequests(); len(got) != 0 {
+		t.Errorf("a query string reached the role: %+v", got)
+	}
+}
+
+// TestUpdateRefusesUnrowableIDsBeforeAnyDatabaseWork: the dispatcher's id bound
+// applied here, because this route is NOT on the dispatcher's pattern and would
+// otherwise be the one write on the surface without one.
+func TestUpdateRefusesUnrowableIDsBeforeAnyDatabaseWork(t *testing.T) {
+	for _, tc := range []struct{ name, id string }{
+		{"longer than the column", strings.Repeat("b", types.MaxFieldLen+1)},
+		{"carrying a control character", "bd-1%00"},
+		{"carrying a C1 introducer", "bd-1%C2%9B"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lifecycle := &roleLifecycle{}
+			ts := newUpdateServer(t, lifecycle)
+
+			resp := ts.updateIssue(t, "/v0/beads/issues/"+tc.id, `{"actor":"alice","patch":{"title":"t"}}`)
+			if resp.StatusCode != http.StatusNotFound {
+				t.Fatalf("status = %d, want 404: %s", resp.StatusCode, readAll(t, resp))
+			}
+			if got := lifecycle.updateRequests(); len(got) != 0 {
+				t.Errorf("an unrowable id reached the role: %+v", got)
+			}
+		})
+	}
+}
+
+// TestPatchOnACustomMethodSegmentIsNeverTheCustomMethod is the routing-safety
+// property this operation introduces.
+//
+// `PATCH /v0/beads/issues/{id}` is a single-segment wildcard, so it MATCHES
+// /v0/beads/issues/bd-1:close — which the POST dispatcher would read as a
+// close. The two live on one path under different methods, and what must never
+// happen is a PATCH executing as a lifecycle verb. It is an update of an issue
+// whose id is literally "bd-1:close", which no row holds.
+func TestPatchOnACustomMethodSegmentIsNeverTheCustomMethod(t *testing.T) {
+	for _, segment := range []string{"bd-1:close", "bd-1:reopen", "bd-1:claim"} {
+		t.Run(segment, func(t *testing.T) {
+			lifecycle := &roleLifecycle{updateResult: issueops.UpdateResult{Issue: updatedIssue(segment), Changed: true}}
+			ts := newUpdateServer(t, lifecycle)
+
+			resp := ts.updateIssue(t, "/v0/beads/issues/"+segment, `{"actor":"alice","patch":{"title":"t"}}`)
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+			}
+			// It reached the UPDATE verb, with the whole segment as the id.
+			if got := lifecycle.updateRequests(); len(got) != 1 || got[0].IssueID != segment {
+				t.Fatalf("the role received %+v, want an update of %q", got, segment)
+			}
+			if got := lifecycle.closeRequests(); len(got) != 0 {
+				t.Errorf("a PATCH executed as a close: %+v", got)
+			}
+			if got := lifecycle.reopenRequests(); len(got) != 0 {
+				t.Errorf("a PATCH executed as a reopen: %+v", got)
+			}
+		})
+	}
+}
+
+// TestUpdateRefusesALifecycleThatAnswersWithNothing is
+// checkedLifecycle.Update's reason for existing.
+func TestUpdateRefusesALifecycleThatAnswersWithNothing(t *testing.T) {
+	lifecycle := &roleLifecycle{updateResult: issueops.UpdateResult{Changed: true}}
+	ts := newUpdateServer(t, lifecycle)
+
+	resp := ts.updateIssue(t, updatePath, `{"actor":"alice","patch":{"title":"t"}}`)
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if body := decodeBody(t, resp); body["code"] != string(CodeInternal) {
+		t.Errorf("code = %v, want %s", body["code"], CodeInternal)
+	}
+}
+
+// TestUpdatePathReachesItsHandler drives the documented path and method. It
+// shares its pattern with getIssue and differs only in method, which is the
+// whole argument for the method.
+func TestUpdatePathReachesItsHandler(t *testing.T) {
+	lifecycle := &roleLifecycle{updateResult: issueops.UpdateResult{Issue: updatedIssue("bd-1"), Changed: true}}
+	ts := newUpdateServer(t, lifecycle)
+
+	if resp := ts.updateIssue(t, updatePath, `{"actor":"alice","patch":{"title":"t"}}`); resp.StatusCode != http.StatusOK {
+		t.Fatalf("PATCH the documented path: status = %d, want 200", resp.StatusCode)
+	}
+	line := findLogLine(t, ts.stderr.String(), "method=PATCH")
+	if !strings.Contains(line, "op="+OpUpdateIssue) {
+		t.Errorf("the documented update path is served by another operation:\n%s", line)
+	}
+}
+
+// TestUpdateKeepsItsPatternEqualToItsSpecPath is the argument for PATCH stated
+// as a test: a plain method needs no routing exception, so this row must NOT
+// declare a specPath or a customMethod. A future edit that turned it into a
+// custom method would be a design change, not a refactor.
+func TestUpdateKeepsItsPatternEqualToItsSpecPath(t *testing.T) {
+	for _, rt := range routeTable {
+		if rt.op != OpUpdateIssue {
+			continue
+		}
+		if rt.method != http.MethodPatch {
+			t.Errorf("the update route registers %s, want PATCH", rt.method)
+		}
+		if rt.specPath != "" || rt.customMethod != "" {
+			t.Errorf("the update route declares specPath %q / customMethod %q; a plain method needs neither",
+				rt.specPath, rt.customMethod)
+		}
+		if rt.pattern != "/v0/beads/issues/{id}" {
+			t.Errorf("the update route's pattern is %q, want the issue-detail path", rt.pattern)
+		}
+		if rt.bypassSemaphore {
+			t.Error("the update route bypasses the database semaphore; only handlers that touch no database may")
+		}
+		return
+	}
+	t.Fatalf("no %s row in the route table", OpUpdateIssue)
+}
+
+// TestUpdateResolvesAcrossBothPlanes, as close and reopen do.
+func TestUpdateResolvesAcrossBothPlanes(t *testing.T) {
+	wisp := seededIssue("bd-w1", "alice", types.StatusOpen)
+	lifecycle := &roleLifecycle{updateResult: issueops.UpdateResult{Issue: wisp, Changed: true}}
+	ts := newUpdateServer(t, lifecycle)
+
+	resp := ts.updateIssue(t, "/v0/beads/issues/bd-w1", `{"actor":"alice","patch":{"title":"t"}}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("updating a wisp id: status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if got := lifecycle.updateRequests(); len(got) != 1 || got[0].IssuePlaneOnly {
+		t.Fatalf("the role received %+v, want a both-plane resolve", got)
+	}
+}


### PR DESCRIPTION
## Stack position

**PR 3 of 3** in the v0 write-lifecycle series. Base: `lifecycle-reopen`.

```
main
└── lifecycle-close (#5423)
    └── lifecycle-reopen (#5417)
        └── lifecycle-update (#5422)   ← this PR
```

#5410 has merged, so the stack now sits on `main`; the close PR was recreated as #5423 when GitHub closed #5416 along with its deleted base branch.

`updateIssue` goes last of the three because it has **the widest body vocabulary but no new routing and no new codes** — so it lands once the patch-decode pattern has the close and reopen bodies as precedent. `bodyActor` and `storedTextMember`, factored out in the two PRs below, are what this one builds on rather than inventing.

> Review only the top commit; the parents are #5423 and #5417.

## What lands

`PATCH /v0/beads/issues/{id}` — spec, `routeTable` row, `operationCodes` row, handler and tests together.

### A plain method

Not a custom method, by the memories precedent: partial update of one named resource is what `PATCH` already means, exactly as one named resource with no body is what `DELETE` means for `forgetMemory`. It registers directly, keeps `pattern == specPath`, and leaves the custom-method namespace for the operations that are not CRUD. The claim-route commentary calling the issue-detail path "GET-only" is updated in the same change.

### Member presence is the signal

This is the reason the body is decoded as raw members rather than into the generated struct: a member **present** sets the role's `Field`, a member **absent** leaves the field untouched, and the generated struct cannot tell those apart because it models both as a nil pointer.

Explicit `null` is a third state, read off the raw bytes before any typed decode:

- on the four **nullable** members — exactly the ones the role models as `Field[*T]` — it **clears**, since `null` is the only wire spelling a clear has
- on every other member it is a **400 naming the member**

Without that pre-check, `{"title": null}` unmarshals to a nil pointer and slides through as "untouched" — a write the client asked for and the server silently dropped.

### The vocabulary boundary

`status`, `assignee` and `metadata` are excluded and refused **by name**. Keeping them out is half the reason this operation documents no `409` at all: they are exactly where close policy, the claim fence and the metadata algebra would have entered its code set. `parent_id`, `persistence`, `owner`, `closed_by_session`, `spec_id` and `await_id` are absent for the reasons this operation's own description in `openapi.v0.yaml` enumerates — a set `parent_id` atomically replaces ALL parents, so it is a graph edit in patch clothing; `persistence` is an atomic aggregate migration between planes; `owner` is `assignee`'s argument; `closed_by_session` is written under first-close-wins by `{id}:close`, which a patch write would bypass; and `spec_id`/`await_id` are workflow plumbing this surface publishes nowhere yet. Each is additive to publish later.

`labels` is complete replacement, and an empty array is a clear rather than an empty patch — a distinction the tests pin on both sides.

### Two new spec gates

`TestUpdateRequestMembersMatchTheHandler` covers **both levels** of the body. The handler's accepted set is a hand-rolled copy of the widest member list on the surface, and it could otherwise drift from the document with `make api-check` and every other spec test green.

`TestNullablePatchMembersAreExactlyTheDocumentsNullableOnes` pins the clear-vs-refuse set from both sides, because drift there is silent in the worst direction: a member the handler treats as nullable but the document does not is an unannounced clear on a field nobody agreed could be cleared.

### One routing interaction, pinned rather than papered over

`PATCH /v0/beads/issues/{id}` is a single-segment wildcard, so it matches `/v0/beads/issues/bd-1:close` too. That is the detail path's long-standing behavior — `GET` has always answered the same way — and it resolves as an update of an issue whose id is literally `bd-1:close`, which no row holds, so it 404s. `TestPatchOnACustomMethodSegmentIsNeverTheCustomMethod` pins the property that actually matters: **a PATCH never executes as a lifecycle verb**. The proxied test asserts the same thing against a real row.

This surfaced as a red test in PR 1's `TestCloseIsNotReachableByOtherMethods`, which listed PATCH among the unrouted methods; that entry is now correctly excluded, with the reason recorded next to it.

## Gates

- `go test ./internal/httpapi/` — green, including all parity tests
- `TestProxiedServerServeLifecycle` and `TestServerModeServe` — green (`BEADS_TEST_PROXIED_SERVER=1`). This commit adds `issues.update` to the single `servedCapabilities` list #5423 introduces, so the commit stays self-contained.
- `make api-check` — green (types regenerated from the spec in the same commit)
- `make ci-pr-lint` — green (gofmt, golangci-lint, golangci-lint windows: 0 issues)
- Red/green observed. Two mutations confirm the presence machinery is load-bearing: forcing `set("description")` true fails `TestUpdateLeavesAbsentMembersUntouched`, and disabling the explicit-null pre-check fails `TestUpdateClearsTheNullableMembers` and all nine cases of `TestUpdateRefusesNullOnEveryOtherMember`.

## Retained real-dependency proof

`TestProxiedServerServeUpdate` (`cmd/bd`, against real Dolt), the three-way read-back the document's "member presence is the signal" rule demands:

- one issue carrying a **set** member (`title`, `priority`), a **null-cleared** member (`external_ref`), and **untouched** members (`description`, `acceptance_criteria`, `status`) — all read back after the PATCH
- `changed: false` on a **same-value resend**
- label replacement removing a label the request omitted
- the workspace-vocabulary refusal arriving as the documented **400** rather than falling through to a 500
- the parity oracle against `bd update --json`[0], empty allowlist
- a PATCH on a custom-method segment leaving the issue open

## Deviations from the published spec

None. `internal/httpapi/spec/openapi.v0.yaml` and the handler land in the same commit, and `make api-check` plus the parity tests hold them together.

`Claim`, the force flags and every `Expected*` precondition stay zero, asserted by a test rather than left implicit (`TestUpdateForwardsEveryDocumentedMember`). Each is unpublished for a reason the document already states somewhere: `Claim` and the assignee force are the claim's compare-and-set territory, `ForceClosePolicy` belongs to `{id}:close`, and the `Expected*` preconditions have no frozen refusal code to land on — `issueops.ErrVersionMismatch` is unmapped in `problem.go`, so publishing one would render its refusal as `500 internal`. Adding that status+code pair is the one-way door `bd-serve-v0.md` describes under "The error-code vocabulary", which is exactly the kind of decision this PR declines to make in passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


