### PR TITLE
fix(validation): canonicalize actor/assignee separators before comparing (ga-wzl83)

### DIFF
--- a/internal/validation/issue.go
+++ b/internal/validation/issue.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -70,14 +71,65 @@ func NotPinned(force bool) IssueValidator {
 	}
 }
 
+// canonicalActor normalizes an identity string so two spellings of the same
+// Gas Town identity compare equal. The same identity arrives at bd in more
+// than one spelling depending on which layer produced the string it was
+// handed: a dotted alias like "gastown.mayor" gets its dot replaced wherever
+// a dot is unsafe for that context — "__" in a session name, "_" in a Dolt
+// table/database name, "-" elsewhere — and bd only ever sees the resulting
+// string, never the substitution itself (ga-wzl83). None of ".", "_", "-"
+// carries meaning in an identity string: each is always a positional
+// separator between a rig and a role/agent name, never part of either name.
+// Collapsing any run of them to one canonical separator lets two spellings
+// of the same identity compare equal without weakening comparisons between
+// genuinely different identities, whose non-separator characters still
+// differ (e.g. "gastown.mayor" vs "gastown.dog-3" stay distinct).
+//
+// Empty stays empty: an actual absence of an actor must never canonicalize
+// to the same value as a non-empty one, or AssigneeMatches would start
+// accepting an empty actor against an assigned issue.
+func canonicalActor(s string) string {
+	if s == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	inSeparator := false
+	for _, r := range s {
+		switch r {
+		case '.', '_', '-':
+			if !inSeparator {
+				b.WriteByte('_')
+				inSeparator = true
+			}
+		default:
+			b.WriteRune(r)
+			inSeparator = false
+		}
+	}
+	return b.String()
+}
+
+// actorMatches reports whether actor has the same authority as assignee:
+// either they're byte-identical, or they canonicalize to the same identity
+// (see canonicalActor). The byte-identical check is not redundant — it is
+// what keeps two DIFFERENT identities that happen to canonicalize the same
+// way from ever being needed for this to matter in practice, and it avoids
+// paying canonicalization on the overwhelmingly common exact-match path.
+func actorMatches(assignee, actor string) bool {
+	return assignee == actor || canonicalActor(assignee) == canonicalActor(actor)
+}
+
 // AssigneeMatches validates that the actor has authority to close the issue.
 // Authority means the issue is unassigned or the actor matches the current
 // assignee. Returns an error on mismatch unless force is true.
 //
-// Authority is identity-by-string: actor is compared verbatim to assignee, so
-// two principals sharing one actor name both pass. bd has no identity layer,
-// so this matches the existing semantics of the actor field — the guard
-// removes silent cross-actor closes without adding new identity guarantees.
+// Authority is identity-by-string: actor is compared to assignee under
+// canonicalActor, so two principals sharing one canonical actor name both
+// pass — including the same principal spelled two different ways by two
+// different layers of Gas Town (ga-wzl83). bd has no identity layer, so this
+// matches the existing semantics of the actor field — the guard removes
+// silent cross-actor closes without adding new identity guarantees.
 //
 // This guards against the silent-success bug where actor A closes a bead that
 // was concurrently re-claimed by actor B: storage accepts the close (id-only
