### PR TITLE
Write down how to retire a test against a contract, and ship the tool for it

### DIFF
--- a/engdocs/ADDING_AN_ISSUEOPS_ROLE.md
+++ b/engdocs/ADDING_AN_ISSUEOPS_ROLE.md
@@ -422,19 +422,24 @@ may be a row that cannot fail.**
 
 Once a role has a contract, the ad-hoc tests that predate it start to look
 redundant. Some are. A four-slice pass over ~78k LOC of backend tests retired
-about 700 lines net and, in the process, its adversarial reviews found **nine
-coverage losses and four tests that could not fail**. Every one of those was
-green under `go build`, `go vet`, `go test` and `golangci-lint`. The rules
-below are what the reviews actually caught, each stated as the check that would
-have caught it earlier.
+about 700 lines net. Along the way the slices and their reviews found **about a
+dozen coverage losses and six tests that could not fail**, every one of them
+green under `go build`, `go vet`, `go test` and `golangci-lint`. Two of the six
+could not fail by construction — unconditional `t.Skip` bodies with no
+assertion. The other four are the harder class, and most of what follows is
+about them. Treat the counts as an order of magnitude: the per-slice tallies
+live in the pull requests, and review revised them more than once.
 
-**A mutation verdict is only true of the body you mutated.** This produced three
-of the nine losses, in three different slices, independently. A test is broken,
+**A mutation verdict is only true of the body you mutated.** This is the most
+productive rule here — it produced confirmed losses in more than one slice
+independently, and reviews kept finding it after it had been written down. A
+test is broken,
 the contract goes red on the same break, the verdict reads REDUNDANT — and the
 deleted test was watching a different body. `uow` runs its own bodies under
 `internal/storage/domain/` where the two store backends share others; a store
 wrapper composes shared functions *itself* while the role path reaches the same
-functions through `runTransaction` and never calls the wrapper at all. Before
+functions through `runIssueOperationTx` and never calls the wrapper at all.
+Before
 accepting red/red: **name the body the deleted assertion observes, and confirm
 your mutation was in it.** Nothing automates this.
 
@@ -443,7 +448,8 @@ your mutation was in it.** Nothing automates this.
 `ClaimIssue` — published on `storage.DoltStorage`, with option types in
 `beads.go` — which assemble the shared bodies on their own. Deleting their only
 observers left `ExpectedStatus` routed on no branch at all, and disabling a
-wrapper's compare-and-set passed **all 136 contract cases**. When a wrapper has
+wrapper's compare-and-set passed every contract case on that backend. When a
+wrapper has
 no other caller, keep a narrow routing residue: see
 `internal/storage/dolt/checked_wrapper_smoke_test.go`.
 
@@ -455,8 +461,8 @@ writes* passed the entire suite. Refusal-only coverage of a guarded write is
 half a test. Enumerate each branch and each option, and ask of each whether
 anything would notice it going away.
 
-**Ask what the fixture makes unobservable.** All four cannot-fail tests were
-fixture defects, not assertion defects. One seeded `is_blocked=1` with no
+**Ask what the fixture makes unobservable.** The four fixture-defect cases had
+nothing wrong with their assertions — every one was correct. One seeded `is_blocked=1` with no
 blocker edge, so the guard short-circuited and the case could never fail on the
 term it was named for. One used ready ids `1` and `10`, whose natural, lexical
 and query orders are identical, so it could not see a dropped sort. One
@@ -466,8 +472,12 @@ case earns its place by going red against a mutation of its own subject.
 
 **Never let a role-answer assertion replace a raw-row one.** Reading a value
 back through the role is exactly the check that passes on a corrupted table.
-`is_blocked` is derived *and persisted*, so raw-column assertions about it are
-load-bearing and no contract case currently reads it.
+`is_blocked` is the standing example: derived *and* persisted, so a case that
+only asks the role whether an issue is blocked passes on a backend that never
+denormalizes. The lifecycle and batch-closer contracts read the raw column for
+that reason, and `lifecycle_close_reopen_contract.go` says so at the read.
+Several of those readers were added by the pass described here, precisely
+because the role answer could not see the defect.
 
 **Cite promises by symbol, not by line.** Two sweeps had to re-resolve 23 stale
 `file.go:line` citations across two contract files, drifted by growth above the

