### PR TITLE
Wire-surface polish for the v0 write wave: include-leg depth, derive-proof prose, the missing member-list gates, changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,76 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`bd serve` grows the write half of the agent loop** (v0 wire surface,
+  [#5410](https://github.com/gastownhall/beads/pull/5410),
+  [#5417](https://github.com/gastownhall/beads/pull/5417),
+  [#5422](https://github.com/gastownhall/beads/pull/5422),
+  [#5423](https://github.com/gastownhall/beads/pull/5423),
+  [#5429](https://github.com/gastownhall/beads/pull/5429)). v0 shipped with one
+  mutation, the claim, which meant an HTTP client could take work and had to
+  fork a `bd` subprocess to finish it. Five operations close that loop:
+
+  - `POST /v0/beads/issues/{id}:close` and `POST /v0/beads/issues/{id}:reopen`
+    — the two halves of the lifecycle move. Both are idempotent, and both say
+    so in the body rather than in a status: a close of a closed issue answers
+    `200` with `already_closed: true`, a reopen of an open one
+    `already_open: true`, and each still carries the row.
+  - `PATCH /v0/beads/issues/{id}` — partial update of one issue. The `patch`
+    object publishes thirteen members; four of them (`estimated_minutes`,
+    `external_ref`, `due_at`, `defer_until`) are nullable, and an explicit
+    `null` CLEARS them. That set is closed and machine-checked against the
+    document, so a `null` on any other member is a `400` rather than an
+    unannounced clear. A patch that changes nothing answers `200` with
+    `changed: false`.
+  - `POST /v0/beads/dependencies:add` — up to 100 edges per request, asserted
+    all or none, echoed back in request order. A refusal names the offending
+    edge as `edges[i].member`, so a client learns which edge and which member
+    rather than that something in the batch was wrong.
+  - `POST /v0/beads/dependencies:remove` — removes exactly the edge the body
+    names. Idempotent at the role: an edge that is not there is
+    `removed: false` with a `200`, never a 404, so a replayed teardown does not
+    have to classify an error to discover it already ran.
+
+  **Every one of them carries the claim's posture, unchanged.** The `actor` is
+  caller-asserted provenance for the audit trail and not authenticated
+  identity; hooks do not fire; the per-command auto-commit machinery does not
+  run. The only durable effect is the single storage commit the role makes
+  inside its own transaction, so durability is per request on every write, not
+  just the claim.
+
+  **Three codes join the frozen error vocabulary**, all 409 and all typed so a
+  client never has to substring-match a message. `not_closable` is close policy
+  refusing an unforced close of an issue with open children or a live blocker.
+  `dependency_exists` is the pair that already carries an edge of a DIFFERENT
+  type, and carries `existing_type` and `requested_type`. `dependency_cycle`
+  covers both never-makes-progress refusals: the plain scheduling cycle, and a
+  blocking edge against the issue's own ancestor or descendant — the second
+  carries `issue_id`, `blocker_id` and `blocker_is_ancestor`, and their ABSENCE
+  is what tells a client which of the two it got. Every extension member is
+  read off the refusing transaction's own typed error; the hierarchy members
+  have no other source, since the conflicting edge may exist only inside the
+  batch that was rolled back. An edge naming an endpoint this database can see
+  the absence of is a `400` on `edges[i].issue_id` or `edges[i].depends_on_id`,
+  not a 404: the request BODY is what is wrong, and there is no path id to have
+  missed.
+
+  **`GET /v0/beads/issues/{id}` takes two new parameters.**
+  `include_comments` populates `comments` with the full comment bodies and
+  `include_dependents` populates `dependents` with the issues that depend on
+  this one, each carrying its edge type. Both default to false, because both
+  are extra reads nobody should pay for by accident — and when a caller does
+  not ask, `comment_count`, `dependent_count` and `comments_omitted` still
+  report what was left out, so an absent `comments` is never ambiguous between
+  "no comments" and "not included in this response". A malformed boolean is
+  this operation's own `400 invalid_argument` / `reason: "invalid_value"`,
+  which is deliberately not the `unknown_parameter` a client should read as
+  version skew.
+
+  `GET /v0/beads/context` advertises `issues.close`, `issues.reopen`,
+  `issues.update`, `dependencies.add` and `dependencies.remove` alongside the
+  rest — derived from the registered handlers as always, so probing
+  `capabilities` remains the way to ask one server what it can do.
+
 - **The two dependency-endpoint refusals now carry an identity** (bd-yby99.9).
   `DependencyEditor.AddDependencies` refuses an edge whose SOURCE names no row,
   and one whose TARGET names no row this database can see the absence of. Both

--- a/engdocs/design/bd-serve-v0.md
+++ b/engdocs/design/bd-serve-v0.md
@@ -23,16 +23,35 @@ so.
 
 ## The surface
 
-Six operations, all under `/v0` except liveness.
+Everything is under `/v0` except liveness. The operation list is **not
+reproduced here**, on purpose: `internal/httpapi/routes.go` is the router,
+`TestSpecRouteParity` welds that table to `openapi.v0.yaml` by exact set
+equality in both directions, and `capabilities` on the handshake is derived
+from the same table. A fourth copy in this page could only ever go stale — as
+one did — so read the surface from the document, from the route table, or from
+a running server.
 
-| Operation | Route | What it answers |
-|---|---|---|
-| `health` | `GET /healthz` | Process liveness. Never touches the database. |
-| `getContext` | `GET /v0/beads/context` | Workspace and API identity, from a startup snapshot. |
-| `listReadyWork` | `GET /v0/beads/ready` | Unblocked open work, in the requested sort order. |
-| `listIssues` | `GET /v0/beads/issues` | A page of issues under the request's filters. |
-| `getIssue` | `GET /v0/beads/issues/{id}` | One issue's detail view. |
-| `claimIssue` | `POST /v0/beads/issues/{id}:claim` | Compare-and-set claim for a caller-named actor. |
+What the shape is, and will stay:
+
+- **Liveness and identity answer from the process.** `GET /healthz` and
+  `GET /v0/beads/context` touch no database, which is what keeps them
+  answerable while every connection slot is held. They alone carry
+  `bypassSemaphore`.
+- **Reads are collection reads plus one detail read per resource.** Issues,
+  ready work, dependencies, config, memories and stats each publish their own,
+  and each hands its whole request to one `issueops` role — never to a filter
+  built in the handler.
+- **Writes come in two spellings.** A custom method (`:claim`, `:close`,
+  `:reopen`, `:sweep`, `:delete`, `:add`, `:remove`, `:batchCreate`) where the
+  operation is not CRUD, and a plain method (`PATCH` on one issue, `POST` and
+  `DELETE` on one memory) where it is. `routes.go` states the rule per row.
+- **Every write carries the same posture.** The `actor` is caller-asserted
+  provenance, not authenticated identity; hooks do not fire; the per-command
+  auto-commit machinery does not run. Durability is one storage commit per
+  request, inside the role's own transaction. The claim was the first write and
+  the others adopted its posture verbatim; [No hooks](#no-hooks),
+  [No auto-commit](#no-auto-commit) and [Write throughput](#write-throughput)
+  state it once for all of them.
 
 `GET /v0/beads/context` reports which operations this build actually
 implements, in `capabilities`. That list is derived from the registered
@@ -78,6 +97,9 @@ on.
 | `not_found` | 404 | No issue or wisp with that id. | — |
 | `already_claimed` | 409 | Another actor holds the claim. Carries `assignee`. | — |
 | `not_claimable` | 409 | The issue is not in a claimable state. Carries `issue_status`. | — |
+| `not_closable` | 409 | Close policy refused an unforced close: open children, or a blocker. | Close the children or clear the blocker, or re-send with force. |
+| `dependency_cycle` | 409 | The requested edges would never clear — a scheduling cycle, or a blocking edge against the issue's own ancestor or descendant. The hierarchy case carries `issue_id`, `blocker_id` and `blocker_is_ancestor`; their absence is what identifies the plain cycle. | Send different edges. Nothing was written. |
+| `dependency_exists` | 409 | The pair already carries an edge of a different type. Carries `existing_type` and `requested_type`. | Remove the existing edge before re-adding. |
 | `busy` | 503 | Retryable contention: the transaction retry budget was spent, or the in-flight limit was saturated. Carries `Retry-After`. | Retry after the header's delay. |
 | `db_unavailable` | 503 | Retryable connectivity failure reaching the database. Carries `Retry-After`. | Retry after the header's delay. |
 | `internal` | 500 | Anything else. | — |
@@ -114,6 +136,15 @@ A client that classified claim conflicts by substring-matching error text
 losing transaction, never from parsing fragments out of the sentinel's message.
 That substring classification is exactly what an adopting client gets to
 delete, and it can only delete it because the server never does it either.
+
+The dependency conflicts work the same way and are read the same way.
+`dependency_exists` carries `existing_type` and `requested_type`;
+`dependency_cycle` carries `issue_id`, `blocker_id` and `blocker_is_ancestor`
+when the refusal is the hierarchy rule, and carries nothing when it is a plain
+scheduling cycle — the ABSENCE is what tells the two apart. Every one of those
+members is read off the role's typed error inside the refusing transaction,
+which is the only place the hierarchy members can come from at all: the
+conflicting edge may exist only inside the batch that was rolled back.
 
 ## The cursor contract
 
@@ -176,11 +207,12 @@ IP-literal `Host`, because the browser sends the hostname from the attacker's
 URL. Matching is on parsed addresses, so every spelling of an allowed address
 is allowed.
 
-**The JSON-only content type on the claim**, which is a CSRF control rather
+**The JSON-only content type on every body**, which is a CSRF control rather
 than pedantry: a JSON content type is not CORS-"simple", so a cross-origin
-claim always triggers a preflight this server never approves. Accepting
-`text/plain` or a form encoding would let a page skip the preflight and drive
-the one write on this surface from any browser on the host.
+write always triggers a preflight this server never approves. Accepting
+`text/plain` or a form encoding would let a page skip the preflight and drive a
+write from any browser on the host. The document states the rule once, at the
+document level, because it holds for every body-carrying operation.
 
 **The mode-dependent refusal of an unlimited read.** `limit=0` means unlimited
 on both list operations, exactly as `bd list --limit 0` does — except under
@@ -201,8 +233,8 @@ both win, and guarantees nothing about who either of them really is.
 
 ## No hooks
 
-Hooks do not fire on an HTTP claim. A CLI claim runs `on_update`; this does
-not.
+Hooks do not fire on any write over this surface. A CLI claim runs `on_update`;
+the HTTP one does not, and neither does any write added since.
 
 A hook is a user-controlled subprocess per mutation. In a concurrent server
 that is an unbounded latency multiplier and an orphaned child at shutdown, and
@@ -210,29 +242,32 @@ the working-directory-derived hook lookup that finds them is meaningless in a
 server process that does not share the client's working directory.
 
 This is a contract statement, not a gap to be closed later. A client that needs
-hook side effects on a claim runs the claim through the CLI.
+hook side effects on a mutation runs that mutation through the CLI.
 
 ## No auto-commit
 
 The per-command auto-commit, export and push maintenance that wraps a CLI
-invocation does not run here. Durability is per request: a successful claim
-commits inside its own transaction, exactly as a proxied CLI claim does today.
+invocation does not run here. Durability is per request: a write that changes
+something commits inside its own transaction, exactly as the proxied CLI does
+today.
 
 Two consequences worth stating for an adopting client:
 
 - There is no end-of-process flush. Anything the server did is already durable
   when the response is written, or it is not going to be.
-- An idempotent re-claim by the current holder writes no commit. The
-  compare-and-set matched no row because there was nothing to change, and an
-  empty commit message tells the transaction runner to skip the commit — so a
-  polling client cannot mint an empty storage commit per call.
+- An idempotent write by the party that already got the outcome it asked for
+  writes no commit. A re-claim by the current holder, a re-close of a closed
+  issue, a reopen of an open one: the compare-and-set matched no row because
+  there was nothing to change, and an empty commit message tells the
+  transaction runner to skip the commit — so a polling client cannot mint an
+  empty storage commit per call.
 
-## Claim throughput
+## Write throughput
 
-The claim is the only mutation in v0, and its cost is a storage commit. Sizing
-follows from that, not from HTTP:
+Every mutation on this surface costs a storage commit. Sizing follows from
+that, not from HTTP:
 
-- **A claim that changes something commits.** Its throughput ceiling is the
+- **A write that changes something commits.** Its throughput ceiling is the
   store's write path, which serializes commits, and not the request pipeline in
   front of it. HTTP concurrency does not raise that ceiling.
 - **Contention surfaces as a retryable 503, not as a stall.** The transaction
@@ -246,7 +281,7 @@ follows from that, not from HTTP:
   `Retry-After: 1`, because slot pressure clears quickly. Shedding load
   introduces no new status vocabulary — one code, two delays, and the header is
   the thing to obey.
-- **An idempotent re-claim costs no commit** (above), so a client polling to
+- **An idempotent write costs no commit** (above), so a client polling to
   confirm it still holds a claim does not consume write throughput.
 - **Reads are bounded by slots, not by commits.** Every database-touching
   handler holds one of a fixed number of in-flight slots, and each slot pins one
@@ -262,8 +297,10 @@ Carried across from `internal/httpapi/doc.go` and `issueops/reader.go`, which
 are the source of truth for it. Stated once and in full so it can be checked
 sentence by sentence, and deliberately not strengthened here.
 
-**SHARED.** All three issue reads on this surface go through `issueops.Reader`,
-and so does `bd show --json`'s detail view on both its routes. `bd list` and
+**SHARED.** `GET /v0/beads/ready`, `GET /v0/beads/issues` and
+`GET /v0/beads/issues/{id}` go through `issueops.Reader`, and so does
+`bd show --json`'s detail view on both its routes. This says nothing about the
+surface's other reads, which are on sibling roles. `bd list` and
 `bd ready` are *not* on the role and share instead the request types, the two
 builders in `internal/workapi` that their golden files pin, and
 `workapi.FinishPage` — `bd list` on both routes in every mode but the

--- a/internal/httpapi/claim.go
+++ b/internal/httpapi/claim.go
@@ -31,17 +31,18 @@ const (
 	// documented one is a handful of short members, so this is pure refusal of
 	// the absurd.
 	maxJSONBodyBytes = 1 << 20
-	// claimContentType is the one media type this operation accepts, and
-	// refusing anything else is a CSRF control, not pedantry: a JSON content
-	// type is not CORS-"simple", so a cross-origin claim always triggers a
-	// preflight this server never approves. Accepting text/plain or a form
-	// encoding would let an attacker's page skip the preflight and drive the
-	// one write on this surface from any browser on the host.
+	// claimContentType is the one media type this surface accepts on a body —
+	// requireJSONContent enforces it for every body-carrying operation, not
+	// only the claim — and refusing anything else is a CSRF control, not
+	// pedantry: a JSON content type is not CORS-"simple", so a cross-origin
+	// write always triggers a preflight this server never approves. Accepting
+	// text/plain or a form encoding would let an attacker's page skip the
+	// preflight and drive a write from any browser on the host.
 	claimContentType = "application/json"
 )
 
-// handleClaim is the one write in v0: a compare-and-set claim of a single issue
-// for a caller-named actor.
+// handleClaim is v0's compare-and-set claim of a single issue for a
+// caller-named actor, and the write whose posture every later one adopted.
 //
 // ACTOR SEMANTICS, stated because adopting this endpoint depends on them. The
 // actor is caller-ASSERTED provenance for the audit trail, not authenticated
@@ -355,7 +356,7 @@ func (p timedProvider) IssueReader() (issueops.Reader, error) {
 
 // IssueClaimer builds the claimer OVER THIS WRAPPER, for the same reason and
 // with the same hazard as IssueReader above: the role's units of work must go
-// through NewUOW below or the one write on this surface reports uow_ms=0.000.
+// through NewUOW below or every claim reports uow_ms=0.000.
 // TestAClaimTimesTheUnitsOfWorkItsClaimerOpens is the assertion that fails
 // instead of the recursion looking correct.
 func (p timedProvider) IssueClaimer() (issueops.Claimer, error) {

--- a/internal/httpapi/claim_test.go
+++ b/internal/httpapi/claim_test.go
@@ -707,9 +707,10 @@ func TestClaimRetriesOnWriteContention(t *testing.T) {
 	}
 }
 
-// TestClaimTakesADatabaseSlot: the one write on this surface is not exempt from
-// the in-flight limit. An exempt write would keep opening connections while
-// every reader is already queued — the saturation case the semaphore exists for.
+// TestClaimTakesADatabaseSlot: the claim is not exempt from the in-flight
+// limit. An exempt write would keep opening connections while every reader is
+// already queued — the saturation case the semaphore exists for. Each later
+// write carries the same assertion against its own row.
 func TestClaimTakesADatabaseSlot(t *testing.T) {
 	for _, rt := range routeTable {
 		if rt.op != OpClaimIssue {
@@ -756,8 +757,8 @@ func TestClaimNeverReachesTheWispPlane(t *testing.T) {
 // tempting edit: `p.inner.IssueClaimer()` — "add the layer by recursion, like
 // every other decorator". This decorator's layer is on NewUOW, which only a
 // claimer holding THIS wrapper can reach, so recursion hands back a claimer
-// bound to the untimed provider. It compiles, and the one write on this
-// surface reports uow_ms=0.000 forever.
+// bound to the untimed provider. It compiles, and every claim reports
+// uow_ms=0.000 forever.
 func TestAClaimTimesTheUnitsOfWorkItsClaimerOpens(t *testing.T) {
 	issues := &fakeIssues{issue: seededIssue("bd-1", "alice", types.StatusInProgress)}
 	provider := &fakeProvider{issues: issues, delay: 5 * time.Millisecond}

--- a/internal/httpapi/doc.go
+++ b/internal/httpapi/doc.go
@@ -4,20 +4,32 @@
 //
 // What is live: the process lifecycle (Listen and Serve), the bind policy, the
 // route table and the request path in front of it — Host allowlist, connection
-// cap, database semaphore, per-request deadline, structured request log — the
-// two operations that answer from the process itself, GET /healthz and
-// GET /v0/beads/context, the three reads — GET /v0/beads/ready,
-// GET /v0/beads/issues and GET /v0/beads/issues/{id} — and the one write,
-// POST /v0/beads/issues/{id}:claim. ContextResponse.capabilities is derived
-// from the implemented handlers, so a release cut mid-slice never advertises
-// an operation that does not work.
+// cap, database semaphore, per-request deadline, structured request log — and
+// every operation routeTable carries.
 //
-// The reads hold no query logic of their own. Each decodes its parameters and
-// hands the whole request to issueops.Reader, obtained from the provider's own
-// capability accessor — the same role, reached the same way, that `bd show
-// --json` reaches on a store. Filter construction, the workspace config it
-// depends on, the default limits and the wisp fallback all live inside that
-// role. A handler cannot WRITE a filter here, and that is machine-checked by
+// WHICH operations those are is deliberately not restated here. routes.go is
+// the router, TestSpecRouteParity welds it to the document by exact set
+// equality in both directions, and ContextResponse.capabilities is derived from
+// the same table gated on `implemented` — so the table, the spec and a running
+// server's own handshake are three spellings of one answer, and a fourth
+// spelled in prose could only ever go stale. Read the surface from routeTable
+// or ask a server for it; a release cut mid-slice never advertises an operation
+// that does not work.
+//
+// Two rows answer from the process itself and touch no database (GET /healthz
+// and GET /v0/beads/context); they carry bypassSemaphore for that reason, and
+// nothing else may.
+//
+// No handler here holds query logic of its own. Each decodes its parameters
+// and hands the whole request to a role obtained from the provider's own
+// capability accessor — the same roles, reached the same way, the CLI reaches
+// on a store. Three of them reach issueops.Reader (GET /v0/beads/ready,
+// GET /v0/beads/issues, GET /v0/beads/issues/{id}), which is the role `bd show
+// --json` reaches and the one the property below is about; the rest reach
+// siblings of it, one role per operation. Filter construction, the workspace
+// config it depends on, the default limits and the wisp fallback all live
+// inside the role. A handler cannot WRITE a filter here, and that is
+// machine-checked by
 // two rules in .golangci.yml covering the two ways one gets written:
 // httpapi-transport-boundary (depguard) denies internal/workapi from this
 // package's non-test files, so the builders are not callable; the forbidigo
@@ -46,9 +58,11 @@
 // hidden-row TOTAL this surface has no member for.
 //
 // THE CLAIM, stated once and in full so it can be checked sentence by
-// sentence. SHARED: all three issue reads on this surface go through
-// issueops.Reader, and so does `bd show --json`'s detail view on both its
-// routes; `bd list` and `bd ready` are not on the role and share instead the
+// sentence. SHARED: the three reads named above go through issueops.Reader,
+// and so does `bd show --json`'s detail view on both its routes — this says
+// nothing about the surface's OTHER reads, which are on sibling roles and
+// carry their own conformance suites; `bd list` and `bd ready` are not on the
+// role and share instead the
 // request types, the two builders in internal/workapi that their golden files
 // pin, and workapi.FinishPage — `bd list` on both routes in every mode but the
 // hierarchical --parent tree, `bd ready` on its proxied route only.
@@ -84,15 +98,22 @@
 // is the domain.ContextInfo startup snapshot it is handed, and handlers.go,
 // whose contextResponse projects that snapshot through domain.PublishedContext
 // — the same projection `bd context` publishes, and where the credential and
-// host-path exclusions live. reads.go and claim.go carry no exception.
+// host-path exclusions live. No handler file is on that list, and adding one
+// to it is the edit review has to catch.
 //
-// The claim OPERATION is the only mutation this surface has, and claim.go
-// states the two things a client must know before adopting it: the actor is
-// caller-asserted provenance rather than authenticated identity, and hooks do
-// not fire. It shares no function with `bd update --claim` above the
-// transaction and deliberately so — the CAS itself is already one
-// implementation one level down, in the domain's issue use case, which both
-// reach. claimOnUOW says why nothing above that is worth extracting.
+// EVERY MUTATION ON THIS SURFACE CARRIES THE CLAIM'S POSTURE, and claim.go
+// states the two things a client must know before adopting any of them: the
+// actor is caller-asserted provenance rather than authenticated identity, and
+// hooks do not fire — nor does the per-command auto-commit machinery, so
+// durability is per request. The claim was the first write and is where that
+// posture is written down in full; each write added since restates only what
+// is its own and points here for the rest. Which rows are writes is read from
+// routeTable, not from a list kept here.
+//
+// The claim shares no function with `bd update --claim` above the transaction
+// and deliberately so — the CAS itself is already one implementation one level
+// down, in the domain's issue use case, which both reach. claimOnUOW says why
+// nothing above that is worth extracting.
 //
 // The Host allowlist is the DNS-rebinding defense, and it has no off switch.
 // Every bind answers to the loopback spellings and to the bound address itself;

--- a/internal/httpapi/get_issue_test.go
+++ b/internal/httpapi/get_issue_test.go
@@ -26,6 +26,48 @@ import (
 // backend/conformance/reader_contract.go holds the real implementations to. It
 // models that and nothing else, because that is exactly what these parameters
 // select.
+//
+// Both lists carry TWO rows, and they differ on every member the wire schema
+// says a row has. One row cannot show order, and rows that agree on a member
+// cannot show that member survived: a handler that re-marshalled comments
+// through a struct without Author, or stamped one edge type onto every
+// dependent, would answer a single-row fixture indistinguishably from a
+// correct one.
+func seededComments(issueID string) []*types.Comment {
+	return []*types.Comment{
+		{
+			ID:        "c-1",
+			IssueID:   issueID,
+			Author:    "alice",
+			Text:      "the first comment body",
+			CreatedAt: time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC),
+		},
+		{
+			ID:        "c-2",
+			IssueID:   issueID,
+			Author:    "bob",
+			Text:      "the second comment body",
+			CreatedAt: time.Date(2026, 7, 31, 12, 0, 5, 0, time.UTC),
+		},
+	}
+}
+
+// seededDependents carries two DIFFERENT edge types because the type is what
+// `bd show` groups its dependents by: a surface that flattened every edge to
+// one type would still render, into the wrong section.
+func seededDependents() []*types.IssueWithDependencyMetadata {
+	return []*types.IssueWithDependencyMetadata{
+		{
+			Issue:          *seededIssue("bd-2", "", types.StatusOpen),
+			DependencyType: types.DepBlocks,
+		},
+		{
+			Issue:          *seededIssue("bd-3", "", types.StatusOpen),
+			DependencyType: types.DepParentChild,
+		},
+	}
+}
+
 type includeAwareReader struct {
 	roleReader
 }
@@ -34,32 +76,23 @@ func (r *includeAwareReader) Get(ctx context.Context, req issueops.GetRequest) (
 	if _, err := r.roleReader.Get(ctx, req); err != nil {
 		return nil, err
 	}
-	one := int64(1)
+	two := int64(2)
 	omitted := true
 	details := &issueops.IssueDetails{
 		Issue:           *seededIssue(req.ID, "", types.StatusOpen),
-		CommentCount:    &one,
-		DependentCount:  &one,
+		CommentCount:    &two,
+		DependentCount:  &two,
 		CommentsOmitted: &omitted,
 	}
 	if req.IncludeComments {
-		details.Comments = []*types.Comment{{
-			ID:        "c-1",
-			IssueID:   req.ID,
-			Author:    "alice",
-			Text:      "the comment body",
-			CreatedAt: time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC),
-		}}
+		details.Comments = seededComments(req.ID)
 		// Never set alongside a populated list: the flag exists to tell "no
 		// comments" from "not asked for", and a caller that asked has neither
 		// question.
 		details.CommentsOmitted = nil
 	}
 	if req.IncludeDependents {
-		details.Dependents = []*types.IssueWithDependencyMetadata{{
-			Issue:          *seededIssue("bd-2", "", types.StatusOpen),
-			DependencyType: types.DepBlocks,
-		}}
+		details.Dependents = seededDependents()
 	}
 	return details, nil
 }
@@ -169,6 +202,117 @@ func TestGetIssueIncludeParametersReachTheRole(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestGetIssueIncludeLegsCarryTheWireShape is the half the presence checks
+// above cannot reach: what is IN the two lists once a caller has paid for them.
+//
+// Presence is the cheap property. The row CONTENT is the expensive one and the
+// one clients read — `bd show` prints each comment's author and time in the
+// order it received them, and GROUPS dependents by edge type — so a surface
+// that answered the rows in a different order, dropped Author, or flattened
+// every dependent onto one edge type would satisfy every other test in this
+// file and still render wrong. Both lists are asserted row by row, by index,
+// because the index IS the order promise: the handler is a projection of the
+// role's answer and may not sort, filter or reshape it.
+//
+// The required-member sweep is deliberately DERIVED from the document rather
+// than listed here. A member added to `Comment` or
+// `IssueWithDependencyMetadata` tomorrow is covered the moment the schema
+// declares it, without an edit to this test — which is the only version of this
+// check that cannot go stale.
+func TestGetIssueIncludeLegsCarryTheWireShape(t *testing.T) {
+	ts, _ := newGetIssueServer(t)
+
+	resp := ts.get(t, "/v0/beads/issues/bd-1?include_comments=true&include_dependents=true")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	body := decodeBody(t, resp)
+
+	comments := objectRows(t, body, "comments")
+	wantComments := seededComments("bd-1")
+	if len(comments) != len(wantComments) {
+		t.Fatalf("%d comments, want %d — the handler answers the role's rows, all of them", len(comments), len(wantComments))
+	}
+	for i, got := range comments {
+		want := wantComments[i]
+		if got["id"] != want.ID {
+			t.Errorf("comments[%d].id = %v, want %q — the rows are answered in the role's order", i, got["id"], want.ID)
+		}
+		if got["issue_id"] != want.IssueID {
+			t.Errorf("comments[%d].issue_id = %v, want %q", i, got["issue_id"], want.IssueID)
+		}
+		if got["author"] != want.Author {
+			t.Errorf("comments[%d].author = %v, want %q", i, got["author"], want.Author)
+		}
+		if got["text"] != want.Text {
+			t.Errorf("comments[%d].text = %v, want %q", i, got["text"], want.Text)
+		}
+		if stamp := want.CreatedAt.Format(time.RFC3339); got["created_at"] != stamp {
+			t.Errorf("comments[%d].created_at = %v, want %q", i, got["created_at"], stamp)
+		}
+	}
+	requireDocumentedMembers(t, "Comment", comments)
+
+	dependents := objectRows(t, body, "dependents")
+	wantDependents := seededDependents()
+	if len(dependents) != len(wantDependents) {
+		t.Fatalf("%d dependents, want %d", len(dependents), len(wantDependents))
+	}
+	for i, got := range dependents {
+		want := wantDependents[i]
+		if got["id"] != want.ID {
+			t.Errorf("dependents[%d].id = %v, want %q — the rows are answered in the role's order", i, got["id"], want.ID)
+		}
+		if got["dependency_type"] != string(want.DependencyType) {
+			t.Errorf("dependents[%d].dependency_type = %v, want %q — the edge type is what `bd show` groups this row by",
+				i, got["dependency_type"], want.DependencyType)
+		}
+	}
+	requireDocumentedMembers(t, "IssueWithDependencyMetadata", dependents)
+}
+
+// objectRows reads one array-of-objects member out of a decoded body.
+func objectRows(t *testing.T, body map[string]any, member string) []map[string]any {
+	t.Helper()
+	raw, ok := body[member].([]any)
+	if !ok {
+		t.Fatalf("`%s` is %T, want an array of objects: %v", member, body[member], body[member])
+	}
+	rows := make([]map[string]any, 0, len(raw))
+	for i, item := range raw {
+		row, ok := item.(map[string]any)
+		if !ok {
+			t.Fatalf("`%s[%d]` is %T, want an object", member, i, item)
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+// requireDocumentedMembers asserts that every row carries every member the
+// document marks REQUIRED on its schema. Read from the spec, so a schema that
+// grows a required member the serve path cannot fill fails here rather than at
+// a client.
+func requireDocumentedMembers(t *testing.T, schema string, rows []map[string]any) {
+	t.Helper()
+	doc := loadSpec(t)
+	node := mapAt(t, mapAt(t, mapAt(t, doc, "components"), "schemas"), schema)
+	required := toStrings(t, node["required"])
+	if len(required) == 0 {
+		t.Fatalf("the %s schema declares no required members; re-point this guard at the document's row shape", schema)
+	}
+	if len(rows) == 0 {
+		t.Fatalf("no %s rows to check", schema)
+	}
+	for i, row := range rows {
+		for _, member := range required {
+			if value, ok := row[member]; !ok || value == nil {
+				t.Errorf("%s[%d] omits `%s`, which the document marks required: %v", schema, i, member, row)
+			}
+		}
 	}
 }
 

--- a/internal/httpapi/reads.go
+++ b/internal/httpapi/reads.go
@@ -9,8 +9,12 @@ import (
 	"github.com/steveyegge/beads/issueops"
 )
 
-// The three read operations. Each one decodes its parameters, hands the whole
-// request to the reader role, and shapes the answer onto the wire.
+// The issue-collection reads. Each one decodes its parameters, hands the whole
+// request to a role, and shapes the answer onto the wire. Three are on
+// issueops.Reader (ready, list, detail); the count and the query are on
+// ReadyCounter and Querier, siblings reached the same way through the same
+// provider accessors. What follows is about the Reader three, and holds for
+// the other two in every respect but which role they name.
 //
 // WHAT IS NOT HERE IS THE POINT. No filter is built, no ConfigSource is wired,
 // no default limit is applied, no status exclusion is chosen, no wisp fallback

--- a/internal/httpapi/roles_test.go
+++ b/internal/httpapi/roles_test.go
@@ -729,9 +729,9 @@ func countedPage() []*types.IssueWithCounts {
 //
 // The two refusals are different mistakes and must stay distinguishable. A
 // PARTIAL set is the dangerous one: a Config carrying a reader and no claimer
-// would bind, answer every read, and fail the one write on this surface with a
-// nil dereference — at claim time, in a handler, on a live server. Each role an
-// operation reaches has a row below for that reason.
+// would bind, answer every read, and fail every claim with a nil dereference —
+// at claim time, in a handler, on a live server. Each role an operation reaches
+// has a row below for that reason.
 func TestListenRequiresExactlyOneDatabaseSource(t *testing.T) {
 	for _, tc := range []struct {
 		name    string

--- a/internal/httpapi/spec_parity_test.go
+++ b/internal/httpapi/spec_parity_test.go
@@ -747,6 +747,87 @@ func TestUpdateRequestMembersMatchTheHandler(t *testing.T) {
 	}
 }
 
+// TestReopenRequestMembersMatchTheHandler is the claim's and the close's gate
+// for the reopen body. The reopen decodes raw members for the same reason its
+// mirror does — so a refusal can name the offending one, which is what makes
+// the schema's additionalProperties: false enforceable by a client that has
+// stopped parsing prose — and pays the same price: a hand-rolled copy of the
+// member list with nothing tying it to the document.
+func TestReopenRequestMembersMatchTheHandler(t *testing.T) {
+	accepted := map[string]bool{}
+	for _, name := range reopenRequestMembers {
+		accepted[name] = true
+	}
+
+	goFields := jsonTagNames(t, reflect.TypeOf(apigen.ReopenIssueRequest{}))
+	if extra := diff(goFields, accepted); len(extra) > 0 {
+		t.Errorf("generated ReopenIssueRequest declares members the reopen handler refuses as unknown: %v\n"+
+			"teach reopenRequest to honor them, or the document promises a member the server turns down", extra)
+	}
+	if missing := diff(accepted, goFields); len(missing) > 0 {
+		t.Errorf("the reopen handler accepts members ReopenIssueRequest does not declare: %v", missing)
+	}
+
+	doc := loadSpec(t)
+	schema := mapAt(t, mapAt(t, mapAt(t, doc, "components"), "schemas"), "ReopenIssueRequest")
+	specProps := schemaProperties(t, doc, schema)
+	if extra := diff(specProps, accepted); len(extra) > 0 {
+		t.Errorf("the ReopenIssueRequest schema documents members the reopen handler refuses: %v", extra)
+	}
+	if missing := diff(accepted, specProps); len(missing) > 0 {
+		t.Errorf("the reopen handler accepts members the ReopenIssueRequest schema does not document: %v", missing)
+	}
+}
+
+// TestDependencyRequestMembersMatchTheHandlers is the same gate for the two
+// dependency bodies, and for the add's NESTED level — the update's table-driven
+// form because, exactly as there, the body has a level below it.
+//
+// `edges[i]` is where this matters most on the graph side. It is the only
+// member list on the surface checked inside a loop, its refusals are reported
+// as `edges[i].member` rather than by bare name, and a member the document grew
+// there would be refused per edge with an index attached — a failure that reads
+// like a data problem in one row rather than like version skew, which is the
+// slowest possible way to discover a spec revision.
+func TestDependencyRequestMembersMatchTheHandlers(t *testing.T) {
+	doc := loadSpec(t)
+	schemas := mapAt(t, mapAt(t, doc, "components"), "schemas")
+
+	for _, tc := range []struct {
+		schema   string
+		accepted []string
+		goType   reflect.Type
+	}{
+		{"AddDependenciesRequest", addDependenciesMembers, reflect.TypeOf(apigen.AddDependenciesRequest{})},
+		{"DependencyEdge", dependencyEdgeMembers, reflect.TypeOf(apigen.DependencyEdge{})},
+		{"RemoveDependencyRequest", removeDependencyMembers, reflect.TypeOf(apigen.RemoveDependencyRequest{})},
+	} {
+		t.Run(tc.schema, func(t *testing.T) {
+			accepted := map[string]bool{}
+			for _, name := range tc.accepted {
+				accepted[name] = true
+			}
+
+			goFields := jsonTagNames(t, tc.goType)
+			if extra := diff(goFields, accepted); len(extra) > 0 {
+				t.Errorf("generated %s declares members the handler refuses as unknown: %v\n"+
+					"teach the handler to honor them, or the document promises a member the server turns down", tc.schema, extra)
+			}
+			if missing := diff(accepted, goFields); len(missing) > 0 {
+				t.Errorf("the handler accepts members %s does not declare: %v", tc.schema, missing)
+			}
+
+			specProps := schemaProperties(t, doc, mapAt(t, schemas, tc.schema))
+			if extra := diff(specProps, accepted); len(extra) > 0 {
+				t.Errorf("the %s schema documents members the handler refuses: %v", tc.schema, extra)
+			}
+			if missing := diff(accepted, specProps); len(missing) > 0 {
+				t.Errorf("the handler accepts members the %s schema does not document: %v", tc.schema, missing)
+			}
+		})
+	}
+}
+
 // TestNullablePatchMembersAreExactlyTheDocumentsNullableOnes pins the closed set
 // on which explicit `null` CLEARS rather than refuses.
 //

--- a/internal/httpapi/update_test.go
+++ b/internal/httpapi/update_test.go
@@ -437,8 +437,9 @@ func TestUpdateRefusesAQueryParameter(t *testing.T) {
 }
 
 // TestUpdateRefusesUnrowableIDsBeforeAnyDatabaseWork: the dispatcher's id bound
-// applied here, because this route is NOT on the dispatcher's pattern and would
-// otherwise be the one write on the surface without one.
+// applied here, because this route is NOT on the dispatcher's pattern — it is
+// the one write that takes an issue id from the PATH without going through
+// customMethodTarget, so it would otherwise have no id bound at all.
 func TestUpdateRefusesUnrowableIDsBeforeAnyDatabaseWork(t *testing.T) {
 	for _, tc := range []struct{ name, id string }{
 		{"longer than the column", strings.Repeat("b", types.MaxFieldLen+1)},


### PR DESCRIPTION
## Summary

Four independent pieces of polish on the v0 HTTP surface, one commit each. The write wave (#5410, #5417, #5422, #5423, #5429) landed the operations; this lands the parts a wave tends to leave behind — the test depth the wire shape actually needs, the orientation prose that went stale under it, the parity gates that were applied to three bodies out of six, and the changelog reconcile.

No wire change. `openapi.v0.yaml` and `types.gen.go` are untouched.

## What each commit does

**1. `test(httpapi)`: assert what the getIssue include legs actually carry**

The include parameters were pinned by presence alone — one comment whose `text` was checked, one dependent whose `id` was checked. `Comment` requires `author` and `created_at`; `IssueWithDependencyMetadata` requires `dependency_type`; and OpenAPI `required` enforces key presence, never value correctness and never array order. So a store answering comments newest-first, or stamping one edge type onto every dependent, emitted schema-valid JSON and passed.

Both are CLI-observable: `bd show` prints each comment's author and time in the order it received them, and groups dependents into sections by edge type.

Both fixtures now carry two rows that differ on every member the schema declares, asserted row by row by index — the index *is* the order promise. The required-member sweep is read from the embedded document rather than listed in the test, so a schema that grows a required member the serve path cannot fill fails here instead of at a client.

**2. `docs(httpapi)`: stop the orientation prose enumerating a surface it no longer has**

`doc.go` still said "the three reads … and the one write, `POST /v0/beads/issues/{id}:claim`" and "the claim OPERATION is the only mutation this surface has". `bd-serve-v0.md` still opened with "Six operations" over a six-row table and sized the server under "Claim throughput — the claim is the only mutation in v0". The route table serves 27 operations, 11 of them writes. `bd-serve-v0.md`'s own header rule says nothing in it may contradict the spec, `doc.go` or the reader role — so the rule was violating itself.

**The counts are removed, not corrected.** `routes.go` is the router, `TestSpecRouteParity` welds it to the spec by exact set equality in both directions, and `capabilities` derives from the same table. A fourth copy spelled in prose can only go stale — as this one did, silently, across five merged PRs. What replaces the design page's table is the surface's *shape*, which does not change when an operation is added.

Statements true only of the claim are widened where the code widened them (the JSON content type is enforced for every body-carrying operation; hooks fire for no write) and narrowed where they were overstated (the reader property covers three named reads, not "all" reads — the count, the query, stats, config, memories and the dependency reads are on sibling roles). Also sweeps the seven stale "one write on this surface" comments and `reads.go`'s "the three read operations" header over a file that now holds five.

**3. `test(httpapi)`: gate the four request member lists the wave left ungated**

The wave shipped six hand-rolled request member lists and gates for two of them. `reopenRequestMembers`, `addDependenciesMembers`, `dependencyEdgeMembers` and `removeDependencyMembers` had none — a tree-wide grep finds them referenced only by their own handlers. That is precisely the drift class `spec_parity_test.go`'s own doc comment calls "the one failure this file exists to prevent".

Nothing else closes the seam: the bijection test covers only `x-go-type`-pinned schemas, `make api-check` ties the struct to the schema by codegen but ties neither to the handler's list, and `reopen_test.go` / `dependency_edit_test.go` never consult the spec.

There is no live bug — all four lists match today. This is the gate that keeps them matching.

**4. `docs(changelog)`: record the v0 write surface under Unreleased**

The wave added 25 lines to `CHANGELOG.md`, all for the role-level typed refusals in #5415, none for the wire. A whole-file grep for every operationId, parameter and code the wave published returned zero hits — so the next cut would have shipped notes announcing the facade programme's twelve operations while omitting the five that turned this API from read-only-plus-claim into something an agent can finish work through. This is the missing reconcile step, written to the section's existing conventions.

## RED evidence

Each new gate was proved to fail against a real defect before being made green.

**Include-leg asserts** — reversing the seeded comments (a store answering newest-first) and stamping one edge type onto every dependent:

```
--- FAIL: TestGetIssueIncludeLegsCarryTheWireShape
    comments[0].id = c-2, want "c-1" — the rows are answered in the role's order
    comments[0].author = bob, want "alice"
    comments[0].created_at = 2026-07-31T12:00:05Z, want "2026-07-31T12:00:00Z"
    ... (9 assertions)
    dependents[1].dependency_type = blocks, want "parent-child" — the edge type is what `bd show` groups this row by
```

**Schema-derived sweep** — adding `thread_id` to the `Comment` schema's `required` list:

```
--- FAIL: TestGetIssueIncludeLegsCarryTheWireShape
    Comment[0] omits `thread_id`, which the document marks required: map[author:alice created_at:... id:c-1 ...]
    Comment[1] omits `thread_id`, which the document marks required: map[author:bob ...]
```

**Member-list gates** — the money shot. A `note` member added to `ReopenIssueRequest`, `AddDependenciesRequest` and `RemoveDependencyRequest` in the spec, **with `make api-gen` run** so the generated structs agree with the document exactly:

```
--- FAIL: TestReopenRequestMembersMatchTheHandler
    generated ReopenIssueRequest declares members the reopen handler refuses as unknown: [note]
    the ReopenIssueRequest schema documents members the reopen handler refuses: [note]
--- FAIL: TestDependencyRequestMembersMatchTheHandlers/AddDependenciesRequest
    generated AddDependenciesRequest declares members the handler refuses as unknown: [note]
    the AddDependenciesRequest schema documents members the handler refuses: [note]
--- FAIL: TestDependencyRequestMembersMatchTheHandlers/RemoveDependencyRequest
    ... same, both directions
```

In that state `make api-check` passes and **every other test in the package passes**. Only the three new subtests fail. That green-everywhere-else run is the failure mode these gates exist for, reproduced.

## One correction worth flagging

Three codes joined the frozen vocabulary in this wave, not four: `not_closable`, `dependency_cycle` and `dependency_exists`. `already_closed` is a required member of the `200 CloseIssueResponse` and never appears in a problem body. The changelog records it as what it is.

## Gates

| Gate | Result |
|---|---|
| `go test ./internal/httpapi/` | ok (all parity tests, including the 3 new ones) |
| `make api-check` | clean — spec and generated types untouched |
| `make ci-pr-lint` (gofmt, golangci-lint ×2) | 0 issues |
| `go test -tags=gms_pure_go ./test/docsync` | ok |
| `./scripts/check-doc-freshness.sh` | PASSED |
| `git diff --check` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
