### PR TITLE
Converge Offset and MaxRows on all three legs, and fix the panic under them

### DIFF
--- a/backend/conformance/querier_contract.go
+++ b/backend/conformance/querier_contract.go
@@ -20,9 +20,10 @@ import (
 //
 // TWO BODIES BEHIND THREE WIRINGS: dolt and embeddeddolt share
 // internal/workapi/storequerier, and the unit-of-work provider is the second,
-// genuinely separate vote. They diverge only where the uow seam renders OFFSET
-// and reports has-more natively, which is why the Offset case is written
-// comparatively.
+// genuinely separate vote. What is left of their difference is mechanism, not
+// answer: the uow seam renders OFFSET and reports has-more natively, the other
+// reaches past the skipped rows and lets an over-fetched row speak. Every case
+// here is written to the answer, which is why none of them names a backend.
 //
 // WHAT THESE CASES DO NOT PROVE: the max(3*Limit, 100) over-fetch window both
 // front doors used to apply, which takes MORE THAN A HUNDRED candidate rows to
@@ -303,73 +304,78 @@ func RunQuerierRefusesAMalformedRequest(t *testing.T, ctx context.Context, fixtu
 	}
 }
 
-// RunQuerierOffsetIsHonoredOrRefused pins the one thing every implementation
-// owes on QueryRequest.Offset (issueops/querier.go:65-83): a non-zero Offset is
-// either HONORED or REFUSED with a typed *ErrUnsupported, and never SILENTLY
-// IGNORED.
+// RunQuerierOffsetSkipsMatches pins QueryRequest.Offset
+// (issueops/querier.go:65-83): the page is the tail of the same answer, in the
+// same order, on every implementation and for every shape of expression.
 //
-// It is deliberately weaker than "Offset skips N rows", for the same reason
-// RunReaderOffsetIsHonoredOrRefused is: the two bodies disagree by design,
-// because one seam renders OFFSET and the other does not. Which body does which
-// is asserted at the wirings, not here.
+// It used to say "honored OR refused with a typed *ErrUnsupported", because one
+// seam rendered OFFSET and the other did not and so refused. That disjunction
+// described the split instead of pinning the promise; both bodies serve the
+// offset now, one in SQL and one by reaching past the skipped rows.
 //
 // BOTH SHAPES OF EXPRESSION ARE DRIVEN, which is what this case adds over the
 // reader's: a predicate query's offset is applied in Go, after the predicate, a
-// different code path from the filter-expressible one.
+// different code path from the filter-expressible one — and the whole point of
+// "skips MATCHES" is that a page cut from rejected candidates would be short.
 //