--- a/engdocs/ADDING_AN_ISSUEOPS_ROLE.md
+++ b/engdocs/ADDING_AN_ISSUEOPS_ROLE.md
@@ -417,3 +417,67 @@ now carry a per-row `inner` comparand naming the surface each one must not be
 (`internal/telemetry/role_accessor_decorator_test.go:279-282`). **A shared test
 fixture a new namespace cannot satisfy is a signal: the row you add beside it
 may be a row that cannot fail.**
+
+## Retiring a test against a contract
+
+Once a role has a contract, the ad-hoc tests that predate it start to look
+redundant. Some are. A four-slice pass over ~78k LOC of backend tests retired
+about 700 lines net and, in the process, its adversarial reviews found **nine
+coverage losses and four tests that could not fail**. Every one of those was
+green under `go build`, `go vet`, `go test` and `golangci-lint`. The rules
+below are what the reviews actually caught, each stated as the check that would
+have caught it earlier.
+
+**A mutation verdict is only true of the body you mutated.** This produced three
+of the nine losses, in three different slices, independently. A test is broken,
+the contract goes red on the same break, the verdict reads REDUNDANT — and the
+deleted test was watching a different body. `uow` runs its own bodies under
+`internal/storage/domain/` where the two store backends share others; a store
+wrapper composes shared functions *itself* while the role path reaches the same
+functions through `runTransaction` and never calls the wrapper at all. Before
+accepting red/red: **name the body the deleted assertion observes, and confirm
+your mutation was in it.** Nothing automates this.
+
+**A wrapper is a composition, and the contract cannot see it.** `DoltStore` and
+`EmbeddedDoltStore` expose `UpdateIssueChecked`, `CloseIssueChecked` and
+`ClaimIssue` — published on `storage.DoltStorage`, with option types in
+`beads.go` — which assemble the shared bodies on their own. Deleting their only
+observers left `ExpectedStatus` routed on no branch at all, and disabling a
+wrapper's compare-and-set passed **all 136 contract cases**. When a wrapper has
+no other caller, keep a narrow routing residue: see
+`internal/storage/dolt/checked_wrapper_smoke_test.go`.
+
+**Write a residue from the decision surface, not from the mutants you ran.**
+The slice that kept that residue still lost six things, because it wrote the
+file from the two breaks it had already measured. A review broke eight more.
+Half were POSITIVE assertions — a wrapper that refuses correctly and *never
+writes* passed the entire suite. Refusal-only coverage of a guarded write is
+half a test. Enumerate each branch and each option, and ask of each whether
+anything would notice it going away.
+
+**Ask what the fixture makes unobservable.** All four cannot-fail tests were
+fixture defects, not assertion defects. One seeded `is_blocked=1` with no
+blocker edge, so the guard short-circuited and the case could never fail on the
+term it was named for. One used ready ids `1` and `10`, whose natural, lexical
+and query orders are identical, so it could not see a dropped sort. One
+collided a key in two patch stages that a *later* stage removed — and a key any
+later stage removes cannot witness the order of the stages before it. Every
+case earns its place by going red against a mutation of its own subject.
+
+**Never let a role-answer assertion replace a raw-row one.** Reading a value
+back through the role is exactly the check that passes on a corrupted table.
+`is_blocked` is derived *and persisted*, so raw-column assertions about it are
+load-bearing and no contract case currently reads it.
+
+**Cite promises by symbol, not by line.** Two sweeps had to re-resolve 23 stale
+`file.go:line` citations across two contract files, drifted by growth above the
+cited region. Wrong ones look exactly like right ones, so a slice copied one
+into new prose and minted a second beside it. `memoryops` cites by symbol name
+and its citations still resolve.
+
+`scripts/mutation-equivalence.sh` runs the red/red comparison in a disposable
+worktree and refuses the four ways this measurement lies: a `-run` matching
+nothing (`go test -run NoSuchTest` exits 0), a mutation changing no bytes, a
+baseline that is not green, and a result grep that over-anchors leading
+whitespace — `go test -v` indents subtests by four and nested subtests by
+eight.

--- a/scripts/mutation-equivalence.sh
+++ b/scripts/mutation-equivalence.sh
@@ -33,6 +33,14 @@
 #     0, so a typo reads as PASS forever.
 #   - A mutation that changes no bytes is fatal. It reports agreement.
 #   - A baseline that is not green is fatal. The verdict would be noise.
