### PR TITLE
docs: document ado.reconcile_interval and inventory every storage span

### DIFF
--- a/docs/integrations/azure-devops.md
+++ b/docs/integrations/azure-devops.md
@@ -255,12 +255,26 @@ When the same issue has been modified both locally and in ADO:
 | `--dry-run` | Preview sync without making changes |
 | `--no-create` | Only update existing items, never create new ones |
 | `--bootstrap-match` | Enable heuristic title matching for first sync |
-| `--reconcile` | Force reconciliation scan for deleted items |
+| `--reconcile` | Force reconciliation scan for deleted items (see Reconciliation below) |
 | `--issues` | Sync specific issues by bead ID or ADO work item ID |
 | `--parent` | Push only a bead and its descendants (push mode only; mutually exclusive with `--issues`) |
 | `--project` | Project name(s) for this run, repeatable — overrides `ado.project`/`ado.projects` |
 | `--states` | Filter by work item states (comma-separated) |
 | `--types` | Filter by work item types (comma-separated) |
+
+### Reconciliation
+
+A reconciliation scan re-checks work items beads already tracks, so items deleted
+in ADO (404) or no longer readable (403) are detected instead of lingering. It
+does not run on every sync — that would cost an API call per tracked item — so it
+runs periodically, and `--reconcile` forces it immediately.
+
+| Config Key | Default | Description |
+|---|---|---|
+| `ado.reconcile_interval` | `10` | Number of syncs between automatic reconciliation scans |
+
+`ado.syncs_since_reconcile` also appears in config: it is the counter beads keeps
+to know when the next scan is due, not a setting to edit.
 
 ## PAT Permissions
 