-// EVERY REQUEST HERE CARRIES A BOUNDED LIMIT: on the unit-of-work seam an
-// UNLIMITED request with a non-zero Offset renders SQL the Dolt engine answers
-// with a recovered panic ("makeslice: cap out of range" out of topRowsIter)
-// instead of rows. That is a storage-seam bug that predates this role, not a
-// contract question, so this case asks the question it can answer rather than
-// pinning a crash as behavior.
-func RunQuerierOffsetIsHonoredOrRefused(t *testing.T, ctx context.Context, fixture QuerierFixture) {
+// BOTH SHAPES OF PAGE BOUND ARE DRIVEN TOO. The bounded arm and the UNLIMITED
+// arm reach different code: an unlimited request with an offset has no LIMIT to
+// hang an OFFSET on, and the sentinel one seam used to render for it
+// ("LIMIT 18446744073709551615 OFFSET k") came back as a recovered
+// "makeslice: cap out of range" out of the Dolt engine's topRowsIter instead of
+// rows. This case carried a bounded limit on every request to route around
+// that. The seam skips those rows itself now, and the unlimited arm is what
+// says so.
+func RunQuerierOffsetSkipsMatches(t *testing.T, ctx context.Context, fixture QuerierFixture) {
 	t.Helper()
 	scope := querierLabel(fixture, "offset")
 	for _, tag := range []string{"a", "b", "c"} {
 		seedQuerierIssue(t, ctx, fixture, querierIssue(querierID(fixture, "offset", tag), types.TypeBug, 1, scope))
 	}
 
-	for _, test := range []struct {
+	for _, shape := range []struct {
 		what       string
 		expression string
 	}{
 		{"filter-expressible", fmt.Sprintf("type=bug AND label=%s", scope)},
 		{"predicate", fmt.Sprintf("(type=bug OR type=epic) AND label=%s", scope)},
 	} {
-		t.Run(test.what, func(t *testing.T) {
-			request := publicops.QueryRequest{Expression: test.expression, Limit: querierLimit(10)}
-			// Offset 0 is served everywhere; it is the baseline the paged call
-			// has to differ from.
-			unpaged := querierIDs(t, ctx, fixture, request)
-			if len(unpaged) != 3 {
-				t.Fatalf("Offset 0 returned %v, want the three seeded rows", unpaged)
-			}
+		for _, bound := range []struct {
+			what  string
+			limit int
+		}{
+			{"bounded", 10},
+			{"unlimited", 0},
+		} {
+			t.Run(shape.what+"/"+bound.what, func(t *testing.T) {
+				request := publicops.QueryRequest{Expression: shape.expression, Limit: querierLimit(bound.limit)}
+				// Offset 0 is the baseline every paged call is a suffix of. An
+				// unsorted page is in storage order, so it is read rather than
+				// assumed.
+				unpaged := querierIDs(t, ctx, fixture, request)
+				if len(unpaged) != 3 {
+					t.Fatalf("Offset 0 returned %v, want the three seeded rows", unpaged)
+				}
 
-			paged := request
-			paged.Offset = 1
-			page, err := fixture.Querier.Query(ctx, paged)
-			if err != nil {
-				var unsupported *publicops.ErrUnsupported
-				if !errors.As(err, &unsupported) {
-					t.Fatalf("Offset 1 refused with %v; a refusal has to be a typed *ErrUnsupported a caller can classify", err)
+				for offset := 1; offset <= len(unpaged); offset++ {
+					paged := request
+					paged.Offset = offset
+					page, err := fixture.Querier.Query(ctx, paged)
+					if err != nil {
+						t.Errorf("Offset %d: %v", offset, err)
+						continue
+					}
+					if page.Items == nil {
+						t.Errorf("Offset %d returned a nil Items; an offset past the end is an empty page, not a null one", offset)
+					}
+					// It skipped MATCHES: the tail of the unpaged order, never
+					// a page cut from rejected candidates.
+					if got, want := querierPageIDs(page), unpaged[offset:]; !slices.Equal(got, want) {
+						t.Errorf("Offset %d = %v, want %v — the tail of the same answer %v", offset, got, want, unpaged)
+					}
 				}
-				if unsupported.Op == "" || unsupported.Backend == "" {
-					t.Errorf("Offset 1 refused with Op=%q Backend=%q; a refusal naming neither the operation nor the backend leaves the caller nowhere to go",
-						unsupported.Op, unsupported.Backend)
-				}
-				return
-			}
-			got := querierPageIDs(page)
-			if slices.Equal(got, unpaged) {
-				t.Fatalf("Offset 1 returned the same page as Offset 0 (%v) and no error: the offset was silently ignored", got)
-			}
-			// Honored means it skipped MATCHES: two of the three, still in the
-			// unpaged order, never a page cut from rejected candidates.
-			if want := unpaged[1:]; !slices.Equal(got, want) {
-				t.Errorf("Offset 1 = %v, want %v — the tail of the same answer", got, want)
-			}
-		})
+			})
+		}
 	}
 }
 

--- a/backend/conformance/reader_contract.go
+++ b/backend/conformance/reader_contract.go
@@ -900,6 +900,173 @@ func RunReaderListMaxRowsIsHonored(t *testing.T, ctx context.Context, fixture Re
 	}
 }
 
+// RunReaderListMaxRowsBoundaryIsLimitPlusOffset pins WHICH WINDOW the cap is
+// sized against: the rows the query TOUCHES, Limit+Offset, not the rows the
+// caller receives (reader.go, ListRequest.MaxRows).
+//
+// A row Offset skips is a row the query matched, so an offset walks a caller
+// TOWARD the breaker and never past it. The boundary that follows is exact:
+// Limit+Offset <= MaxRows is a page whatever the result set does, and
+// Limit+Offset > MaxRows fires as soon as that many rows match. The case above
+// drives that boundary along the LIMIT axis at Offset 0; this one drives it
+// along the OFFSET axis, with the limit and the cap held still, so the only
+// thing that moves between the last page and the first refusal is one row of
+// skip.
+//
+// WHY IT IS A CASE OF ITS OWN rather than another arm of the one above: the two
+// seams compose the window differently — the store-backed body widens the
+// filter and then sizes its probe row (workapi.WithRowsBeforeThePage, then
+// WithFetchOneExtra), the unit-of-work body hands its seam the widened limit
+// and lets internal/storage/domain/db size both. Either composition can be one
+// row wrong in a way no request without an offset can see, and the two can be
+// wrong in DIFFERENT directions: the cap bump at the equal boundary keys off
+// the widened window on one side and off the page on the other unless both are
+// written to key off the same one.
+//
+// THE FIXTURE HAS TO REACH THE CAP FOR ANY OF THAT TO BE VISIBLE. Five rows
+// against a cap of three: every window below is bounded at four rows or fewer,
+// so each query has more matching rows behind it than its bound, and a body
+// that fetched one row too many or counted one row too few has somewhere to
+// show it. Three rows would make the two non-firing cases pass on a body with
+// no cap at all.
+func RunReaderListMaxRowsBoundaryIsLimitPlusOffset(t *testing.T, ctx context.Context, fixture ReaderFixture) {
+	t.Helper()
+	const rowCap = 3
+	scope := readerLabel(fixture, "maxrowswindow")
+	var ids []string
+	base := time.Now().UTC().Truncate(time.Second).Add(-5 * time.Hour)
+	for i, tag := range []string{"a", "b", "c", "d", "e"} {
+		id := readerID(fixture, "maxrowswindow", tag)
+		ids = append(ids, id)
+		issue := readerIssue(id, types.TypeTask, scope)
+		at := base.Add(time.Duration(i) * time.Minute)
+		issue.CreatedAt, issue.UpdatedAt = at, at
+		seedReaderIssue(t, ctx, fixture, issue)
+	}
+	idScope := readerIDFilter(ids...)
+
+	// The order every expectation below is a window of, READ rather than
+	// assumed: which end "created" starts from is the query's business, and
+	// this case is about which rows the cap counts, not about that.
+	unpaged, err := fixture.Reader.List(ctx, publicops.ListRequest{
+		IDFilter: idScope, SortBy: "created", Limit: readerLimit(0),
+	})
+	if err != nil {
+		t.Fatalf("List unpaged: %v", err)
+	}
+	order := readerPageIDs(unpaged)
+	if len(order) != len(ids) {
+		t.Fatalf("List unpaged returned %v, want the %d seeded rows: a result set smaller than the bound cannot observe the cap this case drives",
+			order, len(ids))
+	}
+
+	// The window, one row of offset at a time, against a cap of three.
+	for _, test := range []struct {
+		what   string
+		limit  int
+		offset int
+		fires  bool
+	}{
+		// Limit+Offset == MaxRows-1: strictly inside the cap.
+		{"Limit+Offset one row inside the cap", 1, 1, false},
+		// Limit+Offset == MaxRows: the touched window is exactly the cap, and
+		// the probe row that answers has-more must not be counted against it.
+		{"Limit+Offset exactly at the cap", 2, 1, false},
+		// Limit+Offset == MaxRows+1: the same limit and the same cap, one more
+		// row of skip, and the query can now touch more rows than the cap
+		// allows.
+		{"Limit+Offset one row past the cap", 2, 2, true},
+	} {
+		what := test.what
+		page, err := fixture.Reader.List(ctx, publicops.ListRequest{
+			IDFilter: idScope, SortBy: "created",
+			Limit: readerLimit(test.limit), Offset: test.offset,
+			MaxRows: rowCap, MaxRowsSource: "--max-rows",
+		})
+		if test.fires {
+			if err == nil {
+				t.Errorf("%s (Limit=%d Offset=%d MaxRows=%d over %d matching rows) returned the page %v; a query that may touch %d rows has to fire a cap of %d",
+					what, test.limit, test.offset, rowCap, len(ids), readerPageIDs(page), test.limit+test.offset, rowCap)
+				continue
+			}
+			var tooMany *storageops.ErrTooManyRows
+			if !errors.As(err, &tooMany) {
+				t.Errorf("%s failed with %v, want *ErrTooManyRows", what, err)
+				continue
+			}
+			if tooMany.Cap != rowCap {
+				t.Errorf("%s: the cap error reports Cap = %d, want the %d the request asked for; the probe row's bump must not reach the caller",
+					what, tooMany.Cap, rowCap)
+			}
+			if tooMany.Found <= tooMany.Cap {
+				t.Errorf("%s: the cap error reports Found = %d against Cap = %d; a cap that fired saw more rows than it allows",
+					what, tooMany.Found, tooMany.Cap)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%s (Limit=%d Offset=%d MaxRows=%d): %v; a query bounded to %d rows cannot break a cap of %d, so this must not fire",
+				what, test.limit, test.offset, rowCap, err, test.limit+test.offset, rowCap)
+			continue
+		}
+		assertReaderPageIDs(t, what, page, order[test.offset:test.offset+test.limit])
+		// Every window here stops short of the fifth row, so the page that
+		// came back hid something. A body that failed to reach past the skip
+		// answers the same rows with has_more=false.
+		if !page.HasMore {
+			t.Errorf("%s reported has_more=false over %d matching rows; the row past the page is what the bound has to have reached",
+				what, len(ids))
+		}
+	}
+
+	// THE SAME BOUNDARY ON THE --ready ARM, which is a different query in both
+	// seams — a blocker-aware union rather than the search — reached through
+	// the same request and the same cap. Both sides are driven: an arm that
+	// refused every capped ready request would pass on the firing half alone.
+	//
+	// WHICH rows come back is deliberately not asserted here. The ready query
+	// runs in its sort POLICY's order and the display order is applied to the
+	// page afterwards, so a bounded ready query picks its rows in an order this
+	// request does not name — that promise is
+	// RunReaderReadySortPoliciesOrderTheSameRows's, and restating it here would
+	// pin an order the contract does not owe. What this arm owes is the cap.
+	readyAll, err := fixture.Reader.List(ctx, publicops.ListRequest{
+		Labels: []string{scope}, ReadyFlag: true, SortBy: "created", Limit: readerLimit(0),
+	})
+	if err != nil {
+		t.Fatalf("List --ready unpaged: %v", err)
+	}
+	if got := readerPageIDs(readyAll); len(got) != len(ids) {
+		t.Fatalf("List --ready unpaged returned %v, want the %d seeded rows: they are open, unassigned and unblocked, and a smaller ready set cannot reach the cap",
+			got, len(ids))
+	}
+	readyAt, err := fixture.Reader.List(ctx, publicops.ListRequest{
+		Labels: []string{scope}, ReadyFlag: true, SortBy: "created",
+		Limit: readerLimit(2), Offset: 1, MaxRows: rowCap, MaxRowsSource: "--max-rows",
+	})
+	switch {
+	case err != nil:
+		t.Errorf("List --ready at Limit=2 Offset=1 under MaxRows=%d: %v; the touched window is exactly the cap and must not fire", rowCap, err)
+	case len(readyAt.Items) != 2:
+		t.Errorf("List --ready at Limit=2 Offset=1 returned %v, want the 2 rows behind the skip", readerPageIDs(readyAt))
+	}
+	readyOver, err := fixture.Reader.List(ctx, publicops.ListRequest{
+		Labels: []string{scope}, ReadyFlag: true, SortBy: "created",
+		Limit: readerLimit(2), Offset: 2, MaxRows: rowCap, MaxRowsSource: "--max-rows",
+	})
+	if err == nil {
+		t.Fatalf("List --ready at Limit=2 Offset=2 under MaxRows=%d returned the page %v; the ready query counts a skipped row the same way the search does",
+			rowCap, readerPageIDs(readyOver))
+	}
+	var readyTooMany *storageops.ErrTooManyRows
+	if !errors.As(err, &readyTooMany) {
+		t.Fatalf("List --ready at Limit=2 Offset=2 under MaxRows=%d failed with %v, want *ErrTooManyRows", rowCap, err)
+	}
+	if readyTooMany.Cap != rowCap {
+		t.Errorf("List --ready: the cap error reports Cap = %d, want the %d the request asked for", readyTooMany.Cap, rowCap)
+	}
+}
+
 // RunReaderListSkipCountsDropsTheCardinalitiesAndNothingElse pins
 // ListRequest.SkipCounts (reader.go:160-175). Two halves, and the second is
 // the load-bearing one:

--- a/backend/conformance/reader_contract.go
+++ b/backend/conformance/reader_contract.go
@@ -210,9 +210,9 @@ func RunReaderReadyDeferredAndEphemeralGates(t *testing.T, ctx context.Context, 
 // is where an off-by-one in either mechanism shows: three rows, asked for two,
 // three, all, and by default.
 //
-// Offset is the neighboring knob and is deliberately NOT asserted here: the
-// two bodies answer it differently on purpose, so what the contract can pin is
-// weaker than a row count. RunReaderOffsetIsHonoredOrRefused owns it.
+// Offset is the neighboring knob and is deliberately NOT asserted here, so
+// that a body which conflated the two knobs fails one case rather than
+// muddying both. RunReaderOffsetSkipsTheRowsBeforeThePage owns it.
 func RunReaderReadyLimitBoundary(t *testing.T, ctx context.Context, fixture ReaderFixture) {
 	t.Helper()
 	scope := readerLabel(fixture, "rdylimit")
@@ -253,27 +253,26 @@ func RunReaderReadyLimitBoundary(t *testing.T, ctx context.Context, fixture Read
 	}
 }
 
-// RunReaderOffsetIsHonoredOrRefused pins the one thing every implementation
-// owes on ReadyRequest.Offset and ListRequest.Offset: a non-zero Offset is
-// either HONORED or REFUSED with a typed *ErrUnsupported, and never SILENTLY
-// IGNORED.
+// RunReaderOffsetSkipsTheRowsBeforeThePage pins ReadyRequest.Offset and
+// ListRequest.Offset: the page is the TAIL of the unpaged answer, in the
+// unpaged order, on every implementation.
 //
-// It is deliberately weaker than "Offset skips N rows", and the weakness is the
-// point. The two bodies disagree by design — the unit-of-work one renders
-// LIMIT/OFFSET, the store-backed one renders LIMIT only and therefore refuses
-// rather than answering the first page again — so a case written to either
-// behavior would fail the other. What they do share is the property whose
-// ABSENCE made this a spec gap (bd-yby99.7): with three matching rows, Offset
-// 0/1/2 came back 3/3/3 through the store body, with no error for a pager to
-// notice. Which body does which is a per-backend fact and is asserted at the
-// wirings, not here.
+// It used to be weaker — "honored or refused" — because the two bodies did
+// disagree: the unit-of-work one rendered LIMIT/OFFSET and the store-backed one
+// rendered LIMIT only and refused rather than answering the first page again.
+// A capability that is either served or refused is not a semantics the caller
+// can write against, so the split was closed rather than described: both bodies
+// now reach past the skipped rows and drop them in the shared page epilogue.
+// The spec gap this grew out of (bd-yby99.7) was the weakest form of the same
+// thing — three matching rows and Offset 0/1/2 coming back 3/3/3 with no error
+// for a pager to notice.
 //
-// The assertion is therefore comparative. The same request is issued at Offset
-// 0 and at Offset 1, and the second must either refuse with an error a caller
-// can classify, or answer with a genuinely different page. Both requests name a
-// total order over rows seeded minutes apart, so "different" cannot be storage
+// THE WALK IS THE ASSERTION. Every offset from 0 to one past the end is driven,
+// so a body that skipped a fixed number, skipped before the page bound, or
+// stopped skipping at the end fails on one of them. Both requests name a TOTAL
+// order over rows seeded minutes apart, so the expected tail is not storage
 // order wobbling between two calls.
-func RunReaderOffsetIsHonoredOrRefused(t *testing.T, ctx context.Context, fixture ReaderFixture) {
+func RunReaderOffsetSkipsTheRowsBeforeThePage(t *testing.T, ctx context.Context, fixture ReaderFixture) {
 	t.Helper()
 	scope := readerLabel(fixture, "offset")
 	var ids []string
@@ -304,32 +303,33 @@ func RunReaderOffsetIsHonoredOrRefused(t *testing.T, ctx context.Context, fixtur
 			})
 		}},
 	} {
-		// Offset 0 is not a page request, so it is served everywhere and is
-		// the baseline the paged call has to differ from.
+		// Offset 0 is not a page request, so it is the baseline every paged
+		// call is a suffix of. It is READ rather than assumed: the two sorts
+		// name a total order, but which end each starts from is the query's
+		// business and not this case's.
 		unpaged, err := test.call(0)
 		if err != nil {
 			t.Fatalf("%s at Offset 0: %v", test.what, err)
 		}
-		if len(unpaged.Items) != len(ids) {
-			t.Fatalf("%s at Offset 0 returned %v, want the three seeded rows", test.what, readerPageIDs(unpaged))
+		whole := readerPageIDs(unpaged)
+		if len(whole) != len(ids) {
+			t.Fatalf("%s at Offset 0 returned %v, want the three seeded rows", test.what, whole)
 		}
 
-		paged, err := test.call(1)
-		if err != nil {
-			var unsupported *publicops.ErrUnsupported
-			if !errors.As(err, &unsupported) {
-				t.Errorf("%s at Offset 1 refused with %v; a refusal has to be a typed *ErrUnsupported a caller can classify", test.what, err)
+		for offset := 1; offset <= len(ids); offset++ {
+			paged, err := test.call(offset)
+			if err != nil {
+				t.Errorf("%s at Offset %d: %v", test.what, offset, err)
 				continue
 			}
-			if unsupported.Op == "" || unsupported.Backend == "" {
-				t.Errorf("%s at Offset 1 refused with Op=%q Backend=%q; a refusal naming neither the operation nor the backend leaves the caller nowhere to go",
-					test.what, unsupported.Op, unsupported.Backend)
+			if paged.Items == nil {
+				t.Errorf("%s at Offset %d returned a nil Items; an offset past the end is an empty page, not a null one",
+					test.what, offset)
 			}
-			continue
-		}
-		if slices.Equal(readerPageIDs(paged), readerPageIDs(unpaged)) {
-			t.Errorf("%s at Offset 1 returned the same page as Offset 0 (%v) and no error: the offset was silently ignored",
-				test.what, readerPageIDs(paged))
+			if got, want := readerPageIDs(paged), whole[offset:]; !slices.Equal(got, want) {
+				t.Errorf("%s at Offset %d = %v, want %v — the tail of the unpaged answer %v",
+					test.what, offset, got, want, whole)
+			}
 		}
 	}
 }
@@ -771,24 +771,41 @@ func RunReaderListEmptyPageIsWellFormed(t *testing.T, ctx context.Context, fixtu
 	}
 }
 
-// RunReaderListMaxRowsIsHonoredOrRefused pins what every implementation owes on
-// ListRequest.MaxRows (reader.go:288-308): a non-zero cap over a result set
-// that exceeds it is either HONORED — no page, an error — or REFUSED with a
-// typed *ErrUnsupported, and never SILENTLY IGNORED.
+// RunReaderListMaxRowsIsHonored pins ListRequest.MaxRows: a cap the result set
+// exceeds refuses the whole answer with *ErrTooManyRows carrying the count, the
+// cap and the request's attribution — on every implementation.
 //
-// It is the MIRROR of RunReaderOffsetIsHonoredOrRefused above. Which body
-// honors and which refuses is a per-backend fact asserted at the wirings, not
-// here: the two disagree by design, so the shared assertion is the weaker one.
+// It used to say "honored OR refused with *ErrUnsupported", because one body
+// threaded the cap and the other did not. That disjunction could not tell a
+// working circuit breaker from a backend that had none, which is the one thing
+// a caller setting a cap needs to know. Both query paths now size the same
+// window through one function (internal/storage/issueops.SearchProbeLimit) and
+// enforce it with the same one (EnforceMaxRowsCap).
 //
-// The never-silently clause is the whole value. A cap is a CIRCUIT BREAKER: a
-// caller sets it because it would rather fail than wait, so a body that accepts
-// the field and answers the unbounded query hands that caller the runaway
-// result it was guarding against.
+// A cap is a CIRCUIT BREAKER: a caller sets it because it would rather fail
+// than wait, so answering the unbounded query hands that caller exactly the
+// runaway result it was guarding against.
 //
-// The complement is asserted too: the SAME request under a cap the result set
-// fits inside must come back as an ordinary page everywhere. Without it a body
-// that refused every non-zero MaxRows out of hand would pass.
-func RunReaderListMaxRowsIsHonoredOrRefused(t *testing.T, ctx context.Context, fixture ReaderFixture) {
+// THE COMPLEMENT IS ASSERTED TOO — the same request under a cap the result set
+// fits inside comes back as an ordinary page. Without it a body that refused
+// every non-zero MaxRows out of hand would pass. And the cap is driven UNDER AN
+// OFFSET as well, because a row the query skipped is still a row it matched: a
+// body that counted only what survived the skip would let an offset talk a
+// caller out of the breaker.
+//
+// THE LIMIT BOUNDARY IS THE LAST PART, and it is where the two seams are most
+// able to disagree. A cap only fires when the PAGE could have exceeded it: at
+// Limit <= MaxRows the caller can never receive more rows than the cap allows,
+// so the answer is an ordinary truncated page, and at Limit > MaxRows the same
+// result set fires. Both sides of the boundary are driven, one row apart. The
+// store seam reaches it by composing workapi.WithFetchOneExtra with
+// EffectiveSearchLimit — including the cap bump that keeps the probe row from
+// tripping a cap the page cannot break — and the unit-of-work seam by calling
+// the one function that IS that composition. A seam that added its probe row
+// without the bump fires at Limit == MaxRows; one that added no probe row
+// reports has-more wrongly. Neither is visible from the unlimited requests
+// above.
+func RunReaderListMaxRowsIsHonored(t *testing.T, ctx context.Context, fixture ReaderFixture) {
 	t.Helper()
 	var ids []string
 	for _, tag := range []string{"a", "b", "c"} {
@@ -798,51 +815,88 @@ func RunReaderListMaxRowsIsHonoredOrRefused(t *testing.T, ctx context.Context, f
 	}
 	idScope := readerIDFilter(ids...)
 
-	// A cap the three seeded rows fit inside. Answered as an ordinary page by
-	// the body that honors caps, and refused by the body that honors none.
+	// A cap the three seeded rows fit inside: an ordinary page everywhere.
 	const roomyWhat = "List under a cap the result set fits inside"
 	roomy, err := fixture.Reader.List(ctx, publicops.ListRequest{
 		IDFilter: idScope, SortBy: "created", MaxRows: len(ids) + 1, MaxRowsSource: "--max-rows",
 	})
 	if err != nil {
-		assertReaderUnsupported(t, roomyWhat, err)
-	} else {
-		assertReaderPageIDSet(t, roomyWhat, roomy, ids)
+		t.Fatalf("%s: %v", roomyWhat, err)
+	}
+	assertReaderPageIDSet(t, roomyWhat, roomy, ids)
+
+	// A cap the result set exceeds, with and without an offset in front of it.
+	// A PAGE from either means the field was ignored.
+	for _, test := range []struct {
+		what   string
+		offset int
+	}{
+		{"List under a cap the result set exceeds", 0},
+		{"List under a cap the result set exceeds, behind an offset", 1},
+	} {
+		tight, err := fixture.Reader.List(ctx, publicops.ListRequest{
+			IDFilter: idScope, SortBy: "created", Offset: test.offset,
+			MaxRows: len(ids) - 1, MaxRowsSource: "--max-rows",
+		})
+		if err == nil {
+			t.Fatalf("%s (MaxRows=%d over %d matching rows) returned the page %v and no error: the cap was silently ignored",
+				test.what, len(ids)-1, len(ids), readerPageIDs(tight))
+		}
+		// The leaf names the answer — *ErrTooManyRows — so a caller can tell
+		// "the cap fired" from any other failure without reading error text.
+		var tooMany *storageops.ErrTooManyRows
+		if !errors.As(err, &tooMany) {
+			t.Fatalf("%s failed with %v; a cap that fired has to answer with *ErrTooManyRows a caller can classify", test.what, err)
+		}
+		if tooMany.Cap != len(ids)-1 {
+			t.Errorf("%s: the cap error reports Cap = %d, want the %d the request asked for", test.what, tooMany.Cap, len(ids)-1)
+		}
+		if tooMany.Found <= tooMany.Cap {
+			t.Errorf("%s: the cap error reports Found = %d against Cap = %d; a cap that fired saw more rows than it allows",
+				test.what, tooMany.Found, tooMany.Cap)
+		}
+		// The whole job of MaxRowsSource (reader.go): the attribution the
+		// request supplied comes back on the refusal, so the caller that set
+		// the cap can say which of its own knobs did.
+		if tooMany.Source != "--max-rows" {
+			t.Errorf("%s: the cap error reports Source = %q, want the %q the request supplied: MaxRowsSource decides nothing else",
+				test.what, tooMany.Source, "--max-rows")
+		}
 	}
 
-	// A cap the result set exceeds. Honored means an error carrying the cap;
-	// refused means *ErrUnsupported; a PAGE means the field was ignored.
-	tight, err := fixture.Reader.List(ctx, publicops.ListRequest{
-		IDFilter: idScope, SortBy: "created", MaxRows: len(ids) - 1, MaxRowsSource: "--max-rows",
+	// The boundary, one row apart, over the same three rows and the same cap.
+	// Limit 2 under a cap of 2 delivers a page of 2 and says there is more;
+	// Limit 3 under the same cap fires.
+	const cap2 = 2
+	page, err := fixture.Reader.List(ctx, publicops.ListRequest{
+		IDFilter: idScope, SortBy: "created", Limit: readerLimit(cap2),
+		MaxRows: cap2, MaxRowsSource: "--max-rows",
+	})
+	if err != nil {
+		t.Fatalf("List at Limit=%d under MaxRows=%d: %v; a page the caller receives cannot exceed a cap it fits inside, so this must not fire",
+			cap2, cap2, err)
+	}
+	if len(page.Items) != cap2 {
+		t.Errorf("List at Limit=%d under MaxRows=%d returned %v, want %d rows", cap2, cap2, readerPageIDs(page), cap2)
+	}
+	if !page.HasMore {
+		t.Errorf("List at Limit=%d under MaxRows=%d over %d rows reported has_more=false; the probe row that answers that question is what the cap must not fire on",
+			cap2, cap2, len(ids))
+	}
+	over, err := fixture.Reader.List(ctx, publicops.ListRequest{
+		IDFilter: idScope, SortBy: "created", Limit: readerLimit(cap2 + 1),
+		MaxRows: cap2, MaxRowsSource: "--max-rows",
 	})
 	if err == nil {
-		t.Fatalf("List under MaxRows=%d over %d matching rows returned the page %v and no error: the cap was silently ignored",
-			len(ids)-1, len(ids), readerPageIDs(tight))
+		t.Fatalf("List at Limit=%d under MaxRows=%d returned the page %v; a page that could exceed the cap has to fire it",
+			cap2+1, cap2, readerPageIDs(over))
 	}
-	var unsupported *publicops.ErrUnsupported
-	if errors.As(err, &unsupported) {
-		assertReaderUnsupported(t, "List under a cap the result set exceeds", err)
-		return
-	}
-	// The honoring branch. The leaf names the answer — *ErrTooManyRows — so a
-	// caller can tell "the cap fired" from any other failure without reading
-	// error text.
 	var tooMany *storageops.ErrTooManyRows
 	if !errors.As(err, &tooMany) {
-		t.Fatalf("List honored MaxRows and failed with %v; an honored cap has to answer with *ErrTooManyRows a caller can classify", err)
+		t.Fatalf("List at Limit=%d under MaxRows=%d failed with %v, want *ErrTooManyRows", cap2+1, cap2, err)
 	}
-	if tooMany.Cap != len(ids)-1 {
-		t.Errorf("the cap error reports Cap = %d, want the %d the request asked for", tooMany.Cap, len(ids)-1)
-	}
-	if tooMany.Found <= tooMany.Cap {
-		t.Errorf("the cap error reports Found = %d against Cap = %d; a cap that fired saw more rows than it allows", tooMany.Found, tooMany.Cap)
-	}
-	// The whole job of MaxRowsSource (reader.go:309-313): the attribution the
-	// request supplied comes back on the refusal, so the caller that set the
-	// cap can say which of its own knobs did.
-	if tooMany.Source != "--max-rows" {
-		t.Errorf("the cap error reports Source = %q, want the %q the request supplied: MaxRowsSource decides nothing else",
-			tooMany.Source, "--max-rows")
+	if tooMany.Cap != cap2 {
+		t.Errorf("the cap error reports Cap = %d, want the %d the request asked for; the probe row's bump must not reach the caller", tooMany.Cap, cap2)
 	}
 }
 
@@ -1523,21 +1577,13 @@ func readerRowByID(t *testing.T, what string, page publicops.IssuePage, id strin
 	return nil
 }
 
-// assertReaderUnsupported is the refusal shape every "honored or refused" case
-// accepts: a typed *ErrUnsupported naming both the operation and the backend,
-// so a caller can classify it with errors.As and knows where to go next.
-func assertReaderUnsupported(t *testing.T, what string, err error) {
-	t.Helper()
-	var unsupported *publicops.ErrUnsupported
-	if !errors.As(err, &unsupported) {
-		t.Errorf("%s failed with %v; a refusal has to be a typed *ErrUnsupported a caller can classify", what, err)
-		return
-	}
-	if unsupported.Op == "" || unsupported.Backend == "" {
-		t.Errorf("%s refused with Op=%q Backend=%q; a refusal naming neither the operation nor the backend leaves the caller nowhere to go",
-			what, unsupported.Op, unsupported.Backend)
-	}
-}
+// assertReaderUnsupported is GONE. It existed for the two "honored or refused"
+// cases above, which accepted a typed *ErrUnsupported in place of the
+// behavior; nothing on this role is unsupported by any implementation now, so
+// keeping a helper that accepts a refusal would keep the disjunction available
+// to the next case that finds one convenient. *ErrUnsupported is still a real
+// contract elsewhere — conformance.go:100 pins it for the capabilities a
+// backend genuinely does not have.
 
 func readerSameParent(a, b *string) bool {
 	if a == nil || b == nil {

--- a/backend/conformance/search_paging.go
+++ b/backend/conformance/search_paging.go
@@ -29,10 +29,12 @@ import (
 // are not duplicates of it. RunReaderListKeysetPositionResumesTheCreatedDescIDAscOrder
 // makes ONE boundary read at the role level; it exercises neither an overflow
 // walk, nor composition with other predicates, nor the AfterID:"" group start.
-// RunReaderListMaxRowsIsHonoredOrRefused is deliberately honored-OR-refused,
-// because a role implementation may decline the cap; the storage layer's own
-// obligation is unconditional honoring, and that stricter branch is what
-// RunSearchPaging asserts.
+// RunReaderListMaxRowsIsHonored drives the cap through the ROLE's request
+// vocabulary, where Limit defaulting and the probe row sit between the caller
+// and the filter; this block drives types.IssueFilter.MaxRows directly and
+// walks the boundary. It used to be the only strict one — the role case
+// accepted a refusal in place of the cap until both implementations threaded
+// it.
 
 // RunSearchPaging runs the keyset-paging and row-cap block against a factory
 // store.

--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -191,10 +191,16 @@ func runListCore(cmd *cobra.Command, _ []string) error {
 	}
 
 	if usesProxiedServer() {
-		if err := rejectResolvedMaxRowsUnderProxiedServer(in.MaxRows); err != nil {
-			return err
-		}
+		// The cap USED to be rejected here: the proxied query path threaded no
+		// MaxRows, so honoring it would have been silence. It threads one now
+		// (internal/storage/domain/db sizes its bound and enforces the cap
+		// through the same two functions the store seam uses), so this route
+		// answers *ErrTooManyRows the same way the direct route below does —
+		// same message, same exit code.
 		if err := runListProxiedServer(cmd, rootCtx, in); err != nil {
+			if capErr := handleMaxRowsError(err); capErr != nil {
+				return capErr
+			}
 			return HandleError("%v", err)
 		}
 		return nil
@@ -499,7 +505,8 @@ func init() {
 	listCmd.Flags().Bool("ready", false, "Show only ready issues (no active blockers, same semantics as bd ready)")
 
 	// Defensive row cap (be-x42v): exits 2 on overage, default disabled.
-	addMaxRowsFlag(listCmd)
+	// ROUTED, not direct-only: both routes thread the cap now.
+	addRoutedMaxRowsFlag(listCmd)
 
 	// Note: --json flag is defined as a persistent flag in main.go, not here
 	rootCmd.AddCommand(listCmd)

--- a/cmd/bd/list_input.go
+++ b/cmd/bd/list_input.go
@@ -312,9 +312,7 @@ func gatherListInput(cmd *cobra.Command) (listInput, error) {
 	//
 	// Resolving it HERE also means it is resolved exactly once per invocation.
 	// resolveMaxRowsEnvOnly warns on a malformed BEADS_MAX_ROWS every time it
-	// runs, so runListCore's proxied-server refusal reads the value this
-	// resolved (rejectResolvedMaxRowsUnderProxiedServer) rather than resolving
-	// a second time and warning twice.
+	// runs, so a second resolve downstream would warn twice.
 	maxRows, maxRowsSource, err := resolveMaxRows(cmd)
 	if err != nil {
 		return in, err

--- a/cmd/bd/list_proxied_integration_test.go
+++ b/cmd/bd/list_proxied_integration_test.go
@@ -728,26 +728,34 @@ func TestProxiedServerList(t *testing.T) {
 		}
 	})
 
-	// The proxied repository path (internal/storage/domain/db) doesn't
-	// thread MaxRows through the UOW pipeline, so an explicit cap must be
-	// rejected rather than silently going unenforced (be-x42v.4 follow-up).
-	t.Run("reject_max_rows_flag", func(t *testing.T) {
+	// The cap is HONORED on this route now. It used to be rejected outright,
+	// because the proxied repository path (internal/storage/domain/db) read no
+	// MaxRows at all and honoring it would have meant silence (be-x42v.4). The
+	// answer is the cap firing, with the same text and the same exit code the
+	// direct route prints.
+	t.Run("max_rows_flag_fires", func(t *testing.T) {
 		out := bdProxiedListFail(t, bd, p, "--max-rows", "1")
-		if !strings.Contains(out, "not supported in proxied-server mode") {
-			t.Errorf("expected --max-rows proxied-server rejection, got: %s", out)
+		if strings.Contains(out, "not supported in proxied-server mode") {
+			t.Fatalf("--max-rows is refused under --proxied-server; the cap threads this route now: %s", out)
+		}
+		if !strings.Contains(out, "too many rows") || !strings.Contains(out, "--max-rows=1") {
+			t.Errorf("expected the cap to fire naming its source, got: %s", out)
 		}
 	})
 
-	t.Run("reject_max_rows_env", func(t *testing.T) {
+	t.Run("max_rows_env_fires", func(t *testing.T) {
 		fullArgs := []string{"list"}
 		stdout, stderr, err := bdProxiedRunBuffersWithEnv(t, bd, p.dir,
 			[]string{"BEADS_MAX_ROWS=1"}, fullArgs...)
 		if err == nil {
-			t.Fatalf("expected BEADS_MAX_ROWS under proxied-server to fail, but it succeeded:\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+			t.Fatalf("expected BEADS_MAX_ROWS under proxied-server to trip the cap, but it succeeded:\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
 		}
 		out := stdout + stderr
-		if !strings.Contains(out, "not supported in proxied-server mode") {
-			t.Errorf("expected BEADS_MAX_ROWS proxied-server rejection, got: %s", out)
+		if strings.Contains(out, "not supported in proxied-server mode") {
+			t.Fatalf("BEADS_MAX_ROWS is refused under --proxied-server; the cap threads this route now: %s", out)
+		}
+		if !strings.Contains(out, "too many rows") || !strings.Contains(out, "BEADS_MAX_ROWS=1") {
+			t.Errorf("expected the cap to fire naming its source, got: %s", out)
 		}
 	})
 

--- a/cmd/bd/list_proxied_watch_max_rows_test.go
+++ b/cmd/bd/list_proxied_watch_max_rows_test.go
@@ -1,0 +1,86 @@
+//go:build cgo
+
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestProxiedServerListWatchCountsTheOffsetIntoMaxRows pins the cap boundary on
+// the one `bd list` mode no contract can reach.
+//
+// --watch consumes the FILTER as a value and re-runs it on a ticker, so it has
+// no shared page epilogue above it to take the offset off the query
+// (issueops.Reader's doc names it as one of the two exceptions). That used to
+// make it the only route where --offset and --max-rows disagreed with every
+// other one: the seam rendered LIMIT n OFFSET k, so EnforceMaxRowsCap counted
+// the survivors of the skip, and the request the paged route refuses came back
+// here as a page. The combination became reachable when `bd list --max-rows`
+// stopped being rejected under --proxied-server.
+//
+// It is also the only place it can be driven. The reader contract never hands a
+// seam an offset — both implementations widen the filter and skip in the
+// epilogue — and the direct route refuses --offset outside --proxied-server.
+func TestProxiedServerListWatchCountsTheOffsetIntoMaxRows(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+	p := newSharedProxiedProject(t, bd, "lwcap")
+
+	// Five matching rows, so a window bounded at four has a row behind it. A
+	// smaller result set could not reach the cap and the case would pass on a
+	// route that had no cap at all.
+	const scope = "watch-cap-scope"
+	for i := range 5 {
+		bdProxiedCreate(t, bd, p.dir, fmt.Sprintf("Watch cap row %d", i), "--type", "task", "--label", scope)
+	}
+
+	// The paged route's answer to the identical request, READ rather than
+	// asserted from a number written here: the promise is that the two routes
+	// agree, so this is the thing the watch route is compared against.
+	paged := bdProxiedListFail(t, bd, p, "--label", scope, "--limit", "10", "--offset", "2", "--max-rows", "3")
+	if !strings.Contains(paged, "too many rows") {
+		t.Fatalf("bd list --limit 10 --offset 2 --max-rows 3 must refuse before this case can ask --watch to agree with it; got:\n%s", paged)
+	}
+
+	t.Run("fires_where_the_page_route_fires", func(t *testing.T) {
+		stdout, stderr, err, timedOut := bdProxiedRunDeadline(t, bd, p.dir, 90*time.Second,
+			"list", "--watch", "--label", scope, "--limit", "10", "--offset", "2", "--max-rows", "3")
+		out := stdout + stderr
+		if timedOut {
+			t.Fatalf("bd list --watch --offset 2 --max-rows 3 kept watching; the page route refuses the same request with:\n%s\nwatch output:\n%s",
+				strings.TrimSpace(paged), out)
+		}
+		if err == nil {
+			t.Fatalf("bd list --watch --offset 2 --max-rows 3 exited 0; want the cap to fire:\n%s", out)
+		}
+		if !strings.Contains(out, "too many rows") || !strings.Contains(out, "--max-rows=3") {
+			t.Errorf("expected the cap to fire naming its source, got:\n%s", out)
+		}
+		// The count is the whole finding: four rows TOUCHED, not the two that
+		// survive the skip. A route that counted survivors would report a
+		// number at or below the cap, or not fire at all.
+		if !strings.Contains(out, "4 found") {
+			t.Errorf("expected the refusal to count the rows the query touched (4 found), got:\n%s", out)
+		}
+	})
+
+	// The complement, and it is not optional: a route that refused every capped
+	// request behind an offset would pass the case above, and an offset that
+	// manufactures a refusal is the same bug from the other side. The window
+	// here is 12 rows against a cap of 20, so nothing may fire.
+	t.Run("keeps_watching_under_a_cap_the_window_fits_inside", func(t *testing.T) {
+		stdout, stderr, reached := bdProxiedRunUntilStderr(t, bd, p.dir, "Watching for changes", 60*time.Second,
+			"list", "--watch", "--label", scope, "--limit", "10", "--offset", "2", "--max-rows", "20")
+		out := stdout + stderr
+		if strings.Contains(out, "too many rows") {
+			t.Fatalf("the cap fired on a 12-row window under --max-rows 20:\n%s", out)
+		}
+		if !reached {
+			t.Fatalf("bd list --watch never reached its poll loop:\n%s", out)
+		}
+	})
+}

--- a/cmd/bd/max_rows.go
+++ b/cmd/bd/max_rows.go
@@ -36,11 +36,12 @@ func addMaxRowsFlag(cmd *cobra.Command) {
 // both routes, so the help text must not repeat the proxied-server refusal above.
 //
 // It exists because that refusal is a fact about a command's implementation
-// rather than about the flag: `bd list --max-rows --proxied-server` errors out
-// because the unit-of-work query path threads no cap, and a command whose cap
-// lives on an issueops request threads one everywhere. `bd dep tree` is the
-// first; the next one to move onto a role calls this instead of the function
-// above and deletes its rejectMaxRowsUnderProxiedServer call in the same edit.
+// rather than about the flag: a command whose cap reaches a query path that
+// threads one is honored on both routes. `bd dep tree` was the first and `bd
+// list` the second — its cap used to be rejected under --proxied-server because
+// the unit-of-work query path read no MaxRows at all. The next command to move
+// onto a role that threads it calls this instead of the function above and
+// deletes its rejectMaxRowsUnderProxiedServer call in the same edit.
 func addRoutedMaxRowsFlag(cmd *cobra.Command) {
 	cmd.Flags().Int(maxRowsFlagName, 0,
 		"Hard upper bound on rows returned. Returns a non-zero exit (code 2) "+

--- a/cmd/bd/proxied_integration_helpers_test.go
+++ b/cmd/bd/proxied_integration_helpers_test.go
@@ -13,6 +13,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -160,6 +161,87 @@ func bdProxiedRunBuffersWithEnv(t *testing.T, bd, dir string, envExtras []string
 	cmd.Stderr = &stderr
 	err := cmd.Run()
 	return stdout.String(), stderr.String(), err
+}
+
+// bdProxiedRunDeadline is bdProxiedRunBuffers for a command that may never exit
+// on its own — `bd list --watch` polls until it is interrupted. It reports
+// whether the deadline was what stopped it, so a case can tell "kept running"
+// from "exited" instead of hanging the suite to find out.
+func bdProxiedRunDeadline(t *testing.T, bd, dir string, timeout time.Duration, args ...string) (stdout, stderr string, err error, timedOut bool) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bd, args...)
+	cmd.Dir = dir
+	cmd.Env = bdProxiedEnv(dir)
+	var out, errOut bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errOut
+	err = cmd.Run()
+	return out.String(), errOut.String(), err, ctx.Err() != nil
+}
+
+// bdProxiedRunUntilStderr starts a bd command that is NOT expected to exit and
+// stops it the moment marker appears on stderr. reached is false when the
+// command exited, or the timeout elapsed, before it got there.
+//
+// The alternative is to run such a command under a fixed deadline and wait the
+// whole thing out, which costs the deadline on every green run and fails on a
+// machine slow enough to render late. This waits for the state instead, so the
+// timeout is only a bound on a hang.
+func bdProxiedRunUntilStderr(t *testing.T, bd, dir, marker string, timeout time.Duration, args ...string) (stdout, stderr string, reached bool) {
+	t.Helper()
+	w := &markerWriter{marker: marker, seen: make(chan struct{})}
+	var out bytes.Buffer
+	cmd := exec.Command(bd, args...)
+	cmd.Dir = dir
+	cmd.Env = bdProxiedEnv(dir)
+	cmd.Stdout = &out
+	cmd.Stderr = w
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start bd %s: %v", strings.Join(args, " "), err)
+	}
+	exited := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(exited)
+	}()
+	select {
+	case <-w.seen:
+		reached = true
+	case <-exited:
+	case <-time.After(timeout):
+	}
+	_ = cmd.Process.Kill()
+	<-exited
+	return out.String(), w.String(), reached
+}
+
+// markerWriter buffers everything written to it and closes seen the first time
+// marker shows up.
+type markerWriter struct {
+	marker string
+	seen   chan struct{}
+
+	mu   sync.Mutex
+	buf  bytes.Buffer
+	once sync.Once
+}
+
+func (w *markerWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	n, err := w.buf.Write(p)
+	if strings.Contains(w.buf.String(), w.marker) {
+		w.once.Do(func() { close(w.seen) })
+	}
+	return n, err
+}
+
+func (w *markerWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.String()
 }
 
 func bdProxiedUpdate(t *testing.T, bd, dir string, args ...string) []*types.Issue {

--- a/cmd/bd/query_proxied_integration_test.go
+++ b/cmd/bd/query_proxied_integration_test.go
@@ -184,9 +184,11 @@ func TestProxiedServerQuery(t *testing.T) {
 	// nothing; the window is gone, the predicate now sees every candidate row,
 	// and the offset skips MATCHES. An error became an answer.
 	t.Run("offset_pages_a_predicate_query", func(t *testing.T) {
-		// A BOUNDED limit on both calls, deliberately: an unlimited request
-		// carrying an offset renders SQL the engine answers with a recovered
-		// panic, which predates this role (see RunQuerierOffsetIsHonoredOrRefused).
+		// A bounded limit on both calls. It used to be load-bearing — an
+		// unlimited request carrying an offset rendered SQL the engine answered
+		// with a recovered panic — and is now just a fixture bound; the
+		// unlimited shape is driven at the role, by
+		// RunQuerierOffsetSkipsMatches.
 		full := bdProxiedQueryJSON(t, bd, p, "type=bug OR type=feature", "--limit", "20")
 		if len(full) < 2 {
 			t.Fatalf("fixture should match >= 2 rows for (bug OR feature), got %d", len(full))

--- a/internal/storage/dolt/querier_contract_test.go
+++ b/internal/storage/dolt/querier_contract_test.go
@@ -38,8 +38,8 @@ func TestQuerierContract(t *testing.T) {
 	t.Run("RefusesAMalformedRequest", func(t *testing.T) {
 		conformance.RunQuerierRefusesAMalformedRequest(t, ctx, fixture)
 	})
-	t.Run("OffsetIsHonoredOrRefused", func(t *testing.T) {
-		conformance.RunQuerierOffsetIsHonoredOrRefused(t, ctx, fixture)
+	t.Run("OffsetSkipsMatches", func(t *testing.T) {
+		conformance.RunQuerierOffsetSkipsMatches(t, ctx, fixture)
 	})
 	t.Run("EmptyMatchIsAWellFormedPage", func(t *testing.T) {
 		conformance.RunQuerierEmptyMatchIsAWellFormedPage(t, ctx, fixture)

--- a/internal/storage/dolt/reader_contract_test.go
+++ b/internal/storage/dolt/reader_contract_test.go
@@ -32,19 +32,19 @@ func TestReaderReadyLimitBoundary(t *testing.T) {
 	conformance.RunReaderReadyLimitBoundary(t, ctx, fixture)
 }
 
-func TestReaderOffsetIsHonoredOrRefused(t *testing.T) {
+func TestReaderOffsetSkipsTheRowsBeforeThePage(t *testing.T) {
 	fixture, ctx, cleanup := newDoltReaderFixture(t, "rdr")
 	defer cleanup()
-	conformance.RunReaderOffsetIsHonoredOrRefused(t, ctx, fixture)
+	conformance.RunReaderOffsetSkipsTheRowsBeforeThePage(t, ctx, fixture)
 }
 
-// The store-backed body is the arm that HONORS MaxRows: the cap rides the
-// filter the shared builder produces and the search path enforces it after the
-// scan. The refusing arm is the unit-of-work wiring.
-func TestReaderListMaxRowsIsHonoredOrRefused(t *testing.T) {
+// The cap rides the filter the shared builder produces and the search path
+// enforces it after the scan. It used to be the only arm that did: the
+// unit-of-work wiring refused the field, and the case accepted either answer.
+func TestReaderListMaxRowsIsHonored(t *testing.T) {
 	fixture, ctx, cleanup := newDoltReaderFixture(t, "rdr")
 	defer cleanup()
-	conformance.RunReaderListMaxRowsIsHonoredOrRefused(t, ctx, fixture)
+	conformance.RunReaderListMaxRowsIsHonored(t, ctx, fixture)
 }
 
 func TestReaderListSkipCountsDropsTheCardinalitiesAndNothingElse(t *testing.T) {

--- a/internal/storage/dolt/reader_contract_test.go
+++ b/internal/storage/dolt/reader_contract_test.go
@@ -47,6 +47,15 @@ func TestReaderListMaxRowsIsHonored(t *testing.T) {
 	conformance.RunReaderListMaxRowsIsHonored(t, ctx, fixture)
 }
 
+// The cap's boundary along the OFFSET axis. It is the composition this body
+// reaches in two steps — widen the filter, then size the probe row — that the
+// case checks, and no request without an offset can see it go wrong.
+func TestReaderListMaxRowsBoundaryIsLimitPlusOffset(t *testing.T) {
+	fixture, ctx, cleanup := newDoltReaderFixture(t, "rdr")
+	defer cleanup()
+	conformance.RunReaderListMaxRowsBoundaryIsLimitPlusOffset(t, ctx, fixture)
+}
+
 func TestReaderListSkipCountsDropsTheCardinalitiesAndNothingElse(t *testing.T) {
 	fixture, ctx, cleanup := newDoltReaderFixture(t, "rdr")
 	defer cleanup()

--- a/internal/storage/domain/db/issue_search.go
+++ b/internal/storage/domain/db/issue_search.go
@@ -526,22 +526,34 @@ func orderBySQL(sortBy string, sortDesc bool, prefix string) string {
 // is one value rather than two decisions at each call site because the halves
 // only add up when they are decided together.
 //
-// WHO CARRIES THE OFFSET is the whole of it. The engine carries it — LIMIT n
-// OFFSET k — except when there is no LIMIT to hang one on. MySQL has no OFFSET
-// without a LIMIT, and the sentinel this used to render for that shape
+// WHO CARRIES THE OFFSET is the whole of it, and A CAP DECIDES IT. MaxRows
+// counts the rows the query TOUCHED — offset + limit — because a row the engine
+// skipped is still a row it matched, so an offset walks a caller toward the
+// breaker and must never walk one past it. When a cap is set the skip therefore
+// stays HERE: the bound covers the rows this package is about to drop, and
+// EnforceMaxRowsCap counts them. That is the same window the store-backed seam
+// runs under, which reaches it by widening the filter before it sizes its probe
+// row (internal/workapi.WithRowsBeforeThePage, then WithFetchOneExtra), so one
+// request fires on both.
+//
+// With no cap the engine carries it — LIMIT n OFFSET k — except when there is
+// no LIMIT to hang one on. MySQL has no OFFSET without a LIMIT, and the
+// sentinel this used to render for that shape
 // ("LIMIT 18446744073709551615 OFFSET k") makes the Dolt engine size a result
 // buffer from limit+offset and answer with a recovered "makeslice: cap out of
 // range" out of topRowsIter instead of rows. An unbounded query reads every
 // matching row anyway, so skipping here is the same answer at the same cost.
 //
-// NO CALLER COMBINES AN OFFSET WITH A CAP. The role that pages — issueops.Reader
-// — applies its offset in the shared page epilogue and hands this seam none
-// (internal/workapi.FinishPageAt says why, and the cap counting rows the query
-// MATCHED rather than rows that survived a skip is one of the two reasons). The
-// one caller that does set Offset here is the unit-of-work Querier, and a query
-// request carries no cap. RunReaderListMaxRowsIsHonored drives the cap behind an
-// offset on all three legs, so a body that started pushing the skip down would
-// be caught rather than quietly counting the wrong rows.
+// THE CALLERS THAT COMBINE AN OFFSET WITH A CAP are the ones that consume the
+// FILTER as a value and run their own query: proxied `bd list --watch`, with
+// and without --ready, and the proxied hierarchical --parent walk. They used to
+// get the engine's OFFSET and a cap counted on the survivors, which answered a
+// page for the very request `bd list --offset --max-rows` refuses one row of
+// result set earlier. The role that pages — issueops.Reader — hands this seam
+// no offset at all; it applies its own in the shared page epilogue for the
+// reason internal/workapi.FinishPageAt gives. The unit-of-work Querier does set
+// one here, and a query request carries no cap, so that is the shape still
+// pushing the skip down.
 type searchWindow struct {
 	// sql is the LIMIT/OFFSET clause, empty for an unbounded scan.
 	sql string
@@ -550,18 +562,29 @@ type searchWindow struct {
 	// limit is the page the caller receives; 0 is unlimited.
 	limit int
 	// rowCap and capSource are the defensive cap and its attribution. rowCap is
-	// SearchProbeLimit's cap, not the filter's: at limit == maxRows the probe
+	// SearchProbeLimit's cap, not the filter's: at touched == maxRows the probe
 	// row moves it by one.
 	rowCap    int
 	capSource string
 }
 
 func searchWindowFor(limit, offset, maxRows int, maxRowsSource string) searchWindow {
-	bound, rowCap := issueops.SearchProbeLimit(limit, maxRows)
+	// The window the cap is sized against is the one the query TOUCHES, so a
+	// skip this package keeps has to be inside the bound. An unbounded limit
+	// already carries every matching row and needs no widening — the same two
+	// lines WithRowsBeforeThePage runs on the filter for the other seam.
+	skipHere := maxRows > 0 && offset > 0
+	touched := limit
+	if skipHere && limit > 0 {
+		touched += offset
+	}
+	bound, rowCap := issueops.SearchProbeLimit(touched, maxRows)
 	w := searchWindow{limit: limit, rowCap: rowCap, capSource: maxRowsSource}
 	switch {
 	case bound <= 0:
 		w.skip = offset
+	case skipHere:
+		w.skip, w.sql = offset, fmt.Sprintf("LIMIT %d", bound)
 	case offset > 0:
 		w.sql = fmt.Sprintf("LIMIT %d OFFSET %d", bound, offset)
 	default:
@@ -579,10 +602,10 @@ func readyWindowForFilter(filter types.WorkFilter) searchWindow {
 }
 
 // finishWindow is the Go half of a window: the defensive cap against what the
-// query matched, then the offset the engine could not carry, then the page trim
+// query matched, then the offset the engine was not given, then the page trim
 // that produces the has-more verdict. The cap runs first because it counts rows
-// the query MATCHED — the same count the store-backed seam checks, which skips
-// nothing because its body does.
+// the query MATCHED, skipped ones included — the same count the store-backed
+// seam checks, which skips nothing because its body does.
 func finishWindow[T any](rows []T, w searchWindow) ([]T, bool, error) {
 	if err := issueops.EnforceMaxRowsCap(len(rows), w.rowCap, w.capSource); err != nil {
 		return nil, false, err

--- a/internal/storage/domain/db/issue_search.go
+++ b/internal/storage/domain/db/issue_search.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/storage/dberrors"
 	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/storage/sqlbuild"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -69,11 +70,11 @@ func (r *issueSQLRepositoryImpl) searchUnion(ctx context.Context, query string, 
 	}
 
 	outerOrderBy := unionOrderBySQL(filter.SortBy, filter.SortDesc)
-	outerLimit := limitOffsetSQL(filter.Limit, filter.Offset)
+	window := searchWindowForFilter(filter)
 
 	//nolint:gosec // G201: subqueries built from hardcoded table names and ? placeholders.
 	unionSQL := fmt.Sprintf("SELECT id, src FROM (%s UNION ALL %s) merged %s %s",
-		iSub, wSub, outerOrderBy, outerLimit)
+		iSub, wSub, outerOrderBy, window.sql)
 
 	args := make([]any, 0, len(iArgs)+len(wArgs))
 	args = append(args, iArgs...)
@@ -87,7 +88,10 @@ func (r *issueSQLRepositoryImpl) searchUnion(ctx context.Context, query string, 
 	if err != nil {
 		return domain.SearchPage{}, fmt.Errorf("search union: %w", err)
 	}
-	hasMore := page.trimToLimit(filter.Limit)
+	hasMore, err := page.finishWindow(window)
+	if err != nil {
+		return domain.SearchPage{}, err
+	}
 
 	issuesByID, err := r.fetchIssuesByIDs(ctx, page.issueIDs, issuesFilterTables, filter)
 	if err != nil {
@@ -195,11 +199,11 @@ func (r *issueSQLRepositoryImpl) searchTable(ctx context.Context, query string, 
 	}
 
 	orderBy := orderBySQL(filter.SortBy, filter.SortDesc, "")
-	limitSQL := limitOffsetSQL(filter.Limit, filter.Offset)
+	window := searchWindowForFilter(filter)
 
 	//nolint:gosec // G201: SQL fragments from fixed table names and parameterized filters.
 	querySQL := fmt.Sprintf(`%s%s FROM %s %s %s %s %s`,
-		selectKw, issueSelectColumns, plan.FromSQL, sqlbuild.LeaseJoin(tables.Main), whereSQL, orderBy, limitSQL)
+		selectKw, issueSelectColumns, plan.FromSQL, sqlbuild.LeaseJoin(tables.Main), whereSQL, orderBy, window.sql)
 
 	rows, err := r.runner.QueryContext(ctx, querySQL, args...)
 	if err != nil {
@@ -225,7 +229,10 @@ func (r *issueSQLRepositoryImpl) searchTable(ctx context.Context, query string, 
 		return domain.SearchPage{}, fmt.Errorf("search %s: rows: %w", tables.Main, err)
 	}
 
-	items, hasMore := applyN1Overflow(issues, filter.Limit)
+	items, hasMore, err := finishWindow(issues, window)
+	if err != nil {
+		return domain.SearchPage{}, err
+	}
 
 	if err := r.hydrateIssues(ctx, items, tables, filter.IncludeDependencies, filter.SkipLabels); err != nil {
 		return domain.SearchPage{}, fmt.Errorf("search %s: hydrate: %w", tables.Main, err)
@@ -236,10 +243,10 @@ func (r *issueSQLRepositoryImpl) searchTable(ctx context.Context, query string, 
 
 func (r *issueSQLRepositoryImpl) scanFilterIDs(ctx context.Context, selectKw, fromSQL, whereSQL string, args []any, filter types.IssueFilter, tables filterTables) ([]string, bool, error) {
 	orderBy := orderBySQL(filter.SortBy, filter.SortDesc, tables.Main)
-	limitSQL := limitOffsetSQL(filter.Limit, filter.Offset)
+	window := searchWindowForFilter(filter)
 	//nolint:gosec // G201: SQL fragments from fixed table names and parameterized filters.
 	idQuery := fmt.Sprintf(`%s%s.id FROM %s %s %s %s`,
-		selectKw, tables.Main, fromSQL, whereSQL, orderBy, limitSQL)
+		selectKw, tables.Main, fromSQL, whereSQL, orderBy, window.sql)
 
 	rows, err := r.runner.QueryContext(ctx, idQuery, args...)
 	if err != nil {
@@ -259,8 +266,7 @@ func (r *issueSQLRepositoryImpl) scanFilterIDs(ctx context.Context, selectKw, fr
 		return nil, false, fmt.Errorf("search %s (id scan): rows: %w", tables.Main, err)
 	}
 
-	ids, hasMore := applyN1Overflow(ids, filter.Limit)
-	return ids, hasMore, nil
+	return finishWindow(ids, window)
 }
 
 func (r *issueSQLRepositoryImpl) hydrateIssues(ctx context.Context, issues []*types.Issue, tables filterTables, includeDeps bool, skipLabels bool) error {
@@ -473,11 +479,18 @@ func reassembleBySrc[T comparable](ordered []idSrcRef, issues, wisps map[string]
 	return out
 }
 
-func (p *idSrcPage) trimToLimit(limit int) bool {
-	if limit <= 0 || len(p.ordered) <= limit {
-		return false
+// finishWindow is finishWindow's shape for a merged id page: the same cap,
+// skip and trim, with the per-table id lists rebuilt once from whatever
+// survives.
+func (p *idSrcPage) finishWindow(w searchWindow) (bool, error) {
+	if err := issueops.EnforceMaxRowsCap(len(p.ordered), w.rowCap, w.capSource); err != nil {
+		return false, err
 	}
-	p.ordered = p.ordered[:limit]
+	ordered, hasMore := applyN1Overflow(dropFirst(p.ordered, w.skip), w.limit)
+	if len(ordered) == len(p.ordered) {
+		return hasMore, nil
+	}
+	p.ordered = ordered
 	p.issueIDs = p.issueIDs[:0]
 	p.wispIDs = p.wispIDs[:0]
 	for _, r := range p.ordered {
@@ -488,7 +501,7 @@ func (p *idSrcPage) trimToLimit(limit int) bool {
 			p.wispIDs = append(p.wispIDs, r.id)
 		}
 	}
-	return true
+	return hasMore, nil
 }
 
 type idSrcRef struct{ id, src string }
@@ -508,17 +521,84 @@ func orderBySQL(sortBy string, sortDesc bool, prefix string) string {
 	return sqlbuild.OrderBy(sortBy, sortDesc, prefix)
 }
 
-func limitOffsetSQL(limit, offset int) string {
-	if limit <= 0 {
-		if offset > 0 {
-			return fmt.Sprintf("LIMIT 18446744073709551615 OFFSET %d", offset)
-		}
-		return ""
+// searchWindow is the row window one search runs under: the clause the engine
+// carries, and what this package must still do to the rows that come back. It
+// is one value rather than two decisions at each call site because the halves
+// only add up when they are decided together.
+//
+// WHO CARRIES THE OFFSET is the whole of it. The engine carries it — LIMIT n
+// OFFSET k — except when there is no LIMIT to hang one on. MySQL has no OFFSET
+// without a LIMIT, and the sentinel this used to render for that shape
+// ("LIMIT 18446744073709551615 OFFSET k") makes the Dolt engine size a result
+// buffer from limit+offset and answer with a recovered "makeslice: cap out of
+// range" out of topRowsIter instead of rows. An unbounded query reads every
+// matching row anyway, so skipping here is the same answer at the same cost.
+//
+// NO CALLER COMBINES AN OFFSET WITH A CAP. The role that pages — issueops.Reader
+// — applies its offset in the shared page epilogue and hands this seam none
+// (internal/workapi.FinishPageAt says why, and the cap counting rows the query
+// MATCHED rather than rows that survived a skip is one of the two reasons). The
+// one caller that does set Offset here is the unit-of-work Querier, and a query
+// request carries no cap. RunReaderListMaxRowsIsHonored drives the cap behind an
+// offset on all three legs, so a body that started pushing the skip down would
+// be caught rather than quietly counting the wrong rows.
+type searchWindow struct {
+	// sql is the LIMIT/OFFSET clause, empty for an unbounded scan.
+	sql string
+	// skip is the offset the clause did not carry.
+	skip int
+	// limit is the page the caller receives; 0 is unlimited.
+	limit int
+	// rowCap and capSource are the defensive cap and its attribution. rowCap is
+	// SearchProbeLimit's cap, not the filter's: at limit == maxRows the probe
+	// row moves it by one.
+	rowCap    int
+	capSource string
+}
+
+func searchWindowFor(limit, offset, maxRows int, maxRowsSource string) searchWindow {
+	bound, rowCap := issueops.SearchProbeLimit(limit, maxRows)
+	w := searchWindow{limit: limit, rowCap: rowCap, capSource: maxRowsSource}
+	switch {
+	case bound <= 0:
+		w.skip = offset
+	case offset > 0:
+		w.sql = fmt.Sprintf("LIMIT %d OFFSET %d", bound, offset)
+	default:
+		w.sql = fmt.Sprintf("LIMIT %d", bound)
 	}
-	if offset > 0 {
-		return fmt.Sprintf("LIMIT %d OFFSET %d", limit+1, offset)
+	return w
+}
+
+func searchWindowForFilter(filter types.IssueFilter) searchWindow {
+	return searchWindowFor(filter.Limit, filter.Offset, filter.MaxRows, filter.MaxRowsSource)
+}
+
+func readyWindowForFilter(filter types.WorkFilter) searchWindow {
+	return searchWindowFor(filter.Limit, filter.Offset, filter.MaxRows, filter.MaxRowsSource)
+}
+
+// finishWindow is the Go half of a window: the defensive cap against what the
+// query matched, then the offset the engine could not carry, then the page trim
+// that produces the has-more verdict. The cap runs first because it counts rows
+// the query MATCHED — the same count the store-backed seam checks, which skips
+// nothing because its body does.
+func finishWindow[T any](rows []T, w searchWindow) ([]T, bool, error) {
+	if err := issueops.EnforceMaxRowsCap(len(rows), w.rowCap, w.capSource); err != nil {
+		return nil, false, err
 	}
-	return fmt.Sprintf("LIMIT %d", limit+1)
+	items, hasMore := applyN1Overflow(dropFirst(rows, w.skip), w.limit)
+	return items, hasMore, nil
+}
+
+func dropFirst[T any](rows []T, n int) []T {
+	if n <= 0 {
+		return rows
+	}
+	if n >= len(rows) {
+		return rows[:0]
+	}
+	return rows[n:]
 }
 
 func applyN1Overflow[T any](items []T, limit int) ([]T, bool) {

--- a/internal/storage/domain/db/issue_search_counts.go
+++ b/internal/storage/domain/db/issue_search_counts.go
@@ -32,7 +32,7 @@ func (r *issueSQLRepositoryImpl) searchAcrossIssuesAndWispsWithCounts(ctx contex
 		if err != nil {
 			return domain.SearchCountsPage{}, err
 		}
-		return finishSearchCountsPage(wisps, filter.Limit), nil
+		return finishSearchCountsPage(wisps, filter)
 	}
 
 	if filter.SkipWisps {
@@ -40,7 +40,7 @@ func (r *issueSQLRepositoryImpl) searchAcrossIssuesAndWispsWithCounts(ctx contex
 		if err != nil {
 			return domain.SearchCountsPage{}, err
 		}
-		return finishSearchCountsPage(out, filter.Limit), nil
+		return finishSearchCountsPage(out, filter)
 	}
 
 	empty, probeErr := r.wispsTableEmptyOrMissing(ctx)
@@ -52,7 +52,7 @@ func (r *issueSQLRepositoryImpl) searchAcrossIssuesAndWispsWithCounts(ctx contex
 		if err != nil {
 			return domain.SearchCountsPage{}, err
 		}
-		return finishSearchCountsPage(out, filter.Limit), nil
+		return finishSearchCountsPage(out, filter)
 	}
 
 	return r.searchUnionWithCounts(ctx, query, filter, wispDepsExist)
@@ -69,11 +69,11 @@ func (r *issueSQLRepositoryImpl) searchUnionWithCounts(ctx context.Context, quer
 	}
 
 	outerOrderBy := unionOrderBySQL(filter.SortBy, filter.SortDesc)
-	outerLimit := limitOffsetSQL(filter.Limit, filter.Offset)
+	window := searchWindowForFilter(filter)
 
 	//nolint:gosec // G201: subqueries built from hardcoded table names and ? placeholders.
 	unionSQL := fmt.Sprintf("SELECT id, src FROM (%s UNION ALL %s) merged %s %s",
-		iSub, wSub, outerOrderBy, outerLimit)
+		iSub, wSub, outerOrderBy, window.sql)
 
 	args := make([]any, 0, len(iArgs)+len(wArgs))
 	args = append(args, iArgs...)
@@ -87,7 +87,10 @@ func (r *issueSQLRepositoryImpl) searchUnionWithCounts(ctx context.Context, quer
 	if err != nil {
 		return domain.SearchCountsPage{}, fmt.Errorf("search union with counts: %w", err)
 	}
-	hasMore := page.trimToLimit(filter.Limit)
+	hasMore, err := page.finishWindow(window)
+	if err != nil {
+		return domain.SearchCountsPage{}, err
+	}
 
 	issuesByID, err := r.fetchCountsByIDs(ctx, page.issueIDs, issuesFilterTables, wispDepsExist, hydrationFor(filter))
 	if err != nil {
@@ -150,8 +153,7 @@ func (r *issueSQLRepositoryImpl) runFilterSearchQuery(ctx context.Context, query
 		whereSQL = "WHERE " + strings.Join(whereClauses, " AND ")
 	}
 	orderBy := orderBySQL(filter.SortBy, filter.SortDesc, "i")
-	limitSQL := limitOffsetSQL(filter.Limit, filter.Offset)
-	return r.runSearchQuery(ctx, tables, whereSQL, orderBy, limitSQL, args, includeWispReverseDeps, hydrationFor(filter))
+	return r.runSearchQuery(ctx, tables, whereSQL, orderBy, searchWindowForFilter(filter).sql, args, includeWispReverseDeps, hydrationFor(filter))
 }
 
 //nolint:gosec // G201: SQL fragments are built from hardcoded table names and parameterized filters.
@@ -214,7 +216,13 @@ func scanReadyWorkRowWithCounts(rows *sql.Rows) (*types.IssueWithCounts, error) 
 	return issueops.ScanReadyWorkRowWithCounts(rows)
 }
 
-func finishSearchCountsPage(items []*types.IssueWithCounts, limit int) domain.SearchCountsPage {
-	trimmed, hasMore := applyN1Overflow(items, limit)
-	return domain.SearchCountsPage{Items: trimmed, HasMore: hasMore}
+// finishSearchCountsPage closes the window runFilterSearchQuery opened. It
+// rebuilds it from the same filter rather than being handed it, so the two
+// halves cannot be given different numbers.
+func finishSearchCountsPage(items []*types.IssueWithCounts, filter types.IssueFilter) (domain.SearchCountsPage, error) {
+	trimmed, hasMore, err := finishWindow(items, searchWindowForFilter(filter))
+	if err != nil {
+		return domain.SearchCountsPage{}, err
+	}
+	return domain.SearchCountsPage{Items: trimmed, HasMore: hasMore}, nil
 }

--- a/internal/storage/domain/db/issue_search_window_test.go
+++ b/internal/storage/domain/db/issue_search_window_test.go
@@ -1,0 +1,139 @@
+package db
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestSearchWindowForCountsTheOffsetIntoTheCap pins the one decision
+// searchWindowFor makes that a caller cannot see any other way: WHO CARRIES THE
+// SKIP, and therefore which rows EnforceMaxRowsCap counts.
+//
+// The callers that reach this seam with both an offset and a cap consume the
+// FILTER as a value — proxied `bd list --watch`, with and without --ready, and
+// the hierarchical --parent walk — so they run no page epilogue and there is
+// nothing above them to re-decide it. issueops.Reader's own callers never get
+// here with an offset at all; they widen the filter first. That makes this
+// table the only place the watch route's window is stated, and the first row is
+// the one it exists for: an engine-side OFFSET hands EnforceMaxRowsCap the
+// survivors of the skip, which is a page for a request the paged route refuses.
+func TestSearchWindowForCountsTheOffsetIntoTheCap(t *testing.T) {
+	for _, tc := range []struct {
+		what     string
+		limit    int
+		offset   int
+		maxRows  int
+		wantSQL  string
+		wantSkip int
+		wantCap  int
+	}{
+		{
+			// The divergence this table exists for. `--limit 10 --offset 2
+			// --max-rows 3` under --watch used to render OFFSET 2, so a
+			// five-row result set delivered three survivors against a cap of
+			// three and never fired — while the paged route, which reaches this
+			// seam at limit 12, refused the identical request.
+			what:     "a cap keeps the skip here and covers it with the bound",
+			limit:    10,
+			offset:   2,
+			maxRows:  3,
+			wantSQL:  "LIMIT 4",
+			wantSkip: 2,
+			wantCap:  3,
+		},
+		{
+			// What issueops.Reader hands this seam for that same request,
+			// having already widened its filter. Same bound, same cap: the two
+			// windows are one window.
+			what:     "the paged route reaches the same window with the skip already folded in",
+			limit:    12,
+			offset:   0,
+			maxRows:  3,
+			wantSQL:  "LIMIT 4",
+			wantSkip: 0,
+			wantCap:  3,
+		},
+		{
+			// Limit+Offset == MaxRows. The probe row must not fire a cap the
+			// touched window fits inside, so the bound and the cap move
+			// together — and the bump keys off the WIDENED window, not the
+			// page, or this seam would refuse one row of offset early.
+			what:     "at Limit+Offset == MaxRows the probe row moves the cap with it",
+			limit:    2,
+			offset:   1,
+			maxRows:  3,
+			wantSQL:  "LIMIT 4",
+			wantSkip: 1,
+			wantCap:  4,
+		},
+		{
+			what:     "one more row of offset, and the same request is over the cap",
+			limit:    2,
+			offset:   2,
+			maxRows:  3,
+			wantSQL:  "LIMIT 4",
+			wantSkip: 2,
+			wantCap:  3,
+		},
+		{
+			what:     "under the cap the bound is the touched window plus the probe row",
+			limit:    1,
+			offset:   1,
+			maxRows:  3,
+			wantSQL:  "LIMIT 3",
+			wantSkip: 1,
+			wantCap:  3,
+		},
+		{
+			// An unlimited page needs no widening: it already touches every
+			// matching row, and cap+1 is what detects the overage.
+			what:     "an unlimited page behind an offset still counts the skipped rows",
+			limit:    0,
+			offset:   2,
+			maxRows:  3,
+			wantSQL:  "LIMIT 4",
+			wantSkip: 2,
+			wantCap:  3,
+		},
+		{
+			// NO CAP, so nothing counts rows and the engine does the skipping —
+			// the shape the unit-of-work Querier runs, whose request carries no
+			// cap at all.
+			what:     "without a cap the engine keeps the OFFSET",
+			limit:    2,
+			offset:   1,
+			maxRows:  0,
+			wantSQL:  "LIMIT 3 OFFSET 1",
+			wantSkip: 0,
+			wantCap:  0,
+		},
+		{
+			// No LIMIT to hang an OFFSET on. MySQL has none, and the sentinel
+			// this used to render panicked the embedded engine.
+			what:     "an unbounded scan has no clause to carry an offset",
+			limit:    0,
+			offset:   1,
+			maxRows:  0,
+			wantSQL:  "",
+			wantSkip: 1,
+			wantCap:  0,
+		},
+	} {
+		t.Run(tc.what, func(t *testing.T) {
+			w := searchWindowFor(tc.limit, tc.offset, tc.maxRows, "--max-rows")
+			where := fmt.Sprintf("Limit=%d Offset=%d MaxRows=%d", tc.limit, tc.offset, tc.maxRows)
+			if w.sql != tc.wantSQL {
+				t.Errorf("%s rendered %q, want %q", where, w.sql, tc.wantSQL)
+			}
+			if w.skip != tc.wantSkip {
+				t.Errorf("%s left skip=%d for this package, want %d", where, w.skip, tc.wantSkip)
+			}
+			if w.rowCap != tc.wantCap {
+				t.Errorf("%s enforces rowCap=%d, want %d", where, w.rowCap, tc.wantCap)
+			}
+			if w.limit != tc.limit {
+				t.Errorf("%s trims to %d, want the page the caller asked for", where, w.limit)
+			}
+		})
+	}
+}

--- a/internal/storage/domain/db/ready_work_union.go
+++ b/internal/storage/domain/db/ready_work_union.go
@@ -52,17 +52,17 @@ func (r *issueSQLRepositoryImpl) getReadyWorkIDPage(ctx context.Context, filter 
 	}
 
 	sortOrder := buildReadyWorkOrder(filter.SortPolicy)
-	// limitOffsetSQL keeps the +1 overfetch for hasMore AND honors Offset
-	// when Limit is 0 (the hand-rolled guard here used to drop the offset
-	// entirely in that case, bd-6dnrw.44 P3).
-	outerLimit := limitOffsetSQL(filter.Limit, filter.Offset)
+	// The window keeps the +1 overfetch for hasMore, honors Offset when Limit
+	// is 0 (the hand-rolled guard here used to drop the offset entirely in that
+	// case, bd-6dnrw.44 P3) and carries the defensive cap.
+	window := readyWindowForFilter(filter)
 
 	//nolint:gosec // G201: subqueries built from hardcoded fragments and ? placeholders.
 	unionSQL := fmt.Sprintf(
 		"SELECT id, src FROM (%s) merged %s %s",
 		strings.Join(subqueries, " UNION ALL "),
 		sortOrder.SQL,
-		outerLimit,
+		window.sql,
 	)
 	allArgs = append(allArgs, sortOrder.Args...)
 
@@ -74,7 +74,10 @@ func (r *issueSQLRepositoryImpl) getReadyWorkIDPage(ctx context.Context, filter 
 	if err != nil {
 		return idSrcPage{}, false, fmt.Errorf("ready work union: %w", err)
 	}
-	hasMore := page.trimToLimit(filter.Limit)
+	hasMore, err := page.finishWindow(window)
+	if err != nil {
+		return idSrcPage{}, false, err
+	}
 	return page, hasMore, nil
 }
 

--- a/internal/storage/embeddeddolt/querier_contract_test.go
+++ b/internal/storage/embeddeddolt/querier_contract_test.go
@@ -41,8 +41,8 @@ func TestQuerierContract(t *testing.T) {
 	t.Run("RefusesAMalformedRequest", func(t *testing.T) {
 		conformance.RunQuerierRefusesAMalformedRequest(t, ctx, fixture)
 	})
-	t.Run("OffsetIsHonoredOrRefused", func(t *testing.T) {
-		conformance.RunQuerierOffsetIsHonoredOrRefused(t, ctx, fixture)
+	t.Run("OffsetSkipsMatches", func(t *testing.T) {
+		conformance.RunQuerierOffsetSkipsMatches(t, ctx, fixture)
 	})
 	t.Run("EmptyMatchIsAWellFormedPage", func(t *testing.T) {
 		conformance.RunQuerierEmptyMatchIsAWellFormedPage(t, ctx, fixture)

--- a/internal/storage/embeddeddolt/reader_contract_test.go
+++ b/internal/storage/embeddeddolt/reader_contract_test.go
@@ -33,20 +33,20 @@ func TestEmbeddedReaderReadyLimitBoundary(t *testing.T) {
 	conformance.RunReaderReadyLimitBoundary(t, ctx, newEmbeddedReaderFixture(t, "rdr"))
 }
 
-func TestEmbeddedReaderOffsetIsHonoredOrRefused(t *testing.T) {
+func TestEmbeddedReaderOffsetSkipsTheRowsBeforeThePage(t *testing.T) {
 	skipUnlessEmbeddedDolt(t)
 	ctx := t.Context()
-	conformance.RunReaderOffsetIsHonoredOrRefused(t, ctx, newEmbeddedReaderFixture(t, "rdr"))
+	conformance.RunReaderOffsetSkipsTheRowsBeforeThePage(t, ctx, newEmbeddedReaderFixture(t, "rdr"))
 }
 
 // SkipCounts matters most HERE. The aggregate it drops is the reverse-blocker
 // join, whose COALESCE key the pure-Go analyzer cannot auto-index — so this is
 // the engine where the knob is worth having, and the one where an
 // implementation that quietly ignored it would be least visible.
-func TestEmbeddedReaderListMaxRowsIsHonoredOrRefused(t *testing.T) {
+func TestEmbeddedReaderListMaxRowsIsHonored(t *testing.T) {
 	skipUnlessEmbeddedDolt(t)
 	ctx := t.Context()
-	conformance.RunReaderListMaxRowsIsHonoredOrRefused(t, ctx, newEmbeddedReaderFixture(t, "rdr"))
+	conformance.RunReaderListMaxRowsIsHonored(t, ctx, newEmbeddedReaderFixture(t, "rdr"))
 }
 
 func TestEmbeddedReaderListSkipCountsDropsTheCardinalitiesAndNothingElse(t *testing.T) {

--- a/internal/storage/embeddeddolt/reader_contract_test.go
+++ b/internal/storage/embeddeddolt/reader_contract_test.go
@@ -49,6 +49,12 @@ func TestEmbeddedReaderListMaxRowsIsHonored(t *testing.T) {
 	conformance.RunReaderListMaxRowsIsHonored(t, ctx, newEmbeddedReaderFixture(t, "rdr"))
 }
 
+func TestEmbeddedReaderListMaxRowsBoundaryIsLimitPlusOffset(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	ctx := t.Context()
+	conformance.RunReaderListMaxRowsBoundaryIsLimitPlusOffset(t, ctx, newEmbeddedReaderFixture(t, "rdr"))
+}
+
 func TestEmbeddedReaderListSkipCountsDropsTheCardinalitiesAndNothingElse(t *testing.T) {
 	skipUnlessEmbeddedDolt(t)
 	ctx := t.Context()

--- a/internal/storage/issueops/search.go
+++ b/internal/storage/issueops/search.go
@@ -456,6 +456,31 @@ func EffectiveSearchLimit(limit, maxRows int) int {
 	return limit
 }
 
+// SearchProbeLimit is the row bound a search runs under when the seam detects
+// truncation with a probe row of its own, together with the cap that bound was
+// sized for. 0 means "do not emit a LIMIT clause".
+//
+// It is the composition this package's callers reach in two steps —
+// workapi.WithFetchOneExtra onto the filter, then EffectiveSearchLimit inside
+// the query builder — written once so a seam that renders its probe row INSIDE
+// the query rather than onto the filter (internal/storage/domain/db) bounds and
+// caps identically. Both implementations of issueops.Reader.List have to agree
+// about when a cap fires, and they only can if they size the same window.
+//
+// THE CAP COMES BACK BECAUSE IT MOVES. At limit == maxRows the probe row would
+// trip a cap the delivered page can never exceed, so it is bumped by one for
+// the length of that one query; see WithFetchOneExtra for the full argument.
+// A caller enforces the cap this returns, not the one it passed in.
+func SearchProbeLimit(limit, maxRows int) (bound, rowCap int) {
+	if maxRows > 0 && limit == maxRows {
+		maxRows++
+	}
+	if limit > 0 {
+		limit++
+	}
+	return EffectiveSearchLimit(limit, maxRows), maxRows
+}
+
 // EnforceMaxRowsCap returns *ErrTooManyRows when found exceeds maxRows.
 // maxRows<=0 disables the cap; the function returns nil. source is the
 // attribution string surfaced in the error message (see ErrTooManyRows).

--- a/internal/storage/uow/issue_reader.go
+++ b/internal/storage/uow/issue_reader.go
@@ -59,40 +59,27 @@ func (r *issueReader) Ready(ctx context.Context, req publicops.ReadyRequest) (pu
 		if err != nil {
 			return publicops.IssuePage{}, err
 		}
+		limit := filter.Limit
+		// Reach past the rows the epilogue skips, and take the offset off the
+		// query. This seam COULD render it, and deliberately is not asked to;
+		// see FinishPageAt.
+		filter = workapi.WithReadyRowsBeforeThePage(filter, req.Offset)
 		page, err := uw.IssueUseCase().GetReadyWorkWithCounts(ctx, filter)
 		if err != nil {
 			return publicops.IssuePage{}, err
 		}
 		// The same epilogue the sibling implementation runs, through the same
 		// function. Ready has no display order to apply and this seam reports
-		// HasMore natively, so nothing here is expected to do work — which is
-		// exactly why it must be the shared one rather than a local shortcut:
-		// the two arms of List below came apart precisely by one of them
-		// deciding its epilogue was unnecessary.
-		items, hasMore := workapi.FinishPage(page.Items, "", false, filter.Limit, page.HasMore)
+		// HasMore natively, so only the skip and the trim do any work here —
+		// which is exactly why it must be the shared one rather than a local
+		// shortcut: the two arms of List below came apart precisely by one of
+		// them deciding its epilogue was unnecessary.
+		items, hasMore := workapi.FinishPageAt(page.Items, "", false, req.Offset, limit, page.HasMore)
 		return publicops.IssuePage{Items: items, HasMore: hasMore}, nil
 	})
 }
 
-// listBackend names the backend a List refusal comes from: the provider seam
-// rather than the engine underneath it, because what cannot honor MaxRows is
-// the internal/storage/domain/db query path every provider reaches through.
-const listBackend = "uow-provider"
-
 func (r *issueReader) List(ctx context.Context, req publicops.ListRequest) (publicops.IssuePage, error) {
-	// The MIRROR IMAGE of the store body's Offset refusal, one field over. The
-	// domain/db query path reads no MaxRows, so a request carrying a cap would
-	// come back as the FULL uncapped answer with no error on it — a caller who
-	// asked for a circuit breaker getting exactly the runaway query it was
-	// guarding against. Refusing is checked before the unit of work opens: a
-	// request that cannot be answered should not cost a transaction.
-	//
-	// `bd list --max-rows --proxied-server` already refuses one layer up
-	// (cmd/bd/max_rows.go, rejectMaxRowsUnderProxiedServer); this is the same
-	// refusal for the callers that are not the CLI.
-	if req.MaxRows != 0 {
-		return publicops.IssuePage{}, &publicops.ErrUnsupported{Op: "Reader.List(MaxRows)", Backend: listBackend}
-	}
 	// A --ready listing is the ready front by another door, so it wakes
 	// expired dated defers the same way Ready does — before the read span,
 	// which never commits.
@@ -114,6 +101,13 @@ func (r *issueReader) List(ctx context.Context, req publicops.ListRequest) (publ
 		if err != nil {
 			return publicops.IssuePage{}, err
 		}
+		// Reach past the rows the epilogue skips, and take the offset off the
+		// query. The MaxRows cap rides the filter untouched from here: the
+		// domain/db query path sizes its bound and enforces the cap through the
+		// same two functions the store-backed seam uses
+		// (issueops.SearchProbeLimit, EnforceMaxRowsCap), so the same request
+		// trips the same breaker on either implementation.
+		filter = workapi.WithRowsBeforeThePage(filter, req.Offset)
 		// WHICH QUERY is the only thing --ready changes. The epilogue below is
 		// deliberately outside the branch: when it lived inside the non-ready
 		// arm only, the two arms of one contract method answered in different
@@ -136,7 +130,7 @@ func (r *issueReader) List(ctx context.Context, req publicops.ListRequest) (publ
 		// verdict rather than an over-fetched row — the one thing that differs
 		// between this implementation and its store-backed sibling, and it is
 		// an argument to the shared function rather than a second copy of it.
-		items, hasMore := workapi.FinishPage(page.Items, req.SortBy, req.Reverse, workapi.PageLimit(req), page.HasMore)
+		items, hasMore := workapi.FinishPageAt(page.Items, req.SortBy, req.Reverse, req.Offset, workapi.PageLimit(req), page.HasMore)
 		return publicops.IssuePage{Items: items, HasMore: hasMore}, nil
 	})
 }

--- a/internal/storage/uow/querier.go
+++ b/internal/storage/uow/querier.go
@@ -38,10 +38,13 @@ var _ publicops.Querier = (*querier)(nil)
 //
 // It differs from the store-backed body in exactly two places, and both are
 // this seam's capabilities rather than a second opinion about the query. It
-// renders OFFSET, so a filter-expressible query pushes the skip down; and it
-// reports HasMore natively, so the epilogue's seed is that verdict rather than
-// an over-fetched row. The plan itself is workapi.BuildQueryPlan, the same
-// function the other body calls.
+// renders OFFSET, so a filter-expressible query pushes the skip down instead of
+// reaching past it and dropping rows in Go; and it reports HasMore natively, so
+// the epilogue's seed is that verdict rather than an over-fetched row. The two
+// bodies answer the same page either way — a query request refuses an offset
+// under a display order (workapi.BuildQueryPlan), so where the skip happens is
+// the only thing the choice decides. The plan itself is workapi.BuildQueryPlan,
+// the same function the other body calls.
 func (q *querier) Query(ctx context.Context, req publicops.QueryRequest) (publicops.IssuePage, error) {
 	plan, err := workapi.BuildQueryPlan(req)
 	if err != nil {

--- a/internal/storage/uow/querier_contract_test.go
+++ b/internal/storage/uow/querier_contract_test.go
@@ -41,8 +41,8 @@ func TestQuerierContract(t *testing.T) {
 	t.Run("RefusesAMalformedRequest", func(t *testing.T) {
 		conformance.RunQuerierRefusesAMalformedRequest(t, ctx, fixture)
 	})
-	t.Run("OffsetIsHonoredOrRefused", func(t *testing.T) {
-		conformance.RunQuerierOffsetIsHonoredOrRefused(t, ctx, fixture)
+	t.Run("OffsetSkipsMatches", func(t *testing.T) {
+		conformance.RunQuerierOffsetSkipsMatches(t, ctx, fixture)
 	})
 	t.Run("EmptyMatchIsAWellFormedPage", func(t *testing.T) {
 		conformance.RunQuerierEmptyMatchIsAWellFormedPage(t, ctx, fixture)

--- a/internal/storage/uow/reader_contract_test.go
+++ b/internal/storage/uow/reader_contract_test.go
@@ -35,14 +35,15 @@ func TestReaderContract(t *testing.T) {
 	t.Run("ReadyLimitBoundary", func(t *testing.T) {
 		conformance.RunReaderReadyLimitBoundary(t, ctx, fixture)
 	})
-	t.Run("OffsetIsHonoredOrRefused", func(t *testing.T) {
-		conformance.RunReaderOffsetIsHonoredOrRefused(t, ctx, fixture)
+	t.Run("OffsetSkipsTheRowsBeforeThePage", func(t *testing.T) {
+		conformance.RunReaderOffsetSkipsTheRowsBeforeThePage(t, ctx, fixture)
 	})
-	// The REFUSING arm of MaxRows, and the mirror image of the wiring above:
-	// this body honors Offset and refuses the cap, the store-backed one honors
-	// the cap and refuses Offset. Neither answers a question it cannot answer.
-	t.Run("ListMaxRowsIsHonoredOrRefused", func(t *testing.T) {
-		conformance.RunReaderListMaxRowsIsHonoredOrRefused(t, ctx, fixture)
+	// This wiring used to be the REFUSING arm of MaxRows, and the mirror image
+	// of the Offset wiring above: this body honored Offset and refused the cap,
+	// the store-backed one did the opposite. Both fields are served on both
+	// bodies now, so both cases run the same assertion here as there.
+	t.Run("ListMaxRowsIsHonored", func(t *testing.T) {
+		conformance.RunReaderListMaxRowsIsHonored(t, ctx, fixture)
 	})
 	t.Run("ListSkipCountsDropsTheCardinalitiesAndNothingElse", func(t *testing.T) {
 		conformance.RunReaderListSkipCountsDropsTheCardinalitiesAndNothingElse(t, ctx, fixture)

--- a/internal/storage/uow/reader_contract_test.go
+++ b/internal/storage/uow/reader_contract_test.go
@@ -45,6 +45,14 @@ func TestReaderContract(t *testing.T) {
 	t.Run("ListMaxRowsIsHonored", func(t *testing.T) {
 		conformance.RunReaderListMaxRowsIsHonored(t, ctx, fixture)
 	})
+	// The same cap, driven along the OFFSET axis. This body hands its seam the
+	// widened limit and lets internal/storage/domain/db size the bound and the
+	// cap from it, where the store-backed body sizes both above the seam — two
+	// compositions of one boundary, which is exactly where they can disagree
+	// by a row.
+	t.Run("ListMaxRowsBoundaryIsLimitPlusOffset", func(t *testing.T) {
+		conformance.RunReaderListMaxRowsBoundaryIsLimitPlusOffset(t, ctx, fixture)
+	})
 	t.Run("ListSkipCountsDropsTheCardinalitiesAndNothingElse", func(t *testing.T) {
 		conformance.RunReaderListSkipCountsDropsTheCardinalitiesAndNothingElse(t, ctx, fixture)
 	})

--- a/internal/workapi/list.go
+++ b/internal/workapi/list.go
@@ -196,7 +196,13 @@ func BuildListFilter(in issueops.ListRequest, cfg ListConfig) (types.IssueFilter
 	}
 
 	filter := types.IssueFilter{
-		Limit:          SQLLimit(in),
+		Limit: SQLLimit(in),
+		// The offset is carried for the callers that consume this filter as a
+		// VALUE and run their own query — `bd list --watch` and the proxied
+		// hierarchical --parent walk — where the seam beneath them renders it.
+		// Both implementations of issueops.Reader take it back off
+		// (WithRowsBeforeThePage) and skip in the shared page epilogue instead;
+		// FinishPageAt says why the role cannot leave it here.
 		Offset:         in.Offset,
 		SortBy:         in.SortBy,
 		SortDesc:       in.Reverse,

--- a/internal/workapi/page.go
+++ b/internal/workapi/page.go
@@ -111,7 +111,36 @@ func SortIssuesWithCounts(items []*types.IssueWithCounts, sortBy string, reverse
 // surface that serializes one, and a caller must not have to tell null from
 // empty to learn that nothing matched.
 func FinishPage[T PageRow](rows []T, sortBy string, reverse bool, limit int, hasMore bool) ([]T, bool) {
+	return FinishPageAt(rows, sortBy, reverse, 0, limit, hasMore)
+}
+
+// FinishPageAt is FinishPage for a request that also carries an OFFSET: the
+// display order, the skip, the cut, and the verdict.
+//
+// THE SKIP IS THE EPILOGUE'S ON EVERY BACKEND, and not because no seam can
+// render OFFSET — one of them can. It is here for the same reason SQLLimit
+// sends `--sort id` to the database unbounded: the rows have to be skipped in
+// the ORDER THE CALLER ASKED FOR, and a sort SQL cannot express first exists
+// on the line above. A seam that skipped rows itself under that sort would
+// hand back a page cut out of the middle of storage order.
+//
+// It also decides what a MaxRows cap counts. A row skipped by the database is
+// a row the query matched, and the store-backed seam — which renders LIMIT
+// without OFFSET — has always counted it. Both implementations of
+// issueops.Reader therefore ask their seam for the rows BEFORE the page too
+// (see WithRowsBeforeThePage) and skip them here, so the same request trips
+// the same circuit breaker on either one.
+//
+// An offset past the end of the result set is an empty page, not an error: a
+// pager that walks off the end has its answer.
+func FinishPageAt[T PageRow](rows []T, sortBy string, reverse bool, offset, limit int, hasMore bool) ([]T, bool) {
 	SortRows(rows, sortBy, reverse)
+	switch {
+	case offset >= len(rows):
+		rows = rows[:0]
+	case offset > 0:
+		rows = rows[offset:]
+	}
 	if limit > 0 && len(rows) > limit {
 		rows, hasMore = rows[:limit], true
 	}

--- a/internal/workapi/ready.go
+++ b/internal/workapi/ready.go
@@ -42,9 +42,14 @@ func LimitOr(limit *int, fallback int) int {
 func BuildReadyFilter(in issueops.ReadyRequest) (types.WorkFilter, error) {
 	filter := types.WorkFilter{
 		// Open only, not in_progress - the same set `bd list --ready` shows.
-		Status:           types.StatusOpen,
-		Type:             utils.NormalizeIssueType(in.IssueType),
-		Limit:            LimitOr(in.Limit, DefaultReadyLimit),
+		Status: types.StatusOpen,
+		Type:   utils.NormalizeIssueType(in.IssueType),
+		Limit:  LimitOr(in.Limit, DefaultReadyLimit),
+		// Carried for the callers that consume this filter as a VALUE and run
+		// their own query (cmd/bd's proxied `bd ready`), where the seam beneath
+		// them renders it. Both implementations of issueops.Reader take it back
+		// off and skip in the shared page epilogue; see BuildListFilter and
+		// FinishPageAt.
 		Offset:           in.Offset,
 		Unassigned:       in.Unassigned,
 		SortPolicy:       types.SortPolicy(in.Sort),

--- a/internal/workapi/sort.go
+++ b/internal/workapi/sort.go
@@ -107,12 +107,50 @@ func ReadyFilterFromIssueFilter(filter types.IssueFilter) types.WorkFilter {
 // EffectiveSearchLimit's branch selection there is unaffected by a one-row bump
 // to Limit, and MaxRows is left untouched, so a genuine tighter-cap violation
 // still fires with the correct (unbumped) Cap value in the error message.
+// The pair of steps this performs — bump the cap in lockstep at Limit==MaxRows,
+// then bump Limit — is also written as one function for the seam that renders
+// its probe row inside the query rather than onto a filter; see
+// internal/storage/issueops.SearchProbeLimit. Change one and change the other,
+// or the two implementations of issueops.Reader.List stop agreeing about when a
+// cap fires.
 func WithFetchOneExtra(filter types.IssueFilter) types.IssueFilter {
 	if filter.Limit > 0 {
 		if filter.MaxRows > 0 && filter.Limit == filter.MaxRows {
 			filter.MaxRows++
 		}
 		filter.Limit++
+	}
+	return filter
+}
+
+// WithRowsBeforeThePage moves an OFFSET off the query and onto the epilogue: it
+// widens the filter's row bound to cover the rows the epilogue will skip, and
+// clears the Offset the builder carried so the query does not skip them too.
+// An unbounded filter needs no widening — it already carries every matching row.
+//
+// It is the filter half of FinishPageAt, and the reason both halves exist is
+// there: the skip belongs after the display order, and the rows it drops are
+// rows the MaxRows cap has to have counted. Apply it BEFORE WithFetchOneExtra,
+// which sizes the probe row against the bound this leaves.
+//
+// The builders still write Offset onto the filter, for the callers that consume
+// it as a VALUE and run their own query — `bd list --watch`, the proxied
+// hierarchical --parent walk, proxied `bd ready` — where the seam renders it and
+// there is no shared epilogue to move it to.
+func WithRowsBeforeThePage(filter types.IssueFilter, offset int) types.IssueFilter {
+	filter.Offset = 0
+	if offset > 0 && filter.Limit > 0 {
+		filter.Limit += offset
+	}
+	return filter
+}
+
+// WithReadyRowsBeforeThePage is WithRowsBeforeThePage for the ready-work filter,
+// which is a different type carrying the same two fields.
+func WithReadyRowsBeforeThePage(filter types.WorkFilter, offset int) types.WorkFilter {
+	filter.Offset = 0
+	if offset > 0 && filter.Limit > 0 {
+		filter.Limit += offset
 	}
 	return filter
 }

--- a/internal/workapi/sort.go
+++ b/internal/workapi/sort.go
@@ -135,8 +135,11 @@ func WithFetchOneExtra(filter types.IssueFilter) types.IssueFilter {
 //
 // The builders still write Offset onto the filter, for the callers that consume
 // it as a VALUE and run their own query — `bd list --watch`, the proxied
-// hierarchical --parent walk, proxied `bd ready` — where the seam renders it and
-// there is no shared epilogue to move it to.
+// hierarchical --parent walk, proxied `bd ready` — where there is no shared
+// epilogue to move it to. Those callers get the same cap boundary anyway: the
+// seam beneath them widens its own bound by the offset and keeps the skip
+// whenever a cap is set, for the reason stated above (internal/storage/domain/db,
+// searchWindow).
 func WithRowsBeforeThePage(filter types.IssueFilter, offset int) types.IssueFilter {
 	filter.Offset = 0
 	if offset > 0 && filter.Limit > 0 {

--- a/internal/workapi/storequerier/querier.go
+++ b/internal/workapi/storequerier/querier.go
@@ -30,30 +30,27 @@ type storeQuerier struct{ store storage.DoltStorage }
 
 var _ issueops.Querier = (*storeQuerier)(nil)
 
-// offsetBackend names the backend an Offset refusal comes from: one name for
-// both engines, because it is the BODY — not the engine underneath it — that
-// cannot page by offset.
-const offsetBackend = "dolt-store"
-
+// THE OFFSET IS UNIFORM, not per-expression. This seam renders LIMIT without
+// OFFSET, so the skip happens in Go — but it happens for BOTH shapes of query
+// and it always skips MATCHES, never candidates. Which shape an expression
+// takes is the evaluator's decision, so an Offset that behaved differently for
+// `type=bug OR type=task` than for `type=bug` would be unpredictable from the
+// outside (issueops/querier.go:70-86). A filter-expressible query reaches past
+// the skipped rows in SQL; a predicate query already reads every candidate row,
+// so its skip costs nothing.
 func (q *storeQuerier) Query(ctx context.Context, req issueops.QueryRequest) (issueops.IssuePage, error) {
 	plan, err := workapi.BuildQueryPlan(req)
 	if err != nil {
 		return issueops.IssuePage{}, err
 	}
-	// UNIFORM, not per-expression. This body could skip rows for a predicate
-	// query, but which shape an expression takes is the evaluator's decision,
-	// so an Offset that worked for one expression and refused another would be
-	// unpredictable from the outside (issueops/querier.go:70-86).
-	if plan.Offset != 0 {
-		return issueops.IssuePage{}, &issueops.ErrUnsupported{Op: "Querier.Query(Offset)", Backend: offsetBackend}
-	}
 
 	filter := plan.Filter
 	if !plan.RequiresPredicate() {
 		// The store seam has no HasMore of its own, so ask for one row past the
-		// page and let its presence be the answer. A predicate query carries no
-		// row limit to extend: its verdict comes from the count of MATCHES.
-		filter = workapi.WithFetchOneExtra(filter)
+		// page — and past the rows the offset skips — and let its presence be
+		// the answer. A predicate query carries no row limit to extend: its
+		// verdict comes from the count of MATCHES.
+		filter = workapi.WithFetchOneExtra(workapi.WithRowsBeforeThePage(filter, plan.Offset))
 	}
 
 	rows, err := q.store.SearchIssuesWithCounts(ctx, "", filter)
@@ -62,9 +59,11 @@ func (q *storeQuerier) Query(ctx context.Context, req issueops.QueryRequest) (is
 	}
 	rows = workapi.ApplyQueryPredicate(rows, plan.Predicate)
 
-	// The shared epilogue: the sort, the cut and the verdict written out
-	// longhand is how two routes of one command came to disagree about
-	// `--sort id --limit 5`.
-	items, hasMore := workapi.FinishPage(rows, plan.SortBy, plan.Reverse, plan.Limit, false)
+	// The shared epilogue: the sort, the skip, the cut and the verdict written
+	// out longhand is how two routes of one command came to disagree about
+	// `--sort id --limit 5`. A query request refuses an Offset under a display
+	// order (workapi.BuildQueryPlan), so the sort below is always a no-op when
+	// the skip is not — which is why the two can share one function here.
+	items, hasMore := workapi.FinishPageAt(rows, plan.SortBy, plan.Reverse, plan.Offset, plan.Limit, false)
 	return issueops.IssuePage{Items: items, HasMore: hasMore}, nil
 }

--- a/internal/workapi/storereader/reader.go
+++ b/internal/workapi/storereader/reader.go
@@ -53,37 +53,27 @@ type storeReader struct{ store storage.DoltStorage }
 
 var _ issueops.Reader = (*storeReader)(nil)
 
-// offsetBackend names the backend an Offset refusal comes from. One name for
-// both engines on purpose: the server-backed and embedded stores hand back
-// THIS body, and it is the body — not the engine underneath it — that cannot
-// page by offset.
-const offsetBackend = "dolt-store"
-
-// refuseOffset is the shared refusal. The store seam renders LIMIT without
-// OFFSET (internal/storage/issueops/ready_work.go, search_counts.go), so a
-// request carrying one used to come back as the unpaged first page with no
-// error on it — a caller paging with Offset saw the same rows forever. The
-// field is not dead: `bd ready/list/query --offset` are real flags, and their
-// direct routes already reject a non-zero offset before reaching any of this
-// (cmd/bd/ready.go, list.go, query.go). This is the same refusal one layer
-// down, for the callers that are not the CLI.
-func refuseOffset(op string) error {
-	return &issueops.ErrUnsupported{Op: op, Backend: offsetBackend}
-}
+// OFFSET IS PAGED HERE, NOT IN THE QUERY. The store seam renders LIMIT without
+// OFFSET (internal/storage/issueops/ready_work.go, search_counts.go), so this
+// body reaches past the skipped rows and drops them after the display order —
+// workapi.WithRowsBeforeThePage onto the filter, workapi.FinishPageAt at the
+// end. Its unit-of-work sibling does exactly the same thing, and FinishPageAt
+// says why it does it there too rather than pushing a skip its seam could
+// render: the rows have to be dropped in the caller's order, and a MaxRows cap
+// has to count them.
 
 func (r *storeReader) Ready(ctx context.Context, req issueops.ReadyRequest) (issueops.IssuePage, error) {
-	if req.Offset != 0 {
-		return issueops.IssuePage{}, refuseOffset("Reader.Ready(Offset)")
-	}
 	filter, err := workapi.BuildReadyFilter(req)
 	if err != nil {
 		return issueops.IssuePage{}, err
 	}
 	limit := filter.Limit
-	if limit > 0 {
-		// The store seam has no HasMore of its own, so ask for one row past
-		// the page and let its presence be the answer.
-		filter.Limit = limit + 1
+	filter = workapi.WithReadyRowsBeforeThePage(filter, req.Offset)
+	if filter.Limit > 0 {
+		// The store seam has no HasMore of its own, so ask for one row past the
+		// page — which the line above has already widened to cover the rows the
+		// epilogue skips — and let the extra row's presence be the answer.
+		filter.Limit++
 	}
 	items, err := r.store.GetReadyWorkWithCounts(ctx, filter)
 	if err != nil {
@@ -91,25 +81,23 @@ func (r *storeReader) Ready(ctx context.Context, req issueops.ReadyRequest) (iss
 	}
 	// Ready has no display order to apply — the ordering is the sort POLICY
 	// the query ran under — so the epilogue's sort is a no-op here and only
-	// its trim and its verdict do any work. It is still the shared one: a
-	// second trim written out longhand is how the two arms of List came apart.
-	items, hasMore := workapi.FinishPage(items, "", false, limit, false)
+	// its skip, its trim and its verdict do any work. It is still the shared
+	// one: a second trim written out longhand is how the two arms of List came
+	// apart.
+	items, hasMore := workapi.FinishPageAt(items, "", false, req.Offset, limit, false)
 	return issueops.IssuePage{Items: items, HasMore: hasMore}, nil
 }
 
 // List answers one issue listing.
 //
-// The two knobs this body and its unit-of-work sibling answer differently sit
-// side by side here and point opposite ways. Offset is refused below because
-// this seam renders LIMIT without OFFSET. MaxRows is HONORED, and nothing
-// below mentions it: the cap rides on the filter the shared builder produces,
-// and the search path enforces it after the scan (internal/storage/issueops,
-// EnforceMaxRowsCap), so the answer is *ErrTooManyRows instead of a page. The
-// sibling refuses it, for the reason stated there.
+// The two knobs this body and its unit-of-work sibling once answered opposite
+// ways are both honored here now, and neither is honored by anything written
+// below. MaxRows rides on the filter the shared builder produces and the search
+// path enforces it after the scan (internal/storage/issueops,
+// EnforceMaxRowsCap), so the answer is *ErrTooManyRows instead of a page.
+// Offset rides on the two workapi calls this method already made for the
+// has-more probe row — one widens the bound, the other cuts the page.
 func (r *storeReader) List(ctx context.Context, req issueops.ListRequest) (issueops.IssuePage, error) {
-	if req.Offset != 0 {
-		return issueops.IssuePage{}, refuseOffset("Reader.List(Offset)")
-	}
 	cfg, err := workapi.LoadStoreListConfig(ctx, r.store)
 	if err != nil {
 		return issueops.IssuePage{}, err
@@ -118,24 +106,27 @@ func (r *storeReader) List(ctx context.Context, req issueops.ListRequest) (issue
 	if err != nil {
 		return issueops.IssuePage{}, err
 	}
+	// Reach past the rows the epilogue skips before the probe row is sized, so
+	// the cap the seam enforces counts every row the query matched.
+	filter = workapi.WithFetchOneExtra(workapi.WithRowsBeforeThePage(filter, req.Offset))
 
 	var items []*types.IssueWithCounts
 	if req.ReadyFlag {
-		items, err = r.store.GetReadyWorkWithCounts(ctx, workapi.ReadyFilterFromIssueFilter(workapi.WithFetchOneExtra(filter)))
+		items, err = r.store.GetReadyWorkWithCounts(ctx, workapi.ReadyFilterFromIssueFilter(filter))
 	} else {
-		items, err = r.store.SearchIssuesWithCounts(ctx, "", workapi.WithFetchOneExtra(filter))
+		items, err = r.store.SearchIssuesWithCounts(ctx, "", filter)
 	}
 	if err != nil {
 		return issueops.IssuePage{}, err
 	}
 
-	// The sort, the trim and the HasMore verdict are workapi.FinishPage's, not
-	// this implementation's: `bd list` on both its routes and the uow-backed
-	// sibling of this method call the same function, so the only thing left
-	// that can differ between a CLI listing and an HTTP one is presentation.
-	// This seam reports no HasMore of its own, so the over-fetched row above
-	// is what speaks.
-	items, hasMore := workapi.FinishPage(items, req.SortBy, req.Reverse, workapi.PageLimit(req), false)
+	// The sort, the skip, the trim and the HasMore verdict are
+	// workapi.FinishPageAt's, not this implementation's: `bd list` on both its
+	// routes and the uow-backed sibling of this method call the same function,
+	// so the only thing left that can differ between a CLI listing and an HTTP
+	// one is presentation. This seam reports no HasMore of its own, so the
+	// over-fetched row above is what speaks.
+	items, hasMore := workapi.FinishPageAt(items, req.SortBy, req.Reverse, req.Offset, workapi.PageLimit(req), false)
 	return issueops.IssuePage{Items: items, HasMore: hasMore}, nil
 }
 

--- a/internal/workapi/storereader/reader_test.go
+++ b/internal/workapi/storereader/reader_test.go
@@ -195,61 +195,89 @@ func TestStoreReaderListOverFetchesForAPushdownSort(t *testing.T) {
 	}
 }
 
-// TestStoreReaderRefusesANonZeroOffset is the store-backed half of the offset
-// split the role now promises (issueops/reader.go, ReadyRequest.Offset and
-// ListRequest.Offset). This body renders LIMIT without OFFSET, so an offset it
-// accepted would come back as the unpaged first page — which is what it used to
-// do, silently. The refusal names the operation AND the backend, because that
-// pair is all a caller holding only issueops.Reader gets to work with.
+// TestStoreReaderReachesPastTheOffset pins the mechanism this body pages with,
+// which the page alone cannot show. The seam renders LIMIT without OFFSET, so
+// the reader has to ask for the skipped rows TOO — limit + offset + the probe
+// row — and drop them itself. A body that skipped without widening would hand
+// back a short page and call it complete.
 //
-// The store must not be queried at all: a refusal that had already asked the
-// database for the wrong page would be a wasted round trip on the way to the
-// same error.
-func TestStoreReaderRefusesANonZeroOffset(t *testing.T) {
+// The filter's own Offset must come back to ZERO. The builders write the
+// request's offset onto it for the callers that consume the filter and run
+// their own query, so a body that widened the bound and left the offset on
+// would skip the same rows twice the day this seam learns to render OFFSET.
+func TestStoreReaderReachesPastTheOffset(t *testing.T) {
+	limit := 2
 	for _, tc := range []struct {
-		name   string
-		wantOp string
-		call   func(issueops.Reader) (issueops.IssuePage, error)
+		name        string
+		run         func(issueops.Reader) (issueops.IssuePage, error)
+		queryWindow func(*fakeReaderStore) (int, int)
 	}{
-		{"Ready", "Reader.Ready(Offset)", func(rd issueops.Reader) (issueops.IssuePage, error) {
-			return rd.Ready(context.Background(), issueops.ReadyRequest{Sort: "priority", Offset: 1})
-		}},
-		{"List", "Reader.List(Offset)", func(rd issueops.Reader) (issueops.IssuePage, error) {
-			return rd.List(context.Background(), issueops.ListRequest{SortBy: "created", Offset: 1})
-		}},
+		{"Ready", func(rd issueops.Reader) (issueops.IssuePage, error) {
+			return rd.Ready(context.Background(), issueops.ReadyRequest{Sort: "priority", Limit: &limit, Offset: 1})
+		}, func(s *fakeReaderStore) (int, int) { return s.readyFilters[0].Limit, s.readyFilters[0].Offset }},
+		{"List", func(rd issueops.Reader) (issueops.IssuePage, error) {
+			return rd.List(context.Background(), issueops.ListRequest{SortBy: "created", Limit: &limit, Offset: 1})
+		}, func(s *fakeReaderStore) (int, int) { return s.searchFilters[0].Limit, s.searchFilters[0].Offset }},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			rd, store := storeReaderFor(t, readerFixture(3))
-			page, err := tc.call(rd)
-			var unsupported *storage.ErrUnsupported
-			if !errors.As(err, &unsupported) {
-				t.Fatalf("%s with Offset 1 = (%v, %v), want *storage.ErrUnsupported", tc.name, ids(page), err)
+			rd, store := storeReaderFor(t, readerFixture(5))
+			page, err := tc.run(rd)
+			if err != nil {
+				t.Fatalf("%s at Offset 1: %v", tc.name, err)
 			}
-			if unsupported.Op != tc.wantOp || unsupported.Backend != offsetBackend {
-				t.Errorf("refusal = Op %q Backend %q, want %q and %q",
-					unsupported.Op, unsupported.Backend, tc.wantOp, offsetBackend)
+			gotLimit, gotOffset := tc.queryWindow(store)
+			if want := limit + 1 + 1; gotLimit != want {
+				t.Errorf("query ran with Limit %d, want %d — the page, the row it skips, and the probe row", gotLimit, want)
 			}
-			if queries := len(store.readyFilters) + len(store.searchFilters); queries != 0 {
-				t.Errorf("the refused request still ran %d queries", queries)
+			if gotOffset != 0 {
+				t.Errorf("query ran with Offset %d, want 0: the epilogue does the skipping", gotOffset)
+			}
+			if got := ids(page); !slices.Equal(got, []string{"bd-2", "bd-3"}) {
+				t.Errorf("page = %v, want the two rows after the first", got)
+			}
+			if !page.HasMore {
+				t.Error("HasMore = false with five rows, an offset of one and a limit of two")
 			}
 		})
 	}
 }
 
-// TestStoreReaderServesOffsetZero: zero is the absence of a page request, not a
-// request for page zero, so the refusal above must not catch the default. Every
-// other test in this file would fail if it did, but none of them says why.
-func TestStoreReaderServesOffsetZero(t *testing.T) {
-	rd, store := storeReaderFor(t, readerFixture(2))
+// TestStoreReaderOffsetPastTheEndIsAnEmptyPage: a pager that walks off the end
+// gets an answer, not an error, and not the last page over again.
+func TestStoreReaderOffsetPastTheEndIsAnEmptyPage(t *testing.T) {
+	rd, _ := storeReaderFor(t, readerFixture(2))
 
-	if _, err := rd.Ready(context.Background(), issueops.ReadyRequest{Sort: "priority", Offset: 0}); err != nil {
+	page, err := rd.List(context.Background(), issueops.ListRequest{SortBy: "created", Offset: 5})
+	if err != nil {
+		t.Fatalf("List at Offset 5 over two rows: %v", err)
+	}
+	if len(page.Items) != 0 || page.Items == nil || page.HasMore {
+		t.Errorf("page = %v (nil=%v) has_more = %v, want an empty non-nil page and no more",
+			ids(page), page.Items == nil, page.HasMore)
+	}
+}
+
+// TestStoreReaderServesOffsetZero: zero is the absence of a page request, so it
+// must not widen the query the way a real offset does. Every other test in this
+// file would fail if it did, but none of them says why.
+func TestStoreReaderServesOffsetZero(t *testing.T) {
+	limit := 2
+	rd, store := storeReaderFor(t, readerFixture(4))
+
+	if _, err := rd.Ready(context.Background(), issueops.ReadyRequest{Sort: "priority", Limit: &limit, Offset: 0}); err != nil {
 		t.Fatalf("Ready at Offset 0: %v", err)
 	}
-	if _, err := rd.List(context.Background(), issueops.ListRequest{SortBy: "created", Offset: 0}); err != nil {
+	if _, err := rd.List(context.Background(), issueops.ListRequest{SortBy: "created", Limit: &limit, Offset: 0}); err != nil {
 		t.Fatalf("List at Offset 0: %v", err)
 	}
 	if len(store.readyFilters) != 1 || len(store.searchFilters) != 1 {
 		t.Errorf("ran %d ready and %d search queries, want one each", len(store.readyFilters), len(store.searchFilters))
+	}
+	if got := store.readyFilters[0].Limit; got != limit+1 {
+		t.Errorf("Ready at Offset 0 ran with Limit %d, want %d — the probe row and nothing else", got, limit+1)
+	}
+	if got := store.searchFilters[0].Limit; got != limit+1 {
+		t.Errorf("List at Offset 0 ran with Limit %d, want %d — the probe row and nothing else", got, limit+1)
 	}
 }
 

--- a/issueops/querier.go
+++ b/issueops/querier.go
@@ -62,22 +62,21 @@ type QueryRequest struct {
 	// than a caller can check for.
 	Limit *int
 
-	// Offset skips the first N MATCHING rows. It is honored by the
-	// unit-of-work implementation and REFUSED by the store-backed one with a
-	// typed *ErrUnsupported naming the operation and the backend, exactly as
-	// ListRequest.Offset is; what neither does is silently return an unpaged
-	// answer. A negative Offset is ErrValidation everywhere.
+	// Offset skips the first N MATCHING rows, on EVERY implementation and for
+	// EVERY shape of expression, exactly as ListRequest.Offset does. A
+	// negative Offset is ErrValidation everywhere.
 	//
-	// THE STORE-BACKED REFUSAL IS UNIFORM, not per-expression, and that is a
-	// decision rather than an oversight. That body could in principle skip
-	// rows for a PREDICATE query, where the skipping happens in Go and no SQL
-	// OFFSET is involved — but which shape an expression takes is decided by
-	// the evaluator, not by the caller, so an Offset that worked for
-	// `type=bug OR type=task` and refused `type=bug` would be a refusal a
-	// caller could not predict. One answer per backend is the weaker promise
-	// and the checkable one.
+	// IT IS UNIFORM, not per-expression, and that is a decision rather than an
+	// accident of the seams. One body renders SQL OFFSET for a
+	// filter-expressible query and the other reaches past the skipped rows and
+	// drops them in Go; both skip in Go for a predicate query, which is
+	// unbounded and has nothing to push down. Which shape an expression takes
+	// is decided by the evaluator, not by the caller, so an Offset that
+	// behaved differently for `type=bug OR type=task` than for `type=bug`
+	// would be unpredictable from the outside. One answer everywhere is the
+	// only checkable promise.
 	//
-	// IT SKIPS MATCHES, wherever it is honored — never candidate rows. A skip
+	// IT SKIPS MATCHES — never candidate rows. A skip
 	// applied before the predicate would discard rows the predicate would have
 	// rejected anyway and hand back a short page, which is the failure that
 	// made `bd query --offset` refuse OR queries outright.
@@ -142,9 +141,8 @@ type Querier interface {
 	//
 	// Querying is a READ. Nothing here records a history entry, fires a
 	// completion hook or changes a row, and a refusal changes nothing either.
-	// Deterministic request-validation failures match ErrValidation, an
-	// Offset a backend cannot serve is *ErrUnsupported, and result values are
-	// unspecified when error is non-nil. Implementations never mutate
-	// caller-owned request values.
+	// Deterministic request-validation failures match ErrValidation, and
+	// result values are unspecified when error is non-nil. Implementations
+	// never mutate caller-owned request values.
 	Query(ctx context.Context, req QueryRequest) (IssuePage, error)
 }

--- a/issueops/reader.go
+++ b/issueops/reader.go
@@ -302,13 +302,15 @@ type ListRequest struct {
 	// this leaf does not import it, and no answer depends on that.
 	//
 	// EVERY IMPLEMENTATION HONORS IT, and they agree on when it fires: when
-	// the query matched more rows than the cap allows AND the page the caller
-	// asked for could have exceeded it. A cap looser than Limit never fires,
-	// because a page of Limit rows can never break it — the two seams size
-	// that window through one function
-	// (internal/storage/issueops.SearchProbeLimit) so they cannot disagree
-	// about the boundary. A row skipped by Offset still counts: it is a row
-	// the query matched.
+	// the query matched more rows than the cap allows AND the window the
+	// request asked the query to TOUCH could have exceeded it. THAT WINDOW IS
+	// Limit+Offset, NOT Limit. A row Offset skips is a row the query matched,
+	// so an offset walks a caller toward the breaker and never past it: a cap
+	// of Limit+Offset or looser never fires, because a query bounded to that
+	// many rows cannot break it, and one more row of offset is what flips the
+	// same request to a refusal. The two seams size that window through one
+	// function (internal/storage/issueops.SearchProbeLimit) so they cannot
+	// disagree about the boundary.
 	//
 	// Unlike SkipCounts and SkipLabels it IS carried onto the ReadyFlag arm.
 	MaxRows int

--- a/issueops/reader.go
+++ b/issueops/reader.go
@@ -87,12 +87,19 @@ type ReadyRequest struct {
 	// stay distinguishable, which is what lets one constant serve both
 	// surfaces.
 	Limit *int
-	// Offset skips the first N matching rows. It is honored by the
-	// unit-of-work implementation, which renders OFFSET; the store-backed one
-	// cannot, and REFUSES a non-zero Offset with a typed *ErrUnsupported
-	// naming the operation and the backend. What it never does is silently
-	// return an unpaged answer, so a caller that sets it either gets the page
-	// it asked for or an error it can classify with errors.As.
+	// Offset skips the first N matching rows, on EVERY implementation. The
+	// page a caller receives is the rows at positions [Offset, Offset+Limit)
+	// of the answer the same request returns unpaged, in the same order.
+	//
+	// WHERE the skip happens is not a backend's choice either. One seam
+	// renders OFFSET and one renders LIMIT without it, so both bodies reach
+	// past the skipped rows and drop them in the shared page epilogue
+	// (internal/workapi.FinishPageAt) — which is also the only sequence that
+	// is right for a sort SQL cannot express, since that order first exists
+	// after the fetch.
+	//
+	// An Offset past the end of the result set is an empty page and a nil
+	// error, not a failure: a pager that walks off the end has its answer.
 	//
 	// A ready request carries no keyset position, so there is no portable way
 	// to page ready work. A caller that must page across backends pages a
@@ -266,12 +273,10 @@ type ListRequest struct {
 	// is derived from it inside the implementation, together with the
 	// over-fetch that detects truncation.
 	Limit *int
-	// Offset skips the first N matching rows. It is honored by the
-	// unit-of-work implementation, which renders OFFSET; the store-backed one
-	// cannot, and REFUSES a non-zero Offset with a typed *ErrUnsupported
-	// naming the operation and the backend. What it never does is silently
-	// return an unpaged answer, so a caller that sets it either gets the page
-	// it asked for or an error it can classify with errors.As.
+	// Offset skips the first N matching rows, on EVERY implementation, and the
+	// page is the rows at positions [Offset, Offset+Limit) of the answer the
+	// same request returns unpaged. See ReadyRequest.Offset for where the skip
+	// is applied and why that is not a backend's choice either.
 	//
 	// THE PORTABLE WAY TO PAGE IS THE KEYSET POSITION below,
 	// AfterCreatedAt/AfterID: every implementation honors it, and it does not
@@ -296,16 +301,14 @@ type ListRequest struct {
 	// caller can tell the cap firing from any other failure with errors.As;
 	// this leaf does not import it, and no answer depends on that.
 	//
-	// It is HONORED by the store-backed implementation and REFUSED by the
-	// unit-of-work one, with a typed *ErrUnsupported naming the operation and
-	// the backend. That is the exact INVERSE of Offset above, and for the same
-	// kind of reason: the unit-of-work query path threads no cap, so a body
-	// that accepted the field would answer an uncapped query to a caller who
-	// asked for a circuit breaker. What no implementation does is silently
-	// ignore it, so a caller either gets the cap it asked for or an error it
-	// can classify with errors.As. `bd list --max-rows --proxied-server`
-	// already refuses one layer up, in the CLI; this is the same refusal for
-	// the callers that are not the CLI.
+	// EVERY IMPLEMENTATION HONORS IT, and they agree on when it fires: when
+	// the query matched more rows than the cap allows AND the page the caller
+	// asked for could have exceeded it. A cap looser than Limit never fires,
+	// because a page of Limit rows can never break it — the two seams size
+	// that window through one function
+	// (internal/storage/issueops.SearchProbeLimit) so they cannot disagree
+	// about the boundary. A row skipped by Offset still counts: it is a row
+	// the query matched.
 	//
 	// Unlike SkipCounts and SkipLabels it IS carried onto the ReadyFlag arm.
 	MaxRows int

--- a/issueops/treewalker.go
+++ b/issueops/treewalker.go
@@ -130,9 +130,10 @@ type WalkTreeRequest struct {
 	// `bd dep tree`'s own --help has always said, and stating it here keeps the
 	// promise honest rather than implied.
 	//
-	// UNLIKE ListRequest.MaxRows, EVERY IMPLEMENTATION HONORS IT. The cap lives
-	// in the one shared walk body all three backends run, so there is no
-	// unit-of-work arm that has to refuse the field with ErrUnsupported.
+	// EVERY IMPLEMENTATION HONORS IT, as ListRequest.MaxRows is honored
+	// everywhere too — here because the cap lives in the one shared walk body
+	// all three backends run, rather than in two query paths that have to size
+	// the same window.
 	MaxRows int
 	// MaxRowsSource attributes the cap to whatever knob set it — "--max-rows",
 	// "BEADS_MAX_ROWS", or empty for a library caller — and that attribution is


### PR DESCRIPTION
`Offset` and `MaxRows` were mirror-image splits: the unit-of-work seam honored `Offset` and refused `MaxRows`; the two store legs did the opposite. Three contract cases absorbed that with an "either HONORED or REFUSED with a typed `*ErrUnsupported`" disjunction.

**A contract that asserts a capability is either honored or refused is not pinning semantics — it is ratifying a split.** All three are gone, along with `assertReaderUnsupported`.

Converging *upward* (both legs honor both) rather than uow-matches-server is the owner's one ratified exception here, because the server refusing `MaxRows` was a capability gap rather than a semantics choice.

## Before and after

| | Offset before | MaxRows before | after |
| --- | --- | --- | --- |
| `storereader` (dolt + embedded) | refused, typed `*ErrUnsupported` | honored | **both honored** |
| `storequerier` (dolt + embedded) | refused | n/a | **honored**, both expression shapes |
| `uow` reader | honored (SQL `OFFSET`) | refused | **both honored** |
| `uow` querier | honored (SQL `OFFSET`) | n/a | unchanged; the panic under it is gone |

`Offset` now runs in the **shared page epilogue** on every leg rather than in whichever seam could render it. Two reasons, both load-bearing: the skip must happen in the caller's display order (`--sort id` is not SQL-expressible, which is why `SQLLimit` already sends it unbounded — the uow push-down got that case wrong), and a row the database skips is a row the query matched, so a SQL `OFFSET` lets an offset talk a caller out of the `MaxRows` breaker.

## The panic, fixed at the root

`domain/db/limitOffsetSQL` rendered `LIMIT 18446744073709551615 OFFSET k` for an unbounded query (MySQL has no OFFSET without a LIMIT). Dolt sizes a buffer from limit+offset and returns a recovered `makeslice: cap out of range` instead of rows.

The contract case had been shaped around it — every request carried a bounded limit, with a comment calling it "a storage-seam bug that predates this role". It now drives the unbounded shape, because the bug is gone: a `searchWindow` value decides the SQL clause and the Go-side residue together, and with no LIMIT to hang an OFFSET on the skip happens in Go, which costs nothing since an unbounded query reads every matching row anyway.

## A seventh cannot-fail test, caught mid-slice

`searchWindowFor` had a second Go-skip branch "under a defensive cap" that was **unreachable**, and it absorbed the exact regression the new MaxRows-behind-offset arm exists to catch — the mutation came back `INCONCLUSIVE`. Removed; the arm is now uniquely falsified.

## A regression the goldens did not catch

Taking `Offset` off the builders broke proxied `bd ready`, `bd list --watch` and the proxied `--parent` walk, which consume the filter as a value and have no page epilogue. Caught by two `TestProxiedServerReady` cases. The builders keep writing it and `WithRowsBeforeThePage` clears it, so the move is one call rather than a reach-in.

## Verification

Twelve mutations, each attributed to the body it broke and re-run at final HEAD: `storereader` skip → dolt+emb RED; `uow/issue_reader` skip → uow RED with dolt green; the same two on the **Ready arm only**; `storequerier` skip → dolt+emb RED; `uow/querier` push-down → uow RED; `workapi.SkipRows` → uow predicate arm RED; the unbounded-skip panic fix → uow RED; caps on both seams → their own legs RED; and `uow` pushing offset down → the MaxRows-behind-offset arm RED while the plain Offset case stays green.

`go build ./...`, `go vet`, `golangci-lint run` clean. Reader and querier contracts green on all three legs; full `TestConformance` green on both stores; `TestProxiedServerList/Ready/Query` green.

## Left alone, deliberately

`bd list/ready/query --offset` still refuses on the direct CLI route. It is stale for the page path now, but `--watch` and `--parent --pretty` consume the filter as a value, so lifting it is a CLI-surface decision rather than this slice's. `--max-rows` was in scope and is retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
