### PR TITLE
test(conformance): an accessor-only Update contract, and the claim→close loop

### DIFF
--- a/backend/conformance/lifecycle_close_reopen_contract.go
+++ b/backend/conformance/lifecycle_close_reopen_contract.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/steveyegge/beads/internal/types"
 	publicops "github.com/steveyegge/beads/issueops"
@@ -601,6 +602,89 @@ func RunLifecycleCloseIsIdempotentAndKeepsTheFirstClose(t *testing.T, ctx contex
 	}
 }
 
+// RunLifecycleCloseAndReopenKeepTheClaimHolder pins the second half of the
+// agent loop against the state the first half leaves: an in_progress row a named
+// actor holds is CLOSEABLE, and the holder survives both the close and a later
+// reopen.
+//
+// Every other close target in this package — here, in claim.go, in the audit
+// files, in issue_operations_contract.go's close-policy seeds and in
+// batch_closer_contract.go — is seeded OPEN and unassigned, so nothing pins the
+// only close a working agent actually performs: the one on the row it is
+// currently holding. Two divergences pass the whole suite today. A backend whose
+// close admits open rows only refuses every claimed issue, so `bd claim` and
+// `bd close` stop composing. A backend that clears assignee as part of the
+// close — a defensible reading of "the work is over" — silently drops the
+// attribution `bd show` renders and `bd list --assignee` filters on, and the
+// reopen half loses it again for a caller handing the work back to the same
+// holder.
+//
+// The reopen leg asserts the holder for a second reason: Reopen already clears
+// the close attribution (CloseRequest.Reason "A Reopen clears both, because they
+// describe a closure that no longer holds"), and assignee is the neighboring
+// column that is NOT part of that closure record. An implementation sweeping the
+// closure fields is exactly the one likely to take assignee with them.
+func RunLifecycleCloseAndReopenKeepTheClaimHolder(t *testing.T, ctx context.Context, fixture LifecycleCloseReopenFixture) {
+	t.Helper()
+
+	const holder = "worker-1"
+	id := fixture.IssuePrefix + "-lcr-held"
+	lifecycleCloseReopenSeedClaimedIssue(t, ctx, fixture, id, holder)
+
+	seeded := lifecycleCloseReopenReadRow(t, ctx, fixture, id)
+	if types.Status(seeded.Status) != types.StatusInProgress || seeded.Assignee != holder {
+		t.Fatalf("seeded %s as {status %q assignee %q}, want {%q %q} — the case has nothing to prove otherwise",
+			id, seeded.Status, seeded.Assignee, types.StatusInProgress, holder)
+	}
+
+	closed, err := fixture.Lifecycle.Close(ctx, publicops.CloseRequest{
+		Actor: holder, IssueID: id, Reason: "work finished", Session: "session-held",
+	})
+	if err != nil {
+		t.Fatalf("close %s while %s holds it: %v — an in_progress row is the one an agent actually closes", id, holder, err)
+	}
+	if !closed.Changed {
+		t.Errorf("close of in_progress %s reported Changed = false, want a committed close", id)
+	}
+	if closed.Issue == nil {
+		t.Fatalf("close of %s answered a nil Issue, want a post-state snapshot", id)
+	}
+	if closed.Issue.Status != types.StatusClosed {
+		t.Errorf("CloseResult.Issue.Status = %q, want %q", closed.Issue.Status, types.StatusClosed)
+	}
+	if closed.Issue.Assignee != holder {
+		t.Errorf("CloseResult.Issue.Assignee = %q, want %q — closing the work does not un-assign it", closed.Issue.Assignee, holder)
+	}
+	closedRow := lifecycleCloseReopenReadRow(t, ctx, fixture, id)
+	if types.Status(closedRow.Status) != types.StatusClosed || closedRow.Assignee != holder {
+		t.Errorf("stored row after the close = {status %q assignee %q}, want {%q %q}",
+			closedRow.Status, closedRow.Assignee, types.StatusClosed, holder)
+	}
+
+	reopened, err := fixture.Lifecycle.Reopen(ctx, publicops.ReopenRequest{Actor: holder, IssueID: id, Reason: "regressed"})
+	if err != nil {
+		t.Fatalf("reopen %s: %v", id, err)
+	}
+	if !reopened.Changed {
+		t.Errorf("reopen of closed %s reported Changed = false, want a committed reopen", id)
+	}
+	if reopened.Issue == nil {
+		t.Fatalf("reopen of %s answered a nil Issue, want a post-state snapshot", id)
+	}
+	if reopened.Issue.Assignee != holder {
+		t.Errorf("ReopenResult.Issue.Assignee = %q, want %q — the reopen clears the closure record, not the holder", reopened.Issue.Assignee, holder)
+	}
+	reopenedRow := lifecycleCloseReopenReadRow(t, ctx, fixture, id)
+	if types.Status(reopenedRow.Status) != types.StatusOpen || reopenedRow.Assignee != holder {
+		t.Errorf("stored row after the reopen = {status %q assignee %q}, want {%q %q}",
+			reopenedRow.Status, reopenedRow.Assignee, types.StatusOpen, holder)
+	}
+	if reopenedRow.CloseReason != "" || reopenedRow.ClosedBySession != "" {
+		t.Errorf("close attribution after reopening %s = (%q, %q), want both cleared — only the closure record goes",
+			id, reopenedRow.CloseReason, reopenedRow.ClosedBySession)
+	}
+}
+
 // RunLifecycleReopenLeavesNonDoneStatusesUnchanged pins the Reopen no-op.
 // issueops/issueops.go:429-432 promises Reopen "moves literal StatusClosed and
 // configured done statuses to StatusOpen; non-done statuses unchanged", and
@@ -634,16 +718,25 @@ func RunLifecycleReopenLeavesNonDoneStatusesUnchanged(t *testing.T, ctx context.
 		t.Fatalf("installed status.custom = %q, want %q", installed, lifecycleCloseReopenCustomStatuses)
 	}
 