@@ -88,7 +140,7 @@ func AssigneeMatches(actor string, force bool) IssueValidator {
 		if issue == nil || force {
 			return nil
 		}
-		if issue.Assignee == "" || issue.Assignee == actor {
+		if issue.Assignee == "" || actorMatches(issue.Assignee, actor) {
 			return nil
 		}
 		return fmt.Errorf("cannot close %s: assignee is %q, actor is %q; reclaim or use --force to override", id, issue.Assignee, actor)
@@ -101,10 +153,14 @@ func AssigneeMatches(actor string, force bool) IssueValidator {
 // stripping a live claim is what bd unclaim refuses without --force).
 //
 // The refusal fires only when every clause holds; each one is load-bearing:
-//   - Assignee != ""          — unassigned issues are freely assignable.
-//   - Assignee != actor       — an actor editing its own claim is untouched.
-//   - Assignee != newAssignee — an idempotent re-assert of the current holder
-//     stays a success (retry/replay safety on the proxied path).
+//   - Assignee != ""                    — unassigned issues are freely
+//     assignable.
+//   - Assignee doesn't canonicalize to actor       — an actor editing its
+//     own claim is untouched, under any spelling of its own identity.
+//   - Assignee doesn't canonicalize to newAssignee — an idempotent re-assert
+//     of the current holder stays a success (retry/replay safety on the
+//     proxied path), even when the re-assert names the holder under a
+//     different spelling.
 //   - Status == in_progress   — reassigning an OPEN bead stays frictionless:
 //     dispatchers hand-dole open beads and pool-queue takes happen constantly,
 //     which is why this cannot reuse the unclaim/close ownership rule verbatim.
@@ -114,15 +170,18 @@ func AssigneeMatches(actor string, force bool) IssueValidator {
 //     bead. poolAliases is a thunk so call sites don't pay the config read on
 //     the overwhelmingly common non-conflicting paths.
 //
-// Like AssigneeMatches, authority is identity-by-string: bd has no identity
-// layer, so this removes silent cross-actor takeovers without adding new
-// identity guarantees.
+// Like AssigneeMatches, authority is identity-by-string — compared under
+// canonicalActor rather than verbatim (ga-wzl83), so this removes silent
+// cross-actor takeovers without adding new identity guarantees, and without
+// falsely treating the current holder as a stranger when actor or
+// newAssignee names it under a different layer's spelling of the same
+// identity.
 func AssigneeNotStolen(actor, newAssignee string, poolAliases func() []string, force bool) IssueValidator {
 	return func(id string, issue *types.Issue) error {
 		if issue == nil || force {
 			return nil
 		}
-		if issue.Assignee == "" || issue.Assignee == actor || issue.Assignee == newAssignee {
+		if issue.Assignee == "" || actorMatches(issue.Assignee, actor) || actorMatches(issue.Assignee, newAssignee) {
 			return nil
 		}
 		if issue.Status != types.StatusInProgress {

--- a/internal/validation/issue_test.go
+++ b/internal/validation/issue_test.go
@@ -144,6 +144,55 @@ func TestNotPinned(t *testing.T) {
 	}
 }
 
+func TestCanonicalActor(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty stays empty", in: "", want: ""},
+		{name: "no separators is unchanged", in: "alice", want: "alice"},
+		{name: "dot separator canonicalizes", in: "gastown.mayor", want: "gastown_mayor"},
+		{name: "double-underscore separator canonicalizes to the same form", in: "gastown__mayor", want: "gastown_mayor"},
+		{name: "hyphen separator canonicalizes to the same form", in: "gastown-mayor", want: "gastown_mayor"},
+		{name: "single underscore is already canonical", in: "gastown_mayor", want: "gastown_mayor"},
+		{name: "mixed separators each collapse to one canonical separator", in: "gastown.dog-3", want: "gastown_dog_3"},
+		{name: "leading separator is preserved as a separator, not dropped", in: ".mayor", want: "_mayor"},
+		{name: "trailing separator is preserved as a separator, not dropped", in: "mayor.", want: "mayor_"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := canonicalActor(tt.in); got != tt.want {
+				t.Errorf("canonicalActor(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestActorMatches(t *testing.T) {
+	tests := []struct {
+		name     string
+		assignee string
+		actor    string
+		want     bool
+	}{
+		{name: "byte-identical matches", assignee: "alice", actor: "alice", want: true},
+		{name: "different spellings of the same identity match (ga-wzl83)", assignee: "gastown.mayor", actor: "gastown__mayor", want: true},
+		{name: "genuinely different identities do not match", assignee: "gastown.mayor", actor: "gastown.dog-3", want: false},
+		{name: "both empty match", assignee: "", actor: "", want: true},
+		{name: "empty assignee never matches a non-empty actor", assignee: "", actor: "mayor", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := actorMatches(tt.assignee, tt.actor); got != tt.want {
+				t.Errorf("actorMatches(%q, %q) = %v, want %v", tt.assignee, tt.actor, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestAssigneeMatches(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -190,6 +239,41 @@ func TestAssigneeMatches(t *testing.T) {
 			name:        "empty actor with assigned bead fails",
 			issue:       &types.Issue{ID: "bd-test", Assignee: "bob"},
 			actor:       "",
+			wantErr:     true,
+			wantErrFrag: "assignee is",
+		},
+		// ga-wzl83: the assignee is stored under one layer's spelling of an
+		// identity ("gastown.mayor") while actor resolution can hand back a
+		// DIFFERENT layer's spelling of the SAME identity — a session name
+		// sanitizes the dot to "__" because a dot is unsafe there. The owner
+		// closing its own bead must not need --force just because two layers
+		// spelled its name differently.
+		{
+			name:    "same identity under session-name spelling passes (ga-wzl83)",
+			issue:   &types.Issue{ID: "bd-test", Assignee: "gastown.mayor"},
+			actor:   "gastown__mayor",
+			wantErr: false,
+		},
+		{
+			name:    "same identity under hyphen spelling passes",
+			issue:   &types.Issue{ID: "bd-test", Assignee: "gastown.mayor"},
+			actor:   "gastown-mayor",
+			wantErr: false,
+		},
+		{
+			name:    "same identity under single-underscore spelling passes",
+			issue:   &types.Issue{ID: "bd-test", Assignee: "gastown.mayor"},
+			actor:   "gastown_mayor",
+			wantErr: false,
+		},
+		// The control that keeps the guard from becoming a no-op: a genuinely
+		// DIFFERENT agent must still be refused, even though its own name also
+		// contains separator characters that canonicalize.
+		{
+			name:        "genuinely different identity stays rejected despite shared separators",
+			issue:       &types.Issue{ID: "bd-test", Assignee: "gastown.mayor"},
+			actor:       "gastown.dog-3",
+			force:       false,
 			wantErr:     true,
 			wantErrFrag: "assignee is",
 		},
@@ -299,6 +383,31 @@ func TestAssigneeNotStolen(t *testing.T) {
 			actor:       "alice",
 			newAssignee: "alice",
 			pools:       nil,
+			wantErr:     true,
+		},
+		// ga-wzl83: same class as AssigneeMatches — actor and newAssignee are
+		// compared against the stored assignee under canonicalActor, so a
+		// different layer's spelling of the current holder's own identity is
+		// not mistaken for a stranger.
+		{
+			name:        "actor editing its own claim passes under a different spelling",
+			issue:       inProgress("gastown.mayor"),
+			actor:       "gastown__mayor",
+			newAssignee: "bob",
+			wantErr:     false,
+		},
+		{
+			name:        "idempotent re-assert under a different spelling of the current holder passes",
+			issue:       inProgress("gastown.mayor"),
+			actor:       "alice",
+			newAssignee: "gastown__mayor",
+			wantErr:     false,
+		},
+		{
+			name:        "different identity with shared separators still refused",
+			issue:       inProgress("gastown.mayor"),
+			actor:       "gastown.dog-3",
+			newAssignee: "gastown.dog-3",
 			wantErr:     true,
 		},
 	}


### PR DESCRIPTION
## What

`AssigneeMatches` (`bd close`'s ownership guard) and `AssigneeNotStolen` (`bd update -a` / `bd assign`'s reassignment fence) compared `actor` to `issue.Assignee` verbatim. Add `canonicalActor`/`actorMatches`: collapse any run of `.`, `_`, `-` to one canonical separator before comparing, so two spellings of the same identity compare equal while genuinely different identities stay distinct.

## Why

The same Gas Town identity reaches `bd` spelled differently depending on which layer produced the string it was handed — a dotted alias like `gastown.mayor` gets its dot replaced wherever a dot is unsafe for that context (`__` in a session name, `_` in a Dolt table/database name, `-` elsewhere) — and `bd` only ever sees the resulting string, never the substitution itself.

Concretely (ga-wzl83): an agent with `GC_AGENT=gastown.mayor` tries to close a bead assigned to itself and gets refused:

```
cannot close BEAD-ID: assignee is "gastown.mayor", actor is "gastown__mayor"; reclaim or use --force to override
```

Both strings name the same principal. The error message teaches the agent that `--force` is the normal path for closing its own bead — which is exactly backwards, and erodes the guard's actual purpose (be-035: refusing a close from an actor with no authority over the bead) for anyone who internalizes "closing my own bead needs --force".

`AssigneeNotStolen` has the identical pattern (its own doc comment says "Like AssigneeMatches, authority is identity-by-string") and is fixed the same way, so the reassignment fence doesn't mistake the current holder for a stranger under a different spelling of its own identity either.

Only separator characters fold; non-separator characters still differ between genuinely different identities (`"gastown.mayor"` → `gastown_mayor`, `"gastown.dog-3"` → `gastown_dog_3` — distinct), so the guard cannot become a no-op.

## Out of scope (filed separately: ga-5ksp5)

The identical verbatim-comparison defect also lives in:
- `internal/storage/issueops/unclaim.go` (`bd unclaim`) — here the comparison is embedded directly in the SQL CAS predicate (`UPDATE ... WHERE id = ? AND assignee = ?`), not just a Go-side precheck, so canonicalizing only the Go check wouldn't fix it end-to-end.
- `internal/storage/issueops/aggregate.go`'s `AuthorizeAssigneeTransferWithPools` — per its own doc comment, "the single source of the predicate" shared by both the direct-DBTX and unit-of-work backends for `bd update -a`/`bd assign`'s actual server-side enforcement (this PR's `AssigneeNotStolen` fix is a CLI-side pre-check mirror of that authoritative predicate, not the predicate itself).

Both are materially higher-risk than this PR's two pure-Go boolean validators and need their own investigation rather than a mechanical port of this fix.

## Verification

- `internal/validation`: `go build`, `go vet`, `golangci-lint run` all clean; full package test suite passes (`go test ./internal/validation/...`).
- New regression tests cover the ACEITE pair from ga-wzl83 directly: `gastown.mayor` (stored assignee) vs `gastown__mayor` / `gastown-mayor` / `gastown_mayor` (actor) all pass without `--force`, for both `AssigneeMatches` and `AssigneeNotStolen`. A genuinely different identity (`gastown.mayor` vs `gastown.dog-3`) still refuses in both — the guard is not a no-op.
- **Confirmed the new tests actually catch the bug**, not just pass trivially: temporarily reverted just the two comparison call sites back to the old verbatim form (keeping `canonicalActor`/`actorMatches` defined so the package still compiles), reran, and got exactly 5 failures — one per new "same identity, different spelling" case — reproducing the exact reported error message (`assignee is "gastown.mayor", actor is "gastown__mayor"`) byte-for-byte. Restored the fix and confirmed green again.
- `go build ./...` (full repo, `-tags gms_pure_go` per `.buildflags`) — clean, independently confirmed twice.
- `go build ./cmd/bd/...` (the direct consumer of both changed functions) — clean.
- The repo's own pre-commit hook ran a full `golangci-lint` pass on commit — 0 issues.
- I attempted `go test ./cmd/bd/...` (both the full package and a `-run` subset scoped to Close/Assign/Reassign/Unclaim/Claim) from this sandbox but could not get a clean run: the shared local Go build cache on this machine hit repeated transient "no such file or directory" errors on unrelated third-party packages (`regexp`, `sync/atomic`, etc.) consistent with concurrent cache contention from other processes on the same host, not anything in this diff — a `go build` immediately after each failure recompiled the same "missing" packages without issue. Given `go build`/`go vet`/`golangci-lint` are all clean and `internal/validation`'s own suite is exhaustively verified (including the before/after proof above), I'm shipping on that basis rather than continuing to fight local cache flakiness — CI should run the full `cmd/bd` suite properly in its own isolated environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)