--- a/engdocs/design/otel/otel-data-model.md
+++ b/engdocs/design/otel/otel-data-model.md
@@ -42,7 +42,8 @@ OTel SDK names use **dot notation** internally. Prometheus-compatible backends (
 | Event | Category | Status |
 |-------|----------|--------|
 | `bd.command` | CLI | ✅ Implemented |
-| `storage.*` | Storage | ✅ Implemented |
+| `storage.<Method>` | Storage (direct) | ✅ Implemented |
+| `storage.<Role>.<Method>` | Storage (issueops surface) | ✅ Implemented |
 | `dolt.*` | Dolt Backend | ✅ Implemented |
 | `doltserver.*` | Server Lifecycle | 🔲 Roadmap (Tier 1) |
 | `hook.exec` | Hooks | ✅ Implemented (span only) |
@@ -159,6 +160,68 @@ Emitted when executing a transaction.
 |---|---|---|
 | `db.operation` | string | `"RunInTransaction"` |
 | `db.commit_msg` | string | Commit message |
+
+### Naming rule and complete inventory
+
+Every storage span is named `storage.` + the operation name, and carries that
+same bare name in the `db.operation` attribute
+(`internal/telemetry/storage.go`, `InstrumentedStorage.op`). The sections above
+detail the highest-traffic spans; the rest follow the identical shape, so they
+are inventoried here rather than repeated.
+
+There are two families.
+
+**Direct storage operations** — `storage.<Method>`, one per storage method
+(72 spans):
+
+```
+AddDependency AddIssueComment AddLabel CloseIssue CloseIssueChecked
+CountDependencies CountDependents CountEvents CountIssueComments CountIssues
+CountIssuesByGroup CreateIssue CreateIssues DeleteIssue GetAllConfig
+GetAllEventsSince GetBlockedIssues GetConfig GetDependencies
+GetDependenciesWithMetadata GetDependencyTree GetDependents
+GetDependentsWithMetadata GetEpicsEligibleForClosure GetEvents GetIssue
+GetIssueByExternalRef GetIssueComments GetIssueCommentsPage GetIssuesByIDs
+GetIssuesByLabel GetLabels GetLocalMetadata GetProvenanceByRef
+GetProvenanceEvents GetReadyWork GetReadyWorkWithCounts GetStatistics
+IterAllEventsSince IterBlockedIssues IterDependenciesWithMetadata
+IterDependentsWithMetadata IterEvents IterIssueComments IterIssues
+IterReadyWork IterWisps ListWisps MergeMetadata MergeSlotAcquire
+MergeSlotCheck MergeSlotCreate MergeSlotRelease RecordProvenanceEvent
+RemoveDependency RemoveLabel ReopenIssue RunInIssueLifecycleTransaction
+RunInTransaction SearchIssueIDs SearchIssues SearchIssuesWithCounts SetConfig
+SetLocalMetadata SlotClear SlotGet SlotSet UnclaimIssue UnclaimIssueIfAssignee
+UpdateIssue UpdateIssueChecked UpdateIssueType
+```
+
+**Issueops role operations** — `storage.<Role>.<Method>`, emitted when a caller
+goes through the guarded issueops surface instead of calling storage directly
+(39 spans):
+
+```
+BatchCloser.CloseBatch BatchCreator.CreateBatch
+BlockingAnnotator.AnnotateBlocking Bootstrapper.Bootstrap Commenter.AddComment
+Counter.Count Counter.CountByGroup CycleDetector.DetectCycles Deleter.Delete
+DependencyEditor.AddDependencies DependencyEditor.RemoveDependency
+EdgeReader.ReadEdges InitVerifier.VerifyIdentity IssueClaimer.Claim
+IssueOperations.Close IssueOperations.Create IssueOperations.Reopen
+IssueOperations.Update IssueReader.Get IssueReader.List IssueReader.Ready
+IssueRelations.Related Memories.Forget Memories.List Memories.Recall
+Memories.Remember Querier.Query ReadyClaimer.ClaimNext ReadyCounter.CountReady
+StatsReporter.AssigneeStats StatsReporter.Stats Sweeper.Sweep
+TreeWalker.WalkTree VersionReconciler.ReconcileVersion
+VersionReconciler.RecordedVersion WorkspaceConfig.GetSetting
+WorkspaceConfig.ListSettings WorkspaceConfig.SetSetting
+WorkspaceConfig.UnsetSetting
+```
+
+The two families do **not** double-count. The role decorators wrap the
+*uninstrumented* store (`InstrumentedStorage.IssueLifecycle` calls `Unwrap()`
+before wrapping), so one logical operation through the issueops front door emits
+its role span only — not a second `storage.<Method>` span beneath it. A create
+via issueops is one `storage.IssueOperations.Create`; a create via direct
+storage is one `storage.CreateIssue`. Counters and duration histograms are
+therefore comparable across both paths.
 
 ---
 


### PR DESCRIPTION
Both docs had their `Last reviewed` markers refreshed today without the content
gaps being closed, so freshness is currently green on two files that are missing
real material. This closes the gaps.

## `docs/integrations/azure-devops.md`

`ado.reconcile_interval` is undocumented. It is real, user-tunable config
(`internal/ado/reconcile.go`, default `10`) controlling how many syncs pass
between automatic reconciliation scans — and the doc already documents the
`--reconcile` flag that forces one, so the periodic behaviour it complements was
invisible.

Adds a Reconciliation section, and notes that `ado.syncs_since_reconcile` is the
counter beads maintains rather than a setting to edit (it shows up in `bd config`
output, so it's worth saying).

## `engdocs/design/otel/otel-data-model.md`

The doc opens with "Complete schema of all telemetry events emitted by Beads"
and lists **7** of **111** storage spans. Everything the issueops role
decomposition added — `IssueOperations.*`, `IssueReader.*`, `Memories.*`,
`WorkspaceConfig.*`, and 35 others — is absent, so anyone building dashboards
from this doc would miss the entire guarded surface.

Rather than 100+ more prose sections that would drift again, this states the rule
the code actually follows and inventories both families:

- span name is `"storage." + operation name`, which is also the `db.operation`
  attribute (`InstrumentedStorage.op`)
- **72** direct `storage.<Method>` spans
- **39** `storage.<Role>.<Method>` spans

It also records a property worth knowing: the two families **do not
double-count**. The role decorators wrap the *uninstrumented* store
(`InstrumentedStorage.IssueLifecycle` calls `Unwrap()` before wrapping), so one
logical operation through the issueops front door emits its role span only, not a
second `storage.<Method>` span beneath it. Counters and duration histograms stay
comparable across both paths.

## Verification

`./scripts/check-doc-freshness.sh` — PASSED. No behaviour change; documentation
catching up to the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)