### PR TITLE
feat(httpapi): serve closeIssue over v0

### DIFF
--- a/cmd/bd/serve.go
+++ b/cmd/bd/serve.go
@@ -180,6 +180,7 @@ func runServe() error {
 			AllowNonLoopback:  serveAllowNonLoopback,
 			Reader:            roles.reader,
 			Claimer:           roles.claimer,
+			Lifecycle:         roles.lifecycle,
 			Settings:          roles.settings,
 			Stats:             roles.stats,
 			CycleDetector:     roles.cycles,
@@ -434,6 +435,7 @@ func serveIssueRoles(src storage.DoltStorage) (serveRoles, error) {
 	for _, b := range []binding{
 		{"issue reader", func() (err error) { roles.reader, err = src.IssueReader(); return }},
 		{"issue claimer", func() (err error) { roles.claimer, err = src.IssueClaimer(); return }},
+		{"issue lifecycle", func() (err error) { roles.lifecycle, err = src.IssueLifecycle(); return }},
 		{"workspace config", func() (err error) { roles.settings, err = src.WorkspaceConfig(); return }},
 		{"stats reporter", func() (err error) { roles.stats, err = src.StatsReporter(); return }},
 		{"cycle detector", func() (err error) { roles.cycles, err = src.CycleDetector(); return }},
@@ -461,6 +463,7 @@ func serveIssueRoles(src storage.DoltStorage) (serveRoles, error) {
 type serveRoles struct {
 	reader       issueops.Reader
 	claimer      issueops.Claimer
+	lifecycle    issueops.Lifecycle
 	settings     issueops.WorkspaceConfig
 	stats        issueops.StatsReporter
 	cycles       issueops.CycleDetector

--- a/cmd/bd/serve_close_proxied_integration_test.go
+++ b/cmd/bd/serve_close_proxied_integration_test.go
@@ -1,0 +1,262 @@
+//go:build cgo
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// End-to-end for the close, against real Dolt through a real `bd serve`
+// subprocess. The pure tests in internal/httpapi cover the wire edge on a fake
+// role; what only this level can prove is the TRANSACTION — that first-close-
+// wins is a property of the stored row rather than of a fake's bookkeeping, and
+// that the open-children refusal and its force bypass are the real policy the
+// CLI enforces, over a graph a fake has no way to hold.
+//
+// The role-level transition itself is owned against a real store by
+// internal/storage/uow/lifecycle_close_reopen_contract_test.go. This test owns
+// the wire-to-role seam and cites that one rather than duplicating it.
+
+// closeIssue posts a close for id and returns the status and decoded body.
+func (sp *serveProcess) closeIssue(t *testing.T, id, body string) (int, map[string]any) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, sp.url("/v0/beads/issues/"+id+":close"), strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("new close request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := sp.client.Do(req)
+	if err != nil {
+		t.Fatalf("POST close %s: %v\nstderr:\n%s", id, err, sp.stderr.String())
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read close body: %v", err)
+	}
+	var m map[string]any
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &m); err != nil {
+			t.Fatalf("decode close body %q: %v", raw, err)
+		}
+	}
+	return resp.StatusCode, m
+}
+
+func TestProxiedServerServeClose(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+	p := newSharedProxiedProject(t, bd, "srvclo")
+	sp := startServe(t, bd, p.dir, bdProxiedEnv(p.dir))
+
+	// THE FIRST-CLOSE-WINS PROOF, read back through a second close. A fake role
+	// can report Changed false; only a real store can show that the second
+	// close left the first one's reason and session in the columns.
+	t.Run("the first close wins and a re-close does not rewrite it", func(t *testing.T) {
+		issue := bdProxiedCreate(t, bd, p.dir, "close over http", "-p", "1")
+
+		status, body := sp.closeIssue(t, issue.ID, `{"actor":"http-agent","reason":"shipped it","session":"session-a"}`)
+		if status != http.StatusOK {
+			t.Fatalf("first close: status = %d, want 200: %v", status, body)
+		}
+		if body["already_closed"] != false {
+			t.Errorf("already_closed = %v, want false on a fresh close", body["already_closed"])
+		}
+		closed, ok := body["issue"].(map[string]any)
+		if !ok {
+			t.Fatalf("issue = %#v, want an object", body["issue"])
+		}
+		if closed["status"] != "closed" || closed["close_reason"] != "shipped it" {
+			t.Errorf("the response does not describe the closed row: %v", closed)
+		}
+
+		// The CLI reads the same row through its own path.
+		shown := bdProxiedShow(t, bd, p.dir, issue.ID)
+		if string(shown.Status) != "closed" || shown.CloseReason != "shipped it" || shown.ClosedBySession != "session-a" {
+			t.Fatalf("bd show reports status %q reason %q session %q; the HTTP close did not land",
+				shown.Status, shown.CloseReason, shown.ClosedBySession)
+		}
+
+		// The replay. It succeeds, reports the idempotent flag, and — the whole
+		// point — writes NEITHER value, so the record of why the work ended
+		// cannot be rewritten by a client replaying its own recovery.
+		status, body = sp.closeIssue(t, issue.ID, `{"actor":"other-agent","reason":"REWRITTEN","session":"session-b"}`)
+		if status != http.StatusOK {
+			t.Fatalf("re-close: status = %d, want 200: %v", status, body)
+		}
+		if body["already_closed"] != true {
+			t.Errorf("already_closed = %v, want true for a re-close", body["already_closed"])
+		}
+
+		after := bdProxiedShow(t, bd, p.dir, issue.ID)
+		if after.CloseReason != "shipped it" {
+			t.Errorf("close_reason = %q after the replay, want the FIRST close's value", after.CloseReason)
+		}
+		if after.ClosedBySession != "session-a" {
+			t.Errorf("closed_by_session = %q after the replay, want the FIRST close's value", after.ClosedBySession)
+		}
+	})
+
+	// THE FORCED-CLOSE PROOF. The open-children refusal is the role's, over a
+	// real parent-child edge; the count in the problem body comes from the
+	// transaction that refused, and the force bypass is what a caller does next.
+	t.Run("open children refuse an unforced close and force bypasses them", func(t *testing.T) {
+		parent := bdProxiedCreate(t, bd, p.dir, "the parent", "-p", "1")
+		for i := range 2 {
+			child := bdProxiedCreate(t, bd, p.dir, fmt.Sprintf("child %d", i), "-p", "2")
+			if out, err := bdProxiedRun(t, bd, p.dir, "dep", "add", child.ID, parent.ID, "--type", "parent-child"); err != nil {
+				t.Fatalf("bd dep add: %v\n%s", err, out)
+			}
+		}
+
+		status, body := sp.closeIssue(t, parent.ID, `{"actor":"http-agent","reason":"too soon"}`)
+		if status != http.StatusConflict {
+			t.Fatalf("unforced close over open children: status = %d, want 409: %v", status, body)
+		}
+		if body["code"] != "not_closable" {
+			t.Errorf("code = %v, want not_closable", body["code"])
+		}
+		// Read inside the refusing transaction, never parsed out of the prose.
+		if body["open_children"] != float64(2) {
+			t.Errorf("open_children = %v, want 2", body["open_children"])
+		}
+		if body["request_id"] == nil {
+			t.Error("no request_id on the problem body")
+		}
+
+		// A refusal writes nothing.
+		if shown := bdProxiedShow(t, bd, p.dir, parent.ID); string(shown.Status) == "closed" {
+			t.Fatalf("the refused close closed the issue anyway: status %q", shown.Status)
+		}
+
+		status, body = sp.closeIssue(t, parent.ID, `{"actor":"http-agent","reason":"closing anyway","force":true}`)
+		if status != http.StatusOK {
+			t.Fatalf("forced close: status = %d, want 200: %v", status, body)
+		}
+		// A forced close reports what it bypassed, which is exactly what the
+		// caller who bypassed it wants to know.
+		if body["open_children"] != float64(2) {
+			t.Errorf("open_children = %v on the forced close, want the 2 it bypassed", body["open_children"])
+		}
+		if shown := bdProxiedShow(t, bd, p.dir, parent.ID); string(shown.Status) != "closed" {
+			t.Errorf("bd show reports status %q after a forced close", shown.Status)
+		}
+	})
+
+	// The rule-8 oracle. Every other operation on this surface is checked
+	// against its CLI equivalent by comparing FULL item JSON, and "parity holds
+	// by construction" is exactly the reasoning that rule exists to forbid: a
+	// later CLI-side enrichment of close output must fail here rather than drift
+	// silently against the HTTP body.
+	//
+	// The CLI side is an idempotent RE-close, the claim oracle's device: it
+	// writes nothing under first-close-wins, so both surfaces describe the same
+	// row from the same post-state snapshot. `bd show --json` is deliberately
+	// not the oracle — it answers IssueDetails, with the counts and the revision
+	// this response does not carry, so it would compare two different shapes.
+	t.Run("the closed issue matches bd close --json element 0", func(t *testing.T) {
+		issue := bdProxiedCreate(t, bd, p.dir, "parity oracle", "-p", "1",
+			"-d", "described", "--acceptance", "accepted", "--label", "oracle")
+
+		status, body := sp.closeIssue(t, issue.ID, `{"actor":"parity-agent","reason":"done","session":"oracle-session"}`)
+		if status != http.StatusOK {
+			t.Fatalf("status = %d, want 200: %v", status, body)
+		}
+		fromHTTP, ok := body["issue"].(map[string]any)
+		if !ok {
+			t.Fatalf("issue = %#v, want an object", body["issue"])
+		}
+
+		fromCLI := bdProxiedCloseOneRaw(t, bd, p.dir, issue.ID, "--reason", "ignored under first-close-wins")
+
+		// The allowlist is EMPTY: both surfaces marshal the same canonical
+		// struct from the same post-state snapshot, so any difference at all is
+		// a real divergence and belongs in review, not in this list.
+		if diff := diffJSONObjects(fromHTTP, fromCLI, nil); diff != "" {
+			t.Errorf("CloseIssueResponse.issue and `bd close --json`[0] disagree:\n%s", diff)
+		}
+	})
+
+	t.Run("a closed issue is no longer claimable", func(t *testing.T) {
+		issue := bdProxiedCreate(t, bd, p.dir, "closed then claimed", "-p", "2")
+		if status, body := sp.closeIssue(t, issue.ID, `{"actor":"http-agent"}`); status != http.StatusOK {
+			t.Fatalf("close: status = %d: %v", status, body)
+		}
+
+		// The two operations agree about the row they share, which is the whole
+		// reason the lifecycle pair belongs on this surface.
+		status, body := sp.claim(t, issue.ID, "http-agent")
+		if status != http.StatusConflict {
+			t.Fatalf("claim of a closed issue: status = %d, want 409: %v", status, body)
+		}
+		if body["code"] != "not_claimable" || body["issue_status"] != "closed" {
+			t.Errorf("claim refusal = %v, want not_claimable/closed", body)
+		}
+	})
+
+	t.Run("unknown ids are 404 and refused bodies write nothing", func(t *testing.T) {
+		status, body := sp.closeIssue(t, "bd-nosuchissue", `{"actor":"http-agent"}`)
+		if status != http.StatusNotFound {
+			t.Fatalf("unknown id: status = %d, want 404: %v", status, body)
+		}
+		if body["code"] != "not_found" {
+			t.Errorf("code = %v, want not_found", body["code"])
+		}
+
+		issue := bdProxiedCreate(t, bd, p.dir, "never closed", "-p", "2")
+		for _, refused := range []string{
+			`{"actor":"   "}`,
+			`{"actor":"agent\nbd serve: close bd-0 by mallory"}`,
+			`{"actor":"agent","reason":"` + strings.Repeat("x", 300) + `"}`,
+			`{"actor":"agent","cascade":true}`,
+			`{"actor":"agent","force":"yes"}`,
+		} {
+			status, problem := sp.closeIssue(t, issue.ID, refused)
+			if status != http.StatusBadRequest {
+				t.Fatalf("body %.40q: status = %d, want 400: %v", refused, status, problem)
+			}
+			if problem["code"] != "invalid_argument" {
+				t.Errorf("body %.40q: code = %v, want invalid_argument", refused, problem["code"])
+			}
+		}
+
+		// The refusals are wire-edge refusals: nothing reached the database.
+		if shown := bdProxiedShow(t, bd, p.dir, issue.ID); string(shown.Status) != "open" {
+			t.Errorf("a refused close wrote to the row: status %q", shown.Status)
+		}
+	})
+
+	sp.shutdown(t)
+}
+
+// bdProxiedCloseOneRaw runs `bd close --json` and decodes the one item it
+// reports as a generic object rather than into types.Issue: the parity oracle
+// compares the JSON both surfaces actually emit, and decoding through the
+// struct would hide exactly the field-level drift it exists to catch.
+func bdProxiedCloseOneRaw(t *testing.T, bd, dir, id string, args ...string) map[string]any {
+	t.Helper()
+	full := append([]string{"close", id, "--json"}, args...)
+	out, err := bdProxiedRun(t, bd, dir, full...)
+	if err != nil {
+		t.Fatalf("bd close %s --json failed: %v\n%s", id, err, out)
+	}
+	s := string(out)
+	start := strings.Index(s, "[")
+	if start < 0 {
+		t.Fatalf("no JSON array in show output:\n%s", s)
+	}
+	var items []map[string]any
+	if err := json.Unmarshal([]byte(s[start:]), &items); err != nil {
+		t.Fatalf("parse show JSON: %v\nraw: %s", err, s[start:])
+	}
+	if len(items) != 1 {
+		t.Fatalf("show returned %d items, want 1:\n%s", len(items), s[start:])
+	}
+	return items[0]
+}

--- a/cmd/bd/serve_proxied_integration_test.go
+++ b/cmd/bd/serve_proxied_integration_test.go
@@ -125,6 +125,46 @@ func (sp *serveProcess) wait() error {
 
 func (sp *serveProcess) url(path string) string { return "http://" + sp.addr + path }
 
+// servedCapabilities is what GET /v0/beads/context must advertise, spelled out
+// ONCE for every topology that checks it.
+//
+// It is deliberately a literal rather than httpapi.Capabilities(): comparing the
+// server against its own derivation would pass for any surface at all, and the
+// point of this list is that adding an operation costs a line here. The
+// assertion is on the whole list rather than a count, so an operation that
+// arrives stubbed still fails — which is what it did when the facade programme
+// took this from four operations to sixteen. Update it deliberately when you
+// add one.
+//
+// ONE COPY, and that is the fix this list arrived with. It used to be written
+// out separately in each topology's test, on the theory that the two must agree
+// — and they silently stopped agreeing: the server-mode copy sat at four
+// entries through every expansion since, asserting a surface that had not
+// existed for a long time. Two literals that MUST match are one literal; a
+// package's own gates cannot catch an expectation stored as data outside it.
+var servedCapabilities = []any{
+	"config.get", "config.list",
+	"dependencies.blocking", "dependencies.cycles", "dependencies.list", "dependencies.tree",
+	"issues.batchCreate", "issues.claim", "issues.delete", "issues.get", "issues.list",
+	"issues.query", "issues.sweep",
+	"memories.forget", "memories.get", "memories.list", "memories.remember",
+	"ready.count", "ready.list", "stats.get",
+}
+
+// assertServedCapabilities checks a decoded context body against
+// servedCapabilities. Every topology asserts the same thing, because a mode
+// changes where the data lives and never what the handshake advertises.
+func assertServedCapabilities(t *testing.T, body map[string]any) {
+	t.Helper()
+	caps, ok := body["capabilities"].([]any)
+	if !ok {
+		t.Fatalf("capabilities = %#v, want an array", body["capabilities"])
+	}
+	if !reflect.DeepEqual(caps, servedCapabilities) {
+		t.Errorf("capabilities = %v, want %v", caps, servedCapabilities)
+	}
+}
+
 func (sp *serveProcess) get(t *testing.T, path string) (int, map[string]any, http.Header) {
 	t.Helper()
 	resp, err := sp.client.Get(sp.url(path))
@@ -219,27 +259,7 @@ func TestProxiedServerServeLifecycle(t *testing.T) {
 		if body["bd_version"] == "" || body["bd_version"] == nil {
 			t.Error("bd_version is empty")
 		}
-		// The handshake advertises exactly what this build implements. A client
-		// that gates on capabilities is then correct without knowing which
-		// release it hit. The assertion is on the derived list, not on a count,
-		// so the next operation to arrive stubbed still fails here — which is
-		// what it did when the facade programme took this from four operations
-		// to sixteen. Update it deliberately when you add one.
-		caps, ok := body["capabilities"].([]any)
-		if !ok {
-			t.Fatalf("capabilities = %#v, want an array", body["capabilities"])
-		}
-		want := []any{
-			"config.get", "config.list",
-			"dependencies.blocking", "dependencies.cycles", "dependencies.list", "dependencies.tree",
-			"issues.batchCreate", "issues.claim", "issues.delete", "issues.get", "issues.list",
-			"issues.query", "issues.sweep",
-			"memories.forget", "memories.get", "memories.list", "memories.remember",
-			"ready.count", "ready.list", "stats.get",
-		}
-		if !reflect.DeepEqual(caps, want) {
-			t.Errorf("capabilities = %v, want %v", caps, want)
-		}
+		assertServedCapabilities(t, body)
 		// The allowlist is enforced in internal/httpapi; this is the end-to-end
 		// half — a real workspace's real config, over a real socket.
 		for _, forbidden := range []string{"sync_remote", "server_host", "server_port", "data_dir", "proxied_dir", "role"} {

--- a/cmd/bd/serve_proxied_integration_test.go
+++ b/cmd/bd/serve_proxied_integration_test.go
@@ -145,8 +145,8 @@ func (sp *serveProcess) url(path string) string { return "http://" + sp.addr + p
 var servedCapabilities = []any{
 	"config.get", "config.list",
 	"dependencies.blocking", "dependencies.cycles", "dependencies.list", "dependencies.tree",
-	"issues.batchCreate", "issues.claim", "issues.delete", "issues.get", "issues.list",
-	"issues.query", "issues.sweep",
+	"issues.batchCreate", "issues.claim", "issues.close", "issues.delete",
+	"issues.get", "issues.list", "issues.query", "issues.sweep",
 	"memories.forget", "memories.get", "memories.list", "memories.remember",
 	"ready.count", "ready.list", "stats.get",
 }

--- a/cmd/bd/serve_server_mode_integration_test.go
+++ b/cmd/bd/serve_server_mode_integration_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -148,19 +147,12 @@ func TestServerModeServe(t *testing.T) {
 		if body["api_version"] != "v0" {
 			t.Errorf("api_version = %v, want v0", body["api_version"])
 		}
-		caps, ok := body["capabilities"].([]any)
-		if !ok {
-			t.Fatalf("capabilities = %#v, want an array", body["capabilities"])
-		}
-		// Same build, same handlers: what a mode changes is where the data lives,
-		// never what the handshake advertises. This is deliberately the same
-		// assertion TestProxiedServerServeLifecycle makes against the proxied
-		// path — if the two ever have to be written differently, a mode has
-		// started changing the contract and that is the bug.
-		want := []any{"issues.claim", "issues.get", "issues.list", "ready.list"}
-		if !reflect.DeepEqual(caps, want) {
-			t.Errorf("capabilities = %v, want %v", caps, want)
-		}
+		// Same build, same handlers: what a mode changes is where the data
+		// lives, never what the handshake advertises. This is LITERALLY the same
+		// assertion the proxied path makes — if the two ever have to be written
+		// differently, a mode has started changing the contract and that is the
+		// bug.
+		assertServedCapabilities(t, body)
 	})
 
 	t.Run("a read operation answers from the server-mode database", func(t *testing.T) {

--- a/cmd/bd/serve_source_test.go
+++ b/cmd/bd/serve_source_test.go
@@ -92,8 +92,8 @@ func TestServeIssueRolesComeFromBeneathTheHookDecorator(t *testing.T) {
 	// peeling all of them (storage.UnwrapStore) is the mistake that looks
 	// identical on a single-layer chain. The middle store stands in for the
 	// telemetry layer bd wires there, which is an Unwrapper too.
-	inner := &serveRolesStore{reader: &serveStubReader{}, claimer: &serveStubClaimer{}}
-	middle := &serveRolesStore{reader: &serveStubReader{}, claimer: &serveStubClaimer{}, inner: inner}
+	inner := &serveRolesStore{reader: &serveStubReader{}, claimer: &serveStubClaimer{}, lifecycle: &serveStubLifecycle{}}
+	middle := &serveRolesStore{reader: &serveStubReader{}, claimer: &serveStubClaimer{}, lifecycle: &serveStubLifecycle{}, inner: inner}
 	chained := wireStorageDecorators(middle, hooks.NewRunner(t.TempDir()), false)
 
 	if _, ok := chained.(*storage.HookFiringStore); !ok {
@@ -105,6 +105,16 @@ func TestServeIssueRolesComeFromBeneathTheHookDecorator(t *testing.T) {
 	}
 	if !storage.RoleFiresHooks(fromTheStore) {
 		t.Fatal("the store's own accessor no longer returns a hook-firing claimer; this test proves nothing")
+	}
+	// Same precondition for the lifecycle: RoleFiresHooks has to KNOW about the
+	// decorator's lifecycle wrapper, or the peel assertion below would pass on a
+	// predicate that answers false for everything.
+	lifecycleFromTheStore, err := chained.IssueLifecycle()
+	if err != nil {
+		t.Fatalf("IssueLifecycle: %v", err)
+	}
+	if !storage.RoleFiresHooks(lifecycleFromTheStore) {
+		t.Fatal("the store's own accessor no longer returns a hook-firing lifecycle; this test proves nothing")
 	}
 
 	roles, err := serveIssueRoles(chained)
@@ -122,6 +132,16 @@ func TestServeIssueRolesComeFromBeneathTheHookDecorator(t *testing.T) {
 	}
 	if reader != issueops.Reader(middle.reader) {
 		t.Errorf("reader came from %p, want the layer directly beneath the hooks (%p)", reader, middle.reader)
+	}
+
+	// The lifecycle is the OTHER role the hook decorator wraps, and it wraps
+	// four verbs rather than one — so an unpeeled lifecycle would run this
+	// workspace's on_create, on_update and close hooks for every HTTP mutation.
+	if storage.RoleFiresHooks(roles.lifecycle) {
+		t.Error("bd serve would run this workspace's hooks on every HTTP lifecycle mutation")
+	}
+	if roles.lifecycle != issueops.Lifecycle(middle.lifecycle) {
+		t.Errorf("lifecycle came from %p, want the layer directly beneath the hooks (%p)", roles.lifecycle, middle.lifecycle)
 	}
 
 	t.Run("a workspace with hooks disabled has no layer to peel", func(t *testing.T) {
@@ -188,14 +208,21 @@ func writeBrokenBeadsConfig(t *testing.T, beadsDir string) {
 // because the extraction does not inspect them.
 type serveRolesStore struct {
 	storage.DoltStorage
-	reader  *serveStubReader
-	claimer *serveStubClaimer
-	inner   storage.DoltStorage
+	reader    *serveStubReader
+	claimer   *serveStubClaimer
+	lifecycle *serveStubLifecycle
+	inner     storage.DoltStorage
 }
 
 func (s *serveRolesStore) IssueReader() (issueops.Reader, error)   { return s.reader, nil }
 func (s *serveRolesStore) IssueClaimer() (issueops.Claimer, error) { return s.claimer, nil }
 func (s *serveRolesStore) Unwrap() storage.DoltStorage             { return s.inner }
+
+// IssueLifecycle carries an identifiable value for the same reason the reader
+// and the claimer do: it is the OTHER role the hook decorator wraps, so a peel
+// of the wrong depth would hand bd serve a lifecycle that runs the workspace's
+// hooks on every close.
+func (s *serveRolesStore) IssueLifecycle() (issueops.Lifecycle, error) { return s.lifecycle, nil }
 
 func (*serveRolesStore) WorkspaceConfig() (issueops.WorkspaceConfig, error)     { return nil, nil }
 func (*serveRolesStore) StatsReporter() (issueops.StatsReporter, error)         { return nil, nil }
@@ -228,4 +255,22 @@ type serveStubClaimer struct{}
 
 func (*serveStubClaimer) Claim(context.Context, issueops.ClaimRequest) (issueops.ClaimResult, error) {
 	return issueops.ClaimResult{}, errors.ErrUnsupported
+}
+
+type serveStubLifecycle struct{}
+
+func (*serveStubLifecycle) Create(context.Context, issueops.CreateRequest) (issueops.CreateResult, error) {
+	return issueops.CreateResult{}, errors.ErrUnsupported
+}
+
+func (*serveStubLifecycle) Update(context.Context, issueops.UpdateRequest) (issueops.UpdateResult, error) {
+	return issueops.UpdateResult{}, errors.ErrUnsupported
+}
+
+func (*serveStubLifecycle) Close(context.Context, issueops.CloseRequest) (issueops.CloseResult, error) {
+	return issueops.CloseResult{}, errors.ErrUnsupported
+}
+
+func (*serveStubLifecycle) Reopen(context.Context, issueops.ReopenRequest) (issueops.ReopenResult, error) {
+	return issueops.ReopenResult{}, errors.ErrUnsupported
 }

--- a/cmd/bd/serve_store_identity_test.go
+++ b/cmd/bd/serve_store_identity_test.go
@@ -182,6 +182,9 @@ func (s *serveIdentityStore) Close() error { return nil }
 // They hand back serveIdentityRole, which satisfies each interface by
 // EMBEDDING it rather than implementing it: non-nil, so the set is complete,
 // while an actual call panics naming the method it reached.
+func (*serveIdentityStore) IssueLifecycle() (issueops.Lifecycle, error) {
+	return serveIdentityRole{}, nil
+}
 func (*serveIdentityStore) WorkspaceConfig() (issueops.WorkspaceConfig, error) {
 	return serveIdentityRole{}, nil
 }
@@ -209,11 +212,12 @@ func (*serveIdentityStore) Memories() (memoryops.Memories, error) {
 	return serveIdentityRole{}, nil
 }
 
-// serveIdentityRole satisfies all twelve at once, which it can because no two
+// serveIdentityRole satisfies all thirteen at once, which it can because no two
 // of those interfaces declare a method of the same name. If a future role
 // collides, split this into one type per role — the embedded method would stop
 // being promoted and the build would say so.
 type serveIdentityRole struct {
+	issueops.Lifecycle
 	issueops.WorkspaceConfig
 	issueops.StatsReporter
 	issueops.CycleDetector

--- a/internal/httpapi/apigen/types.gen.go
+++ b/internal/httpapi/apigen/types.gen.go
@@ -199,6 +199,33 @@ type ClaimResponse struct {
 	Issue Issue `json:"issue"`
 }
 
+// CloseIssueRequest defines model for CloseIssueRequest.
+type CloseIssueRequest struct {
+	// Actor Who is closing the issue. `ClaimRequest.actor`'s rules exactly: the server trims it, then refuses an empty result, anything longer than 256 BYTES (the `maxLength` above counts characters — the byte limit is the binding one), and any control character including newline. The value reaches stored columns, event-stream attribution and the storage commit message, so an unvalidated newline would forge audit-trail lines.
+	Actor string `json:"actor"`
+
+	// Force Bypass close policy — the open-children refusal and the live-blocker refusal — and nothing else. The refusals are the ROLE's, so this endpoint cannot skip a guard by forgetting one exists. A forced close still reports `open_children`.
+	Force *bool `json:"force,omitempty"`
+
+	// Reason Why the issue is closed. Stored on the issue and read back as `close_reason`. THE FIRST CLOSE WINS: an idempotent re-close writes neither this nor `session`, so a replayed close cannot rewrite the record of why the work ended. Refused for control characters, and bounded by what the column holds rather than by the number above.
+	Reason *string `json:"reason,omitempty"`
+
+	// Session The working session that closed the issue, stored and read back as `closed_by_session`, under the same first-close-wins rule and the same bounds as `reason`.
+	Session *string `json:"session,omitempty"`
+}
+
+// CloseIssueResponse defines model for CloseIssueResponse.
+type CloseIssueResponse struct {
+	// AlreadyClosed True when the issue was already closed and this call changed nothing — the idempotent re-close, mirroring `ClaimResponse.already_claimed`. The response still carries the row, and `reason`/`session` were not rewritten.
+	AlreadyClosed bool `json:"already_closed"`
+
+	// Issue A tracked work item. Property semantics documented here apply to every schema that repeats them below.
+	Issue Issue `json:"issue"`
+
+	// OpenChildren How many open children the close observed. Reported by a FORCED close — including an idempotent re-close — because a caller that bypassed the guard is exactly the caller that wants the number. An unforced close that got this far had none, so it reports 0.
+	OpenChildren int `json:"open_children"`
+}
+
 // Comment defines model for Comment.
 type Comment = types.Comment
 
@@ -216,7 +243,7 @@ type ContextResponse struct {
 	// BeadsDir Absolute path of the served workspace's `.beads` directory. A host path, kept because it is the single-workspace server's only workspace-identity handshake; disclosing it to network peers is part of what an operator accepts when binding beyond loopback.
 	BeadsDir string `json:"beads_dir"`
 
-	// Capabilities The operations this server actually implements, derived from its route table. v0's vocabulary is `ready.list`, `ready.count`, `issues.list`, `issues.query`, `issues.get`, `issues.claim`, `issues.sweep`, `issues.delete`, `issues.batchCreate`, `stats.get`, `config.list`, `config.get`, `dependencies.cycles`, `dependencies.list`, `dependencies.blocking`, `dependencies.tree`, `memories.list`, `memories.get`, `memories.remember`, `memories.forget`; it grows additively, and an operation never appears here unless it is fully implemented. This is how a client checks for an operation — never the version string.
+	// Capabilities The operations this server actually implements, derived from its route table. v0's vocabulary is `ready.list`, `ready.count`, `issues.list`, `issues.query`, `issues.get`, `issues.claim`, `issues.close`, `issues.sweep`, `issues.delete`, `issues.batchCreate`, `stats.get`, `config.list`, `config.get`, `dependencies.cycles`, `dependencies.list`, `dependencies.blocking`, `dependencies.tree`, `memories.list`, `memories.get`, `memories.remember`, `memories.forget`; it grows additively, and an operation never appears here unless it is fully implemented. This is how a client checks for an operation — never the version string.
 	Capabilities []string `json:"capabilities"`
 
 	// Database Logical database name (not a host or a DSN).
@@ -403,7 +430,7 @@ type Problem struct {
 	// Assignee With `already_claimed`: the actor currently holding the issue.
 	Assignee *string `json:"assignee,omitempty"`
 
-	// Code The stable machine-readable reason, and the ONLY member a client may dispatch on. v0's vocabulary: `invalid_argument` (400, also emitted by the Host-header middleware on any route), `invalid_cursor` (400), `not_found` (404), `already_claimed` (409), `not_claimable` (409), `busy` (503), `db_unavailable` (503), `internal` (500). Renaming or removing a status+code pair is a breaking change; ADDING one is not, so clients MUST default-branch on unknown values and fall back to the status class (unknown 4xx → client bug, fail loud; unknown 503 → retry per `Retry-After`; other unknown 5xx → server fault).
+	// Code The stable machine-readable reason, and the ONLY member a client may dispatch on. v0's vocabulary: `invalid_argument` (400, also emitted by the Host-header middleware on any route), `invalid_cursor` (400), `not_found` (404), `already_claimed` (409), `not_claimable` (409), `not_closable` (409), `busy` (503), `db_unavailable` (503), `internal` (500). Renaming or removing a status+code pair is a breaking change; ADDING one is not, so clients MUST default-branch on unknown values and fall back to the status class (unknown 4xx → client bug, fail loud; unknown 503 → retry per `Retry-After`; other unknown 5xx → server fault).
 	Code string `json:"code"`
 
 	// Detail Optional prose, never load-bearing. For 5xx codes it is a FIXED string per code and carries nothing about the underlying failure: driver and dial errors routinely embed the DSN, database user and host:port, and this API supports binding beyond loopback. 4xx details reflect the caller's own input back and are specific.
@@ -411,6 +438,11 @@ type Problem struct {
 
 	// IssueStatus With `already_claimed` or `not_claimable`: the issue's status at the moment of refusal.
 	IssueStatus *string `json:"issue_status,omitempty"`
+
+	// OpenChildren With `not_closable`: how many open children the transaction that refused the close observed, read inside that transaction rather than parsed out of `detail`.
+	//
+	// PRESENT ONLY for the open-children refusal. The other `not_closable` refusal is a live blocker and carries no such member, so member presence — not prose — is how a client tells the two apart. Both are bypassed by `force`.
+	OpenChildren *int `json:"open_children,omitempty"`
 
 	// Param With `invalid_argument`: the offending query parameter, body member or header name. Present on every 400 except a body that fails to parse at all.
 	Param *string `json:"param,omitempty"`
@@ -936,6 +968,9 @@ type GetStatsParams struct {
 
 // ClaimIssueJSONRequestBody defines body for ClaimIssue for application/json ContentType.
 type ClaimIssueJSONRequestBody = ClaimRequest
+
+// CloseIssueJSONRequestBody defines body for CloseIssue for application/json ContentType.
+type CloseIssueJSONRequestBody = CloseIssueRequest
 
 // BatchCreateIssuesJSONRequestBody defines body for BatchCreateIssues for application/json ContentType.
 type BatchCreateIssuesJSONRequestBody = BatchCreateRequest

--- a/internal/httpapi/batch_create.go
+++ b/internal/httpapi/batch_create.go
@@ -93,7 +93,7 @@ func (s *Server) batchCreateRequest(w http.ResponseWriter, r *http.Request) (iss
 		return issueops.CreateBatchRequest{}, false
 	}
 
-	actor, ok := s.batchCreateActor(w, r, members)
+	actor, ok := s.bodyActor(w, r, members)
 	if !ok {
 		return issueops.CreateBatchRequest{}, false
 	}
@@ -102,30 +102,6 @@ func (s *Server) batchCreateRequest(w http.ResponseWriter, r *http.Request) (iss
 		return issueops.CreateBatchRequest{}, false
 	}
 	return issueops.CreateBatchRequest{Actor: actor, Items: items}, true
-}
-
-// batchCreateActor validates `actor` under the claim's rules, shared rather
-// than restated: the value lands in the same columns and the same storage
-// commit message, so a newline forges the same audit-trail lines.
-func (s *Server) batchCreateActor(w http.ResponseWriter, r *http.Request, members map[string]json.RawMessage) (string, bool) {
-	raw, ok := members[claimActorMember]
-	if !ok {
-		s.fail(w, r, InvalidArgument(claimActorMember, ReasonInvalidValue, "`"+claimActorMember+"` is required"))
-		return "", false
-	}
-	// Through a POINTER so that `null` reaches the type-mismatch branch, for
-	// the reason claimActor gives.
-	var actor *string
-	if err := json.Unmarshal(raw, &actor); err != nil || actor == nil {
-		s.fail(w, r, InvalidArgument(claimActorMember, ReasonInvalidValue, "`"+claimActorMember+"` must be a string"))
-		return "", false
-	}
-	trimmed, res := validateActor(*actor)
-	if res != nil {
-		s.fail(w, r, *res)
-		return "", false
-	}
-	return trimmed, true
 }
 
 // batchCreateItems validates `items` and projects it onto the role's items.

--- a/internal/httpapi/batch_create_test.go
+++ b/internal/httpapi/batch_create_test.go
@@ -261,7 +261,7 @@ func TestBatchCreateRefusesANonJSONContentType(t *testing.T) {
 	creator := &roleBatchCreator{}
 	ts := newBatchCreateServer(t, creator)
 
-	resp := ts.claimRequest(t, batchCreatePath, "text/plain", `{"actor":"alice","items":[{"title":"t"}]}`)
+	resp := ts.postBody(t, batchCreatePath, "text/plain", `{"actor":"alice","items":[{"title":"t"}]}`)
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
 	}

--- a/internal/httpapi/claim.go
+++ b/internal/httpapi/claim.go
@@ -21,14 +21,6 @@ import (
 )
 
 const (
-	// claimPathValue names the ServeMux wildcard the claim route registers. The
-	// route table builds its pattern from this constant and claimSuffix below
-	// splits the custom method back off it, so the two halves of the one path
-	// exception cannot drift apart.
-	claimPathValue = "idop"
-	// claimSuffix is the custom method the document spells on the id segment:
-	// POST /v0/beads/issues/{id}:claim.
-	claimSuffix = ":claim"
 	// claimActorMember is the only member ClaimRequest carries. The schema is
 	// additionalProperties: false, so anything else is refused by name.
 	claimActorMember = "actor"
@@ -73,10 +65,9 @@ const (
 // refusal vocabulary — belongs to issueops.Claimer, reached through the
 // provider's own accessor.
 func (s *Server) handleClaim(w http.ResponseWriter, r *http.Request) {
-	id, ok := s.claimTarget(w, r)
-	if !ok {
-		return
-	}
+	// The custom-method dispatcher split the id off the segment and bounded it
+	// before this handler was chosen at all; see customMethodTarget.
+	id := r.PathValue(customMethodIDValue)
 	if !s.requireNoQuery(w, r) {
 		return
 	}
@@ -104,40 +95,6 @@ func (s *Server) handleClaim(w http.ResponseWriter, r *http.Request) {
 		Issue:          *result.Issue,
 		AlreadyClaimed: !result.Changed,
 	})
-}
-
-// claimTarget splits the custom method off the segment the router matched, and
-// reports whether the request may proceed.
-//
-// ServeMux wildcards match a whole path segment, so `{id}:claim` is not
-// expressible as a pattern: the route registers `POST /v0/beads/issues/{idop}`
-// and the parse lands here. A segment that does not end in the custom method is
-// NOT an id — the only documented POST on this surface is this operation — so
-// it gets the same 404 the catch-all gives any other unrouted path. That is
-// what keeps POST on the issue-detail path, which the document declares
-// GET-only, from being answered as a claim of the issue named there.
-//
-// The id itself is bounded HERE, for the same reason the actor is: this is the
-// last point before a request buys a concurrency slot and two database round
-// trips. `issues.id` is VARCHAR(255) and the document calls the parameter an
-// exact canonical id, so a longer one — or one carrying a control character,
-// which a percent-escape in the path decodes to — names no row that can exist.
-// Answering it from the edge costs the server nothing and tells the caller
-// exactly what a read would have: 404.
-func (s *Server) claimTarget(w http.ResponseWriter, r *http.Request) (string, bool) {
-	id, ok := strings.CutSuffix(r.PathValue(claimPathValue), claimSuffix)
-	if !ok || id == "" {
-		s.fail(w, r, newResult(CodeNotFound, "no such route on this server"))
-		return "", false
-	}
-	if types.CheckFieldLen("id", id) != nil || strings.ContainsFunc(id, isControlChar) {
-		// The SAME 404 a real miss gets. A distinct refusal here would let a
-		// caller map the server's notion of a well-formed id, and there is
-		// nothing to learn from it: no such row exists either way.
-		s.fail(w, r, NotFound())
-		return "", false
-	}
-	return id, true
 }
 
 // requireJSONContent enforces the request media type. It reports whether the
@@ -352,6 +309,7 @@ type timedProvider struct {
 var (
 	_ uow.IssueReaderSource       = timedProvider{}
 	_ uow.IssueClaimerSource      = timedProvider{}
+	_ uow.IssueLifecycleSource    = timedProvider{}
 	_ uow.WorkspaceConfigSource   = timedProvider{}
 	_ uow.StatsReporterSource     = timedProvider{}
 	_ uow.CycleDetectorSource     = timedProvider{}
@@ -401,6 +359,14 @@ func (p timedProvider) IssueReader() (issueops.Reader, error) {
 // instead of the recursion looking correct.
 func (p timedProvider) IssueClaimer() (issueops.Claimer, error) {
 	return uow.NewIssueClaimer(p)
+}
+
+// IssueLifecycle builds the guarded-mutation role OVER THIS WRAPPER, for the
+// same reason and with the same hazard as IssueClaimer: this role opens the
+// longest write transactions on the surface, so a claimer-style recursion here
+// would report uow_ms=0.000 for exactly the requests whose timing matters most.
+func (p timedProvider) IssueLifecycle() (issueops.Lifecycle, error) {
+	return uow.NewIssueOperations(p)
 }
 
 // WorkspaceConfig builds the settings role OVER THIS WRAPPER, for the same

--- a/internal/httpapi/claim_test.go
+++ b/internal/httpapi/claim_test.go
@@ -110,9 +110,10 @@ func newClaimServer(t *testing.T, issues *fakeIssues) (*testServer, *fakeProvide
 
 const claimPath = "/v0/beads/issues/bd-1:claim"
 
-// claimRequest posts a body with an explicit media type, because the media type
-// is part of what this endpoint checks.
-func (ts *testServer) claimRequest(t *testing.T, path, contentType, body string) *http.Response {
+// postBody posts a body with an explicit media type, because the media type is
+// part of what every body-carrying endpoint checks. Shared by the operations
+// that take one; the claim's own wrapper below fills in the ordinary type.
+func (ts *testServer) postBody(t *testing.T, path, contentType, body string) *http.Response {
 	t.Helper()
 	req, err := http.NewRequest(http.MethodPost, ts.base+path, strings.NewReader(body))
 	if err != nil {
@@ -131,7 +132,7 @@ func (ts *testServer) claimRequest(t *testing.T, path, contentType, body string)
 
 func (ts *testServer) claim(t *testing.T, path, body string) *http.Response {
 	t.Helper()
-	return ts.claimRequest(t, path, "application/json", body)
+	return ts.postBody(t, path, "application/json", body)
 }
 
 // TestClaimWritesOnceAndAnswersWithTheRowItWrote is the happy path and the two
@@ -585,7 +586,7 @@ func TestClaimRejectsMalformedRequests(t *testing.T) {
 			if path == "" {
 				path = claimPath
 			}
-			resp := ts.claimRequest(t, path, tc.contentType, tc.body)
+			resp := ts.postBody(t, path, tc.contentType, tc.body)
 			if resp.StatusCode != http.StatusBadRequest {
 				t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
 			}
@@ -629,18 +630,29 @@ func TestClaimBodyCapIsEnforcedWhileReading(t *testing.T) {
 	}
 }
 
-// TestClaimNarrowsThePOSTSurface. ServeMux wildcards match a whole segment, so
-// the claim route's pattern is POST /v0/beads/issues/{idop} and every POST under
-// that prefix reaches this handler. The issue-detail path is documented
-// GET-only, and a POST to it must NOT be read as a claim of the issue named
-// there: it is an unrouted path, and it gets the unrouted path's answer.
-func TestClaimNarrowsThePOSTSurface(t *testing.T) {
+// TestCustomMethodsNarrowThePOSTSurface. ServeMux wildcards match a whole
+// segment, so the single-resource custom methods share one pattern —
+// POST /v0/beads/issues/{idop} — and every POST under that prefix reaches the
+// dispatcher. The issue-detail path is documented GET-only, and a POST to it
+// must NOT be read as an operation on the issue named there: it is an unrouted
+// path, and it gets the unrouted path's answer.
+//
+// The generalization from the claim's own version is the point. A dispatcher
+// that fell back to its first row for an unrecognized suffix would turn every
+// probe of this prefix into a claim, and the suite would stay green because the
+// claim's happy path still worked.
+func TestCustomMethodsNarrowThePOSTSurface(t *testing.T) {
 	for _, path := range []string{
 		"/v0/beads/issues/bd-1",           // the GET-only detail path
-		"/v0/beads/issues/:claim",         // the custom method with no id
+		"/v0/beads/issues/:claim",         // a custom method with no id
+		"/v0/beads/issues/:close",         // the same, on the newer verb
 		"/v0/beads/issues/bd-1:CLAIM",     // the custom method is not a spelling
+		"/v0/beads/issues/bd-1:Close",     // nor is this one
 		"/v0/beads/issues/bd-1:claim-not", // a suffix that merely starts the same
+		"/v0/beads/issues/bd-1:close-not",
 		"/v0/beads/issues/bd-1:unclaim",
+		"/v0/beads/issues/bd-1:reopen", // a verb this build does not serve
+		"/v0/beads/issues/bd-1:delete",
 	} {
 		t.Run(path, func(t *testing.T) {
 			issues := &fakeIssues{issue: seededIssue("bd-1", "alice", types.StatusInProgress)}

--- a/internal/httpapi/close.go
+++ b/internal/httpapi/close.go
@@ -1,0 +1,226 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/steveyegge/beads/internal/httpapi/apigen"
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/issueops"
+)
+
+// closeRequestMembers is the document's member list for CloseIssueRequest. The
+// schema is additionalProperties: false, so anything else is refused BY NAME —
+// which is why the body is decoded as raw members first, the posture claim and
+// batchCreate already take.
+var closeRequestMembers = []string{"actor", "reason", "session", "force"}
+
+// handleClose closes one issue: the second half of the loop this surface exists
+// to serve, and the half that still forked a subprocess.
+//
+// It carries the claim's posture verbatim. The actor is caller-ASSERTED
+// provenance for the audit trail and not authenticated identity; hooks do not
+// fire and the per-command auto-commit machinery does not run, exactly as for
+// POST /v0/beads/issues/{id}:claim. The only durable effect is the single
+// storage commit the role makes inside its own transaction.
+//
+// Everything above the role is argument validation: the media type, the body
+// shape, and the actor, reason and session rules. The close itself — the
+// done-status normalization, first-close-wins on reason and session, the open-
+// children and live-blocker policy, the transaction retry — belongs to
+// issueops.Lifecycle, reached through the provider's own accessor.
+//
+// PLANES. Unlike the claim, this resolves ids across BOTH planes, because the
+// role does and this surface serves the same work contract the CLI serves. A
+// close whose target is a wisp lands on the unversioned plane and records no
+// durable history entry.
+func (s *Server) handleClose(w http.ResponseWriter, r *http.Request) {
+	// The custom-method dispatcher split the id off the segment and bounded it
+	// before this handler was chosen at all; see customMethodTarget.
+	id := r.PathValue(customMethodIDValue)
+	if !s.requireNoQuery(w, r) {
+		return
+	}
+	if !s.requireJSONContent(w, r) {
+		return
+	}
+	request, ok := s.closeRequest(w, r, id)
+	if !ok {
+		return
+	}
+
+	lifecycle, err := s.lifecycle(r)
+	if err != nil {
+		s.failClose(w, r, err)
+		return
+	}
+	result, err := lifecycle.Close(r.Context(), request)
+	if err != nil {
+		s.failClose(w, r, err)
+		return
+	}
+	// `already_closed` is the wire's name for the idempotent re-close, which is
+	// exactly the case the role reports as an unchanged result — and the case
+	// whose `reason` and `session` were NOT rewritten.
+	writeJSON(w, apigen.CloseIssueResponse{
+		Issue:         *result.Issue,
+		AlreadyClosed: !result.Changed,
+		OpenChildren:  result.OpenChildren,
+	})
+}
+
+// closeRequest decodes and validates the body, and reports whether the request
+// may proceed. Every refusal here happens BEFORE any database work, which is
+// what lets the 400s reflect the caller's own input back.
+func (s *Server) closeRequest(w http.ResponseWriter, r *http.Request, id string) (issueops.CloseRequest, bool) {
+	members, res := decodeJSONObjectBody(w, r)
+	if res != nil {
+		s.fail(w, r, *res)
+		return issueops.CloseRequest{}, false
+	}
+	if offender, unknown := unknownMember(members, closeRequestMembers); unknown {
+		s.failUnknownMember(w, r, offender, closeRequestMembers)
+		return issueops.CloseRequest{}, false
+	}
+
+	actor, ok := s.bodyActor(w, r, members)
+	if !ok {
+		return issueops.CloseRequest{}, false
+	}
+	reason, ok := s.storedTextMember(w, r, members, "reason")
+	if !ok {
+		return issueops.CloseRequest{}, false
+	}
+	session, ok := s.storedTextMember(w, r, members, "session")
+	if !ok {
+		return issueops.CloseRequest{}, false
+	}
+	force, ok := s.booleanMember(w, r, members, "force")
+	if !ok {
+		return issueops.CloseRequest{}, false
+	}
+
+	// ExpectedVersion stays unpublished on this surface: a precondition would
+	// need a frozen conflict code for ErrVersionMismatch and a `row_version` on
+	// the issue body for clients to echo. Both are additive later.
+	return issueops.CloseRequest{
+		Actor:   actor,
+		IssueID: id,
+		Reason:  reason,
+		Session: session,
+		Force:   force,
+	}, true
+}
+
+// bodyActor validates `actor` under the claim's rules, shared rather than
+// restated: the value lands in the same columns and the same storage commit
+// message, so a newline forges the same audit-trail lines.
+//
+// It is batchCreateActor's body, lifted so that every operation carrying an
+// actor in an object body reads it the same way. The claim keeps its own
+// because its body has exactly one member and it refuses the rest by name
+// before looking at any of them.
+func (s *Server) bodyActor(w http.ResponseWriter, r *http.Request, members map[string]json.RawMessage) (string, bool) {
+	raw, ok := members[claimActorMember]
+	if !ok {
+		s.fail(w, r, InvalidArgument(claimActorMember, ReasonInvalidValue, "`"+claimActorMember+"` is required"))
+		return "", false
+	}
+	// Through a POINTER so that `null` reaches the type-mismatch branch, for
+	// the reason claimActor gives: unmarshaling JSON null into a string is a
+	// no-op, which would report a null as "empty after trimming" — the right
+	// status attached to prose that misdescribes what the client sent.
+	var actor *string
+	if err := json.Unmarshal(raw, &actor); err != nil || actor == nil {
+		s.fail(w, r, InvalidArgument(claimActorMember, ReasonInvalidValue, "`"+claimActorMember+"` must be a string"))
+		return "", false
+	}
+	trimmed, res := validateActor(*actor)
+	if res != nil {
+		s.fail(w, r, *res)
+		return "", false
+	}
+	return trimmed, true
+}
+
+// storedTextMember reads an optional string member destined for a stored
+// column, or reports the refusal it earned. An absent member is the empty
+// string, which is what the role reads as "not supplied".
+//
+// The bound is types.CheckFieldLen keyed on storage's own constant rather than
+// a second copy of the schema's number — the actor precedent, where the
+// schema's maxLength is prose and the constant is binding. Control characters
+// are refused for the actor's reason: these values land in columns that
+// renderers print, so an unfiltered C1 introducer makes a close reason an
+// escape-sequence payload in anything that shows it.
+//
+// Explicit `null` is a 400 naming the member rather than a clear. This surface
+// has no clearable member here — the role reads absence as "not supplied" and
+// first-close-wins means a re-close writes neither — so admitting null would
+// publish a third state with no meaning behind it.
+func (s *Server) storedTextMember(w http.ResponseWriter, r *http.Request, members map[string]json.RawMessage, name string) (string, bool) {
+	raw, ok := members[name]
+	if !ok {
+		return "", true
+	}
+	refuse := func(detail string) bool {
+		s.fail(w, r, InvalidArgument(name, ReasonInvalidValue, detail))
+		return false
+	}
+	var value *string
+	if err := json.Unmarshal(raw, &value); err != nil || value == nil {
+		return "", refuse("`" + name + "` must be a string")
+	}
+	switch {
+	case types.CheckFieldLen(name, *value) != nil:
+		return "", refuse(fmt.Sprintf("`%s` is %d characters; storage holds at most %d",
+			name, utf8.RuneCountInString(*value), types.MaxFieldLen))
+	case strings.ContainsFunc(*value, isControlChar):
+		return "", refuse("`" + name + "` must not contain control characters")
+	}
+	return *value, true
+}
+
+// booleanMember reads an optional boolean member, defaulting to false — the
+// document's default for every flag on this surface. Explicit `null` is a 400
+// naming the member, by storedTextMember's rule and for its reason.
+func (s *Server) booleanMember(w http.ResponseWriter, r *http.Request, members map[string]json.RawMessage, name string) (bool, bool) {
+	raw, ok := members[name]
+	if !ok {
+		return false, true
+	}
+	var value *bool
+	if err := json.Unmarshal(raw, &value); err != nil || value == nil {
+		s.fail(w, r, InvalidArgument(name, ReasonInvalidValue, "`"+name+"` must be a boolean"))
+		return false, false
+	}
+	return *value, true
+}
+
+// failClose answers a failed close, adding the extension member the
+// open-children 409 carries.
+//
+// The count comes from *issueops.CloseOpenChildrenError's own field, which the
+// role fills inside the transaction that refused — never from parsing the
+// sentinel's message ("%d open child issue(s)"). That substring classification
+// is what a client adopting this endpoint gets to delete, and it can only
+// delete it if the server never does it either.
+//
+// The live-blocker refusal shares the code and carries NO member, which is what
+// makes member presence the discriminator the document promises.
+func (s *Server) failClose(w http.ResponseWriter, r *http.Request, err error) {
+	var openChildren *issueops.CloseOpenChildrenError
+	if !errors.As(err, &openChildren) {
+		s.failErr(w, r, err)
+		return
+	}
+	res := ClassifyError(err)
+	if res.Problem.Code == string(CodeNotClosable) {
+		res = res.WithOpenChildren(openChildren.OpenChildren)
+	}
+	s.fail(w, r, res)
+}

--- a/internal/httpapi/close_test.go
+++ b/internal/httpapi/close_test.go
@@ -1,0 +1,526 @@
+package httpapi
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/issueops"
+)
+
+// These are pure: the close path runs end to end over a real listener against a
+// fake ROLE, so the wire edge — path split, media type, body rules, actor and
+// text rules, response and problem shapes — is covered on every pull request by
+// the PR workflow's unconditional Go test job. What a fake cannot prove is the
+// transaction: first-close-wins read back through a second close, and a forced
+// close over real open children, live in cmd/bd's proxied-server integration
+// test against real Dolt (TestProxiedServerServeClose). The role-level
+// transition is owned against a real store by
+// internal/storage/uow/lifecycle_close_reopen_contract_test.go, which this
+// slice cites rather than duplicates.
+
+const closePath = "/v0/beads/issues/bd-1:close"
+
+func (ts *testServer) closeIssue(t *testing.T, path, body string) *http.Response {
+	t.Helper()
+	return ts.postBody(t, path, "application/json", body)
+}
+
+// newCloseServer wires a server over the store-shaped source with a lifecycle
+// role the case controls. Every other role is a placeholder: Listen refuses a
+// partial source, and a close reaches none of them.
+func newCloseServer(t *testing.T, lifecycle *roleLifecycle) *testServer {
+	t.Helper()
+	return newTestServer(t, rolesConfig(Config{Lifecycle: lifecycle}))
+}
+
+func closedIssue(id string) *types.Issue {
+	issue := seededIssue(id, "alice", types.StatusClosed)
+	issue.CloseReason = "shipped"
+	issue.ClosedBySession = "session-7"
+	return issue
+}
+
+// TestCloseWritesOnceAndAnswersWithTheRowItWrote is the happy path and the two
+// things a client depends on: the role receives exactly what the body asked
+// for, and the response carries the issue as it stands after the close.
+func TestCloseWritesOnceAndAnswersWithTheRowItWrote(t *testing.T) {
+	lifecycle := &roleLifecycle{closeResult: issueops.CloseResult{Issue: closedIssue("bd-1"), Changed: true}}
+	ts := newCloseServer(t, lifecycle)
+
+	resp := ts.closeIssue(t, closePath, `{"actor":"alice","reason":"shipped","session":"session-7"}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+
+	want := issueops.CloseRequest{Actor: "alice", IssueID: "bd-1", Reason: "shipped", Session: "session-7"}
+	if got := lifecycle.closeRequests(); len(got) != 1 || got[0] != want {
+		t.Fatalf("the role received %+v, want exactly one %+v", got, want)
+	}
+
+	body := decodeBody(t, resp)
+	if body["already_closed"] != false {
+		t.Errorf("already_closed = %v, want false on a close that changed the row", body["already_closed"])
+	}
+	// An unforced close that got this far had no open children, and the
+	// document promises the member is present rather than omitted.
+	if body["open_children"] != float64(0) {
+		t.Errorf("open_children = %v, want 0", body["open_children"])
+	}
+	issue, ok := body["issue"].(map[string]any)
+	if !ok {
+		t.Fatalf("issue = %#v, want an object", body["issue"])
+	}
+	if issue["status"] != string(types.StatusClosed) || issue["close_reason"] != "shipped" {
+		t.Errorf("the response does not carry the closed row: %v", issue)
+	}
+}
+
+// TestCloseIsIdempotentForAnAlreadyClosedIssue pins the wire's name for the
+// role's unchanged result. It is the re-claim's answer to the same question: an
+// agent replaying its own recovery should not have to classify an error to
+// learn it already ran.
+func TestCloseIsIdempotentForAnAlreadyClosedIssue(t *testing.T) {
+	lifecycle := &roleLifecycle{closeResult: issueops.CloseResult{Issue: closedIssue("bd-1"), Changed: false}}
+	ts := newCloseServer(t, lifecycle)
+
+	resp := ts.closeIssue(t, closePath, `{"actor":"alice","reason":"a second opinion"}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	body := decodeBody(t, resp)
+	if body["already_closed"] != true {
+		t.Errorf("already_closed = %v, want true for a re-close", body["already_closed"])
+	}
+	// The response still carries the row, and the row still carries what the
+	// FIRST close wrote — the second reason never reached a column.
+	issue, ok := body["issue"].(map[string]any)
+	if !ok {
+		t.Fatalf("issue = %#v, want an object", body["issue"])
+	}
+	if issue["close_reason"] != "shipped" {
+		t.Errorf("close_reason = %v; a re-close must not rewrite the record of why the work ended", issue["close_reason"])
+	}
+}
+
+// TestCloseForwardsForceAndReportsWhatItBypassed: `force` is the ROLE's bypass,
+// so the handler's whole job is to pass it through — and to publish the count
+// the role reports, which is exactly what a caller who forced past the guard
+// wants to know.
+func TestCloseForwardsForceAndReportsWhatItBypassed(t *testing.T) {
+	lifecycle := &roleLifecycle{closeResult: issueops.CloseResult{
+		Issue: closedIssue("bd-1"), Changed: true, OpenChildren: 3,
+	}}
+	ts := newCloseServer(t, lifecycle)
+
+	resp := ts.closeIssue(t, closePath, `{"actor":"alice","force":true}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if got := lifecycle.closeRequests(); len(got) != 1 || !got[0].Force {
+		t.Fatalf("the role received %+v, want Force set", got)
+	}
+	if body := decodeBody(t, resp); body["open_children"] != float64(3) {
+		t.Errorf("open_children = %v, want the 3 the role reported", body["open_children"])
+	}
+}
+
+// TestCloseOpenChildrenIsATypedConflict is the whole reason not_closable exists
+// as a code and open_children as a member: a client classifies the refusal and
+// reads the count without substring-matching "3 open child issue(s)".
+func TestCloseOpenChildrenIsATypedConflict(t *testing.T) {
+	lifecycle := &roleLifecycle{closeErr: fmt.Errorf("close bd-1: %w",
+		&issueops.CloseOpenChildrenError{IssueID: "bd-1", OpenChildren: 3})}
+	ts := newCloseServer(t, lifecycle)
+
+	resp := ts.closeIssue(t, closePath, `{"actor":"alice"}`)
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status = %d, want 409: %s", resp.StatusCode, readAll(t, resp))
+	}
+	body := decodeBody(t, resp)
+	if body["code"] != string(CodeNotClosable) {
+		t.Errorf("code = %v, want %s", body["code"], CodeNotClosable)
+	}
+	if body["open_children"] != float64(3) {
+		t.Errorf("open_children = %v, want the count the refusing transaction observed", body["open_children"])
+	}
+}
+
+// TestCloseBlockedIsTheSameCodeWithoutTheCount is the other half of the
+// discriminator the document promises. Both refusals are `not_closable` and
+// both are bypassed by `force`; only one can say how many children it saw, and
+// MEMBER PRESENCE is how a client tells them apart.
+func TestCloseBlockedIsTheSameCodeWithoutTheCount(t *testing.T) {
+	lifecycle := &roleLifecycle{closeErr: fmt.Errorf("close bd-1: %w", issueops.ErrCloseBlocked)}
+	ts := newCloseServer(t, lifecycle)
+
+	resp := ts.closeIssue(t, closePath, `{"actor":"alice"}`)
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status = %d, want 409: %s", resp.StatusCode, readAll(t, resp))
+	}
+	body := decodeBody(t, resp)
+	if body["code"] != string(CodeNotClosable) {
+		t.Errorf("code = %v, want %s", body["code"], CodeNotClosable)
+	}
+	if _, present := body["open_children"]; present {
+		t.Errorf("the blocker refusal reported open_children, which is the other refusal's discriminator: %v", body)
+	}
+}
+
+// TestCloseUnknownIDIs404 keeps the miss on the shape the document already
+// describes rather than inventing one for this operation.
+func TestCloseUnknownIDIs404(t *testing.T) {
+	lifecycle := &roleLifecycle{closeErr: fmt.Errorf("close bd-9: %w", issueops.ErrNotFound)}
+	ts := newCloseServer(t, lifecycle)
+
+	resp := ts.closeIssue(t, "/v0/beads/issues/bd-9:close", `{"actor":"alice"}`)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if body := decodeBody(t, resp); body["code"] != string(CodeNotFound) {
+		t.Errorf("code = %v, want %s", body["code"], CodeNotFound)
+	}
+}
+
+// TestCloseRejectsTheShapesTheDocumentRefuses is the body vocabulary, refused
+// at the wire edge. Every case asserts that NOTHING reached the role: a 400
+// this handler can answer is a 400 no transaction should be opened for.
+func TestCloseRejectsTheShapesTheDocumentRefuses(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		body  string
+		param string
+	}{
+		{"no actor", `{"reason":"x"}`, "actor"},
+		{"blank actor", `{"actor":"   "}`, "actor"},
+		{"actor with a newline", "{\"actor\":\"alice\\nbd: close bd-1 by mallory\"}", "actor"},
+		{"actor with a C1 control character", `{"actor":"alice\u0085bd: close"}`, "actor"},
+		{"null actor", `{"actor":null}`, "actor"},
+		{"actor is not a string", `{"actor":7}`, "actor"},
+		{"oversize actor", `{"actor":"` + strings.Repeat("x", 300) + `"}`, "actor"},
+		{"unknown member", `{"actor":"alice","cascade":true}`, "cascade"},
+		{"reason is not a string", `{"actor":"alice","reason":7}`, "reason"},
+		// `null` is refused rather than read as a clear: absence already means
+		// "not supplied", so a null would publish a third state with no meaning.
+		{"null reason", `{"actor":"alice","reason":null}`, "reason"},
+		{"oversize reason", `{"actor":"alice","reason":"` + strings.Repeat("x", 300) + `"}`, "reason"},
+		{"reason with a control character", "{\"actor\":\"alice\",\"reason\":\"done\\nbd: forged\"}", "reason"},
+		{"session is not a string", `{"actor":"alice","session":[]}`, "session"},
+		{"null session", `{"actor":"alice","session":null}`, "session"},
+		{"session with a control character", "{\"actor\":\"alice\",\"session\":\"s\\u0000\"}", "session"},
+		{"force is not a boolean", `{"actor":"alice","force":"yes"}`, "force"},
+		{"null force", `{"actor":"alice","force":null}`, "force"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lifecycle := &roleLifecycle{closeResult: issueops.CloseResult{Issue: closedIssue("bd-1")}}
+			ts := newCloseServer(t, lifecycle)
+
+			resp := ts.closeIssue(t, closePath, tc.body)
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
+			}
+			body := decodeBody(t, resp)
+			if body["code"] != string(CodeInvalidArgument) {
+				t.Errorf("code = %v, want %s", body["code"], CodeInvalidArgument)
+			}
+			if body["param"] != tc.param {
+				t.Errorf("param = %v, want %q", body["param"], tc.param)
+			}
+			if got := lifecycle.closeRequests(); len(got) != 0 {
+				t.Errorf("a refused body reached the role: %+v", got)
+			}
+		})
+	}
+}
+
+// TestCloseRefusesABodyItCannotRead covers the refusals with no nameable
+// member, where `param` is documented absent.
+func TestCloseRefusesABodyItCannotRead(t *testing.T) {
+	for _, tc := range []struct{ name, body string }{
+		{"not an object", `["actor"]`},
+		{"a bare null", `null`},
+		{"trailing garbage", `{"actor":"alice"} {"actor":"mallory"}`},
+		{"unparseable", `{`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lifecycle := &roleLifecycle{}
+			ts := newCloseServer(t, lifecycle)
+
+			resp := ts.closeIssue(t, closePath, tc.body)
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
+			}
+			body := decodeBody(t, resp)
+			if body["code"] != string(CodeInvalidArgument) {
+				t.Errorf("code = %v, want %s", body["code"], CodeInvalidArgument)
+			}
+			if _, present := body["param"]; present {
+				t.Errorf("a body with no nameable part reported a param: %v", body)
+			}
+			if got := lifecycle.closeRequests(); len(got) != 0 {
+				t.Errorf("a refused body reached the role: %+v", got)
+			}
+		})
+	}
+}
+
+// TestCloseRefusesAForeignMediaType: the CSRF control, on the surface's newest
+// write. A JSON content type is not CORS-simple, so a cross-origin close always
+// triggers a preflight this server never approves.
+func TestCloseRefusesAForeignMediaType(t *testing.T) {
+	lifecycle := &roleLifecycle{}
+	ts := newTestServer(t, rolesConfig(Config{Lifecycle: lifecycle}))
+
+	resp := ts.postBody(t, closePath, "text/plain", `{"actor":"alice"}`)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if body := decodeBody(t, resp); body["param"] != "Content-Type" {
+		t.Errorf("param = %v, want Content-Type", body["param"])
+	}
+	if got := lifecycle.closeRequests(); len(got) != 0 {
+		t.Errorf("a foreign media type reached the role: %+v", got)
+	}
+}
+
+// TestCloseRefusesAQueryParameter: this operation publishes none, so every key
+// is the document-level unknown-parameter refusal.
+func TestCloseRefusesAQueryParameter(t *testing.T) {
+	lifecycle := &roleLifecycle{}
+	ts := newCloseServer(t, lifecycle)
+
+	resp := ts.closeIssue(t, closePath+"?force=true", `{"actor":"alice"}`)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
+	}
+	body := decodeBody(t, resp)
+	if body["reason"] != string(ReasonUnknownParameter) {
+		t.Errorf("reason = %v, want %s", body["reason"], ReasonUnknownParameter)
+	}
+	if got := lifecycle.closeRequests(); len(got) != 0 {
+		t.Errorf("a query string reached the role: %+v", got)
+	}
+}
+
+// TestCloseRefusesALifecycleThatAnswersWithNothing is checkedLifecycle's
+// reason for existing: handleClose dereferences the issue the role returned, so
+// a role reporting success without one is a nil pointer panic on a live server
+// unless it is folded into the generic 500 first.
+func TestCloseRefusesALifecycleThatAnswersWithNothing(t *testing.T) {
+	lifecycle := &roleLifecycle{closeResult: issueops.CloseResult{Changed: true}}
+	ts := newCloseServer(t, lifecycle)
+
+	resp := ts.closeIssue(t, closePath, `{"actor":"alice"}`)
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if body := decodeBody(t, resp); body["code"] != string(CodeInternal) {
+		t.Errorf("code = %v, want %s", body["code"], CodeInternal)
+	}
+	// The fault is in the log, which is the only place a 5xx detail may say
+	// what happened.
+	if !strings.Contains(ts.stderr.String(), "request_error") {
+		t.Errorf("a broken role produced no request_error line:\n%s", ts.stderr.String())
+	}
+}
+
+// TestClosePathReachesItsHandler drives the path the DOCUMENT spells, which is
+// the one thing route parity cannot check for a custom-method row: it declares
+// its spec path instead of deriving it from the pattern. The parity test bounds
+// the shape of that exception; only a request proves the shared pattern
+// actually serves the documented path — and serves it as THIS operation rather
+// than as the claim that registered the pattern first.
+func TestClosePathReachesItsHandler(t *testing.T) {
+	lifecycle := &roleLifecycle{closeResult: issueops.CloseResult{Issue: closedIssue("bd-1"), Changed: true}}
+	ts := newCloseServer(t, lifecycle)
+
+	if resp := ts.closeIssue(t, closePath, `{"actor":"alice"}`); resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST the documented close path: status = %d, want 200", resp.StatusCode)
+	}
+	line := findLogLine(t, ts.stderr.String(), "path="+closePath)
+	if !strings.Contains(line, "op="+OpCloseIssue) {
+		t.Errorf("the documented close path is served by another operation:\n%s", line)
+	}
+}
+
+// TestCloseTakesADatabaseSlot: the newest write is not exempt from the
+// in-flight limit. An exempt write would keep opening connections while every
+// reader is already queued — the saturation case the semaphore exists for.
+func TestCloseTakesADatabaseSlot(t *testing.T) {
+	for _, rt := range routeTable {
+		if rt.op != OpCloseIssue {
+			continue
+		}
+		if rt.bypassSemaphore {
+			t.Error("the close route bypasses the database semaphore; only handlers that touch no database may")
+		}
+		if !rt.implemented {
+			t.Error("the close route is still marked unimplemented, so capabilities will not advertise it")
+		}
+		return
+	}
+	t.Fatalf("no %s row in the route table", OpCloseIssue)
+}
+
+// TestCloseMapsARetryableRoleFailureOntoTheDocumentedRetry keeps the shared
+// error mapping load-bearing for this operation: an exhausted retry budget is
+// a 503 the client comes back from, never the generic 500.
+func TestCloseMapsARetryableRoleFailureOntoTheDocumentedRetry(t *testing.T) {
+	lifecycle := &roleLifecycle{closeErr: ErrBusy}
+	ts := newCloseServer(t, lifecycle)
+
+	resp := ts.closeIssue(t, closePath, `{"actor":"alice"}`)
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if body := decodeBody(t, resp); body["code"] != string(CodeBusy) {
+		t.Errorf("code = %v, want %s", body["code"], CodeBusy)
+	}
+	if got := resp.Header.Get("Retry-After"); got == "" {
+		t.Error("a retryable refusal carries no Retry-After")
+	}
+}
+
+// TestCloseTrimsTheActor pins that the value the role is handed is the trimmed
+// one, not the caller's whitespace — the same rule the claim applies, applied
+// by the same shared function.
+func TestCloseTrimsTheActor(t *testing.T) {
+	lifecycle := &roleLifecycle{closeResult: issueops.CloseResult{Issue: closedIssue("bd-1"), Changed: true}}
+	ts := newCloseServer(t, lifecycle)
+
+	if resp := ts.closeIssue(t, closePath, `{"actor":"  alice  "}`); resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if got := lifecycle.closeRequests(); len(got) != 1 || got[0].Actor != "alice" {
+		t.Errorf("the role received actor %q, want the trimmed value", got[0].Actor)
+	}
+}
+
+// TestCloseErrorsMapThroughTheSharedClassification pins the two close-policy
+// sentinels onto one code at the mapping rather than at the handler, so any
+// other operation that ever reaches them answers the same way.
+func TestCloseErrorsMapThroughTheSharedClassification(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"open children", &issueops.CloseOpenChildrenError{IssueID: "bd-1", OpenChildren: 2}},
+		{"the bare open-children sentinel", issueops.ErrCloseOpenChildren},
+		{"a live blocker", issueops.ErrCloseBlocked},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res := ClassifyError(fmt.Errorf("wrapped: %w", tc.err))
+			if res.Problem.Status != http.StatusConflict || res.Problem.Code != string(CodeNotClosable) {
+				t.Errorf("ClassifyError = %d/%s, want 409/%s", res.Problem.Status, res.Problem.Code, CodeNotClosable)
+			}
+			// The mapping never attaches the member — failClose does, from the
+			// typed error's field — so a code-only classification stays silent.
+			if res.Problem.OpenChildren != nil {
+				t.Errorf("the shared mapping attached open_children: %v", *res.Problem.OpenChildren)
+			}
+		})
+	}
+}
+
+// TestCloseIsNotReachableByOtherMethods: the dispatcher is registered for POST
+// alone, so the documented path under any other method is an unrouted path.
+func TestCloseIsNotReachableByOtherMethods(t *testing.T) {
+	ts := newCloseServer(t, &roleLifecycle{})
+
+	for _, method := range []string{http.MethodGet, http.MethodPut, http.MethodPatch, http.MethodDelete} {
+		req, err := http.NewRequest(method, ts.base+closePath, strings.NewReader(`{"actor":"alice"}`))
+		if err != nil {
+			t.Fatalf("new %s request: %v", method, err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := ts.client.Do(req)
+		if err != nil {
+			t.Fatalf("%s %s: %v", method, closePath, err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("%s %s: status = %d, want 404", method, closePath, resp.StatusCode)
+		}
+	}
+}
+
+// TestCloseRefusesUnrowableIDsBeforeAnyDatabaseWork: the id bound is the
+// dispatcher's and it is shared, so it holds for this operation without this
+// handler carrying a copy of it. The answer is the SAME 404 a real miss gets —
+// a distinct refusal would let a caller map the server's notion of a
+// well-formed id.
+func TestCloseRefusesUnrowableIDsBeforeAnyDatabaseWork(t *testing.T) {
+	for _, tc := range []struct{ name, id string }{
+		{"longer than the column", strings.Repeat("b", types.MaxFieldLen+1)},
+		{"carrying a control character", "bd-1%00"},
+		{"carrying a C1 introducer", "bd-1%C2%9B"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lifecycle := &roleLifecycle{}
+			ts := newCloseServer(t, lifecycle)
+
+			resp := ts.closeIssue(t, "/v0/beads/issues/"+tc.id+":close", `{"actor":"alice"}`)
+			if resp.StatusCode != http.StatusNotFound {
+				t.Fatalf("status = %d, want 404: %s", resp.StatusCode, readAll(t, resp))
+			}
+			if got := lifecycle.closeRequests(); len(got) != 0 {
+				t.Errorf("an unrowable id reached the role: %+v", got)
+			}
+		})
+	}
+}
+
+// TestCloseBodyCapIsEnforcedWhileReading pins that the megabyte cap refuses
+// before the whole body is buffered, which is what makes it a bound rather than
+// a check.
+func TestCloseBodyCapIsEnforcedWhileReading(t *testing.T) {
+	lifecycle := &roleLifecycle{}
+	ts := newCloseServer(t, lifecycle)
+
+	oversize := `{"actor":"alice","reason":"` + strings.Repeat("x", maxJSONBodyBytes+1) + `"}`
+	resp := ts.closeIssue(t, closePath, oversize)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if got := lifecycle.closeRequests(); len(got) != 0 {
+		t.Errorf("an oversize body reached the role: %+v", got)
+	}
+}
+
+// TestFailCloseNeverParsesTheRefusalsProse is the rule the whole 409 exists to
+// enforce, asserted at the seam: the member comes from the typed error's field,
+// so an error whose MESSAGE mentions open children but whose type is not the
+// typed one carries no member.
+func TestFailCloseNeverParsesTheRefusalsProse(t *testing.T) {
+	lifecycle := &roleLifecycle{closeErr: fmt.Errorf(
+		"cannot close bd-1: 4 open child issue(s); close children first: %w", issueops.ErrCloseBlocked)}
+	ts := newCloseServer(t, lifecycle)
+
+	resp := ts.closeIssue(t, closePath, `{"actor":"alice"}`)
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status = %d, want 409: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if body := decodeBody(t, resp); body["open_children"] != nil {
+		t.Errorf("open_children = %v; it was read out of the message rather than the typed field", body["open_children"])
+	}
+}
+
+// TestCloseResolvesAcrossBothPlanes is the divergence from the claim, pinned:
+// the claim addresses the issues table only, and this operation does not copy
+// that. Nothing here decides the plane — the ROLE does — so what this asserts
+// is that the handler publishes no IssuePlaneOnly-style narrowing of its own.
+func TestCloseResolvesAcrossBothPlanes(t *testing.T) {
+	wisp := seededIssue("bd-w1", "alice", types.StatusClosed)
+	lifecycle := &roleLifecycle{closeResult: issueops.CloseResult{Issue: wisp, Changed: true}}
+	ts := newCloseServer(t, lifecycle)
+
+	resp := ts.closeIssue(t, "/v0/beads/issues/bd-w1:close", `{"actor":"alice"}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("closing a wisp id: status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if got := lifecycle.closeRequests(); len(got) != 1 || got[0].IssueID != "bd-w1" {
+		t.Fatalf("the role received %+v, want the wisp id unchanged", got)
+	}
+}

--- a/internal/httpapi/delete_test.go
+++ b/internal/httpapi/delete_test.go
@@ -18,7 +18,7 @@ const deletePath = "/v0/beads/issues:delete"
 
 func (ts *testServer) delete(t *testing.T, body string) *http.Response {
 	t.Helper()
-	return ts.claimRequest(t, deletePath, "application/json", body)
+	return ts.postBody(t, deletePath, "application/json", body)
 }
 
 // TestDeletePathReachesItsHandler is the sweep row's twin: a LITERAL segment
@@ -257,7 +257,7 @@ func TestDeleteRefusesAForeignMediaType(t *testing.T) {
 	deleter := &roleDeleter{}
 	ts := newTestServer(t, rolesConfig(Config{Deleter: deleter}))
 
-	resp := ts.claimRequest(t, deletePath, "text/plain", `{"ids":["bd-1"]}`)
+	resp := ts.postBody(t, deletePath, "text/plain", `{"ids":["bd-1"]}`)
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
 	}
@@ -274,7 +274,7 @@ func TestDeleteRefusesAForeignMediaType(t *testing.T) {
 func TestDeletePublishesNoQueryParameters(t *testing.T) {
 	ts := newTestServer(t, rolesConfig(Config{Deleter: &roleDeleter{}}))
 
-	resp := ts.claimRequest(t, deletePath+"?force=true", "application/json", `{"ids":["bd-1"]}`)
+	resp := ts.postBody(t, deletePath+"?force=true", "application/json", `{"ids":["bd-1"]}`)
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
 	}

--- a/internal/httpapi/memories_test.go
+++ b/internal/httpapi/memories_test.go
@@ -20,7 +20,7 @@ const memoriesPath = "/v0/beads/memories"
 
 func (ts *testServer) remember(t *testing.T, body string) *http.Response {
 	t.Helper()
-	return ts.claimRequest(t, memoriesPath, "application/json", body)
+	return ts.postBody(t, memoriesPath, "application/json", body)
 }
 
 func (ts *testServer) forget(t *testing.T, path string) *http.Response {
@@ -224,7 +224,7 @@ func TestRememberRefusesAQueryString(t *testing.T) {
 	memories := &roleMemories{}
 	ts := newTestServer(t, rolesConfig(Config{Memories: memories}))
 
-	resp := ts.claimRequest(t, memoriesPath+"?key=k", "application/json", `{"content":"x"}`)
+	resp := ts.postBody(t, memoriesPath+"?key=k", "application/json", `{"content":"x"}`)
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
 	}

--- a/internal/httpapi/problem.go
+++ b/internal/httpapi/problem.go
@@ -16,6 +16,7 @@ import (
 	"github.com/steveyegge/beads/internal/httpapi/apigen"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/uow"
+	"github.com/steveyegge/beads/issueops"
 )
 
 // Every non-2xx byte this server emits is an RFC 9457 problem+json document
@@ -58,6 +59,17 @@ const (
 	// sentinel's message text.
 	CodeAlreadyClaimed Code = "already_claimed"
 	CodeNotClaimable   Code = "not_claimable"
+	// CodeNotClosable is close policy refusing an unforced close: open
+	// children, or a live blocker. The open-children refusal carries the count
+	// in the `open_children` extension member, read inside the refusing
+	// transaction — never parsed out of the sentinel's message text — and its
+	// PRESENCE is how a client tells the two refusals apart without prose.
+	//
+	// A 409 rather than the delete precedent's 400: this is a statement about
+	// the current state of one named resource, so the same request succeeds or
+	// fails on state the client cannot see without reading it. That is the
+	// not_claimable situation and it gets the not_claimable answer.
+	CodeNotClosable Code = "not_closable"
 	// CodeBusy is retryable contention: the transaction retry budget was
 	// exhausted, or the in-flight request limit was saturated.
 	CodeBusy Code = "busy"
@@ -82,6 +94,7 @@ var codeStatus = map[Code]int{
 	CodeNotFound:        http.StatusNotFound,
 	CodeAlreadyClaimed:  http.StatusConflict,
 	CodeNotClaimable:    http.StatusConflict,
+	CodeNotClosable:     http.StatusConflict,
 	CodeBusy:            http.StatusServiceUnavailable,
 	CodeDBUnavailable:   http.StatusServiceUnavailable,
 	CodeInternal:        http.StatusInternalServerError,
@@ -143,13 +156,19 @@ var ErrBusy = errors.New("server busy")
 
 // Operation ids, matching the spec's operationId values exactly.
 const (
-	OpHealth               = "health"
-	OpGetContext           = "getContext"
-	OpListReadyWork        = "listReadyWork"
-	OpGetStats             = "getStats"
-	OpListIssues           = "listIssues"
-	OpGetIssue             = "getIssue"
-	OpClaimIssue           = "claimIssue"
+	OpHealth        = "health"
+	OpGetContext    = "getContext"
+	OpListReadyWork = "listReadyWork"
+	OpGetStats      = "getStats"
+	OpListIssues    = "listIssues"
+	OpGetIssue      = "getIssue"
+	OpClaimIssue    = "claimIssue"
+	// OpCloseIssue is the second half of the agent loop this surface exists to
+	// serve: claim, work, close. It is a named lifecycle action rather than a
+	// status patch because Close carries semantics a patch has nowhere to put —
+	// the reason and session under first-close-wins, the done-status
+	// normalization, and the close policy vocabulary.
+	OpCloseIssue           = "closeIssue"
 	OpListSettings         = "listSettings"
 	OpGetSetting           = "getSetting"
 	OpListDependencyCycles = "listDependencyCycles"
@@ -283,6 +302,15 @@ var operationCodes = map[string][]Code{
 		CodeInvalidArgument, CodeNotFound, CodeAlreadyClaimed, CodeNotClaimable,
 		CodeBusy, CodeDBUnavailable, CodeInternal,
 	},
+	// The 409 is close POLICY, and it is the only conflict this operation has:
+	// an unforced close refused for open children or for a live blocker. There
+	// is no already_claimed here — closing work somebody else holds is not a
+	// refusal on this surface — and the idempotent re-close is a 200 carrying
+	// `already_closed`, the claim's answer to the same question.
+	OpCloseIssue: {
+		CodeInvalidArgument, CodeNotFound, CodeNotClosable,
+		CodeBusy, CodeDBUnavailable, CodeInternal,
+	},
 	// No not_found. The role refuses an edge whose target names nothing, and
 	// that refusal is about the REQUEST BODY the client sent, not about a
 	// resource this operation was asked to address — there is no id in the path
@@ -338,6 +366,19 @@ func (r Result) WithAssignee(assignee string) Result {
 // status at the moment of refusal). Same rule as WithAssignee.
 func (r Result) WithIssueStatus(status string) Result {
 	r.Problem.IssueStatus = &status
+	return r
+}
+
+// WithOpenChildren attaches the `open_children` extension member (how many open
+// children the transaction that refused a close observed). Same rule as
+// WithAssignee: it comes from the typed error's own field, read inside that
+// transaction, never from parsing the refusal's prose.
+//
+// Its PRESENCE is load-bearing. It is attached for the open-children refusal
+// and withheld for the live-blocker one, which is how a client tells the two
+// apart without reading `detail`.
+func (r Result) WithOpenChildren(n int) Result {
+	r.Problem.OpenChildren = &n
 	return r
 }
 
@@ -441,6 +482,17 @@ func ClassifyError(err error) Result {
 
 	case errors.Is(err, storage.ErrNotClaimable):
 		return newResult(CodeNotClaimable, "issue is not in a claimable state")
+
+	// The two close-policy refusals share one code. They are the same statement
+	// to a client — the close was refused for the state of the graph around
+	// this issue, and `force` is the bypass for both — and what distinguishes
+	// them on the wire is the `open_children` member failClose attaches, not a
+	// second vocabulary entry.
+	case errors.Is(err, issueops.ErrCloseOpenChildren):
+		return newResult(CodeNotClosable, "issue has open children; close them first or close with force")
+
+	case errors.Is(err, issueops.ErrCloseBlocked):
+		return newResult(CodeNotClosable, "issue is blocked; clear the blocker or close with force")
 
 	case errors.Is(err, ErrBusy):
 		res := newResult(CodeBusy, "")

--- a/internal/httpapi/roles.go
+++ b/internal/httpapi/roles.go
@@ -91,6 +91,50 @@ func (c checkedBatchCreator) CreateBatch(ctx context.Context, req issueops.Creat
 	return result, nil
 }
 
+// checkedLifecycle is the lifecycle role every mutation handler is handed.
+//
+// Close is the whole reason the type exists on this slice: handleClose writes
+// *result.Issue, which is checkedClaimer's hazard exactly. Create, Update and
+// Reopen pass through because no handler on this surface reaches them yet; each
+// grows a guard in the change that publishes its operation, rather than one
+// written speculatively against a body nobody marshals.
+type checkedLifecycle struct{ inner issueops.Lifecycle }
+
+// Create passes the request through unchanged: this surface publishes no
+// create-one operation (batchCreateIssues reaches issueops.BatchCreator).
+func (c checkedLifecycle) Create(ctx context.Context, req issueops.CreateRequest) (issueops.CreateResult, error) {
+	return c.inner.Create(ctx, req)
+}
+
+// Update passes the request through unchanged; updateIssue is not published on
+// this surface yet.
+func (c checkedLifecycle) Update(ctx context.Context, req issueops.UpdateRequest) (issueops.UpdateResult, error) {
+	return c.inner.Update(ctx, req)
+}
+
+// Close refuses a result that reports success without the row the response body
+// is built from.
+//
+// There is no wire code for it and there must not be one: `already_closed` says
+// the issue was closed earlier and the response still carries the row, and a
+// 404 would tell a client the issue does not exist when nothing here knows
+// that. It is a broken implementation, so it is the generic 500 — with the
+// fault in the log as an error and a request_error line beside it, which is
+// what the panic it replaces did not produce.
+func (c checkedLifecycle) Close(ctx context.Context, req issueops.CloseRequest) (issueops.CloseResult, error) {
+	result, err := c.inner.Close(ctx, req)
+	if err == nil && result.Issue == nil {
+		return issueops.CloseResult{}, fmt.Errorf("close %q: the lifecycle reported success without an issue", req.IssueID)
+	}
+	return result, err
+}
+
+// Reopen passes the request through unchanged; reopenIssue is not published on
+// this surface yet.
+func (c checkedLifecycle) Reopen(ctx context.Context, req issueops.ReopenRequest) (issueops.ReopenResult, error) {
+	return c.inner.Reopen(ctx, req)
+}
+
 // checkedClaimer is the claimer the claim handler is handed.
 type checkedClaimer struct{ inner issueops.Claimer }
 

--- a/internal/httpapi/roles_test.go
+++ b/internal/httpapi/roles_test.go
@@ -361,6 +361,50 @@ func (c *roleClaimer) claimRequests() []issueops.ClaimRequest {
 	return append([]issueops.ClaimRequest(nil), c.claims...)
 }
 
+// roleLifecycle is the store-shaped source's guarded-mutation role. Every case
+// hands Listen a COMPLETE source, so this exists partly to be a placeholder —
+// but the close tests drive it directly, which is what the claim precedent
+// calls the wire edge on a fake role: the path split, the media type, the body
+// rules and the problem shapes, with the transaction and the policy left to the
+// integration test against real Dolt.
+type roleLifecycle struct {
+	closeResult issueops.CloseResult
+	closeErr    error
+
+	mu     sync.Mutex
+	closes []issueops.CloseRequest
+}
+
+func (l *roleLifecycle) Create(_ context.Context, _ issueops.CreateRequest) (issueops.CreateResult, error) {
+	return issueops.CreateResult{}, errors.New("create is not published on this surface")
+}
+
+func (l *roleLifecycle) Update(_ context.Context, _ issueops.UpdateRequest) (issueops.UpdateResult, error) {
+	return issueops.UpdateResult{}, errors.New("update is not published on this surface")
+}
+
+func (l *roleLifecycle) Close(_ context.Context, req issueops.CloseRequest) (issueops.CloseResult, error) {
+	l.mu.Lock()
+	l.closes = append(l.closes, req)
+	l.mu.Unlock()
+	if l.closeErr != nil {
+		return issueops.CloseResult{}, l.closeErr
+	}
+	return l.closeResult, nil
+}
+
+func (l *roleLifecycle) Reopen(_ context.Context, _ issueops.ReopenRequest) (issueops.ReopenResult, error) {
+	return issueops.ReopenResult{}, errors.New("reopen is not published on this surface")
+}
+
+// closeRequests is how a case asserts that a refusal happened at the wire edge:
+// an empty list means nothing reached the role.
+func (l *roleLifecycle) closeRequests() []issueops.CloseRequest {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]issueops.CloseRequest(nil), l.closes...)
+}
+
 type roleSettings struct {
 	value    string
 	settings map[string]string
@@ -454,6 +498,9 @@ func rolesConfig(cfg Config) Config {
 	}
 	if cfg.Claimer == nil {
 		cfg.Claimer = &roleClaimer{}
+	}
+	if cfg.Lifecycle == nil {
+		cfg.Lifecycle = &roleLifecycle{}
 	}
 	if cfg.Settings == nil {
 		cfg.Settings = &roleSettings{}

--- a/internal/httpapi/routes.go
+++ b/internal/httpapi/routes.go
@@ -3,7 +3,65 @@ package httpapi
 import (
 	"net/http"
 	"slices"
+	"strings"
+
+	"github.com/steveyegge/beads/internal/types"
 )
+
+const (
+	// customMethodPathValue names the ServeMux wildcard the single-resource
+	// custom methods share. The route rows build their pattern from it and
+	// customMethodTarget splits the custom method back off the segment it
+	// matched, so the two halves of the one path exception cannot drift apart.
+	customMethodPathValue = "idop"
+	// customMethodPattern is that one registration. Every row carrying a
+	// customMethod declares it, and s.handler collapses them into a single
+	// ServeMux entry.
+	customMethodPattern = "/v0/beads/issues/{" + customMethodPathValue + "}"
+	// customMethodIDValue is where the dispatcher leaves the id it split out,
+	// so a handler reads its target exactly as one on a literal `{id}` pattern
+	// does rather than re-deriving the split.
+	customMethodIDValue = "id"
+)
+
+// customMethodTarget splits the custom method off the segment the router
+// matched, and reports the row that claims it.
+//
+// ServeMux wildcards match a whole path segment, so `{id}:claim` is not
+// expressible as a pattern: the rows register one shared wildcard and the parse
+// lands here. A segment that ends in no REGISTERED suffix is not an addressable
+// resource on this surface — POST on the issue-detail path is documented
+// nowhere — so it gets the same 404 the catch-all gives any other unrouted
+// path. That is what keeps the wide pattern a routing detail rather than
+// undocumented surface.
+//
+// The id itself is bounded HERE, once for every operation on the pattern, for
+// the same reason the actor is bounded at the edge: this is the last point
+// before a request buys a concurrency slot and two database round trips.
+// `issues.id` is VARCHAR(255) and the document calls the parameter an exact
+// canonical id, so a longer one — or one carrying a control character, which a
+// percent-escape in the path decodes to — names no row that can exist.
+func customMethodTarget(rows []route, segment string) (route, string, *Result) {
+	unrouted := func() *Result {
+		res := newResult(CodeNotFound, "no such route on this server")
+		return &res
+	}
+	for _, rt := range rows {
+		id, ok := strings.CutSuffix(segment, rt.customMethod)
+		if !ok || id == "" {
+			continue
+		}
+		if types.CheckFieldLen("id", id) != nil || strings.ContainsFunc(id, isControlChar) {
+			// The SAME 404 a real miss gets. A distinct refusal here would let
+			// a caller map the server's notion of a well-formed id, and there
+			// is nothing to learn from it: no such row exists either way.
+			res := NotFound()
+			return route{}, "", &res
+		}
+		return rt, id, nil
+	}
+	return route{}, "", unrouted()
+}
 
 // route is one row of the surface: an operation, where it lives in the
 // document, where it lives in the router, and what the request lifecycle owes
@@ -21,8 +79,21 @@ type route struct {
 	pattern string
 	// specPath is the path as the DOCUMENT spells it. Declared, never derived
 	// from pattern, because the two genuinely differ for the custom-method
-	// claim route and a derivation would have to encode that exception.
+	// rows below and a derivation would have to encode that exception.
 	specPath string
+	// customMethod is the `:verb` this row answers on a SHARED wildcard
+	// pattern, or "" for a row the router can spell literally.
+	//
+	// ServeMux wildcards match a whole segment, so `{id}:close` is not
+	// expressible as a pattern — and the single-resource custom methods
+	// COLLIDE: three rows cannot each register POST /v0/beads/issues/{idop}.
+	// Rows carrying this field share one registration; the dispatcher splits
+	// the trailing suffix off the matched segment and hands the request to the
+	// row that claims it (see customMethodTarget).
+	//
+	// A row with a customMethod must declare its specPath, because the whole
+	// point is that the router cannot spell the documented path.
+	customMethod string
 	// capability is the token this operation contributes to
 	// ContextResponse.capabilities, or "" for operations outside that
 	// vocabulary. A stub contributes nothing whatever this says.
@@ -198,25 +269,40 @@ var routeTable = []route{
 	{
 		op:      OpClaimIssue,
 		method:  http.MethodPost,
-		pattern: "/v0/beads/issues/{" + claimPathValue + "}",
-		// The one row where pattern and specPath differ. ServeMux wildcards
+		pattern: customMethodPattern,
+		// One of the rows where pattern and specPath differ. ServeMux wildcards
 		// match a whole path segment, so `{id}:claim` is not expressible as a
-		// pattern: the handler takes the segment whole and splits the custom
-		// method off itself (claimTarget). Declaring specPath here keeps the
-		// parity test honest instead of teaching it this exception;
-		// TestSpecRouteParity bounds the exception's shape and
-		// TestClaimPathReachesItsHandler drives the documented path.
+		// pattern: the rows sharing this pattern register once and the
+		// dispatcher splits the custom method off the matched segment
+		// (customMethodTarget). Declaring specPath here keeps the parity test
+		// honest instead of teaching it this exception; TestSpecRouteParity
+		// bounds the exception's shape and TestClaimPathReachesItsHandler
+		// drives the documented path.
 		//
 		// The wildcard therefore matches every POST under /v0/beads/issues/,
 		// including the issue-detail path the document declares GET-only.
-		// claimTarget answers 404 — the same answer the catch-all gives any
-		// other unrouted path — for a segment that does not end in the custom
-		// method, so the wide pattern stays a routing detail rather than
-		// undocumented surface. TestClaimNarrowsThePOSTSurface pins it.
-		specPath:    "/v0/beads/issues/{id}:claim",
-		capability:  "issues.claim",
-		implemented: true,
-		handler:     (*Server).handleClaim,
+		// The dispatcher answers 404 — the same answer the catch-all gives any
+		// other unrouted path — for a segment that ends in no registered
+		// suffix, so the wide pattern stays a routing detail rather than
+		// undocumented surface. TestCustomMethodsNarrowThePOSTSurface pins it.
+		specPath:     "/v0/beads/issues/{id}:claim",
+		customMethod: ":claim",
+		capability:   "issues.claim",
+		implemented:  true,
+		handler:      (*Server).handleClaim,
+	},
+	{
+		op:     OpCloseIssue,
+		method: http.MethodPost,
+		// The second row on the shared wildcard, and the reason the dispatcher
+		// exists: two rows cannot each register this pattern. Everything the
+		// claim row says about the wildcard's width holds here unchanged.
+		pattern:      customMethodPattern,
+		specPath:     "/v0/beads/issues/{id}:close",
+		customMethod: ":close",
+		capability:   "issues.close",
+		implemented:  true,
+		handler:      (*Server).handleClose,
 	},
 	{
 		op:     OpSweepIssues,

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -170,8 +170,14 @@ type Config struct {
 	// one reason — so the units of work they open land in that request's uow_ms
 	// (see Server.reader) — and a role reached this way opens none through this
 	// server, so a rebuild would buy nothing.
-	Reader            issueops.Reader
-	Claimer           issueops.Claimer
+	Reader  issueops.Reader
+	Claimer issueops.Claimer
+	// Lifecycle is the guarded-mutation role behind the issue lifecycle
+	// operations. Required on the same terms as every field here, and the
+	// hook-firing refusal below bites hardest on it: a store's own
+	// IssueLifecycle() returns a role that fires on_create, on_update and the
+	// close hooks for every mutation it lands.
+	Lifecycle         issueops.Lifecycle
 	Settings          issueops.WorkspaceConfig
 	Stats             issueops.StatsReporter
 	CycleDetector     issueops.CycleDetector
@@ -224,6 +230,7 @@ type Server struct {
 	// names because a struct cannot carry both.
 	issueReader       issueops.Reader
 	issueClaimer      issueops.Claimer
+	issueLifecycle    issueops.Lifecycle
 	settings          issueops.WorkspaceConfig
 	issueStats        issueops.StatsReporter
 	issueCycles       issueops.CycleDetector
@@ -334,6 +341,7 @@ func Listen(cfg Config) (*Server, error) {
 		provider:          cfg.Provider,
 		issueReader:       cfg.Reader,
 		issueClaimer:      cfg.Claimer,
+		issueLifecycle:    cfg.Lifecycle,
 		settings:          cfg.Settings,
 		issueStats:        cfg.Stats,
 		issueCycles:       cfg.CycleDetector,
@@ -435,12 +443,12 @@ func Listen(cfg Config) (*Server, error) {
 // actually sets; a typed nil stored in one of these fields is a value as far as
 // this check is concerned.
 func sourceRoles(cfg Config) []any {
-	return []any{cfg.Reader, cfg.Claimer, cfg.Settings, cfg.Stats, cfg.CycleDetector, cfg.EdgeReader, cfg.BlockingAnnotator, cfg.TreeWalker, cfg.ReadyCounter, cfg.Querier, cfg.Sweeper, cfg.Deleter, cfg.BatchCreator, cfg.Memories}
+	return []any{cfg.Reader, cfg.Claimer, cfg.Lifecycle, cfg.Settings, cfg.Stats, cfg.CycleDetector, cfg.EdgeReader, cfg.BlockingAnnotator, cfg.TreeWalker, cfg.ReadyCounter, cfg.Querier, cfg.Sweeper, cfg.Deleter, cfg.BatchCreator, cfg.Memories}
 }
 
 // roleSourceNames spells sourceRoles for the refusal message, in the same
 // order, so a caller reading the error learns the whole set it must pass.
-const roleSourceNames = "Reader, Claimer, Settings, Stats, CycleDetector, EdgeReader, BlockingAnnotator, TreeWalker, ReadyCounter, Querier, Sweeper, Deleter, BatchCreator and Memories"
+const roleSourceNames = "Reader, Claimer, Lifecycle, Settings, Stats, CycleDetector, EdgeReader, BlockingAnnotator, TreeWalker, ReadyCounter, Querier, Sweeper, Deleter, BatchCreator and Memories"
 
 func anyRoleSet(cfg Config) bool {
 	return slices.ContainsFunc(sourceRoles(cfg), func(r any) bool { return r != nil })
@@ -614,6 +622,25 @@ func (s *Server) claimer(r *http.Request) (issueops.Claimer, error) {
 		return nil, err
 	}
 	return checkedClaimer{inner: cl}, nil
+}
+
+// lifecycle returns the guarded issue-mutation surface for one request.
+//
+// Built the same two ways as claimer above and for the same reasons: the
+// configured role on the roles source, and on the provider source one built per
+// request so its units of work are timed into THIS request's log line, held by
+// INTERFACE so uow.IssueLifecycleSource is load-bearing rather than decorative
+// — and, from either source, wrapped in checkedLifecycle.
+func (s *Server) lifecycle(r *http.Request) (issueops.Lifecycle, error) {
+	if s.provider == nil {
+		return checkedLifecycle{inner: s.issueLifecycle}, nil
+	}
+	var src uow.IssueLifecycleSource = timedProvider{inner: s.provider, rec: requestInfo(r.Context())}
+	lc, err := src.IssueLifecycle()
+	if err != nil {
+		return nil, err
+	}
+	return checkedLifecycle{inner: lc}, nil
 }
 
 // workspaceConfig returns the guarded workspace-settings surface for one
@@ -864,8 +891,24 @@ func orDefault(v, fallback time.Duration) time.Duration {
 // middleware in front of both.
 func (s *Server) handler() http.Handler {
 	mux := http.NewServeMux()
+	// Rows carrying a customMethod SHARE a pattern, so they get one
+	// registration between them and a dispatcher in front. Collected in table
+	// order, which is the order customMethodTarget tries the suffixes in.
+	shared := map[string][]route{}
+	var sharedOrder []string
 	for _, rt := range routeTable {
-		mux.Handle(rt.method+" "+rt.pattern, s.route(rt))
+		if rt.customMethod == "" {
+			mux.Handle(rt.method+" "+rt.pattern, s.route(rt))
+			continue
+		}
+		key := rt.method + " " + rt.pattern
+		if _, seen := shared[key]; !seen {
+			sharedOrder = append(sharedOrder, key)
+		}
+		shared[key] = append(shared[key], rt)
+	}
+	for _, key := range sharedOrder {
+		mux.Handle(key, s.dispatchCustomMethod(shared[key]))
 	}
 
 	// Not an operation and deliberately not in the route table: it exists so
@@ -1043,6 +1086,29 @@ func (s *Server) checkHost(next http.Handler) http.Handler {
 			return
 		}
 		next.ServeHTTP(w, r)
+	})
+}
+
+// dispatchCustomMethod is the one registration the single-resource custom
+// methods share. It splits the trailing `:verb` off the matched segment, hands
+// the request to the row that claims it, and leaves the id where that row's
+// handler reads it.
+//
+// The split happens BEFORE s.route, which is what makes an unrouted suffix cost
+// nothing: it takes no database slot and books no operation on the request
+// line, exactly as the catch-all's 404 does. Answering it from inside a row's
+// handler — where the claim answered it while it was the only POST here — would
+// attribute every probe of this prefix to whichever operation happened to be
+// first in the table.
+func (s *Server) dispatchCustomMethod(rows []route) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rt, id, res := customMethodTarget(rows, r.PathValue(customMethodPathValue))
+		if res != nil {
+			s.fail(w, r, *res)
+			return
+		}
+		r.SetPathValue(customMethodIDValue, id)
+		s.route(rt).ServeHTTP(w, r)
 	})
 }
 

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -588,7 +588,7 @@ func TestCapabilitiesAdvertiseEveryImplementedOperation(t *testing.T) {
 	want := []string{
 		"config.get", "config.list", "dependencies.blocking", "dependencies.cycles",
 		"dependencies.list", "dependencies.tree", "issues.batchCreate",
-		"issues.claim", "issues.delete", "issues.get", "issues.list",
+		"issues.claim", "issues.close", "issues.delete", "issues.get", "issues.list",
 		"issues.query", "issues.sweep", "memories.forget", "memories.get",
 		"memories.list", "memories.remember", "ready.count", "ready.list",
 		"stats.get",

--- a/internal/httpapi/spec/openapi.v0.yaml
+++ b/internal/httpapi/spec/openapi.v0.yaml
@@ -56,7 +56,8 @@ info:
       `reason: "unknown_parameter"` and `param` naming the offending key.
       Operations with no parameters at all (`GET /healthz`,
       `GET /v0/beads/context`, `GET /v0/beads/dependencies/cycles`,
-      `POST /v0/beads/issues/{id}:claim`, `POST /v0/beads/issues:sweep`,
+      `POST /v0/beads/issues/{id}:claim`,
+      `POST /v0/beads/issues/{id}:close`, `POST /v0/beads/issues:sweep`,
       `POST /v0/beads/issues:delete`, `GET /v0/beads/config`,
       `GET /v0/beads/config/{key}`) reject every query key the same way.
 
@@ -1297,6 +1298,102 @@ paths:
             `assignee` extension member) or is not in a claimable state
             (`not_claimable`, with the `issue_status` extension member).
           x-bd-codes: [already_claimed, not_claimable]
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '500':
+          $ref: '#/components/responses/InternalError'
+        '503':
+          $ref: '#/components/responses/Unavailable'
+
+  /v0/beads/issues/{id}:close:
+    post:
+      operationId: closeIssue
+      summary: Close one issue
+      description: >-
+        Closes the issue this path names, moving it to the literal `closed`
+        status including from a configured done status. It is the half of the
+        agent loop — claim, work, close — that this surface did not serve
+        before.
+
+
+        A named lifecycle action rather than a status patch, because the close
+        carries semantics a patch has nowhere to put: the reason and session
+        under first-close-wins, the done-status normalization, and the close
+        POLICY vocabulary below.
+
+
+        THE FIRST CLOSE WINS. A re-close of an already-closed issue is
+        idempotent — 200 with `already_closed: true` — and writes neither
+        `reason` nor `session`, so a replayed close cannot rewrite the record of
+        why the work ended. The stored pair keeps what the first close gave it
+        until a reopen clears both.
+
+
+        ## Close policy
+
+
+        An unforced close is refused with `409` / `not_closable` when the issue
+        has open children (the refusal carries `open_children`, the count the
+        refusing transaction observed) or a live blocker (no such member). The
+        MEMBER'S PRESENCE is the discriminator, so telling the two apart never
+        requires reading `detail`. Both refusals are the ROLE's, so `force`
+        bypasses those two and nothing else — this endpoint cannot skip a guard
+        by forgetting one exists.
+
+
+        ## Planes
+
+
+        The id resolves across BOTH planes, unlike
+        `POST /v0/beads/issues/{id}:claim`. A close whose target is a wisp lands
+        on the unversioned plane and records no durable history entry.
+
+
+        ## Hooks and auto-commit
+
+
+        Hooks do not fire and the per-command auto-commit machinery does not
+        run, exactly as for `POST /v0/beads/issues/{id}:claim`. The only durable
+        effect is the single storage commit the role makes in its own
+        transaction.
+      parameters:
+        - $ref: '#/components/parameters/IssueID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CloseIssueRequest'
+      responses:
+        '200':
+          description: The issue is closed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloseIssueResponse'
+        '400':
+          description: >-
+            Invalid request: an unknown query parameter, an unparseable or
+            oversized body, an unknown body member, an `actor` that is empty
+            after trimming, longer than 256 bytes, or carrying control
+            characters — or a `reason` or `session` longer than the column
+            holds or carrying control characters.
+          x-bd-codes: [invalid_argument]
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: >-
+            Close policy refused an unforced close (`not_closable`): the issue
+            has open children — carrying the `open_children` extension member —
+            or a live blocker, which carries none. Resend with `force: true` to
+            bypass both. Nothing was written.
+          x-bd-codes: [not_closable]
           content:
             application/problem+json:
               schema:
@@ -3180,6 +3277,7 @@ components:
             The operations this server actually implements, derived from its
             route table. v0's vocabulary is `ready.list`, `ready.count`,
             `issues.list`, `issues.query`, `issues.get`, `issues.claim`,
+            `issues.close`,
             `issues.sweep`, `issues.delete`, `issues.batchCreate`,
             `stats.get`, `config.list`, `config.get`, `dependencies.cycles`,
             `dependencies.list`, `dependencies.blocking`, `dependencies.tree`,
@@ -4072,6 +4170,70 @@ components:
             nothing — the idempotent re-claim. A claim held by a DIFFERENT
             actor is a 409, not a 200 with this flag.
 
+    CloseIssueRequest:
+      type: object
+      additionalProperties: false
+      required: [actor]
+      properties:
+        actor:
+          type: string
+          minLength: 1
+          maxLength: 256
+          pattern: '^[^\u0000-\u001F\u007F-\u009F\u2028\u2029]+$'
+          description: >-
+            Who is closing the issue. `ClaimRequest.actor`'s rules exactly: the
+            server trims it, then refuses an empty result, anything longer than
+            256 BYTES (the `maxLength` above counts characters — the byte limit
+            is the binding one), and any control character including newline.
+            The value reaches stored columns, event-stream attribution and the
+            storage commit message, so an unvalidated newline would forge
+            audit-trail lines.
+        reason:
+          type: string
+          maxLength: 255
+          description: >-
+            Why the issue is closed. Stored on the issue and read back as
+            `close_reason`. THE FIRST CLOSE WINS: an idempotent re-close writes
+            neither this nor `session`, so a replayed close cannot rewrite the
+            record of why the work ended. Refused for control characters, and
+            bounded by what the column holds rather than by the number above.
+        session:
+          type: string
+          maxLength: 255
+          description: >-
+            The working session that closed the issue, stored and read back as
+            `closed_by_session`, under the same first-close-wins rule and the
+            same bounds as `reason`.
+        force:
+          type: boolean
+          default: false
+          description: >-
+            Bypass close policy — the open-children refusal and the
+            live-blocker refusal — and nothing else. The refusals are the
+            ROLE's, so this endpoint cannot skip a guard by forgetting one
+            exists. A forced close still reports `open_children`.
+
+    CloseIssueResponse:
+      type: object
+      required: [issue, already_closed, open_children]
+      properties:
+        issue:
+          $ref: '#/components/schemas/Issue'
+        already_closed:
+          type: boolean
+          description: >-
+            True when the issue was already closed and this call changed
+            nothing — the idempotent re-close, mirroring
+            `ClaimResponse.already_claimed`. The response still carries the
+            row, and `reason`/`session` were not rewritten.
+        open_children:
+          type: integer
+          description: >-
+            How many open children the close observed. Reported by a FORCED
+            close — including an idempotent re-close — because a caller that
+            bypassed the guard is exactly the caller that wants the number. An
+            unforced close that got this far had none, so it reports 0.
+
     Problem:
       type: object
       description: >-
@@ -4103,7 +4265,8 @@ components:
             may dispatch on. v0's vocabulary: `invalid_argument` (400, also
             emitted by the Host-header middleware on any route),
             `invalid_cursor` (400), `not_found` (404), `already_claimed` (409),
-            `not_claimable` (409), `busy` (503), `db_unavailable` (503),
+            `not_claimable` (409), `not_closable` (409), `busy` (503),
+            `db_unavailable` (503),
             `internal` (500). Renaming or removing a status+code pair is a
             breaking change; ADDING one is not, so clients MUST default-branch
             on unknown values and fall back to the status class (unknown 4xx →
@@ -4143,6 +4306,18 @@ components:
           description: >-
             With `already_claimed` or `not_claimable`: the issue's status at
             the moment of refusal.
+        open_children:
+          type: integer
+          description: >-
+            With `not_closable`: how many open children the transaction that
+            refused the close observed, read inside that transaction rather
+            than parsed out of `detail`.
+
+
+            PRESENT ONLY for the open-children refusal. The other
+            `not_closable` refusal is a live blocker and carries no such
+            member, so member presence — not prose — is how a client tells the
+            two apart. Both are bypassed by `force`.
         request_id:
           type: string
           description: >-

--- a/internal/httpapi/spec_parity_test.go
+++ b/internal/httpapi/spec_parity_test.go
@@ -665,6 +665,84 @@ func TestClaimRequestMembersMatchTheHandler(t *testing.T) {
 	}
 }
 
+// TestCloseRequestMembersMatchTheHandler is TestClaimRequestMembersMatchTheHandler
+// for the close body, and it exists for the same reason: the handler decodes
+// raw members so it can name the offending one, which makes the schema's
+// additionalProperties: false enforceable by a client that has stopped parsing
+// prose — at the cost of a hand-rolled copy of the member list with nothing
+// tying it to the document. A spec revision adding an optional member would
+// otherwise leave `make api-check` and every other spec test green while the
+// server refused the newly documented member as unknown_parameter.
+func TestCloseRequestMembersMatchTheHandler(t *testing.T) {
+	accepted := map[string]bool{}
+	for _, name := range closeRequestMembers {
+		accepted[name] = true
+	}
+
+	goFields := jsonTagNames(t, reflect.TypeOf(apigen.CloseIssueRequest{}))
+	if extra := diff(goFields, accepted); len(extra) > 0 {
+		t.Errorf("generated CloseIssueRequest declares members the close handler refuses as unknown: %v\n"+
+			"teach closeRequest to honor them, or the document promises a member the server turns down", extra)
+	}
+	if missing := diff(accepted, goFields); len(missing) > 0 {
+		t.Errorf("the close handler accepts members CloseIssueRequest does not declare: %v", missing)
+	}
+
+	doc := loadSpec(t)
+	schema := mapAt(t, mapAt(t, mapAt(t, doc, "components"), "schemas"), "CloseIssueRequest")
+	specProps := schemaProperties(t, doc, schema)
+	if extra := diff(specProps, accepted); len(extra) > 0 {
+		t.Errorf("the CloseIssueRequest schema documents members the close handler refuses: %v", extra)
+	}
+	if missing := diff(accepted, specProps); len(missing) > 0 {
+		t.Errorf("the close handler accepts members the CloseIssueRequest schema does not document: %v", missing)
+	}
+}
+
+// TestCustomMethodRowsDeclareTheirDocumentedPath bounds the routing exception
+// from the side TestSpecRouteParity cannot see. That test compares DECLARED
+// spec paths, so it stays green whatever the customMethod field says; the
+// dispatcher, meanwhile, chooses a row purely by that field. If the two
+// disagree — a row whose specPath ends in `:close` while its customMethod is
+// `:reopen` — the documented path would reach the wrong operation with every
+// gate passing.
+//
+// It also pins the invariant the dispatcher depends on: no two rows on one
+// pattern may claim the same suffix, and a row that shares a pattern must
+// declare one.
+func TestCustomMethodRowsDeclareTheirDocumentedPath(t *testing.T) {
+	claimed := map[string]string{}
+	patterns := map[string]int{}
+	for _, rt := range routeTable {
+		patterns[rt.method+" "+rt.pattern]++
+	}
+	for _, rt := range routeTable {
+		key := rt.method + " " + rt.pattern
+		if rt.customMethod == "" {
+			if patterns[key] > 1 {
+				t.Errorf("%s shares the pattern %q with another row but declares no customMethod; "+
+					"the dispatcher has no way to choose between them", rt.op, rt.pattern)
+			}
+			continue
+		}
+		if rt.specPath == "" {
+			t.Errorf("%s declares customMethod %q but no specPath; the router cannot spell the documented path, "+
+				"so it must be declared", rt.op, rt.customMethod)
+			continue
+		}
+		if !strings.HasSuffix(rt.specPath, rt.customMethod) {
+			t.Errorf("%s: documented path %q does not end in the customMethod %q the dispatcher matches on; "+
+				"the documented path would reach a different operation",
+				rt.op, rt.specPath, rt.customMethod)
+		}
+		if prev, dup := claimed[key+rt.customMethod]; dup {
+			t.Errorf("%s and %s both claim the suffix %q on %q; the dispatcher would hand every such request to the first",
+				prev, rt.op, rt.customMethod, rt.pattern)
+		}
+		claimed[key+rt.customMethod] = rt.op
+	}
+}
+
 func toStrings(t *testing.T, v any) []string {
 	t.Helper()
 	if v == nil {

--- a/internal/httpapi/sweep_test.go
+++ b/internal/httpapi/sweep_test.go
@@ -19,7 +19,7 @@ const sweepPath = "/v0/beads/issues:sweep"
 
 func (ts *testServer) sweep(t *testing.T, body string) *http.Response {
 	t.Helper()
-	return ts.claimRequest(t, sweepPath, "application/json", body)
+	return ts.postBody(t, sweepPath, "application/json", body)
 }
 
 // TestSweepPathReachesItsHandler: the sweep path is a LITERAL segment
@@ -292,7 +292,7 @@ func TestSweepRefusesAForeignMediaType(t *testing.T) {
 	sweeper := &roleSweeper{}
 	ts := newTestServer(t, rolesConfig(Config{Sweeper: sweeper}))
 
-	resp := ts.claimRequest(t, sweepPath, "text/plain", `{"tier":"ephemeral"}`)
+	resp := ts.postBody(t, sweepPath, "text/plain", `{"tier":"ephemeral"}`)
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
 	}
@@ -309,7 +309,7 @@ func TestSweepRefusesAForeignMediaType(t *testing.T) {
 func TestSweepPublishesNoQueryParameters(t *testing.T) {
 	ts := newTestServer(t, rolesConfig(Config{Sweeper: &roleSweeper{}}))
 
-	resp := ts.claimRequest(t, sweepPath+"?tier=durable", "application/json", `{"tier":"durable","pattern":"*"}`)
+	resp := ts.postBody(t, sweepPath+"?tier=durable", "application/json", `{"tier":"durable","pattern":"*"}`)
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
 	}

--- a/internal/httpapi/timed_provider_binding_test.go
+++ b/internal/httpapi/timed_provider_binding_test.go
@@ -79,8 +79,8 @@ func TestEveryTimedProviderAccessorBindsToTheWrapper(t *testing.T) {
 
 	// The count is asserted so that deleting accessors, or renaming the type,
 	// cannot make this pass by having nothing to check.
-	if checked < 13 {
-		t.Errorf("checked %d timedProvider accessors, want at least 13: the roles this surface answers from "+
+	if checked < 14 {
+		t.Errorf("checked %d timedProvider accessors, want at least 14: the roles this surface answers from "+
 			"all bind here, so a smaller number means some are no longer being read", checked)
 	}
 }

--- a/internal/storage/hook_decorator.go
+++ b/internal/storage/hook_decorator.go
@@ -86,6 +86,12 @@ func RoleFiresHooks(role any) bool {
 	switch role.(type) {
 	case *hookIssueClaimer:
 		return true
+	// The lifecycle role fires on_create, on_update and the close hooks for
+	// every mutation it lands (hook_issue_operations.go), so it is the same
+	// value the network server must refuse — and a wider one than the claimer,
+	// because it carries four verbs rather than one.
+	case *hookIssueOperations:
+		return true
 	}
 	return false
 }


### PR DESCRIPTION
## Stack position

**PR 1 of 3** in the v0 write-lifecycle series. Base: `main` (#5410 has merged, so this retargeted from `getissue-include-params`).

```
main
└── lifecycle-close (#5423)   ← this PR
    └── lifecycle-reopen (#5417)
        └── lifecycle-update (#5422)
```

### Two commits

1. `test(serve): assert the advertised capability set from one list` — a **pre-existing** fix, landed separately so it stays attributable. See "Capability drift" below.
2. `feat(httpapi): serve closeIssue over v0` — the operation.

`closeIssue` goes first among the three writes, for two reasons. It is the **highest-value** one — claim → work → close is the agent loop this surface exists to serve, and until this PR the claim was the only mutation v0 published (`engdocs/design/bd-serve-v0.md`, "Claim throughput"), so close is the half that still forces a client back to forking a `bd` subprocess. And it is the **hardest**: it introduces the suffix dispatcher and the `not_closable` code, so it is taken while the tranche is freshest and the two PRs above it inherit finished machinery rather than inventing it.

It inherits from #5410 the JSON media-type document rule and the widened `actor` pattern, so nothing here re-argues either.

## What lands

`POST /v0/beads/issues/{id}:close` — spec, `routeTable` row, `operationCodes` row, handler and tests together, under the existing parity gates.

### The routing change is the substantive part

`{id}:close` is not expressible as a ServeMux pattern for the same reason `{id}:claim` is not — wildcards match a whole segment. Unlike the claim, it **collides**: two rows cannot each register `POST /v0/beads/issues/{idop}`.

The route table grows a `customMethod` field. Rows carrying one share a single registration behind a dispatcher that splits the trailing `:suffix` off the matched segment and hands the request to the row that claims it. A segment ending in no registered suffix gets the same 404 the catch-all gives any unrouted path, so the wide pattern stays a routing detail rather than undocumented surface.

The split happens **before** `s.route`, so an unrouted suffix takes no database slot and books no operation on the request line — where the claim, while it was the only POST here, answered that case from inside its own handler and attributed every probe of the prefix to itself.

`TestSpecRouteParity` is untouched in mechanism: each row still declares its own `specPath`, and the test still compares document paths without learning the exception's mechanics. `TestClaimNarrowsThePOSTSurface` generalizes to `TestCustomMethodsNarrowThePOSTSurface` — the test where a dispatcher that fell back to its first row would be caught, since that failure would otherwise leave the claim's happy path green. A new `TestCustomMethodRowsDeclareTheirDocumentedPath` pins the invariant parity cannot see: a row whose `specPath` ends in one verb while its `customMethod` matches another would route the documented path to the wrong operation with every gate passing.

### Vocabulary

`not_closable` (409) joins the frozen code set, with `open_children` as an optional `Problem` extension member. Both close-policy refusals — open children, and a live blocker — share the code, because they are the same statement to a client and `force` is the bypass for both. The member is attached only for the open-children one, from `*CloseOpenChildrenError`'s own field inside the refusing transaction, so **member presence is the discriminator** and no client parses `3 open child issue(s)` out of prose.

409 rather than the delete precedent's 400: this is a statement about the current state of one named resource, so the same request succeeds or fails on state the client cannot see without reading it. That is the `not_claimable` situation and it gets the `not_claimable` answer.

`already_closed` mirrors `already_claimed` for the idempotent re-close, which under first-close-wins rewrites neither `reason` nor `session`.

### One security-relevant fix

`RoleFiresHooks` learns about `*hookIssueOperations`. A store's own `IssueLifecycle()` returns a role that fires `on_create`, `on_update` and the close hooks for every mutation it lands — precisely the value this server documents it does not run. Without that case `bd serve` would have booted with hooks live on four verbs, and the refusal that exists to prevent exactly this would have passed it.

## Capability drift, found and fixed

CI caught this PR widening the context handshake's capability set while `cmd/bd`'s integration tests asserted the old one. Fixing it turned up the more interesting bug behind it.

The set was written out as a **literal in each topology's test**, on the theory that the two must agree. They had silently stopped agreeing: the proxied copy tracked the surface to twenty entries while the server-mode copy sat at **four**, asserting a shape that had not existed since the facade programme. `TestServerModeServe/context` has therefore been failing on its own terms — I verified it fails identically on `main` with none of my commits applied — and only inside the proxied CI tier, where it reads as one more red in a shard that already had some.

Two literals that MUST match are one literal. The first commit gives both topologies a single `servedCapabilities` and an `assertServedCapabilities` helper; each feature commit then adds exactly its own token, so every commit in this stack is self-contained.

The list stays a **literal** rather than becoming `httpapi.Capabilities()`: comparing the server against its own derivation would pass for any surface at all, and the whole value of the assertion is that a new operation has to be admitted deliberately. What it encodes is the lesson that produced the drift — a package's own gates cannot catch an expectation stored as data outside it, so `internal/httpapi` going green said nothing about these two files.

I swept the rest of the repo for capability literals outside `internal/httpapi`. The only other hits are `cmd/bd/serve.go` and `cmd/bd/serve_test.go`, both of which name `issues.claim` in prose or in a `slices.Contains` membership check — neither breaks when the set grows.

## Gates

- `go test ./internal/httpapi/` — green, including all parity tests
- `TestProxiedServerServeLifecycle` and `TestServerModeServe` — green (`BEADS_TEST_PROXIED_SERVER=1`), the two the capability drift was hiding in
- `make api-check` — green (types regenerated from the spec in the same commit)
- `make ci-pr-lint` — green (gofmt, golangci-lint, golangci-lint windows: 0 issues)
- `go test ./internal/storage/...` — green
- Red/green observed per behavior. Two mutations were applied to confirm the new tests bite: a dispatcher falling back to `rows[0]` on an unknown suffix fails all ten `TestCustomMethodsNarrowThePOSTSurface` cases, and dropping the `WithOpenChildren` call fails `TestCloseOpenChildrenIsATypedConflict`.

## Retained real-dependency proof

`TestProxiedServerServeClose` (`cmd/bd`, against real Dolt through a real `bd serve` subprocess):

- **first-close-wins**, read back through a second close: the replay reports `already_closed: true` and the stored `close_reason`/`closed_by_session` still carry the **first** close's values
- **a forced close over two real open children**: the unforced attempt is a 409 carrying `open_children: 2` and writes nothing; `force: true` lands and still reports the 2 it bypassed
- the rule-8 parity oracle against `bd close --json`[0], empty allowlist
- close/claim agreement on the row they share, and refused bodies writing nothing

The role-level transition is already owned against a real store by `internal/storage/uow/lifecycle_close_reopen_contract_test.go`, which this cites rather than duplicates.

## Deviations from the published spec

None. `internal/httpapi/spec/openapi.v0.yaml` and the handler land in the same commit, and `make api-check` plus the parity tests hold them together.

`ExpectedVersion` — the role's optimistic-concurrency fence — stays unpublished, and the reason is the frozen code set rather than a scheduling one. `issueops.ErrVersionMismatch` has no entry in `problem.go`'s classification, so an `expected_version` member would render its own refusal as `500 internal`. Publishing a request member later is additive; publishing the status+code pair it needs is the one-way door `bd-serve-v0.md` describes under "The error-code vocabulary", and `TestSpecStatusCodesMatchHandlerTable` is what forces that pair to be admitted deliberately. The fence ships when its code does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


> Note: supersedes #5416, which was auto-closed when its stacked base branch was deleted after #5410 merged. Same head commit (3c455c27d); base is now main.


