### PR TITLE
Fix a SIGPIPE in the mutation harness's worktree guard

### DIFF
--- a/scripts/mutation-equivalence.sh
+++ b/scripts/mutation-equivalence.sh
@@ -97,7 +97,14 @@ if [ -e "$WT" ]; then
     echo "       cleans that path; running would destroy the checkout it is measuring." >&2
     exit 2
   fi
-  if ! git -C "$REPO" worktree list --porcelain | grep -qx "worktree $WT_ABS"; then
+  # Captured into a variable, NOT piped. `grep -q` exits on the first match,
+  # which SIGPIPEs git; with `pipefail` that makes the whole pipeline nonzero and
+  # the negation below then rejects a perfectly good worktree. It only bites once
+  # the list is large enough for git to still be writing — this repo has ~370
+  # worktrees / 53 KB — so it looks intermittent and machine-specific. It killed
+  # 5 of 9 runs for the first caller who hit it.
+  WT_LIST="$(git -C "$REPO" worktree list --porcelain)"
+  if ! grep -qx "worktree $WT_ABS" <<<"$WT_LIST"; then
     echo "FATAL: $WT exists but is not a worktree of $REPO." >&2
     echo "       This script hard-resets and cleans that path; refusing to touch it." >&2
     exit 2


### PR DESCRIPTION
Found by the first caller to use `scripts/mutation-equivalence.sh` at scale — it killed **5 of 9** mutation runs, presenting as `FATAL: ... is not a worktree of $REPO` for a path that plainly was one.

## The bug

```sh
if ! git -C "$REPO" worktree list --porcelain | grep -qx "worktree $WT_ABS"; then
```

`grep -q` exits on the first match, which SIGPIPEs `git`. Under `set -o pipefail` the pipeline is then nonzero, and the `!` takes the failure branch — rejecting a legitimate worktree.

It only bites once the listing is large enough that git is still writing when grep exits. This repo has ~370 worktrees and a 53 KB listing; a small checkout never sees it, which is why it reads as intermittent and machine-specific.

Reproduced both ways before and after:

```
=== piped (current code) ===
  BUG: says NOT a worktree (grep -q exits early -> SIGPIPE -> pipefail)
=== capture-first (fix)   ===
  ok: recognised
```

## The fix

Capture the listing into a variable and match against it with a here-string. No pipe, no SIGPIPE.

Verified in both directions: a real worktree is now recognised and falls through to the **branch-checked-out** guard as intended (`FATAL: /data/projects/beads has a branch checked out`), rather than being rejected outright.

## Worth recording

The guard this broke was added two commits ago, in response to a review that found the tool would hard-reset a live checkout — including the caller's own. Tightening it introduced a failure mode that made it refuse *legitimate* worktrees.

The reflex when a guard misfires is to loosen the guard. Here the guard was right and its implementation was wrong, and the caller who hit it worked around the symptom (removing the scratch worktree before each run) rather than reporting it as a defect — which is exactly how a tool ends up with a reputation for being flaky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)