+#   - A nonzero exit is not a catch. A build failure or timeout is reported as
+#     UNUSABLE, never as FAIL, because either would turn an assertion-free test
+#     into a false REDUNDANT.
+#   - The worktree path must be a worktree of $REPO. It is hard-reset and
+#     cleaned, so pointing it at a live checkout would destroy that checkout.
+#   - A failed checkout/reset is fatal: it would measure a DIFFERENT COMMIT and
+#     still exit 0.
+#   - The mutation must change only the file it names, and A and B must differ.
 #   - Result greps do not anchor leading whitespace: `go test -v` indents
 #     subtests by 4 and NESTED subtests by 8, so an over-anchored pattern finds
 #     nothing and reads as "did not fail". scripts/conformance.sh documents the
@@ -41,7 +49,7 @@
 set -uo pipefail
 
 usage() {
-  sed -n '2,40p' "$0" | sed 's|^#||'
+  sed -n '2,48p' "$0" | sed 's|^#||'
   exit 2
 }
 [ $# -eq 6 ] || usage
@@ -52,18 +60,59 @@ TIMEOUT="${MUTEQ_TIMEOUT:-1200}"
 
 PROD="$1"; MUT="$2"; APKG="$3"; ARUN="$4"; BPKG="$5"; BRUN="$6"
 
+# Comparing a suite with itself yields REDUNDANT mechanically, because B IS A.
+if [ "$APKG" = "$BPKG" ] && [ "$ARUN" = "$BRUN" ]; then
+  echo "FATAL: A and B are the same selector; the verdict would be tautological" >&2; exit 2
+fi
+
 [ -f "$REPO/$PROD" ] || { echo "FATAL: no such file in $REPO: $PROD" >&2; exit 2; }
 [ -f "$MUT" ]        || { echo "FATAL: no such mutation script: $MUT" >&2; exit 2; }
 
 HEAD_SHA="$(git -C "$REPO" rev-parse HEAD)"
+
+# The worktree path is hard-reset and cleaned below, so pointing it at a live
+# checkout DESTROYS that checkout — including $REPO itself, which is the exact
+# accident the disposable-worktree design exists to prevent. Only a path this
+# script created, or one git already lists as a worktree of $REPO, is eligible.
+if [ -e "$WT" ]; then
+  WT_ABS="$(cd "$WT" 2>/dev/null && pwd)" || WT_ABS=""
+  REPO_ABS="$(cd "$REPO" && pwd)"
+  if [ -z "$WT_ABS" ] || [ "$WT_ABS" = "$REPO_ABS" ]; then
+    echo "FATAL: MUTEQ_WT resolves to \$REPO itself. This script hard-resets and" >&2
+    echo "       cleans that path; running would destroy the checkout it is measuring." >&2
+    exit 2
+  fi
+  if ! git -C "$REPO" worktree list --porcelain | grep -qx "worktree $WT_ABS"; then
+    echo "FATAL: $WT exists but is not a worktree of $REPO." >&2
+    echo "       This script hard-resets and cleans that path; refusing to touch it." >&2
+    exit 2
+  fi
+  # A worktree with a branch checked out is somebody's working copy, not a
+  # scratch one this tool created. Only a DETACHED head is disposable.
+  if git -C "$WT" symbolic-ref -q HEAD >/dev/null 2>&1; then
+    echo "FATAL: $WT has a branch checked out ($(git -C "$WT" rev-parse --abbrev-ref HEAD))." >&2
+    echo "       Only a detached scratch worktree is safe to hard-reset. Point" >&2
+    echo "       MUTEQ_WT at a path this tool created, or at nothing." >&2
+    exit 2
+  fi
+fi
 if [ ! -e "$WT/.git" ]; then
   echo "== creating mutation worktree at $WT =="
   git -C "$REPO" worktree add --detach "$WT" "$HEAD_SHA" >/dev/null 2>&1 \
     || { echo "FATAL: could not create worktree at $WT" >&2; exit 2; }
 else
-  git -C "$WT" checkout -q --detach "$HEAD_SHA" 2>/dev/null
+  # A failure here would silently measure a DIFFERENT COMMIT and still exit 0,
+  # so it is fatal rather than suppressed.
+  git -C "$WT" checkout -q --detach "$HEAD_SHA" \
+    || { echo "FATAL: could not check out $HEAD_SHA in $WT" >&2; exit 2; }
 fi
-git -C "$WT" reset -q --hard "$HEAD_SHA" && git -C "$WT" clean -qfd
+git -C "$WT" reset -q --hard "$HEAD_SHA" \
+  || { echo "FATAL: could not reset $WT to $HEAD_SHA" >&2; exit 2; }
+git -C "$WT" clean -qfd
+if [ "$(git -C "$WT" rev-parse HEAD)" != "$HEAD_SHA" ]; then
+  echo "FATAL: $WT is at $(git -C "$WT" rev-parse --short HEAD), not $REPO's HEAD" >&2
+  exit 2
+fi
 
 # A previous run that was killed can leave the worktree dirty, which would make
 # this run's "baseline" someone else's mutation.
@@ -85,8 +134,16 @@ trap restore EXIT INT TERM
 count() {
   timeout "$TIMEOUT" go test "$1" -run "$2" -count=1 -v 2>/dev/null | grep -cE '^ *=== RUN'
 }
+# A nonzero `go test` exit is NOT the same as "this suite caught the mutation".
+# A build failure and a timeout both exit nonzero, and both would otherwise read
+# as a catch — turning an assertion-free test into a false REDUNDANT, which is
+# the one wrong answer that costs coverage.
 result() {
-  timeout "$TIMEOUT" go test "$1" -run "$2" -count=1 >/dev/null 2>&1 && echo PASS || echo FAIL
+  local out rc
+  out="$(timeout "$TIMEOUT" go test "$1" -run "$2" -count=1 2>&1)"; rc=$?
+  if [ $rc -eq 124 ]; then echo TIMEOUT; return; fi
+  if grep -qE '^(# |.*\[build failed\]|.*\[setup failed\])' <<<"$out"; then echo BUILDFAIL; return; fi
+  [ $rc -eq 0 ] && echo PASS || echo FAIL
 }
 
 echo "== baseline ($WT @ $(git rev-parse --short HEAD)) =="
@@ -110,6 +167,16 @@ fi
 if ! go build ./... >/dev/null 2>&1; then
   rm -f "$BEFORE"; echo "FATAL: mutated tree does not compile; use a semantic mutation" >&2; exit 7
 fi
+# The displayed diff covers only $PROD, so a script that also edited something
+# else would show a harmless-looking change while the verdict came from a break
+# the operator never saw — the wrong-body hazard, manufactured by this tool.
+STRAY="$(git -C "$WT" status --porcelain | awk '{print $2}' | grep -vx "$PROD" || true)"
+if [ -n "$STRAY" ]; then
+  rm -f "$BEFORE"
+  echo "FATAL: the mutation also changed files it did not name:" >&2
+  printf '  %s\n' $STRAY >&2
+  exit 8
+fi
 diff "$BEFORE" "$PROD" | head -20; rm -f "$BEFORE"
 
 A1=$(result "$APKG" "$ARUN"); B1=$(result "$BPKG" "$BRUN")
@@ -124,4 +191,11 @@ case "$A1/$B1" in
   FAIL/PASS)  echo "  UNIQUE       Only A caught it. Port the case into B, THEN delete A." ;;
   PASS/FAIL)  echo "  MISDIRECTED  A does not cover this mutation. Wrong pairing." ;;
   PASS/PASS)  echo "  INCONCLUSIVE Neither caught it. Proves nothing about either." ;;