+	// The wip leg carries a HOLDER, because that is the state a live claim
+	// leaves and the one a no-op reopen must not sweep: the whole row is
+	// compared before and after, so an implementation that cleared assignee on
+	// the way through fails here rather than passing on an empty column.
 	cases := []struct {
-		name   string
-		id     string
-		status types.Status
+		name     string
+		id       string
+		status   types.Status
+		assignee string
 	}{
 		{name: "already open", id: fixture.IssuePrefix + "-lcr-noop-open", status: types.StatusOpen},
-		{name: "built-in wip", id: fixture.IssuePrefix + "-lcr-noop-wip", status: types.StatusInProgress},
+		{name: "built-in wip", id: fixture.IssuePrefix + "-lcr-noop-wip", status: types.StatusInProgress, assignee: "worker-noop"},
 		{name: "configured active", id: fixture.IssuePrefix + "-lcr-noop-custom", status: lifecycleCloseReopenActiveStatus},
 	}
 	for _, tc := range cases {
+		if tc.assignee != "" {
+			lifecycleCloseReopenSeedClaimedIssue(t, ctx, fixture, tc.id, tc.assignee)
+			continue
+		}
 		lifecycleCloseReopenSeedIssue(t, ctx, fixture, tc.id, tc.status, nil)
 	}
 	for _, tc := range cases {
@@ -1026,8 +1119,15 @@ func lifecycleCloseReopenCountHistory(t *testing.T, ctx context.Context, fixture
 // lifecycleCloseReopenRow is the stored close-lifecycle state one assertion
 // compares before and after. row_lock is read as an int64 rather than a string
 // because the version cases hand it straight back as an ExpectedVersion.
+//
+// assignee is part of the row rather than a separate read because every refusal
+// and no-op leg in this file asserts against the whole struct: a close that
+// dropped the holder on a path that changed nothing else would otherwise be
+// invisible here, and `bd show` and `bd list --assignee` would lose the holder
+// after every replayed close.
 type lifecycleCloseReopenRow struct {
 	Status          string
+	Assignee        string
 	RowLock         int64
 	ClosedAt        string
 	CloseReason     string
@@ -1038,8 +1138,8 @@ func lifecycleCloseReopenReadRow(t *testing.T, ctx context.Context, fixture Life
 	t.Helper()
 	var row lifecycleCloseReopenRow
 	if err := fixture.QueryScalar(ctx,
-		"SELECT status, row_lock, COALESCE(CAST(closed_at AS CHAR), ''), COALESCE(close_reason, ''), COALESCE(closed_by_session, '') FROM issues WHERE id = ?",
-		[]any{id}, &row.Status, &row.RowLock, &row.ClosedAt, &row.CloseReason, &row.ClosedBySession); err != nil {
+		"SELECT status, COALESCE(assignee, ''), row_lock, COALESCE(CAST(closed_at AS CHAR), ''), COALESCE(close_reason, ''), COALESCE(closed_by_session, '') FROM issues WHERE id = ?",
+		[]any{id}, &row.Status, &row.Assignee, &row.RowLock, &row.ClosedAt, &row.CloseReason, &row.ClosedBySession); err != nil {
 		t.Fatalf("read close-lifecycle row for %s: %v", id, err)
 	}
 	return row
@@ -1086,6 +1186,22 @@ func lifecycleCloseReopenSeedIssue(t *testing.T, ctx context.Context, fixture Li
 		ID: id, Title: id, Status: status, Priority: 2, IssueType: types.TypeTask, Labels: labels,
 	}, "seed"); err != nil {
 		t.Fatalf("seed %s at status %q: %v", id, status, err)
+	}
+}
+
+// lifecycleCloseReopenSeedClaimedIssue seeds the state a won claim leaves
+// behind: an in_progress row a named actor holds. It seeds directly rather than
+// claiming through the role because the close/reopen assertions answer to the
+// STATE, and a fixture that had to reach it through a Claim would need the
+// claim seam this file otherwise does not use.
+func lifecycleCloseReopenSeedClaimedIssue(t *testing.T, ctx context.Context, fixture LifecycleCloseReopenFixture, id, assignee string) {
+	t.Helper()
+	started := time.Now().UTC()
+	if err := fixture.CreateIssue(ctx, &types.Issue{
+		ID: id, Title: id, Status: types.StatusInProgress, Priority: 2, IssueType: types.TypeTask,
+		Assignee: assignee, StartedAt: &started,
+	}, "seed"); err != nil {
+		t.Fatalf("seed %s as claimed by %s: %v", id, assignee, err)
 	}
 }
 

--- a/backend/conformance/lifecycle_update_contract.go
+++ b/backend/conformance/lifecycle_update_contract.go
@@ -1,0 +1,717 @@
+package conformance
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+	publicops "github.com/steveyegge/beads/issueops"
+)
+
+// This file holds the semantic contract for publicops.Lifecycle.Update as the
+// ROLE reached through storage.Storage.IssueLifecycle() — the accessor-only
+// half of a verb whose owning cases all live behind a staging fixture today.
+//
+// The suite already covers Update at the persistence seam
+// (issue_operations_contract.go), and close/reopen already have their
+// accessor-adoptable half (lifecycle_close_reopen_contract.go). This file
+// exists because the Update cases are unreachable for a backend that cannot
+// supply the staging fixture, which is a gap the suite's own headers concede:
+// issue_claimer_contract.go:33-37 says outright that "the Update-seam cases run
+// only behind IssueOperationsStagingFixture, which demands raw-SQL hooks a
+// partial or remote backend cannot supply", and fixed that for Claimer alone.
+//
+// The reachability problem has two halves, and the raw hooks are only one:
+//
+//   - RAW HOOKS. Every runner in issue_operations_contract.go takes
+//     IssueOperationsStagingFixture (issue_operations_staging.go:14-29), whose
+//     Exec/QueryScalar/UpdateRaw/Commit fields are a version-control-aware SQL
+//     seam. Nothing below needs one: publicops.UpdateResult and the fixture's
+//     GetIssue between them expose every fact these cases assert, including the
+//     RowVersion token that says whether a refusal wrote anything.
+//   - THE FIXTURE'S SINGLE ROLE FIELD. That fixture's Operations is both the
+//     seed route and the subject: several Update cases reach their starting
+//     state through fixture.Operations.Create. A backend whose composition
+//     refuses Create can therefore never wire them even with raw hooks
+//     available. LifecycleCloseReopenFixture and ClaimerFixture already
+//     separate the two, and this fixture follows them.
+//
+// SCOPE: the cases below exercise only the UpdateRequest and IssuePatch members
+// a backend can express without a private extension — title, description,
+// design, acceptance criteria, notes, append_notes, priority, issue type, the
+// label set, the four nullable members, the actor and the id. Everything the
+// staging cases own that needs more than that — Metadata, Status and close
+// policy, Assignee and the transfer fence, Claim, ParentID, Persistence, the
+// Expected* preconditions, Provenance — is deliberately absent: those have
+// owning cases already, and pinning them here would only make the block
+// unadoptable for the backends it exists to serve.
+//
+// DELIBERATE OVERLAP, named rather than hidden. The plane runner re-pins what
+// RunIssueOperationsUpdateIssuePlaneOnlyRefusesWisps asserts. The value is
+// reachability, not a second opinion: that case seeds its wisp through
+// Operations.Create and reads its post-state with QueryScalar, so it is exactly
+// the shape a partial backend cannot run. Everything else here — patch
+// persistence and the hydrated result, Changed:false on a same-value patch,
+// append_notes against a notes replacement, the nullable clears, label replace
+// at the role seam, the unknown-id refusal for a plain Update, the actorless
+// refusal, and a refused patch writing no member — has no owning proof
+// anywhere in the package.
+//
+// HOW MANY VOTES THE THREE LEGS ARE: two. The server-backed and embedded stores
+// share one validate/execute body (internal/storage/issueops/execution.go
+// ExecuteUpdate), so they are ONE reading of every rule below; the unit-of-work
+// backend reaches the same row bodies through domain/db and maps the patch
+// itself (internal/storage/uow/issue_operations.go), which is the second. The
+// same-value and clear cases are where that split has teeth: Changed comes out
+// of the row-write facts on one side and out of a post-state comparison on the
+// other, so "a patch that restated the current values wrote nothing" is a
+// genuine two-implementation question rather than one body asserted twice.
+
+// LifecycleUpdateFixture supplies adapter-specific storage access for the
+// update-role assertions. Every field but GetIssue is named and typed exactly
+// like the per-backend roleFixtureKit hook it is filled from, so a wiring is
+// kit plus accessor plus prefix with no adapter in between.
+type LifecycleUpdateFixture struct {
+	// IssuePrefix namespaces the ids each assertion seeds, so several of them
+	// can share one database.
+	IssuePrefix string
+	// Lifecycle is the role under test, reached through the backend's
+	// capability accessor rather than a constructor.
+	Lifecycle publicops.Lifecycle
+	// CreateIssue seeds a durable issue in the issues plane, including its
+	// labels. It is a SEPARATE hook from the subject on purpose: a backend
+	// whose Lifecycle refuses Create still runs every case below.
+	CreateIssue func(context.Context, *types.Issue, string) error
+	// CreateWisp seeds an ephemeral issue in the wisps plane. A nil CreateWisp
+	// means "this backend has no wisp plane to resolve against", and the plane
+	// runner SKIPS loudly with that reason rather than passing quietly.
+	CreateWisp func(context.Context, *types.Issue, string) error
+	// GetIssue reads a row back. It is the only read these cases need: the
+	// issue it answers carries the patched columns, the label set, and the
+	// RowVersion token that tells a refusal apart from a silent write.
+	//
+	// It is this contract's OUT-OF-BAND hook, built at each wiring site over a
+	// seam the backend already publishes, the way CycleDetectorFixture.Exec and
+	// LifecycleCloseReopenFixture.Exec are. The frozen role fixture kit reads
+	// through QueryScalar, and reading these cases' post-state with raw SQL
+	// would reintroduce exactly the dependency the block exists to remove.
+	GetIssue func(context.Context, string) (*types.Issue, error)
+	// AddDependency seeds ONE edge, so the hydration case can assert the
+	// dependency records UpdateResult promises. Nil means the backend cannot
+	// seed one: that case then drops the dependency half and keeps its labels
+	// half, the way ClaimerFixture.CountClaimEvents drops its event check.
+	AddDependency func(context.Context, *types.Dependency, string) error
+}
+
+// RunLifecycleUpdatePersistsThePatchAndHydratesTheResult pins the two halves of
+// what an ordinary edit answers: every patched member reaches the row, and
+// UpdateResult reports "the post-update issue as a detached post-state snapshot
+// with labels and dependency records" with "Comments are omitted"
+// (issueops/issueops.go:355-364).
+//
+// The result half is the one with teeth. A caller that renders what it just
+// wrote — which is what every non-interactive front door does — gets an issue
+// with no labels and no edges from a backend that answered the bare row, and
+// nothing else in the package would notice: the closest neighbor,
+// RunLifecycleResultsAreHydratedPostStateSnapshots, covers Close and Reopen
+// only, and the Update-seam cases assert result FIELDS rather than the
+// relations hanging off them.
+//
+// One request carries every wire-expressible content member at once, because a
+// patch that arrives as one document is applied as one mutation: a backend that
+// dropped a member would otherwise still pass a case that sent members singly.
+func RunLifecycleUpdatePersistsThePatchAndHydratesTheResult(t *testing.T, ctx context.Context, fixture LifecycleUpdateFixture) {
+	t.Helper()
+
+	id := fixture.IssuePrefix + "-lup-patch"
+	peer := fixture.IssuePrefix + "-lup-patch-peer"
+	seedLifecycleUpdateIssue(t, ctx, fixture, lifecycleUpdateIssue(id, "lup-tag"))
+	if fixture.AddDependency != nil {
+		seedLifecycleUpdateIssue(t, ctx, fixture, lifecycleUpdateIssue(peer))
+		// relates-to, not blocks: the edge has to show up in the result without
+		// changing what any later edit is allowed to do.
+		seedLifecycleUpdateEdge(t, ctx, fixture, id, peer, types.DepRelatesTo)
+	}
+
+	result, err := fixture.Lifecycle.Update(ctx, publicops.UpdateRequest{Actor: "writer", IssueID: id, Patch: publicops.IssuePatch{
+		Title:              publicops.Field[string]{Set: true, Value: "patched title"},
+		Description:        publicops.Field[string]{Set: true, Value: "patched description"},
+		Design:             publicops.Field[string]{Set: true, Value: "patched design"},
+		AcceptanceCriteria: publicops.Field[string]{Set: true, Value: "patched acceptance"},
+		Notes:              publicops.Field[string]{Set: true, Value: "patched notes"},
+		Priority:           publicops.Field[int]{Set: true, Value: 0},
+		IssueType:          publicops.Field[publicops.IssueType]{Set: true, Value: types.TypeBug},
+	}})
+	if err != nil {
+		t.Fatalf("update %s: %v", id, err)
+	}
+	if !result.Changed {
+		t.Errorf("update of %s reported Changed = false, want a committed edit", id)
+	}
+	assertLifecycleUpdateContent(t, "update result", result.Issue)
+	assertLifecycleUpdateContent(t, "stored row", lifecycleUpdateRow(t, ctx, fixture, id))
+
+	if !lifecycleUpdateHasLabel(result.Issue.Labels, "lup-tag") {
+		t.Errorf("update result labels = %v, want the seeded label — the result is promised hydrated", result.Issue.Labels)
+	}
+	if len(result.Issue.Comments) != 0 {
+		t.Errorf("update result carries %d comments, want none — the result doc omits them", len(result.Issue.Comments))
+	}
+	if fixture.AddDependency != nil && !lifecycleUpdateHasEdge(result.Issue.Dependencies, peer) {
+		t.Errorf("update result dependencies = %v, want a record naming %s", result.Issue.Dependencies, peer)
+	}
+}
+
+// RunLifecycleUpdateReportsNoChangeForASameValuePatch pins UpdateResult.Changed:
+// it "reports whether the request persisted a semantic mutation. It is false for
+// same-value patches and no-op updates" (issueops/issueops.go:361-363).
+//
+// Changed is the only signal a polling or replaying caller has that its request
+// was absorbed, and an implementation that answered true unconditionally would
+// have such a caller mint an empty version-control commit per call. The state
+// half is what makes the assertion more than a boolean: RowVersion is "a random
+// non-zero value the engine rewrites on every status/ownership-mutating write"
+// and specifically changes on "the generic update path" (types.go:70-84), so a
+// same-value patch that left it alone is a patch that really wrote nothing —
+// not one that wrote the same bytes back and reported false.
+//
+// The result of a no-op is asserted hydrated too. Nothing in the doc makes the
+// snapshot conditional on Changed, and a backend that returned an early bare row
+// on the no-op path would hand a replaying caller a different body than the
+// first call did.
+func RunLifecycleUpdateReportsNoChangeForASameValuePatch(t *testing.T, ctx context.Context, fixture LifecycleUpdateFixture) {
+	t.Helper()
+
+	id := fixture.IssuePrefix + "-lup-samevalue"
+	seeded := lifecycleUpdateIssue(id, "lup-tag")
+	seeded.Description = "seeded description"
+	seedLifecycleUpdateIssue(t, ctx, fixture, seeded)
+	before := lifecycleUpdateRow(t, ctx, fixture, id)
+
+	result, err := fixture.Lifecycle.Update(ctx, publicops.UpdateRequest{Actor: "writer", IssueID: id, Patch: publicops.IssuePatch{
+		Title:       publicops.Field[string]{Set: true, Value: before.Title},
+		Description: publicops.Field[string]{Set: true, Value: before.Description},
+		Priority:    publicops.Field[int]{Set: true, Value: before.Priority},
+		IssueType:   publicops.Field[publicops.IssueType]{Set: true, Value: before.IssueType},
+	}})
+	if err != nil {
+		t.Fatalf("same-value patch on %s: %v", id, err)
+	}
+	if result.Changed {
+		t.Errorf("restating %s's own values reported Changed = true, want false", id)
+	}
+	if result.Issue == nil {
+		t.Fatalf("same-value patch on %s answered a nil Issue, want a post-state snapshot", id)
+	}
+	if !lifecycleUpdateHasLabel(result.Issue.Labels, "lup-tag") {
+		t.Errorf("same-value patch result labels = %v, want the seeded label — a no-op answers the same hydrated snapshot a change does", result.Issue.Labels)
+	}
+	assertLifecycleUpdateRowUnchanged(t, ctx, fixture, id, "after the same-value patch", before)
+}
+
+// RunLifecycleUpdateAppendsNotesWithoutReplacingThem pins the only pair of
+// IssuePatch members declared mutually exclusive of each other:
+// "Notes replaces the notes and is mutually exclusive with AppendNotes" and
+// "AppendNotes appends to the notes and is mutually exclusive with Notes"
+// (issueops/issueops.go:117-121).
+//
+// Three obligations, and the package has an owning case for none of them: an
+// append keeps what was there and adds a line, a replacement discards it, and
+// the two together are a deterministic validation failure that leaves the notes
+// where they were. An implementation that treated AppendNotes as a second
+// spelling of Notes would silently destroy an agent's running log — the field
+// exists so that appending does not require reading first, which is exactly the
+// case where the caller cannot notice the loss.
+//
+// The append against EMPTY notes is the separator's edge: appending to nothing
+// stores the text alone rather than a leading blank line.
+func RunLifecycleUpdateAppendsNotesWithoutReplacingThem(t *testing.T, ctx context.Context, fixture LifecycleUpdateFixture) {
+	t.Helper()
+
+	id := fixture.IssuePrefix + "-lup-notes"
+	seeded := lifecycleUpdateIssue(id)
+	seeded.Notes = "first"
+	seedLifecycleUpdateIssue(t, ctx, fixture, seeded)
+
+	appended, err := fixture.Lifecycle.Update(ctx, publicops.UpdateRequest{Actor: "writer", IssueID: id, Patch: publicops.IssuePatch{
+		AppendNotes: publicops.Field[string]{Set: true, Value: "second"},
+	}})
+	if err != nil {
+		t.Fatalf("append notes on %s: %v", id, err)
+	}
+	if !appended.Changed {
+		t.Errorf("appending notes on %s reported Changed = false, want a committed edit", id)
+	}
+	if got := lifecycleUpdateRow(t, ctx, fixture, id).Notes; got != "first\nsecond" {
+		t.Errorf("notes after the append = %q, want %q — the append must keep what was there", got, "first\nsecond")
+	}
+
+	replaced, err := fixture.Lifecycle.Update(ctx, publicops.UpdateRequest{Actor: "writer", IssueID: id, Patch: publicops.IssuePatch{
+		Notes: publicops.Field[string]{Set: true, Value: "replaced"},
+	}})
+	if err != nil {
+		t.Fatalf("replace notes on %s: %v", id, err)
+	}
+	if !replaced.Changed {
+		t.Errorf("replacing notes on %s reported Changed = false, want a committed edit", id)
+	}
+	if got := lifecycleUpdateRow(t, ctx, fixture, id).Notes; got != "replaced" {
+		t.Errorf("notes after the replacement = %q, want %q", got, "replaced")
+	}
+
+	before := lifecycleUpdateRow(t, ctx, fixture, id)
+	if _, err := fixture.Lifecycle.Update(ctx, publicops.UpdateRequest{Actor: "writer", IssueID: id, Patch: publicops.IssuePatch{
+		Notes:       publicops.Field[string]{Set: true, Value: "both"},
+		AppendNotes: publicops.Field[string]{Set: true, Value: "both"},
+	}}); !errors.Is(err, storage.ErrValidation) {
+		t.Errorf("a patch setting Notes and AppendNotes together = %v, want ErrValidation — the two are mutually exclusive", err)
+	}
+	assertLifecycleUpdateRowUnchanged(t, ctx, fixture, id, "after the mutually-exclusive refusal", before)
+
+	empty := fixture.IssuePrefix + "-lup-notes-empty"
+	seedLifecycleUpdateIssue(t, ctx, fixture, lifecycleUpdateIssue(empty))
+	if _, err := fixture.Lifecycle.Update(ctx, publicops.UpdateRequest{Actor: "writer", IssueID: empty, Patch: publicops.IssuePatch{
+		AppendNotes: publicops.Field[string]{Set: true, Value: "only"},
+	}}); err != nil {
+		t.Fatalf("append notes on empty %s: %v", empty, err)
+	}
+	if got := lifecycleUpdateRow(t, ctx, fixture, empty).Notes; got != "only" {
+		t.Errorf("notes after appending to an empty field = %q, want %q with no leading separator", got, "only")
+	}
+}
+
+// RunLifecycleUpdateClearsTheNullableMembers pins the four IssuePatch members
+// modeled as Field[*T] — EstimatedMinutes, ExternalRef, DueAt and DeferUntil
+// (issueops/issueops.go:135-139). A pointer is the only thing a clear can write,
+// and a set field carrying a nil pointer is the request that means "make this
+// column empty".
+//
+// Nothing in the package covers a clear. That matters because clearing is the
+// half a caller cannot work around: an implementation that read a nil pointer as
+// "member omitted" would leave a stale due date or a stale external reference in
+// place and report success, and the caller's only recourse would be to write a
+// sentinel value into a column that has a real empty state.
+//
+// The second clear is the no-op leg: already-empty columns cleared again report
+// Changed false, which is what tells "the clear landed" apart from "the clear
+// was ignored twice".
+func RunLifecycleUpdateClearsTheNullableMembers(t *testing.T, ctx context.Context, fixture LifecycleUpdateFixture) {
+	t.Helper()
+
+	id := fixture.IssuePrefix + "-lup-clear"
+	minutes := 45
+	ref := "conformance-ref"
+	due := time.Now().Add(48 * time.Hour).UTC().Truncate(time.Second)
+	deferUntil := time.Now().Add(24 * time.Hour).UTC().Truncate(time.Second)
+	seeded := lifecycleUpdateIssue(id)
+	seeded.EstimatedMinutes = &minutes
+	seeded.ExternalRef = &ref
+	seeded.DueAt = &due
+	seeded.DeferUntil = &deferUntil
+	seedLifecycleUpdateIssue(t, ctx, fixture, seeded)
+
+	before := lifecycleUpdateRow(t, ctx, fixture, id)
+	if before.EstimatedMinutes == nil || before.ExternalRef == nil || before.DueAt == nil || before.DeferUntil == nil {
+		t.Fatalf("seeded %s with {minutes %v, ref %v, due %v, defer %v}, want all four set — the clear has nothing to prove otherwise",
+			id, before.EstimatedMinutes, before.ExternalRef, before.DueAt, before.DeferUntil)
+	}
+
+	clear := publicops.UpdateRequest{Actor: "writer", IssueID: id, Patch: publicops.IssuePatch{
+		EstimatedMinutes: publicops.Field[*int]{Set: true},
+		ExternalRef:      publicops.Field[*string]{Set: true},
+		DueAt:            publicops.Field[*time.Time]{Set: true},
+		DeferUntil:       publicops.Field[*time.Time]{Set: true},
+	}}
+	cleared, err := fixture.Lifecycle.Update(ctx, clear)
+	if err != nil {
+		t.Fatalf("clear the nullable members of %s: %v", id, err)
+	}
+	if !cleared.Changed {
+		t.Errorf("clearing the nullable members of %s reported Changed = false, want a committed edit", id)
+	}
+	assertLifecycleUpdateCleared(t, "update result", cleared.Issue)
+	assertLifecycleUpdateCleared(t, "stored row", lifecycleUpdateRow(t, ctx, fixture, id))
+
+	after := lifecycleUpdateRow(t, ctx, fixture, id)
+	again, err := fixture.Lifecycle.Update(ctx, clear)
+	if err != nil {
+		t.Fatalf("re-clear the nullable members of %s: %v", id, err)
+	}
+	if again.Changed {
+		t.Errorf("re-clearing the already-empty members of %s reported Changed = true, want false", id)
+	}
+	assertLifecycleUpdateRowUnchanged(t, ctx, fixture, id, "after the re-clear", after)
+}
+
+// RunLifecycleUpdateReplacesTheLabelSet pins LabelPatch.Replace, which "supplies
+// the starting complete label set when Set is true" (issueops/issueops.go:78-79),
+// at the role seam and on its own.
+//
+// COMPLETE is the word being pinned. Replace is a set assignment, not a merge:
+// labels the request omits go away, and a Replace carrying nothing clears the
+// set rather than being read as "no label edit requested" — the one place where
+// the omitted/empty distinction Field exists for is load-bearing on a slice.
+//
+// RunIssueOperationsUpdateLabelPatchOrdering covers Replace as the first of
+// three edits applied in order, but only behind the staging fixture and only
+// while Add and Remove are also in play; the empty replacement is covered
+// nowhere. The result set is asserted alongside the stored one because the
+// labels on UpdateResult.Issue are what a front door renders after the write.
+func RunLifecycleUpdateReplacesTheLabelSet(t *testing.T, ctx context.Context, fixture LifecycleUpdateFixture) {
+	t.Helper()
+
+	id := fixture.IssuePrefix + "-lup-labels"
+	seedLifecycleUpdateIssue(t, ctx, fixture, lifecycleUpdateIssue(id, "kept", "dropped"))
+
+	replaced, err := fixture.Lifecycle.Update(ctx, publicops.UpdateRequest{Actor: "writer", IssueID: id, Patch: publicops.IssuePatch{
+		Labels: publicops.LabelPatch{Replace: publicops.Field[[]string]{Set: true, Value: []string{"kept", "added"}}},
+	}})
+	if err != nil {
+		t.Fatalf("replace the labels of %s: %v", id, err)
+	}
+	if !replaced.Changed {
+		t.Errorf("replacing the labels of %s reported Changed = false, want a committed edit", id)
+	}
+	assertLifecycleUpdateLabels(t, "replacement result", replaced.Issue, "added", "kept")
+	assertLifecycleUpdateLabels(t, "stored row after the replacement", lifecycleUpdateRow(t, ctx, fixture, id), "added", "kept")
+
+	before := lifecycleUpdateRow(t, ctx, fixture, id)
+	restated, err := fixture.Lifecycle.Update(ctx, publicops.UpdateRequest{Actor: "writer", IssueID: id, Patch: publicops.IssuePatch{
+		Labels: publicops.LabelPatch{Replace: publicops.Field[[]string]{Set: true, Value: []string{"added", "kept"}}},
+	}})
+	if err != nil {
+		t.Fatalf("restate the labels of %s: %v", id, err)
+	}
+	if restated.Changed {
+		t.Errorf("restating %s's own label set reported Changed = true, want a no-op", id)
+	}
+	assertLifecycleUpdateRowUnchanged(t, ctx, fixture, id, "after the restated label set", before)
+
+	emptied, err := fixture.Lifecycle.Update(ctx, publicops.UpdateRequest{Actor: "writer", IssueID: id, Patch: publicops.IssuePatch{
+		Labels: publicops.LabelPatch{Replace: publicops.Field[[]string]{Set: true}},
+	}})
+	if err != nil {
+		t.Fatalf("clear the labels of %s: %v", id, err)
+	}
+	if !emptied.Changed {
+		t.Errorf("clearing the labels of %s reported Changed = false, want a committed edit — an empty Replace is a replacement, not an omission", id)
+	}
+	assertLifecycleUpdateLabels(t, "cleared result", emptied.Issue)
+	assertLifecycleUpdateLabels(t, "stored row after the clear", lifecycleUpdateRow(t, ctx, fixture, id))
+}
+
+// RunLifecycleUpdateResolvesBothPlanesUnlessRestricted pins what an id resolves
+// against: "The zero value keeps the both-plane auto-resolve every caller gets
+// today", while a set IssuePlaneOnly makes "an ID that names a wisp ErrNotFound
+// rather than an ephemeral row to update" (issueops/issueops.go:251-260).
+//
+// Both halves are one case because either alone passes for the wrong reason: a
+// backend that resolved nothing satisfies the refusal, and one that ignored the
+// flag satisfies the auto-resolve. The durable leg is the third control — the
+// restriction is about the plane the id names, not about the flag being set.
+//
+// This re-pins RunIssueOperationsUpdateIssuePlaneOnlyRefusesWisps at a seam that
+// needs no staging fixture: that case seeds its wisp through Operations.Create
+// and reads its post-state through QueryScalar, and a backend that has neither
+// gets no plane coverage at all.
+//
+// A nil CreateWisp means the backend has no wisp plane to resolve against, and
+// this case SKIPS loudly rather than passing on the durable leg alone.
+func RunLifecycleUpdateResolvesBothPlanesUnlessRestricted(t *testing.T, ctx context.Context, fixture LifecycleUpdateFixture) {
+	t.Helper()
+
+	if fixture.CreateWisp == nil {
+		t.Skip("fixture cannot seed a wisp: CreateWisp is nil, so there is no second plane for an id to resolve against")
+	}
+
+	wisp := fixture.IssuePrefix + "-lup-plane-wisp"
+	seedLifecycleUpdateWisp(t, ctx, fixture, lifecycleUpdateIssue(wisp))
+	before := lifecycleUpdateRow(t, ctx, fixture, wisp)
+
+	restricted := publicops.UpdateRequest{
+		Actor: "writer", IssueID: wisp, IssuePlaneOnly: true,
+		Patch: publicops.IssuePatch{Title: publicops.Field[string]{Set: true, Value: "restricted title"}},
+	}
+	if _, err := fixture.Lifecycle.Update(ctx, restricted); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("issue-plane-only update of wisp %s = %v, want ErrNotFound", wisp, err)
+	}
+	assertLifecycleUpdateRowUnchanged(t, ctx, fixture, wisp, "after the refused plane-only update", before)
+
+	unrestricted := restricted
+	unrestricted.IssuePlaneOnly = false
+	landed, err := fixture.Lifecycle.Update(ctx, unrestricted)
+	if err != nil {
+		t.Fatalf("both-plane update of wisp %s: %v", wisp, err)
+	}
+	if !landed.Changed {
+		t.Errorf("both-plane update of wisp %s reported Changed = false, want the edit committed", wisp)
+	}
+	if got := lifecycleUpdateRow(t, ctx, fixture, wisp).Title; got != "restricted title" {
+		t.Errorf("wisp %s title after the both-plane update = %q, want %q", wisp, got, "restricted title")
+	}
+
+	durable := fixture.IssuePrefix + "-lup-plane-durable"
+	seedLifecycleUpdateIssue(t, ctx, fixture, lifecycleUpdateIssue(durable))
+	if _, err := fixture.Lifecycle.Update(ctx, publicops.UpdateRequest{
+		Actor: "writer", IssueID: durable, IssuePlaneOnly: true,
+		Patch: publicops.IssuePatch{Title: publicops.Field[string]{Set: true, Value: "durable title"}},
+	}); err != nil {
+		t.Fatalf("issue-plane-only update of durable %s: %v", durable, err)
+	}
+	if got := lifecycleUpdateRow(t, ctx, fixture, durable).Title; got != "durable title" {
+		t.Errorf("durable %s title after the plane-only update = %q, want %q — the restriction names the plane, not the flag", durable, got, "durable title")
+	}
+}
+
+// RunLifecycleUpdateRefusesUnknownIDsAndActorlessRequests pins the two refusals
+// every caller of this verb classifies on before it can classify anything else,
+// each with the state clause the Lifecycle doc attaches to it: "Deterministic
+// request validation failures match ErrValidation" and "Refusals and
+// deterministic validation failures leave persistent state unchanged"
+// (issueops/issueops.go:391-404).
+//
+// The actorless legs are the ones with teeth: the id names a real, patchable
+// row, so an implementation that validated after writing fails on the row rather
+// than on the error. The actor is the audit trail the storage commit carries, so
+// a defaulted one would write an unattributable edit.
+//
+// The unknown-id leg has no owning case for a plain Update anywhere: the
+// package's other Update ErrNotFound is the IssuePlaneOnly wisp leg, which is a
+// refusal about a row that DOES exist.
+func RunLifecycleUpdateRefusesUnknownIDsAndActorlessRequests(t *testing.T, ctx context.Context, fixture LifecycleUpdateFixture) {
+	t.Helper()
+
+	id := fixture.IssuePrefix + "-lup-refuse"
+	seedLifecycleUpdateIssue(t, ctx, fixture, lifecycleUpdateIssue(id))
+	before := lifecycleUpdateRow(t, ctx, fixture, id)
+	edit := publicops.IssuePatch{Title: publicops.Field[string]{Set: true, Value: "refused title"}}
+
+	unknown := fixture.IssuePrefix + "-lup-nobody"
+	if _, err := fixture.Lifecycle.Update(ctx, publicops.UpdateRequest{Actor: "writer", IssueID: unknown, Patch: edit}); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("update of an unknown id = %v, want ErrNotFound", err)
+	}
+
+	refusals := map[string]publicops.UpdateRequest{
+		"update without an actor": {IssueID: id, Patch: edit},
+		"update without an id":    {Actor: "writer", Patch: edit},
+		"update without either":   {Patch: edit},
+	}
+	for name, request := range refusals {
+		t.Run(name, func(t *testing.T) {
+			if _, err := fixture.Lifecycle.Update(ctx, request); !errors.Is(err, storage.ErrValidation) {
+				t.Fatalf("%s: err = %v, want ErrValidation", name, err)
+			}
+			assertLifecycleUpdateRowUnchanged(t, ctx, fixture, id, "after "+name, before)
+		})
+	}
+}
+
+// RunLifecycleUpdateRefusalWritesNoMemberOfThePatch pins the ATOMICITY half of
+// the same clause the case above pins the identity half of: a refused update
+// "leaves persistent state unchanged" (issueops/issueops.go:403-404), and
+// Update "validates guards and commits the complete request as one atomic
+// mutation" (:415-416).
+//
+// One member of a multi-member patch is invalid — a priority outside the
+// canonical P0-P4 range — and the rest are ordinary edits that would each have
+// committed alone. A backend that validated per member as it applied them, or
+// that committed the members it had already written before reaching the bad one,
+// leaves an issue carrying half a patch: the caller sees a refusal, retries, and
+// the retry is now a partial no-op against a row it never agreed to.
+//
+// The RowVersion check is what makes this more than a field comparison. It is
+// rewritten on "the generic update path" (types.go:70-84), so a version that did
+// not move is the row-level evidence that no write happened at all — a backend
+// that wrote the good members and then rolled back to the same values would fail
+// here rather than pass a value-only assertion.
+func RunLifecycleUpdateRefusalWritesNoMemberOfThePatch(t *testing.T, ctx context.Context, fixture LifecycleUpdateFixture) {
+	t.Helper()
+
+	id := fixture.IssuePrefix + "-lup-atomic"
+	seeded := lifecycleUpdateIssue(id, "lup-tag")
+	seeded.Description = "seeded description"
+	seeded.Notes = "seeded notes"
+	seedLifecycleUpdateIssue(t, ctx, fixture, seeded)
+	before := lifecycleUpdateRow(t, ctx, fixture, id)
+
+	_, err := fixture.Lifecycle.Update(ctx, publicops.UpdateRequest{Actor: "writer", IssueID: id, Patch: publicops.IssuePatch{
+		Title:       publicops.Field[string]{Set: true, Value: "clobbered title"},
+		Description: publicops.Field[string]{Set: true, Value: "clobbered description"},
+		Notes:       publicops.Field[string]{Set: true, Value: "clobbered notes"},
+		Priority:    publicops.Field[int]{Set: true, Value: lifecycleUpdateInvalidPriority},
+		Labels:      publicops.LabelPatch{Replace: publicops.Field[[]string]{Set: true, Value: []string{"clobbered"}}},
+	}})
+	if !errors.Is(err, storage.ErrValidation) {
+		t.Fatalf("update of %s with an out-of-range priority = %v, want ErrValidation", id, err)
+	}
+	assertLifecycleUpdateRowUnchanged(t, ctx, fixture, id, "after the refused multi-member patch", before)
+	assertLifecycleUpdateLabels(t, "stored row after the refused multi-member patch", lifecycleUpdateRow(t, ctx, fixture, id), "lup-tag")
+}
+
+// lifecycleUpdateInvalidPriority is outside the canonical P0-P4 range
+// types.ValidateIssuePriority enforces, so a patch carrying it is a
+// deterministic validation failure whatever else the patch asks for.
+const lifecycleUpdateInvalidPriority = 9
+
+func lifecycleUpdateIssue(id string, labels ...string) *types.Issue {
+	return &types.Issue{
+		ID:        id,
+		Title:     id,
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Labels:    labels,
+	}
+}
+
+func seedLifecycleUpdateIssue(t *testing.T, ctx context.Context, fixture LifecycleUpdateFixture, issue *types.Issue) {
+	t.Helper()
+	if err := fixture.CreateIssue(ctx, issue, "seed"); err != nil {
+		t.Fatalf("seed issue %s: %v", issue.ID, err)
+	}
+}
+
+func seedLifecycleUpdateWisp(t *testing.T, ctx context.Context, fixture LifecycleUpdateFixture, issue *types.Issue) {
+	t.Helper()
+	issue.Ephemeral = true
+	if err := fixture.CreateWisp(ctx, issue, "seed"); err != nil {
+		t.Fatalf("seed wisp %s: %v", issue.ID, err)
+	}
+}
+
+func seedLifecycleUpdateEdge(t *testing.T, ctx context.Context, fixture LifecycleUpdateFixture, from, to string, kind types.DependencyType) {
+	t.Helper()
+	if err := fixture.AddDependency(ctx, &types.Dependency{IssueID: from, DependsOnID: to, Type: kind}, "seed"); err != nil {
+		t.Fatalf("seed %s %s -> %s: %v", kind, from, to, err)
+	}
+}
+
+func lifecycleUpdateRow(t *testing.T, ctx context.Context, fixture LifecycleUpdateFixture, id string) *types.Issue {
+	t.Helper()
+	issue, err := fixture.GetIssue(ctx, id)
+	if err != nil {
+		t.Fatalf("read back %s: %v", id, err)
+	}
+	if issue == nil {
+		t.Fatalf("read back %s: no row", id)
+	}
+	return issue
+}
+
+// assertLifecycleUpdateRowUnchanged checks that every member a refusal or a
+// no-op could have written is where a previous read left it, RowVersion
+// included: a rewritten version is a write that happened even when the values
+// came out the same.
+func assertLifecycleUpdateRowUnchanged(t *testing.T, ctx context.Context, fixture LifecycleUpdateFixture, id, label string, want *types.Issue) {
+	t.Helper()
+	got := lifecycleUpdateRow(t, ctx, fixture, id)
+	if got.RowVersion != want.RowVersion {
+		t.Errorf("%s %s row version = %d, want it unchanged at %d — something was written", id, label, got.RowVersion, want.RowVersion)
+	}
+	for _, field := range []struct {
+		name      string
+		got, want string
+	}{
+		{"title", got.Title, want.Title},
+		{"description", got.Description, want.Description},
+		{"design", got.Design, want.Design},
+		{"acceptance criteria", got.AcceptanceCriteria, want.AcceptanceCriteria},
+		{"notes", got.Notes, want.Notes},
+		{"status", string(got.Status), string(want.Status)},
+		{"issue type", string(got.IssueType), string(want.IssueType)},
+	} {
+		if field.got != field.want {
+			t.Errorf("%s %s %s = %q, want it unchanged at %q", id, label, field.name, field.got, field.want)
+		}
+	}
+	if got.Priority != want.Priority {
+		t.Errorf("%s %s priority = %d, want it unchanged at %d", id, label, got.Priority, want.Priority)
+	}
+}
+
+func assertLifecycleUpdateContent(t *testing.T, label string, issue *types.Issue) {
+	t.Helper()
+	if issue == nil {
+		t.Fatalf("%s = nil, want the patched issue", label)
+	}
+	for _, field := range []struct {
+		name      string
+		got, want string
+	}{
+		{"title", issue.Title, "patched title"},
+		{"description", issue.Description, "patched description"},
+		{"design", issue.Design, "patched design"},
+		{"acceptance criteria", issue.AcceptanceCriteria, "patched acceptance"},
+		{"notes", issue.Notes, "patched notes"},
+		{"issue type", string(issue.IssueType), string(types.TypeBug)},
+	} {
+		if field.got != field.want {
+			t.Errorf("%s %s = %q, want %q", label, field.name, field.got, field.want)
+		}
+	}
+	if issue.Priority != 0 {
+		t.Errorf("%s priority = %d, want 0 — a zero value a caller set is still a value", label, issue.Priority)
+	}
+}
+
+func assertLifecycleUpdateCleared(t *testing.T, label string, issue *types.Issue) {
+	t.Helper()
+	if issue == nil {
+		t.Fatalf("%s = nil, want the cleared issue", label)
+	}
+	if issue.EstimatedMinutes != nil {
+		t.Errorf("%s estimated minutes = %d, want it cleared", label, *issue.EstimatedMinutes)
+	}
+	if issue.ExternalRef != nil {
+		t.Errorf("%s external ref = %q, want it cleared", label, *issue.ExternalRef)
+	}
+	if issue.DueAt != nil {
+		t.Errorf("%s due at = %v, want it cleared", label, *issue.DueAt)
+	}
+	if issue.DeferUntil != nil {
+		t.Errorf("%s defer until = %v, want it cleared", label, *issue.DeferUntil)
+	}
+}
+
+func assertLifecycleUpdateLabels(t *testing.T, label string, issue *types.Issue, want ...string) {
+	t.Helper()
+	if issue == nil {
+		t.Fatalf("%s = nil, want the labeled issue", label)
+	}
+	got := append([]string(nil), issue.Labels...)
+	sort.Strings(got)
+	sorted := append([]string(nil), want...)
+	sort.Strings(sorted)
+	if len(got) != len(sorted) {
+		t.Errorf("%s labels = %v, want %v", label, issue.Labels, want)
+		return
+	}
+	for i := range got {
+		if got[i] != sorted[i] {
+			t.Errorf("%s labels = %v, want %v", label, issue.Labels, want)
+			return
+		}
+	}
+}
+
+func lifecycleUpdateHasLabel(labels []string, want string) bool {
+	for _, name := range labels {
+		if name == want {
+			return true
+		}
+	}
+	return false
+}
+
+func lifecycleUpdateHasEdge(dependencies []*types.Dependency, wantTarget string) bool {
+	for _, dependency := range dependencies {
+		if dependency != nil && dependency.DependsOnID == wantTarget {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/storage/dolt/lifecycle_close_reopen_contract_test.go
+++ b/internal/storage/dolt/lifecycle_close_reopen_contract_test.go
@@ -41,6 +41,9 @@ func TestLifecycleCloseReopenContract(t *testing.T) {
 	t.Run("CloseIsIdempotentAndKeepsTheFirstClose", func(t *testing.T) {
 		conformance.RunLifecycleCloseIsIdempotentAndKeepsTheFirstClose(t, ctx, fixture)
 	})
+	t.Run("CloseAndReopenKeepTheClaimHolder", func(t *testing.T) {
+		conformance.RunLifecycleCloseAndReopenKeepTheClaimHolder(t, ctx, fixture)
+	})
 	t.Run("ReopenLeavesNonDoneStatusesUnchanged", func(t *testing.T) {
 		conformance.RunLifecycleReopenLeavesNonDoneStatusesUnchanged(t, ctx, fixture)
 	})

--- a/internal/storage/dolt/lifecycle_update_contract_test.go
+++ b/internal/storage/dolt/lifecycle_update_contract_test.go
@@ -1,0 +1,79 @@
+package dolt
+
+import (
+	"context"
+	"testing"
+
+	"github.com/steveyegge/beads/backend/conformance"
+)
+
+// TestLifecycleUpdateContract runs the accessor-only Update half of the
+// Lifecycle contract against the server-backed store. It shares its
+// validate/execute body with the embedded store
+// (internal/storage/issueops.ExecuteUpdate), so this wiring and the embedded one
+// are ONE vote on the semantics; the unit-of-work wiring is the second.
+//
+// The cases are subtests of one parent so the whole block shares one store and
+// one copy-on-write branch: each Run namespaces its ids under the fixture
+// prefix. setupTestStore already marks the PARENT parallel; no subtest here
+// calls t.Parallel.
+func TestLifecycleUpdateContract(t *testing.T) {
+	fixture, ctx, cleanup := newDoltLifecycleUpdateFixture(t, "lup")
+	defer cleanup()
+
+	t.Run("PersistsThePatchAndHydratesTheResult", func(t *testing.T) {
+		conformance.RunLifecycleUpdatePersistsThePatchAndHydratesTheResult(t, ctx, fixture)
+	})
+	t.Run("ReportsNoChangeForASameValuePatch", func(t *testing.T) {
+		conformance.RunLifecycleUpdateReportsNoChangeForASameValuePatch(t, ctx, fixture)
+	})
+	t.Run("AppendsNotesWithoutReplacingThem", func(t *testing.T) {
+		conformance.RunLifecycleUpdateAppendsNotesWithoutReplacingThem(t, ctx, fixture)
+	})
+	t.Run("ClearsTheNullableMembers", func(t *testing.T) {
+		conformance.RunLifecycleUpdateClearsTheNullableMembers(t, ctx, fixture)
+	})
+	t.Run("ReplacesTheLabelSet", func(t *testing.T) {
+		conformance.RunLifecycleUpdateReplacesTheLabelSet(t, ctx, fixture)
+	})
+	t.Run("ResolvesBothPlanesUnlessRestricted", func(t *testing.T) {
+		conformance.RunLifecycleUpdateResolvesBothPlanesUnlessRestricted(t, ctx, fixture)
+	})
+	t.Run("RefusesUnknownIDsAndActorlessRequests", func(t *testing.T) {
+		conformance.RunLifecycleUpdateRefusesUnknownIDsAndActorlessRequests(t, ctx, fixture)
+	})
+	t.Run("RefusalWritesNoMemberOfThePatch", func(t *testing.T) {
+		conformance.RunLifecycleUpdateRefusalWritesNoMemberOfThePatch(t, ctx, fixture)
+	})
+}
+
+func newDoltLifecycleUpdateFixture(t *testing.T, prefix string) (conformance.LifecycleUpdateFixture, context.Context, func()) {
+	t.Helper()
+	store, storeCleanup := setupTestStore(t)
+	ctx, cancel := testContext(t)
+	// Through the capability accessor, not NewIssueOperations: a store that
+	// stopped offering the role is the regression, and a constructor call would
+	// hide it.
+	lifecycle, err := store.IssueLifecycle()
+	if err != nil {
+		cancel()
+		storeCleanup()
+		t.Fatalf("IssueLifecycle(): %v", err)
+	}
+	kit := newDoltRoleFixtureKit(store, prefix)
+	fixture := conformance.LifecycleUpdateFixture{
+		IssuePrefix:   kit.IssuePrefix,
+		Lifecycle:     lifecycle,
+		CreateIssue:   kit.CreateIssue,
+		CreateWisp:    kit.CreateWisp,
+		AddDependency: kit.AddDependency,
+		// The frozen kit reads through QueryScalar. This block reads its
+		// post-state through the store's own issue read instead, so no case in
+		// it depends on raw SQL.
+		GetIssue: store.GetIssue,
+	}
+	return fixture, ctx, func() {
+		cancel()
+		storeCleanup()
+	}
+}

--- a/internal/storage/embeddeddolt/lifecycle_close_reopen_contract_test.go
+++ b/internal/storage/embeddeddolt/lifecycle_close_reopen_contract_test.go
@@ -44,6 +44,9 @@ func TestLifecycleCloseReopenContract(t *testing.T) {
 	t.Run("CloseIsIdempotentAndKeepsTheFirstClose", func(t *testing.T) {
 		conformance.RunLifecycleCloseIsIdempotentAndKeepsTheFirstClose(t, ctx, fixture)
 	})
+	t.Run("CloseAndReopenKeepTheClaimHolder", func(t *testing.T) {
+		conformance.RunLifecycleCloseAndReopenKeepTheClaimHolder(t, ctx, fixture)
+	})
 	t.Run("ReopenLeavesNonDoneStatusesUnchanged", func(t *testing.T) {
 		conformance.RunLifecycleReopenLeavesNonDoneStatusesUnchanged(t, ctx, fixture)
 	})

--- a/internal/storage/embeddeddolt/lifecycle_update_contract_test.go
+++ b/internal/storage/embeddeddolt/lifecycle_update_contract_test.go
@@ -1,0 +1,72 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/backend/conformance"
+)
+
+// TestLifecycleUpdateContract runs the accessor-only Update half of the
+// Lifecycle contract against the embedded store, which shares its
+// validate/execute body with the server-backed store and differs in the
+// transaction wrapper and the engine underneath. That is what this wiring
+// catches; it is not an independent vote on the body.
+//
+// One environment for the whole block: booting an embedded engine per case
+// would dominate the runtime, and the ids are prefix-namespaced.
+func TestLifecycleUpdateContract(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	te := newTestEnv(t, "lup")
+	ctx := t.Context()
+	fixture := newEmbeddedLifecycleUpdateFixture(t, te, "lup")
+
+	t.Run("PersistsThePatchAndHydratesTheResult", func(t *testing.T) {
+		conformance.RunLifecycleUpdatePersistsThePatchAndHydratesTheResult(t, ctx, fixture)
+	})
+	t.Run("ReportsNoChangeForASameValuePatch", func(t *testing.T) {
+		conformance.RunLifecycleUpdateReportsNoChangeForASameValuePatch(t, ctx, fixture)
+	})
+	t.Run("AppendsNotesWithoutReplacingThem", func(t *testing.T) {
+		conformance.RunLifecycleUpdateAppendsNotesWithoutReplacingThem(t, ctx, fixture)
+	})
+	t.Run("ClearsTheNullableMembers", func(t *testing.T) {
+		conformance.RunLifecycleUpdateClearsTheNullableMembers(t, ctx, fixture)
+	})
+	t.Run("ReplacesTheLabelSet", func(t *testing.T) {
+		conformance.RunLifecycleUpdateReplacesTheLabelSet(t, ctx, fixture)
+	})
+	t.Run("ResolvesBothPlanesUnlessRestricted", func(t *testing.T) {
+		conformance.RunLifecycleUpdateResolvesBothPlanesUnlessRestricted(t, ctx, fixture)
+	})
+	t.Run("RefusesUnknownIDsAndActorlessRequests", func(t *testing.T) {
+		conformance.RunLifecycleUpdateRefusesUnknownIDsAndActorlessRequests(t, ctx, fixture)
+	})
+	t.Run("RefusalWritesNoMemberOfThePatch", func(t *testing.T) {
+		conformance.RunLifecycleUpdateRefusalWritesNoMemberOfThePatch(t, ctx, fixture)
+	})
+}
+
+func newEmbeddedLifecycleUpdateFixture(t *testing.T, te *testEnv, prefix string) conformance.LifecycleUpdateFixture {
+	t.Helper()
+	// Through the capability accessor, not NewIssueOperations: a store that
+	// stopped offering the role is the regression, and a constructor call would
+	// hide it.
+	lifecycle, err := te.store.IssueLifecycle()
+	if err != nil {
+		t.Fatalf("IssueLifecycle(): %v", err)
+	}
+	kit := newEmbeddedRoleFixtureKit(te, prefix)
+	return conformance.LifecycleUpdateFixture{
+		IssuePrefix:   kit.IssuePrefix,
+		Lifecycle:     lifecycle,
+		CreateIssue:   kit.CreateIssue,
+		CreateWisp:    kit.CreateWisp,
+		AddDependency: kit.AddDependency,
+		// The frozen kit reads through QueryScalar. This block reads its
+		// post-state through the store's own issue read instead, so no case in
+		// it depends on raw SQL.
+		GetIssue: te.store.GetIssue,
+	}
+}

--- a/internal/storage/uow/lifecycle_close_reopen_contract_test.go
+++ b/internal/storage/uow/lifecycle_close_reopen_contract_test.go
@@ -42,6 +42,9 @@ func TestLifecycleCloseReopenContract(t *testing.T) {
 	t.Run("CloseIsIdempotentAndKeepsTheFirstClose", func(t *testing.T) {
 		conformance.RunLifecycleCloseIsIdempotentAndKeepsTheFirstClose(t, ctx, fixture)
 	})
+	t.Run("CloseAndReopenKeepTheClaimHolder", func(t *testing.T) {
+		conformance.RunLifecycleCloseAndReopenKeepTheClaimHolder(t, ctx, fixture)
+	})
 	t.Run("ReopenLeavesNonDoneStatusesUnchanged", func(t *testing.T) {
 		conformance.RunLifecycleReopenLeavesNonDoneStatusesUnchanged(t, ctx, fixture)
 	})

--- a/internal/storage/uow/lifecycle_update_contract_test.go
+++ b/internal/storage/uow/lifecycle_update_contract_test.go
@@ -1,0 +1,99 @@
+package uow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/steveyegge/beads/backend/conformance"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestLifecycleUpdateContract runs the accessor-only Update half of the
+// Lifecycle contract against the unit-of-work provider — the one Lifecycle
+// implementation that does not share the validate/execute body the two stores
+// share. It maps the patch itself and derives Changed by comparing the
+// post-state snapshot to the pre-state one instead of reading the row-write
+// facts, so this is the wiring where a same-value or clear divergence shows up.
+//
+// One provider for the whole block (each newUOWRoleFixtureProvider boots a real
+// Dolt sql-server) and NO t.Parallel: this backend has no per-test
+// copy-on-write branch, so a parallel subtest would share another subtest's
+// database.
+func TestLifecycleUpdateContract(t *testing.T) {
+	ctx := context.Background()
+	fixture := newUOWLifecycleUpdateFixture(t, ctx, "lup")
+
+	t.Run("PersistsThePatchAndHydratesTheResult", func(t *testing.T) {
+		conformance.RunLifecycleUpdatePersistsThePatchAndHydratesTheResult(t, ctx, fixture)
+	})
+	t.Run("ReportsNoChangeForASameValuePatch", func(t *testing.T) {
+		conformance.RunLifecycleUpdateReportsNoChangeForASameValuePatch(t, ctx, fixture)
+	})
+	t.Run("AppendsNotesWithoutReplacingThem", func(t *testing.T) {
+		conformance.RunLifecycleUpdateAppendsNotesWithoutReplacingThem(t, ctx, fixture)
+	})
+	t.Run("ClearsTheNullableMembers", func(t *testing.T) {
+		conformance.RunLifecycleUpdateClearsTheNullableMembers(t, ctx, fixture)
+	})
+	t.Run("ReplacesTheLabelSet", func(t *testing.T) {
+		conformance.RunLifecycleUpdateReplacesTheLabelSet(t, ctx, fixture)
+	})
+	t.Run("ResolvesBothPlanesUnlessRestricted", func(t *testing.T) {
+		conformance.RunLifecycleUpdateResolvesBothPlanesUnlessRestricted(t, ctx, fixture)
+	})
+	t.Run("RefusesUnknownIDsAndActorlessRequests", func(t *testing.T) {
+		conformance.RunLifecycleUpdateRefusesUnknownIDsAndActorlessRequests(t, ctx, fixture)
+	})
+	t.Run("RefusalWritesNoMemberOfThePatch", func(t *testing.T) {
+		conformance.RunLifecycleUpdateRefusalWritesNoMemberOfThePatch(t, ctx, fixture)
+	})
+}
+
+func newUOWLifecycleUpdateFixture(t *testing.T, ctx context.Context, prefix string) conformance.LifecycleUpdateFixture {
+	t.Helper()
+	provider := newUOWRoleFixtureProvider(t, ctx, prefix)
+	// Through the capability accessor, not NewIssueOperations: a provider that
+	// stopped offering the role is the regression, and a constructor call would
+	// hide it.
+	source, ok := provider.(IssueLifecycleSource)
+	if !ok {
+		t.Fatalf("provider %T does not offer the IssueLifecycle accessor", provider)
+	}
+	lifecycle, err := source.IssueLifecycle()
+	if err != nil {
+		t.Fatalf("IssueLifecycle(): %v", err)
+	}
+	kit := newUOWRoleFixtureKit(provider, prefix)
+	return conformance.LifecycleUpdateFixture{
+		IssuePrefix:   kit.IssuePrefix,
+		Lifecycle:     lifecycle,
+		CreateIssue:   kit.CreateIssue,
+		CreateWisp:    kit.CreateWisp,
+		AddDependency: kit.AddDependency,
+		// The frozen kit reads through QueryScalar. This block reads its
+		// post-state through the backend's own both-plane issue read instead,
+		// so no case in it depends on raw SQL.
+		//
+		// The label set is read straight off the label use case rather than
+		// through hydrateIssueOperation, which is the code the result-shape
+		// assertions are ABOUT: a readback sharing it could not tell a result
+		// that lost its labels from a row that never had them.
+		GetIssue: func(ctx context.Context, id string) (*types.Issue, error) {
+			return RunTxRead(ctx, provider, func(ctx context.Context, uw UnitOfWork) (*types.Issue, error) {
+				issue, isWisp, err := operationIssue(ctx, uw, id, false)
+				if err != nil {
+					return nil, err
+				}
+				if isWisp {
+					issue.Labels, err = uw.LabelUseCase().GetWispLabels(ctx, id)
+				} else {
+					issue.Labels, err = uw.LabelUseCase().GetLabels(ctx, id)
+				}
+				if err != nil {
+					return nil, err
+				}
+				return issue, nil
+			})
+		},
+	}
+}


### PR DESCRIPTION
Two gaps in the Lifecycle proof surface, both of which a divergent backend passes the whole merged conformance suite while breaking.

## 1. `Lifecycle.Update` has no accessor-only contract

All 16 `RunIssueOperationsUpdate*` runners take `IssueOperationsStagingFixture`, whose `Exec`/`QueryScalar`/`UpdateRaw`/`Commit` fields are a version-control-aware SQL seam, and whose single `Operations` field is *both* the seed route and the subject — several cases reach their starting state through `fixture.Operations.Create`. A backend that cannot supply raw SQL, or whose composition refuses `Create`, therefore runs **zero** Update cases.

The suite already concedes this. `issue_claimer_contract.go`'s header says outright that "the Update-seam cases run only behind `IssueOperationsStagingFixture`, which demands raw-SQL hooks a partial or remote backend cannot supply" — and closed the gap for `Claimer` alone. This closes it for `Update`.

`backend/conformance/lifecycle_update_contract.go` binds the accessor plus `CreateIssue`/`CreateWisp`/`AddDependency` seed hooks and one out-of-band `GetIssue`, separating subject from seeding the way `LifecycleCloseReopenFixture` and `ClaimerFixture` already do. Nothing in it reaches for raw SQL: `UpdateResult` and `GetIssue` between them expose every fact the cases assert, including the `RowVersion` token that tells a refusal apart from a silent write.

Eight owning cases, each exercising only patch members a partial backend can express, so it adopts them unmodified:

| Case | Pins |
|---|---|
| `PersistsThePatchAndHydratesTheResult` | every content member reaches the row; the result carries labels and dependency records and omits comments |
| `ReportsNoChangeForASameValuePatch` | `Changed:false`, and `RowVersion` proving nothing was written |
| `AppendsNotesWithoutReplacingThem` | append keeps what was there; `Notes` replaces; both together is `ErrValidation` |
| `ClearsTheNullableMembers` | the four `Field[*T]` clears, and the re-clear no-op |
| `ReplacesTheLabelSet` | `Replace` is a set assignment; an empty `Replace` clears rather than reading as omitted |
| `ResolvesBothPlanesUnlessRestricted` | both-plane auto-resolve, `IssuePlaneOnly` refusal, durable control |
| `RefusesUnknownIDsAndActorlessRequests` | `ErrNotFound`, `ErrValidation`, state unchanged |
| `RefusalWritesNoMemberOfThePatch` | one invalid member refuses the whole patch atomically |

Only the plane runner overlaps an existing case, and the header names the overlap rather than hiding it. `Metadata`, `Status` and close policy, `Assignee` and the transfer fence, `Claim`, `ParentID`, `Persistence`, the `Expected*` preconditions and `Provenance` stay with the staging cases that own them — pinning them here would make the block unadoptable for the backends it exists to serve.

Three wirings, two votes, stated at the top of the file per `engdocs/ADDING_AN_ISSUEOPS_ROLE.md`: the two stores share `ExecuteUpdate`; the unit of work maps the patch itself and derives `Changed` by comparing post-state, which is exactly where the same-value and clear cases have teeth.

## 2. The claim→close loop is unpinned

No case anywhere closes a `StatusInProgress` row, and no close/reopen case seeds or asserts an assignee. Every close target in the package — here, in `claim.go`, in the audit files, in `seedClosePolicyIssue` and in `batch_closer_contract.go` — is seeded open and unassigned. So the only close a working agent performs is the one nothing pins.

Two divergences pass the whole suite today:

- a backend whose close admits open rows only refuses every claimed issue, so `bd claim` and `bd close` stop composing;
- a backend that clears `assignee` as part of the close — a defensible reading of "the work is over" — silently drops the attribution `bd show` renders and `bd list --assignee` filters on, and a reopen loses it again.

`RunLifecycleCloseAndReopenKeepTheClaimHolder` seeds the state a won claim leaves, closes it, asserts the holder on both `CloseResult.Issue` and the stored row, then reopens and asserts it again alongside the close attribution the reopen *is* supposed to clear.

`lifecycleCloseReopenRow` gains `assignee` so the file's existing refusal and no-op legs pin holder stability too, and the reopen no-op's `in_progress` leg now carries a holder — it compared an empty column before, so a clear on that path was invisible.

## Load-bearing evidence

Every case is a green-first pin, so each was proved load-bearing by mutating production and checking it goes red. 18 mutations, 17 caught:

| Mutation | Case |
|---|---|
| `UpdateFields` drops the `design` member | PersistsThePatch… RED |
| store hydration drops the dependency records | PersistsThePatch… RED |
| unit-of-work hydration answers the bare row | PersistsThePatch… RED |
| unit-of-work hydration drops the dependency records | PersistsThePatch… RED |
| `Changed` always true (store, then unit of work) | ReportsNoChange… RED ×2 |
| `append_notes` replaces instead of appending | AppendsNotes… RED |
| `Notes`+`AppendNotes` stops being a refusal | AppendsNotes… RED |
| a set-but-nil `external_ref` read as omitted (store, then unit of work) | ClearsTheNullableMembers RED ×2 |
| `LabelPatch.Replace` merges instead of replacing | ReplacesTheLabelSet RED |
| `IssuePlaneOnly` ignored | ResolvesBothPlanes… RED |
| a missing actor defaulted instead of refused | RefusesUnknownIDs… RED |
| the out-of-range priority dropped instead of refused | RefusalWritesNoMember… RED |
| close clears the assignee | CloseAndReopenKeepTheClaimHolder RED |
| reopen clears the assignee | CloseAndReopenKeepTheClaimHolder RED |
| close refuses an `in_progress` target | CloseAndReopenKeepTheClaimHolder RED |

The one survivor: dropping `issue.Labels = labels` from the store's `HydrateIssueOperationResult` stays green, because `GetIssueInTx` already loads labels on that path. The labels half is load-bearing on the unit-of-work leg, where the mutation does go red.

## Tests

- `TestLifecycleUpdateContract` and `TestLifecycleCloseReopenContract` green on all three wirings — dolt, embeddeddolt, uow (105 subtests).
- `go test ./backend/... ./internal/storage/issueops/... ./issueops/...` green.
- `scripts/ci/pr-lint.sh` clean (gofmt, golangci-lint, golangci-lint windows).
- `internal/storage/dolt` as a whole package times out on this machine under `BEADS_TEST_ENV_RUN_DOLT=1`, failing six `TestCrossProject_*` tests with `failed to initialize schema: context deadline exceeded`. That reproduces **identically at `upstream/main` with no changes applied** — same six tests, same 25m package deadline — so it is a pre-existing capacity issue here, not this branch. `-run '^TestCrossProject'` in isolation passes on both.

Test-only change; no production files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)