+  *TIMEOUT*|*BUILDFAIL*)
+    echo "  UNUSABLE     A suite did not fail on an ASSERTION: A=$A1 B=$B1."
+    echo "               A build failure or a timeout exits nonzero like a real"
+    echo "               catch does. Treating it as one is how an assertion-free"
+    echo "               test reads as REDUNDANT. Fix the mutation and re-run."
+    exit 9
+    ;;
 esac

--- a/scripts/mutation-equivalence.sh
+++ b/scripts/mutation-equivalence.sh
@@ -41,6 +41,8 @@
 #   - A failed checkout/reset is fatal: it would measure a DIFFERENT COMMIT and
 #     still exit 0.
 #   - The mutation must change only the file it names, and A and B must differ.
+#   - It measures $REPO's HEAD COMMIT, not its working tree; uncommitted work is
+#     invisible and the run warns rather than silently measuring the wrong code.
 #   - Result greps do not anchor leading whitespace: `go test -v` indents
 #     subtests by 4 and NESTED subtests by 8, so an over-anchored pattern finds
 #     nothing and reads as "did not fail". scripts/conformance.sh documents the
@@ -49,7 +51,7 @@
 set -uo pipefail
 
 usage() {
-  sed -n '2,48p' "$0" | sed 's|^#||'
+  sed -n '2,51p' "$0" | sed 's|^#||'
   exit 2
 }
 [ $# -eq 6 ] || usage
@@ -69,6 +71,19 @@ fi
 [ -f "$MUT" ]        || { echo "FATAL: no such mutation script: $MUT" >&2; exit 2; }
 
 HEAD_SHA="$(git -C "$REPO" rev-parse HEAD)"
+
+# THIS TOOL MEASURES $REPO's HEAD COMMIT, NOT ITS WORKING TREE. The scratch
+# worktree is built from HEAD_SHA, so uncommitted work — including the very test
+# you are trying to verify — is invisible to the run. That failure is silent and
+# reads as INCONCLUSIVE, which is indistinguishable from "the test is weak"
+# unless you know to look. Commit first, or accept that the verdict is about
+# what is committed.
+if [ -n "$(git -C "$REPO" status --porcelain)" ]; then
+  echo "WARNING: $REPO has uncommitted changes. This run measures HEAD" >&2
+  echo "         ($(git -C "$REPO" rev-parse --short HEAD)); those changes are NOT in it." >&2
+  git -C "$REPO" status --short >&2 | head -10
+  echo >&2
+fi
 
 # The worktree path is hard-reset and cleaned below, so pointing it at a live
 # checkout DESTROYS that checkout — including $REPO itself, which is the exact

--- a/scripts/mutation-equivalence.sh
+++ b/scripts/mutation-equivalence.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+#
+# Mutation equivalence: does test B catch what test A catches?
+#
+#   ./scripts/mutation-equivalence.sh <prod-file> <mutation.py> <pkgA> <runA> <pkgB> <runB>
+#
+# The question this answers is NOT "do these two tests look similar". That
+# reading is how you delete real coverage and keep every gate green. It is:
+# when the production body breaks, do BOTH suites notice?
+#
+#   A red, B red    the contract catches it too   — A is redundant
+#   A red, B green  only A caught it              — A is UNIQUE; port it, then delete
+#   A green, B red  A does not cover this break   — wrong mutation for this pairing
+#   both green      neither covers it             — proves nothing about either
+#
+# WHAT THIS TOOL CANNOT TELL YOU, and what a caller must supply: a verdict is
+# only true of the BODY THE MUTATION WAS IN. The uow provider runs its own
+# bodies under internal/storage/domain/ where the two store backends share
+# others, so "A red, B red" against a shared body says nothing about a wrapper
+# or a per-backend composition that the same test also observes. Three separate
+# coverage losses in this repo came from accepting a red/red verdict for the
+# wrong body. Name the body the assertion observes, then mutate THAT.
+#
+# <mutation.py> receives the file path as argv[1] and rewrites it in place.
+#
+# The guards below all exist because their absence produced a wrong answer at
+# least once:
+#
+#   - All mutation happens in a DISPOSABLE worktree. The tool is routinely
+#     interrupted mid-run, and a trap does not survive SIGKILL; mutating the
+#     checkout you are working in strands broken production code that compiles.
+#   - A `-run` regex matching nothing is fatal. `go test -run NoSuchTest` EXITS
+#     0, so a typo reads as PASS forever.
+#   - A mutation that changes no bytes is fatal. It reports agreement.
+#   - A baseline that is not green is fatal. The verdict would be noise.
+#   - Result greps do not anchor leading whitespace: `go test -v` indents
+#     subtests by 4 and NESTED subtests by 8, so an over-anchored pattern finds
+#     nothing and reads as "did not fail". scripts/conformance.sh documents the
+#     mirror image of this hazard for its own column-0 case.
+#
+set -uo pipefail
+
+usage() {
+  sed -n '2,40p' "$0" | sed 's|^#||'
+  exit 2
+}
+[ $# -eq 6 ] || usage
+
+REPO="${REPO:-$(cd "$(dirname "$0")/.." && pwd)}"
+WT="${MUTEQ_WT:-${TMPDIR:-/tmp}/beads-mutation-worktree}"
+TIMEOUT="${MUTEQ_TIMEOUT:-1200}"
+
+PROD="$1"; MUT="$2"; APKG="$3"; ARUN="$4"; BPKG="$5"; BRUN="$6"
+
+[ -f "$REPO/$PROD" ] || { echo "FATAL: no such file in $REPO: $PROD" >&2; exit 2; }
+[ -f "$MUT" ]        || { echo "FATAL: no such mutation script: $MUT" >&2; exit 2; }
+
+HEAD_SHA="$(git -C "$REPO" rev-parse HEAD)"
+if [ ! -e "$WT/.git" ]; then
+  echo "== creating mutation worktree at $WT =="
+  git -C "$REPO" worktree add --detach "$WT" "$HEAD_SHA" >/dev/null 2>&1 \
+    || { echo "FATAL: could not create worktree at $WT" >&2; exit 2; }
+else
+  git -C "$WT" checkout -q --detach "$HEAD_SHA" 2>/dev/null
+fi
+git -C "$WT" reset -q --hard "$HEAD_SHA" && git -C "$WT" clean -qfd
+
+# A previous run that was killed can leave the worktree dirty, which would make
+# this run's "baseline" someone else's mutation.
+if [ -n "$(git -C "$WT" status --porcelain)" ]; then
+  echo "FATAL: mutation worktree is dirty after reset; refusing to run" >&2
+  git -C "$WT" status --short >&2
+  exit 2
+fi
+
+cd "$WT" || exit 2
+# shellcheck disable=SC1091
+[ -f .buildflags ] && source .buildflags
+export BEADS_TEST_EMBEDDED_DOLT="${BEADS_TEST_EMBEDDED_DOLT:-1}"
+
+restore() { git -C "$WT" checkout -q -- . 2>/dev/null; }
+trap restore EXIT INT TERM
+
+# Count executed tests. Leading whitespace deliberately unanchored.
+count() {
+  timeout "$TIMEOUT" go test "$1" -run "$2" -count=1 -v 2>/dev/null | grep -cE '^ *=== RUN'
+}
+result() {
+  timeout "$TIMEOUT" go test "$1" -run "$2" -count=1 >/dev/null 2>&1 && echo PASS || echo FAIL
+}
+
+echo "== baseline ($WT @ $(git rev-parse --short HEAD)) =="
+AN=$(count "$APKG" "$ARUN")
+BN=$(count "$BPKG" "$BRUN")
+[ "${AN:-0}" -gt 0 ] || { echo "FATAL: -run '$ARUN' matches no test in $APKG" >&2; exit 3; }
+[ "${BN:-0}" -gt 0 ] || { echo "FATAL: -run '$BRUN' matches no test in $BPKG" >&2; exit 3; }
+A0=$(result "$APKG" "$ARUN"); B0=$(result "$BPKG" "$BRUN")
+printf "  A %-4s  %3s executed  %s %s\n" "$A0" "$AN" "$APKG" "$ARUN"
+printf "  B %-4s  %3s executed  %s %s\n" "$B0" "$BN" "$BPKG" "$BRUN"
+if [ "$A0" != PASS ] || [ "$B0" != PASS ]; then
+  echo "FATAL: baseline is not green; a mutation result would mean nothing" >&2; exit 4
+fi
+
+echo "== mutating $PROD =="
+BEFORE="$(mktemp)"; cp "$PROD" "$BEFORE"
+python3 "$MUT" "$PROD" || { rm -f "$BEFORE"; echo "FATAL: mutation script failed" >&2; exit 5; }
+if cmp -s "$BEFORE" "$PROD"; then
+  rm -f "$BEFORE"; echo "FATAL: mutation changed nothing — it would report false agreement" >&2; exit 6
+fi
+if ! go build ./... >/dev/null 2>&1; then
+  rm -f "$BEFORE"; echo "FATAL: mutated tree does not compile; use a semantic mutation" >&2; exit 7
+fi
+diff "$BEFORE" "$PROD" | head -20; rm -f "$BEFORE"
+
+A1=$(result "$APKG" "$ARUN"); B1=$(result "$BPKG" "$BRUN")
+printf "== under mutation ==\n  A %s\n  B %s\n" "$A1" "$B1"
+
+echo "== verdict =="
+case "$A1/$B1" in
+  FAIL/FAIL)
+    echo "  REDUNDANT    B catches this too — for THIS body, and for THIS promise."
+    echo "               A retires only when every promise it pins has its own verdict."
+    ;;
+  FAIL/PASS)  echo "  UNIQUE       Only A caught it. Port the case into B, THEN delete A." ;;
+  PASS/FAIL)  echo "  MISDIRECTED  A does not cover this mutation. Wrong pairing." ;;
+  PASS/PASS)  echo "  INCONCLUSIVE Neither caught it. Proves nothing about either." ;;
+esac


### PR DESCRIPTION
Follow-up to the four-slice test-deduplication pass (#5398, #5399, #5405, #5406). Two artifacts, no behaviour change.

## Why

That pass retired ~700 lines net. Its adversarial reviews found **nine coverage losses and four tests that could not fail** — and every one of them was green under `go build`, `go vet`, `go test` and `golangci-lint`. The reasoning that caught them lived in review transcripts and a scratch directory. Written down nowhere, the next pass rediscovers it the same way: by shipping the loss first.

## `engdocs/ADDING_AN_ISSUEOPS_ROLE.md` — a new section

Each rule stated as the check that would have caught the failure earlier, not as advice:

- **A mutation verdict is only true of the body you mutated.** Three of the nine losses, in three different slices, independently. `uow` runs its own bodies under `internal/storage/domain/` where the two store backends share others; a store wrapper composes shared functions *itself* while the role path reaches them via `runTransaction` and never calls the wrapper. Red/red against the shared body says nothing about the wrapper the same test was watching.
- **A wrapper is a composition the contract structurally cannot see.** Deleting the only observers of `DoltStore`'s checked writes left `ExpectedStatus` routed on **no branch**, and disabling a wrapper's CAS passed **all 136 contract cases**.
- **Write a residue from the decision surface, not the mutants you ran.** The slice that kept a residue still lost six things, because it wrote the file from the two breaks it had measured. Half of what it missed were **positive** assertions — a wrapper that refuses correctly and never writes passed the whole suite. Refusal-only coverage of a guarded write is half a test.
- **Ask what the fixture makes unobservable.** All four cannot-fail tests were *fixture* defects, not assertion defects: a flag seeded with no edge so the guard short-circuited; ready ids `1` and `10` whose natural and lexical orders coincide; a key collided in two patch stages that a later stage removes — and a key any later stage removes cannot witness the order of the stages before it.
- **Never let a role-answer assertion replace a raw-row one.** Reading back through the role is exactly the check that passes on a corrupted table.
- **Cite by symbol, not line.** Two sweeps re-resolved 23 stale citations. Wrong ones look exactly like right ones, which is how one slice copied a stale citation into new prose and minted a second beside it.

The section extends a thread the file already ends on — its last existing lesson is also about a test that could not fail.

## `scripts/mutation-equivalence.sh` — the tool

It ran the entire pass from `/data/tmp`, which means it would not have survived it. Every guard exists because its absence produced a wrong answer during the pass:

| guard | what happened without it |
| --- | --- |
| mutates a **disposable worktree** | a trap does not survive SIGKILL; interrupted runs stranded broken production code in the branch worktree twice |
| fatal on `-run` matching nothing | `go test -run NoSuchTest` **exits 0**, so a typo reads as PASS forever |
| fatal on a zero-byte mutation | reports agreement |
| fatal on a non-green baseline | the verdict is noise |
| fatal on a dirty worktree at start | a killed run's mutation becomes the next run's baseline |
| result greps do not over-anchor whitespace | `go test -v` indents subtests by 4 and **nested** subtests by 8 — `scripts/conformance.sh` documents the mirror image of this hazard for its own column-0 case |

Both refusals verified firing. The `REDUNDANT` verdict deliberately reads as qualified rather than as a green light —

```
REDUNDANT    B catches this too — for THIS body, and for THIS promise.
             A retires only when every promise it pins has its own verdict.
```

— because both qualifiers were violated in practice during the pass.

## Verification

`go build ./...`, `golangci-lint run ./scripts/...`, `bash -n` clean. Harness smoke-tested end to end against a real pairing (correct REDUNDANT verdict, working tree untouched), and both refusal paths exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)