### PR TITLE
Migrate the claim-family audit cases into role contracts, including a lease nobody pinned

### DIFF
--- a/backend/conformance/claimer_contract.go
+++ b/backend/conformance/claimer_contract.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
@@ -548,6 +549,237 @@ func RunClaimerRefusesIncompleteRequestsAndAnAbsentIDWithoutTouchingState(t *tes
 	// The row a valid request would have won is still there, untouched.
 	assertClaimerRowState(t, ctx, fixture, decoy, string(types.StatusOpen), "")
 	assertClaimerCommittedNothing(t, ctx, fixture, before, "three refused requests")
+}
+
+// RunClaimerGrantsALiveLeaseOnTheRowItWonAndLeavesARefusedOneAlone pins the
+// half of the claim that is not on the issues row at all: the LEASE.
+//
+// issueops.UpsertLeaseInTx states the invariant this case reads — "a leases row
+// exists if and only if its issue is a live claim (in_progress with the row's
+// holder as assignee) on this node" — and issueops.ClaimIssueInTx grants it
+// ("what makes the claim recoverable — a worker that dies stops heartbeating
+// and bd reclaim later reverts the issue"). Neither sentence has an observer at
+// this seam today, on any leg.
+//
+// THE LEASE IS READ AS A RAW ROW, and it has to be. A claim that granted a
+// lease and a claim that granted none answer every role-visible question
+// identically: ClaimResult carries no lease member, the issues row carries no
+// lease column (the ephemeral leases table replaced them, bd-lrgn1), and no
+// verb on this role reports one. The difference is only visible in the table,
+// and the consequence of missing it is silent — a claim nothing can take back,
+// because heartbeats have no handle to extend and lease-expiry recovery never
+// sees the row.
+//
+// THE TWO ARMS ARE EACH OTHER'S CONTROL, the same way the ready-claim lease
+// case pairs a durable win with an ephemeral one. Asserting the grant alone
+// would pass over a body that granted a lease on every call including the
+// refusals, which breaks the invariant in the direction that strands a rival's
+// work; asserting the refusal alone would pass on a fixture whose query cannot
+// see the leases table at all, since an unreachable table reports zero rows for
+// everything. The before-count of 0 on both ids is what makes the 1 mean
+// something.
+//
+// A REFUSED CLAIM IS ASSERTED NOT TO TRANSFER THE LEASE, not merely not to
+// create one. "Refusals ... leave persistent state unchanged" is the clause,
+// and the leases table is the one piece of persistent state the existing
+// refusal cases cannot read: a re-grant to the losing actor moves no column on
+// the issues row, records no event and commits nothing, so every detector this
+// contract already owns ties.
+//
+// WHAT THIS FIXTURE CANNOT SEE, none of it the subject: the TTL's value (five
+// minutes today, and issueops.WithLeaseTTL is a context knob no role carries,
+// so a case pinning the number would be pinning the backend); the granting
+// node; renewal, which is HeartbeatIssue's and has no role verb; and the
+// release paths — close, unclaim, reclaim, delete — which are other roles'
+// verbs. What it CAN see is the whole of what a claim itself promises about the
+// lease: that one exists, that it names the claimant, and that it is alive at
+// the moment it is granted rather than born expired.
+func RunClaimerGrantsALiveLeaseOnTheRowItWonAndLeavesARefusedOneAlone(t *testing.T, ctx context.Context, fixture ClaimerFixture) {
+	t.Helper()
+	won := fixture.IssuePrefix + "-cllease-won"
+	held := fixture.IssuePrefix + "-cllease-held"
+	rival := fixture.IssuePrefix + "-cllease-rival"
+	seedClaimerIssue(t, ctx, fixture, claimerIssue(won, types.StatusOpen))
+	seedClaimerIssue(t, ctx, fixture, claimerIssue(held, types.StatusOpen))
+	// Neither row is leased before anything claims it. Without this the "one
+	// lease row" below would also pass over a fixture that had inherited one,
+	// and the "still one, still the rival's" would pass over a table this
+	// query cannot reach.
+	for _, id := range []string{won, held} {
+		if leases := claimerLeaseCount(t, ctx, fixture, id); leases != 0 {
+			t.Fatalf("the seeded issue %s already holds %d lease row(s), want 0; "+
+				"the grant asserted below would then not be this claim's doing", id, leases)
+		}
+	}
+
+	if _, err := fixture.Claimer.Claim(ctx, publicops.ClaimRequest{Actor: claimerStranger, IssueID: won}); err != nil {
+		t.Fatalf("Claim of an open, unassigned issue: %v", err)
+	}
+	assertClaimerRowState(t, ctx, fixture, won, string(types.StatusInProgress), claimerStranger)
+	if leases := claimerLeaseCount(t, ctx, fixture, won); leases != 1 {
+		t.Fatalf("the winning claim left %d lease row(s) for %s, want exactly 1 — a claim with no lease is work "+
+			"nothing can take back, because heartbeats have no handle to extend and lease-expiry recovery never sees it",
+			leases, won)
+	}
+	holder, live, beating := claimerLeaseGrant(t, ctx, fixture, won)
+	if holder != claimerStranger {
+		t.Errorf("the lease on %s is held by %q, want the claiming actor %q — a lease naming anyone else is reclaimed "+
+			"on the wrong worker's behalf", won, holder, claimerStranger)
+	}
+	if !live {
+		t.Error("the granted lease's lease_expires_at is not after its granted_at: the claim was born already expired, " +
+			"so the next reclaim sweep takes the issue straight back off the worker that just won it")
+	}
+	if !beating {
+		t.Error("the granted lease's heartbeat_at is before its granted_at: a lease whose last heartbeat predates the " +
+			"grant is stale the moment it exists")
+	}
+
+	// A claim the role refuses neither mints a lease nor moves the one the
+	// real holder has.
+	if _, err := fixture.Claimer.Claim(ctx, publicops.ClaimRequest{Actor: rival, IssueID: held}); err != nil {
+		t.Fatalf("seed the rival's live claim on %s: %v", held, err)
+	}
+	before := claimerHistoryCount(t, ctx, fixture)
+	_, err := fixture.Claimer.Claim(ctx, publicops.ClaimRequest{Actor: claimerStranger, IssueID: held})
+	assertClaimerRefusal(t, err, publicops.ErrAlreadyClaimed, held, rival, types.StatusInProgress,
+		"an issue another actor holds in progress")
+	if leases := claimerLeaseCount(t, ctx, fixture, held); leases != 1 {
+		t.Errorf("the refused claim left %d lease row(s) for %s, want the 1 the rival won", leases, held)
+	}
+	if holder, _, _ := claimerLeaseGrant(t, ctx, fixture, held); holder != rival {
+		t.Errorf("after a refused claim the lease on %s is held by %q, want the rival %q that still holds the issue — "+
+			"a refusal that re-grants the lease hands recovery to the actor that lost", held, holder, rival)
+	}
+	assertClaimerRowState(t, ctx, fixture, held, string(types.StatusInProgress), rival)
+	assertClaimerCommittedNothing(t, ctx, fixture, before, "a claim refused by a foreign holder")
+}
+
+// RunClaimerStampsStartedAtOnceAcrossTheTwoWritesItChoosesBetween pins the
+// clause issueops.ClaimIssueInTx states beside its compare-and-set — "set
+// started_at on first transition to in_progress (GH#2796); preserve any
+// existing value so re-claims don't overwrite the original start time" — and it
+// is one case rather than two because the two halves are TWO DIFFERENT UPDATE
+// STATEMENTS, chosen by a branch on the pre-image, in each of the bodies under
+// this role.
+//
+// A fixture that only ever seeds an unstamped row reaches one of them. The
+// other — the statement that omits started_at from its SET list — is then never
+// executed at all, so a body that dropped the branch and always stamped `now`
+// is green: every other assertion in this contract reads the status and the
+// assignee, which both statements write identically.
+//
+// THE PRESERVED VALUE IS A DISTANT PAST INSTANT, not a recent one. The two
+// writes differ by whether started_at is re-stamped with the claim's own `now`,
+// and a seeded value close to the test's wall clock renders into the same
+// second-precision DATETIME as the re-stamp would — the tie that already made
+// this contract's updated_at detector blind once (see claimerClaimEventCount).
+// Years apart, the two cannot tie.
+//
+// The stamp is read as a raw column and compared as an opaque string, the way
+// claimerUpdatedAt is: the question is whether a write touched it, and the
+// three fixtures' scan paths render timestamps differently.
+//
+// WHAT THIS FIXTURE CANNOT SEE: what the stamp is SET TO on the first
+// transition — only that it moved from NULL to some value. The claim's `now` is
+// not a value a black-box case can predict, and asserting a range would pin the
+// clock rather than the clause. That is not what either half is named for: the
+// promise is "stamped once, then preserved", and both halves of that are here.
+func RunClaimerStampsStartedAtOnceAcrossTheTwoWritesItChoosesBetween(t *testing.T, ctx context.Context, fixture ClaimerFixture) {
+	t.Helper()
+	fresh := fixture.IssuePrefix + "-clstart-fresh"
+	restarted := fixture.IssuePrefix + "-clstart-restarted"
+	// Distant enough from the claim's own clock that a re-stamp cannot render
+	// into the same second-precision DATETIME.
+	firstStart := time.Date(2021, time.March, 4, 5, 6, 7, 0, time.UTC)
+
+	seedClaimerIssue(t, ctx, fixture, claimerIssue(fresh, types.StatusOpen))
+	carried := claimerIssue(restarted, types.StatusOpen)
+	carried.StartedAt = &firstStart
+	seedClaimerIssue(t, ctx, fixture, carried)
+
+	if !claimerStartedAtIsNull(t, ctx, fixture, fresh) {
+		t.Fatalf("the unstamped seed %s already carries a started_at; the stamp asserted below would not be the claim's doing", fresh)
+	}
+	if claimerStartedAtIsNull(t, ctx, fixture, restarted) {
+		t.Fatalf("seeding %s with a started_at did not land one: this backend's CreateIssue drops the column, so the "+
+			"preserve half below would be a second copy of the stamp half", restarted)
+	}
+	carriedStamp := claimerStartedAt(t, ctx, fixture, restarted)
+
+	if _, err := fixture.Claimer.Claim(ctx, publicops.ClaimRequest{Actor: claimerStranger, IssueID: fresh}); err != nil {
+		t.Fatalf("Claim of an unstarted open issue: %v", err)
+	}
+	if claimerStartedAtIsNull(t, ctx, fixture, fresh) {
+		t.Errorf("started_at on %s is still NULL after the claim that moved it to in-progress; the transition is what "+
+			"stamps it, and every consumer of elapsed work time reads that column", fresh)
+	}
+
+	if _, err := fixture.Claimer.Claim(ctx, publicops.ClaimRequest{Actor: claimerStranger, IssueID: restarted}); err != nil {
+		t.Fatalf("Claim of an open issue that already carries a started_at: %v", err)
+	}
+	assertClaimerRowState(t, ctx, fixture, restarted, string(types.StatusInProgress), claimerStranger)
+	if got := claimerStartedAt(t, ctx, fixture, restarted); got != carriedStamp {
+		t.Errorf("started_at on %s moved %q -> %q across a claim of a row that already carried one; the second of the "+
+			"two writes exists precisely so a re-start does not overwrite the original start time", restarted, carriedStamp, got)
+	}
+}
+
+// claimerLeaseCount reports how many rows the ephemeral leases table holds for
+// id. It counts rather than scanning a row so "no lease" and "a lease this
+// fixture cannot read" stay distinguishable: a failed scan is a fixture error,
+// an empty count is the answer.
+func claimerLeaseCount(t *testing.T, ctx context.Context, fixture ClaimerFixture, id string) int {
+	t.Helper()
+	var rows int
+	if err := fixture.QueryScalar(ctx, "SELECT COUNT(*) FROM leases WHERE issue_id = ?", []any{id}, &rows); err != nil {
+		t.Fatalf("count leases for %s: %v", id, err)
+	}
+	return rows
+}
+
+// claimerLeaseGrant reads the one lease row for id: who holds it, whether it
+// expires after it was granted, and whether its heartbeat is at least as new as
+// the grant.
+//
+// The two temporal questions are answered IN SQL, comparing the row's own
+// columns against each other rather than against a timestamp carried across the
+// seam. A Go-side comparison would have to agree with three fixtures on how a
+// DATETIME renders and on which zone it renders in; "expires after it was
+// granted" is the same promise with neither of those problems, and it is the
+// exact property a born-expired lease violates.
+func claimerLeaseGrant(t *testing.T, ctx context.Context, fixture ClaimerFixture, id string) (holder string, live, beating bool) {
+	t.Helper()
+	if err := fixture.QueryScalar(ctx,
+		"SELECT holder, lease_expires_at > granted_at, heartbeat_at >= granted_at FROM leases WHERE issue_id = ?",
+		[]any{id}, &holder, &live, &beating); err != nil {
+		t.Fatalf("read the lease row for %s: %v", id, err)
+	}
+	return holder, live, beating
+}
+
+// claimerStartedAtIsNull answers the null question in SQL rather than by
+// scanning the column, because a NULL DATETIME reaches the three fixtures'
+// scan paths as three different things and only one of them is an error.
+func claimerStartedAtIsNull(t *testing.T, ctx context.Context, fixture ClaimerFixture, id string) bool {
+	t.Helper()
+	var isNull bool
+	if err := fixture.QueryScalar(ctx, "SELECT started_at IS NULL FROM issues WHERE id = ?", []any{id}, &isNull); err != nil {
+		t.Fatalf("read started_at nullness for %s: %v", id, err)
+	}
+	return isNull
+}
+
+// claimerStartedAt reads one row's started_at as text, compared as an opaque
+// string for the same reason claimerUpdatedAt is: the question is only whether
+// a write touched it.
+func claimerStartedAt(t *testing.T, ctx context.Context, fixture ClaimerFixture, id string) string {
+	t.Helper()
+	var stamp string
+	if err := fixture.QueryScalar(ctx, "SELECT started_at FROM issues WHERE id = ?", []any{id}, &stamp); err != nil {
+		t.Fatalf("read started_at for %s: %v", id, err)
+	}
+	return stamp
 }
 
 // claimerStranger is the actor most cases claim as: a name that appears nowhere

--- a/backend/conformance/ready_claimer_contract.go
+++ b/backend/conformance/ready_claimer_contract.go
@@ -854,9 +854,9 @@ func assertReadyClaimerClaimsNothing(t *testing.T, ctx context.Context, fixture 
 	}
 }
 
-// seedReadyClaimerEdgeOfType seeds ONE edge of a named type. seedReadyClaimerEdge
-// is the blocks-only shorthand every other case uses; the cases that are ABOUT
-// edge type need to say which.
+// seedReadyClaimerTypedEdge seeds ONE edge of a named type.
+// seedReadyClaimerEdge is the blocks-only shorthand every other case uses; the
+// cases that are ABOUT edge type need to say which.
 func seedReadyClaimerTypedEdge(t *testing.T, ctx context.Context, fixture ReadyClaimerFixture, issueID, dependsOnID string, depType types.DependencyType) {
 	t.Helper()
 	if err := fixture.AddDependency(ctx, &types.Dependency{

--- a/backend/conformance/ready_claimer_contract.go
+++ b/backend/conformance/ready_claimer_contract.go
@@ -603,6 +603,295 @@ func RunReadyClaimerDoesNotMutateTheCallerRequest(t *testing.T, ctx context.Cont
 	}
 }
 
+// RunReadyClaimerFencesTheClaimByEveryLabelSetAndTheParentItWasGiven pins the
+// clause that makes ClaimNext safe to point at a lane: the filter it is given
+// is the filter it claims through (issueops/readyclaimer.go:9-14), so a request
+// that fences the ready set to one lane never returns work from another.
+//
+// THIS IS THE DROPPED-FILTER BUG, and it is the reason the case is shaped the
+// way it is. --label-any used to be discarded on the ready/claim path, so a
+// worker asking for its own lane atomically claimed another lane's work while
+// believing it was fenced — a failure that looks exactly like success at every
+// surface a caller can see. Nothing in this contract can see it today:
+// LabelsAny appears only in RunReadyClaimerDoesNotMutateTheCallerRequest, where
+// it is populated and never asserted as a filter, and the two cases that do
+// fence fence with Labels alone.
+//
+// EVERY SEEDED ROW CARRIES THE CASE'S SCOPE LABEL and every request names it in
+// Labels, because the ready front is a property of the whole database. The
+// FENCE under test is therefore LabelsAny and ParentID, layered on top of that
+// scope — which is also what makes the unsatisfiable-AND arm meaningful, since
+// an implementation that let the OR-set stand in for the AND-set answers a row
+// there.
+//
+// THE DECOY IS TOP-PRIORITY AND IN NO LANE. Every arm below is a claim that
+// must NOT take it, so each one doubles as a check that the fence was applied
+// at all rather than a check that some row came back. The requested order is
+// `priority`, so "the fence was dropped" and "the fence was honored" name
+// different rows every time.
+//
+// FOUR THINGS FAIL INDEPENDENTLY and each has an arm:
+//
+//   - the OR-set is an OR. The first request names a lane that matches nothing
+//     alongside the one that does; an implementation reading LabelsAny as a
+//     second AND-set claims nothing.
+//   - the AND-set still binds. An unsatisfiable Labels entry beside a
+//     satisfiable LabelsAny must claim NOTHING, not the row the OR-set alone
+//     would have matched.
+//   - the parent restricts, through BOTH of its arms. The parent clause is a
+//     disjunction — a dotted-id descendant that owns no parent-child edge, OR a
+//     row the recursive descendant walk reached — and the two are separate
+//     bodies of code (issueops.GetDescendantIDsInTx and the unit of work's
+//     hand-copied getDescendantIDs). One row of each shape is seeded, and the
+//     second claim is what proves the walk arm is live.
+//   - an EXHAUSTED fence claims nothing. This is the safety property: the
+//     failure mode worth preventing is not an empty answer, it is a FULL one
+//     from outside the lane. The final unfenced claim takes the decoy, so the
+//     nils above are the fence's doing and not a drained front.
+//
+// WHAT THIS FIXTURE CANNOT SEE: ExcludeLabels, LabelPattern and LabelRegex,
+// which are three more members of the same fence. They are not what the case is
+// named for — the historical defect and the leaf's clause are both about the
+// filter reaching the claim path at all, and a request that carries five
+// predicates through the same builder does not carry three of them and drop
+// two. Adding them would lengthen the case without adding a failure mode.
+func RunReadyClaimerFencesTheClaimByEveryLabelSetAndTheParentItWasGiven(t *testing.T, ctx context.Context, fixture ReadyClaimerFixture) {
+	t.Helper()
+	scope := fixture.IssuePrefix + "-rcfence"
+	laneA := scope + "-lane-a"
+	laneB := scope + "-lane-b"
+	emptyLane := scope + "-lane-c"
+	nobody := scope + "-nobody"
+
+	decoy := scope + "-free"
+	root := scope + "-p"
+	wrongLaneChild := scope + "-p.1"
+	dottedChild := scope + "-p.2"
+	walkedChild := scope + "-pchild"
+	outsider := scope + "-x"
+
+	seedReadyClaimerIssue(t, ctx, fixture, readyClaimerIssue(decoy, 0, scope))
+	// The root sits at the BACK of the scope's order (priorities run 0..4), so
+	// the unfenced claim that closes the case takes the decoy rather than it.
+	seedReadyClaimerIssue(t, ctx, fixture, readyClaimerIssue(root, 4, scope))
+	seedReadyClaimerIssue(t, ctx, fixture, readyClaimerIssue(wrongLaneChild, 1, scope, laneB))
+	seedReadyClaimerIssue(t, ctx, fixture, readyClaimerIssue(outsider, 2, scope, laneA))
+	seedReadyClaimerIssue(t, ctx, fixture, readyClaimerIssue(dottedChild, 3, scope, laneA))
+	seedReadyClaimerIssue(t, ctx, fixture, readyClaimerIssue(walkedChild, 4, scope, laneA))
+	// walkedChild is a descendant of root only through this edge; dottedChild
+	// is one only through its id. The parent clause is a disjunction of those
+	// two shapes and this case drives both.
+	seedReadyClaimerTypedEdge(t, ctx, fixture, walkedChild, root, types.DepParentChild)
+
+	scoped := publicops.ReadyRequest{Labels: []string{scope}, Sort: readyClaimerSort}
+	page, err := fixture.Reader.Ready(ctx, scoped)
+	if err != nil {
+		t.Fatalf("Reader.Ready over the seeded scope: %v", err)
+	}
+	for _, id := range []string{decoy, root, wrongLaneChild, outsider, dottedChild, walkedChild} {
+		if !readyClaimerPageHas(page, id) {
+			t.Fatalf("Reader.Ready did not offer the seeded row %s (page: %v); every arm below is about WHICH ready row "+
+				"the fence selects, so a row missing from the front makes its arm vacuous", id, readyClaimerPageIDs(page))
+		}
+	}
+
+	// The OR-set narrows, the parent narrows, and the two compose: the only
+	// lane-A descendant of root, ahead of a lane-A row outside it and a
+	// higher-priority child in the wrong lane.
+	inLane := publicops.ReadyRequest{
+		Labels:    []string{scope},
+		LabelsAny: []string{laneA, emptyLane},
+		ParentID:  root,
+		Sort:      readyClaimerSort,
+	}
+	if won := readyClaimerWin(t, ctx, fixture, inLane); won != dottedChild {
+		t.Fatalf("ClaimNext(labels-any %v, parent %s) claimed %s, want %s — %s is the wrong lane, %s is outside the "+
+			"parent, and %s is fenced out by both", []string{laneA, emptyLane}, root, won, dottedChild,
+			wrongLaneChild, outsider, decoy)
+	}
+	// The parent clause's OTHER arm: this row is a descendant only through the
+	// parent-child edge, so a body whose descendant walk went missing answers
+	// nil here while the dotted-id arm above still passed.
+	if won := readyClaimerWin(t, ctx, fixture, inLane); won != walkedChild {
+		t.Fatalf("the second ClaimNext(parent %s) claimed %s, want %s — that row is a descendant only through its "+
+			"parent-child edge, which is the arm of the parent clause the dotted id above does not exercise",
+			root, won, walkedChild)
+	}
+
+	// The AND-set still binds beside a satisfiable OR-set.
+	unsatisfiable := publicops.ReadyRequest{
+		Labels:    []string{scope, nobody},
+		LabelsAny: []string{laneA},
+		Sort:      readyClaimerSort,
+	}
+	assertReadyClaimerClaimsNothing(t, ctx, fixture, unsatisfiable,
+		"an unsatisfiable AND-set beside a satisfiable OR-set")
+
+	// The OR-set alone still fences: the lane row, not the top-priority decoy.
+	laneOnly := publicops.ReadyRequest{Labels: []string{scope}, LabelsAny: []string{laneA}, Sort: readyClaimerSort}
+	if won := readyClaimerWin(t, ctx, fixture, laneOnly); won != outsider {
+		t.Fatalf("ClaimNext(labels-any %s) claimed %s, want %s — %s is higher priority and in no lane, so claiming it "+
+			"is the dropped-filter failure this case exists for", laneA, won, outsider, decoy)
+	}
+
+	// THE SAFETY PROPERTY: with the lane drained, the claim takes nothing
+	// rather than falling back to unfenced work.
+	assertReadyClaimerClaimsNothing(t, ctx, fixture, laneOnly, "an exhausted lane")
+
+	// And the rows were claimable all along, so every nil above was the
+	// fence's doing.
+	if won := readyClaimerWin(t, ctx, fixture, scoped); won != decoy {
+		t.Errorf("the unfenced claim took %s, want %s — the refusals above only mean something while this row is still claimable",
+			won, decoy)
+	}
+}
+
+// RunReadyClaimerHydratesOnlyItsBlocksEdgesIntoTheCardinalities pins what the
+// two numbers on a claimed row COUNT. ClaimNext hydrates the row it won
+// (RunReadyClaimerClaimsTheFrontRowAndReturnsThePostClaimState asserts they are
+// populated from real edges), but every fixture in this contract seeds
+// `blocks` edges and nothing else, so a body that counted every edge type
+// answers exactly the same numbers.
+//
+// The two count sets are genuinely different sets. `bd show`'s dependent count
+// is all-types (storage.CountDependents), while the cardinalities carried on a
+// work row are blocks-only (sqlbuild.SearchCountsSQL's dc/rc joins both say
+// `WHERE type = 'blocks'`), and the unit of work computes them in a body of its
+// own. Nothing anywhere tells the two apart at this seam: swap them and every
+// count assertion in this suite still passes.
+//
+// THE WINNER SITS AT THE CENTER OF SIX EDGES, three out and three in, one pair
+// per type — and the raw edge counts are asserted FIRST. That is what makes the
+// answer falsifiable rather than merely small: without them, "DependencyCount
+// is 1" is equally consistent with a body that counts only blocks edges and
+// with a fixture whose extra edges were never written. The case says three
+// edges exist and one is counted.
+//
+// THE NON-BLOCKS EDGES ARE CHOSEN NOT TO MOVE THE ROW OFF THE READY FRONT: the
+// blocks target is CLOSED, relates-to never gates, and a parent-child edge
+// gates a child only through a parent that is itself blocked. So the winner
+// stays claimable and the case is about the counts rather than about readiness,
+// which the blocker-aware cases already own.
+//
+// WHAT THIS FIXTURE CANNOT SEE: the all-types count itself, which no verb on
+// this role reports — the raw edge total stands in for it. That is not what the
+// case is named for; the promise here is that the claim's cardinalities are the
+// blocks-only ones, and a body answering 3 fails on exactly that.
+func RunReadyClaimerHydratesOnlyItsBlocksEdgesIntoTheCardinalities(t *testing.T, ctx context.Context, fixture ReadyClaimerFixture) {
+	t.Helper()
+	scope := fixture.IssuePrefix + "-rccount"
+	offstage := scope + "-off"
+	winner := scope + "-a"
+	blocker := scope + "-blocker"
+	dependent := scope + "-dependent"
+	relatedOut := scope + "-related-out"
+	relatedIn := scope + "-related-in"
+	parent := scope + "-parent"
+	child := scope + "-child"
+
+	seedReadyClaimerIssue(t, ctx, fixture, readyClaimerIssue(winner, 0, scope))
+	// A CLOSED blocks target: it gives the winner a counted dependency without
+	// taking it off the ready front.
+	closed := readyClaimerIssue(blocker, 1, offstage)
+	closed.Status = types.StatusClosed
+	seedReadyClaimerIssue(t, ctx, fixture, closed)
+	for _, id := range []string{dependent, relatedOut, relatedIn, parent, child} {
+		seedReadyClaimerIssue(t, ctx, fixture, readyClaimerIssue(id, 1, offstage))
+	}
+
+	seedReadyClaimerTypedEdge(t, ctx, fixture, winner, blocker, types.DepBlocks)
+	seedReadyClaimerTypedEdge(t, ctx, fixture, winner, relatedOut, types.DepRelatesTo)
+	seedReadyClaimerTypedEdge(t, ctx, fixture, winner, parent, types.DepParentChild)
+	seedReadyClaimerTypedEdge(t, ctx, fixture, dependent, winner, types.DepBlocks)
+	seedReadyClaimerTypedEdge(t, ctx, fixture, relatedIn, winner, types.DepRelatesTo)
+	seedReadyClaimerTypedEdge(t, ctx, fixture, child, winner, types.DepParentChild)
+
+	// Three edges each way really are on the row. Without this the equalities
+	// below hold just as well over a fixture that wrote one edge of each.
+	if out := readyClaimerEdgesFrom(t, ctx, fixture, winner); out != 3 {
+		t.Fatalf("%s carries %d outgoing edges, want the 3 this case seeded; the blocks-only assertion below cannot "+
+			"fail while the other two types are missing", winner, out)
+	}
+	if in := readyClaimerEdgesTo(t, ctx, fixture, winner); in != 3 {
+		t.Fatalf("%s carries %d incoming edges, want the 3 this case seeded", winner, in)
+	}
+
+	result, err := fixture.Claimer.ClaimNext(ctx, publicops.ClaimNextRequest{
+		Actor:  "claimer",
+		Filter: publicops.ReadyRequest{Labels: []string{scope}, Sort: readyClaimerSort},
+	})
+	if err != nil {
+		t.Fatalf("ClaimNext over the seeded scope: %v", err)
+	}
+	if result.Claimed == nil {
+		t.Fatal("ClaimNext returned no row against a front holding one claimable issue")
+	}
+	if result.Claimed.ID != winner {
+		t.Fatalf("claimed %s, want %s", result.Claimed.ID, winner)
+	}
+	if result.Claimed.DependencyCount != 1 {
+		t.Errorf("returned DependencyCount = %d over 3 outgoing edges (one blocks, one relates-to, one parent-child), "+
+			"want 1 — a work row's cardinalities count blocks edges only", result.Claimed.DependencyCount)
+	}
+	if result.Claimed.DependentCount != 1 {
+		t.Errorf("returned DependentCount = %d over 3 incoming edges (one blocks, one relates-to, one parent-child), "+
+			"want 1 — a work row's cardinalities count blocks edges only", result.Claimed.DependentCount)
+	}
+}
+
+// assertReadyClaimerClaimsNothing runs one claim that must take no row and says
+// which row it took when it does, because "the fence was dropped" is only
+// diagnosable from the id.
+func assertReadyClaimerClaimsNothing(t *testing.T, ctx context.Context, fixture ReadyClaimerFixture, filter publicops.ReadyRequest, subject string) {
+	t.Helper()
+	result, err := fixture.Claimer.ClaimNext(ctx, publicops.ClaimNextRequest{Actor: "claimer", Filter: filter})
+	if err != nil {
+		t.Fatalf("ClaimNext with %s: error = %v, want nil — a fence that matches nothing is an EMPTY front, not a failure", subject, err)
+	}
+	if result.Claimed != nil {
+		t.Fatalf("ClaimNext with %s claimed %s; a claim that falls back past its own fence hands an agent work from "+
+			"another lane while the caller believes it is fenced", subject, result.Claimed.ID)
+	}
+}
+
+// seedReadyClaimerEdgeOfType seeds ONE edge of a named type. seedReadyClaimerEdge
+// is the blocks-only shorthand every other case uses; the cases that are ABOUT
+// edge type need to say which.
+func seedReadyClaimerTypedEdge(t *testing.T, ctx context.Context, fixture ReadyClaimerFixture, issueID, dependsOnID string, depType types.DependencyType) {
+	t.Helper()
+	if err := fixture.AddDependency(ctx, &types.Dependency{
+		IssueID: issueID, DependsOnID: dependsOnID, Type: depType,
+	}, "seed"); err != nil {
+		t.Fatalf("seed %s edge %s -> %s: %v", depType, issueID, dependsOnID, err)
+	}
+}
+
+// readyClaimerEdgesFrom counts every dependency row leaving id, whatever its
+// type. It is the all-types control the role itself never reports.
+func readyClaimerEdgesFrom(t *testing.T, ctx context.Context, fixture ReadyClaimerFixture, id string) int {
+	t.Helper()
+	var rows int
+	if err := fixture.QueryScalar(ctx,
+		"SELECT COUNT(*) FROM dependencies WHERE issue_id = ?", []any{id}, &rows); err != nil {
+		t.Fatalf("count outgoing edges for %s: %v", id, err)
+	}
+	return rows
+}
+
+// readyClaimerEdgesTo counts every dependency row arriving at id. The target's
+// own class decides which typed column holds it, so it is resolved through the
+// same COALESCE the rest of the contract family uses.
+func readyClaimerEdgesTo(t *testing.T, ctx context.Context, fixture ReadyClaimerFixture, id string) int {
+	t.Helper()
+	var rows int
+	if err := fixture.QueryScalar(ctx,
+		"SELECT COUNT(*) FROM dependencies WHERE COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external) = ?",
+		[]any{id}, &rows); err != nil {
+		t.Fatalf("count incoming edges for %s: %v", id, err)
+	}
+	return rows
+}
+
 // readyClaimerSort is the order every case names. It is the policy whose SQL is
 // a plain "ORDER BY priority, created_at, id", so a seed with distinct
 // priorities has one unambiguous front row — hybrid's recency bucket would make

--- a/backend/conformance/ready_counter_contract.go
+++ b/backend/conformance/ready_counter_contract.go
@@ -55,6 +55,12 @@ type ReadyCounterFixture struct {
 	// AddDependency seeds ONE edge, which is how a case takes a row OFF the
 	// ready front without deleting or closing it.
 	AddDependency func(context.Context, *types.Dependency, string) error
+	// QueryScalar runs a single-row query and scans it, and RETURNS the error
+	// rather than failing the test. A count case reads rows through it for one
+	// reason: to prove a row this role must NOT count was really seeded in the
+	// state that excludes it. Both surfaces this contract compares hide such a
+	// row, so neither can tell "excluded" from "never written".
+	QueryScalar func(context.Context, string, []any, ...any) error
 	// CountHistory reports how many history entries the fixture's branch has.
 	// A nil hook means "this backend cannot observe history", and the case
 	// that needs it SKIPS with that reason rather than passing quietly.
@@ -320,6 +326,84 @@ func RunReadyCounterDoesNotMutateTheCallerRequest(t *testing.T, ctx context.Cont
 	if !reflect.DeepEqual(request, want) {
 		t.Errorf("CountReady mutated the caller's request:\n got %+v\nwant %+v", request, want)
 	}
+}
+
+// RunReadyCounterCountsOnlyTheOpenRowsItsListingLists pins the STATUS half of
+// the identity this role is (issueops/readycounter.go:60-70). Ready work is
+// open work — "Open only, not in_progress" (internal/workapi.BuildReadyFilter)
+// — and a count that sized a wider set than the page beside it would publish
+// `bd ready`'s "showing 2 of 5" over two different questions.
+//
+// EVERY OTHER CASE IN THIS FILE SEEDS OPEN ROWS AND NOTHING ELSE, so the status
+// predicate is unreachable from all of them: drop it and every count in this
+// contract still ties with its listing, because the only rows in scope were
+// open to begin with. That is a fixture gap rather than a missing assertion,
+// and it matters here more than at the listing — the reader contract pins the
+// ready set's status decision through Reader.Ready
+// (RunReaderReadySetOwnsItsStatusPinnedAndTemplateDecisions), but the two store
+// backends answer THIS role from a different body: one indexed COUNT(*) per
+// plane over its own copy of the filter
+// (internal/storage/issueops.CountReadyWorkInTx), assembled beside the listing
+// rather than by it. A predicate that went missing on that side alone widens
+// the total while the page it sizes stays right.
+//
+// THE TWO EXCLUDED ROWS ARE READ BACK RAW before anything is counted. A closed
+// row and an in-progress row are both invisible to both surfaces, so "excluded"
+// and "the seed never landed in that status" produce byte-identical answers; the
+// raw read is the only thing that tells them apart, and without it a create that
+// silently normalized either to `open` would turn this case into a slow copy of
+// the identity case.
+//
+// WHAT THIS FIXTURE CANNOT SEE: the OR-set form of the same predicate.
+// types.WorkFilter carries a Statuses member and the ready builder renders it,
+// but publicops.ReadyRequest has no status field of any kind, so no
+// implementation of this role can be asked for one — the arm is reachable only
+// from the storage seam. That is not what this case is named for: the promise
+// at THIS seam is that the count's set is the listing's set, and the singular
+// status the builder always sends is the whole of what decides it here.
+func RunReadyCounterCountsOnlyTheOpenRowsItsListingLists(t *testing.T, ctx context.Context, fixture ReadyCounterFixture) {
+	t.Helper()
+	label := fixture.IssuePrefix + "-rcstatus"
+	open := fixture.IssuePrefix + "-rcstatus-open"
+	inProgress := fixture.IssuePrefix + "-rcstatus-wip"
+	closed := fixture.IssuePrefix + "-rcstatus-closed"
+
+	seedReadyCounterIssue(t, ctx, fixture, readyCounterIssue(open, 1, label))
+	wip := readyCounterIssue(inProgress, 1, label)
+	wip.Status = types.StatusInProgress
+	seedReadyCounterIssue(t, ctx, fixture, wip)
+	done := readyCounterIssue(closed, 1, label)
+	done.Status = types.StatusClosed
+	seedReadyCounterIssue(t, ctx, fixture, done)
+
+	for _, seed := range []struct {
+		id   string
+		want types.Status
+	}{{inProgress, types.StatusInProgress}, {closed, types.StatusClosed}} {
+		if got := readyCounterStoredStatus(t, ctx, fixture, seed.id); got != string(seed.want) {
+			t.Fatalf("the row seeded as %s is stored with status %q; a row that is not in the status this case "+
+				"excludes cannot show that the count excludes it", seed.want, got)
+		}
+	}
+
+	assertReadyCounterAgreesWithTheListing(t, ctx, fixture,
+		publicops.ReadyRequest{Labels: []string{label}, Sort: readyCounterSort}, 1,
+		"ready work is open work: neither the in-progress row nor the closed one is in the set this role sizes")
+}
+
+// readyCounterStoredStatus reads one durable row's status column. It is the
+// only raw read in this contract, and it exists because the rows a count
+// EXCLUDES are invisible to both surfaces the rest of the file compares.
+func readyCounterStoredStatus(t *testing.T, ctx context.Context, fixture ReadyCounterFixture, id string) string {
+	t.Helper()
+	if fixture.QueryScalar == nil {
+		t.Skip("fixture cannot read rows: QueryScalar is nil, so an excluded row cannot be told from an unseeded one")
+	}
+	var status string
+	if err := fixture.QueryScalar(ctx, "SELECT status FROM issues WHERE id = ?", []any{id}, &status); err != nil {
+		t.Fatalf("read status for %s: %v", id, err)
+	}
+	return status
 }
 
 // readyCounterSort is the order every case names: the policy whose SQL is a

--- a/internal/storage/dolt/claimer_contract_test.go
+++ b/internal/storage/dolt/claimer_contract_test.go
@@ -43,6 +43,18 @@ func TestClaimerRefusesABuiltInIneligibleStatusWithTheStateThatRefusedIt(t *test
 	conformance.RunClaimerRefusesABuiltInIneligibleStatusWithTheStateThatRefusedIt(t, ctx, fixture)
 }
 
+func TestClaimerGrantsALiveLeaseOnTheRowItWonAndLeavesARefusedOneAlone(t *testing.T) {
+	fixture, ctx, cleanup := newDoltClaimerFixture(t, "cllease")
+	defer cleanup()
+	conformance.RunClaimerGrantsALiveLeaseOnTheRowItWonAndLeavesARefusedOneAlone(t, ctx, fixture)
+}
+
+func TestClaimerStampsStartedAtOnceAcrossTheTwoWritesItChoosesBetween(t *testing.T) {
+	fixture, ctx, cleanup := newDoltClaimerFixture(t, "clstart")
+	defer cleanup()
+	conformance.RunClaimerStampsStartedAtOnceAcrossTheTwoWritesItChoosesBetween(t, ctx, fixture)
+}
+
 func TestClaimerRefusesAWispIDAsNotFound(t *testing.T) {
 	fixture, ctx, cleanup := newDoltClaimerFixture(t, "clwisp")
 	defer cleanup()

--- a/internal/storage/dolt/ready_claimer_contract_test.go
+++ b/internal/storage/dolt/ready_claimer_contract_test.go
@@ -43,6 +43,18 @@ func TestReadyClaimerLeasesADurableWinButNotAnEphemeralOne(t *testing.T) {
 	conformance.RunReadyClaimerLeasesADurableWinButNotAnEphemeralOne(t, ctx, fixture)
 }
 
+func TestReadyClaimerFencesTheClaimByEveryLabelSetAndTheParentItWasGiven(t *testing.T) {
+	fixture, ctx, cleanup := newDoltReadyClaimerFixture(t, "rcfence")
+	defer cleanup()
+	conformance.RunReadyClaimerFencesTheClaimByEveryLabelSetAndTheParentItWasGiven(t, ctx, fixture)
+}
+
+func TestReadyClaimerHydratesOnlyItsBlocksEdgesIntoTheCardinalities(t *testing.T) {
+	fixture, ctx, cleanup := newDoltReadyClaimerFixture(t, "rccount")
+	defer cleanup()
+	conformance.RunReadyClaimerHydratesOnlyItsBlocksEdgesIntoTheCardinalities(t, ctx, fixture)
+}
+
 func TestReadyClaimerAnswersTheQuestionReaderReadyLists(t *testing.T) {
 	fixture, ctx, cleanup := newDoltReadyClaimerFixture(t, "rcagree")
 	defer cleanup()

--- a/internal/storage/dolt/ready_counter_contract_test.go
+++ b/internal/storage/dolt/ready_counter_contract_test.go
@@ -32,6 +32,9 @@ func TestReadyCounterContract(t *testing.T) {
 	t.Run("EphemeralGateMatchesTheListing", func(t *testing.T) {
 		conformance.RunReadyCounterEphemeralGateMatchesTheListing(t, ctx, fixture)
 	})
+	t.Run("CountsOnlyTheOpenRowsItsListingLists", func(t *testing.T) {
+		conformance.RunReadyCounterCountsOnlyTheOpenRowsItsListingLists(t, ctx, fixture)
+	})
 	t.Run("EmptyFrontIsZeroAndNil", func(t *testing.T) {
 		conformance.RunReadyCounterEmptyFrontIsZeroAndNil(t, ctx, fixture)
 	})
@@ -72,6 +75,7 @@ func newDoltReadyCounterFixture(t *testing.T, prefix string) (conformance.ReadyC
 		CreateIssue:   kit.CreateIssue,
 		CreateWisp:    kit.CreateWisp,
 		AddDependency: kit.AddDependency,
+		QueryScalar:   kit.QueryScalar,
 		CountHistory:  kit.CountHistory,
 	}, ctx, stop
 }

--- a/internal/storage/embeddeddolt/claimer_contract_test.go
+++ b/internal/storage/embeddeddolt/claimer_contract_test.go
@@ -50,6 +50,18 @@ func TestEmbeddedClaimerRefusesAWispIDAsNotFound(t *testing.T) {
 	conformance.RunClaimerRefusesAWispIDAsNotFound(t, ctx, newEmbeddedClaimerFixture(t, "clwisp"))
 }
 
+func TestEmbeddedClaimerGrantsALiveLeaseOnTheRowItWonAndLeavesARefusedOneAlone(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	ctx := t.Context()
+	conformance.RunClaimerGrantsALiveLeaseOnTheRowItWonAndLeavesARefusedOneAlone(t, ctx, newEmbeddedClaimerFixture(t, "cllease"))
+}
+
+func TestEmbeddedClaimerStampsStartedAtOnceAcrossTheTwoWritesItChoosesBetween(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	ctx := t.Context()
+	conformance.RunClaimerStampsStartedAtOnceAcrossTheTwoWritesItChoosesBetween(t, ctx, newEmbeddedClaimerFixture(t, "clstart"))
+}
+
 func TestEmbeddedClaimerRefusesIncompleteRequestsAndAnAbsentIDWithoutTouchingState(t *testing.T) {
 	skipUnlessEmbeddedDolt(t)
 	ctx := t.Context()

--- a/internal/storage/embeddeddolt/ready_claimer_contract_test.go
+++ b/internal/storage/embeddeddolt/ready_claimer_contract_test.go
@@ -56,6 +56,18 @@ func TestEmbeddedReadyClaimerSkipsIneligibleFrontRows(t *testing.T) {
 	conformance.RunReadyClaimerSkipsIneligibleFrontRows(t, ctx, newEmbeddedReadyClaimerFixture(t, "rcskip"))
 }
 
+func TestEmbeddedReadyClaimerFencesTheClaimByEveryLabelSetAndTheParentItWasGiven(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	ctx := t.Context()
+	conformance.RunReadyClaimerFencesTheClaimByEveryLabelSetAndTheParentItWasGiven(t, ctx, newEmbeddedReadyClaimerFixture(t, "rcfence"))
+}
+
+func TestEmbeddedReadyClaimerHydratesOnlyItsBlocksEdgesIntoTheCardinalities(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	ctx := t.Context()
+	conformance.RunReadyClaimerHydratesOnlyItsBlocksEdgesIntoTheCardinalities(t, ctx, newEmbeddedReadyClaimerFixture(t, "rccount"))
+}
+
 func TestEmbeddedReadyClaimerRecordsOneHistoryEntryForAWin(t *testing.T) {
 	skipUnlessEmbeddedDolt(t)
 	ctx := t.Context()

--- a/internal/storage/embeddeddolt/ready_counter_contract_test.go
+++ b/internal/storage/embeddeddolt/ready_counter_contract_test.go
@@ -36,6 +36,9 @@ func TestReadyCounterContract(t *testing.T) {
 	t.Run("EphemeralGateMatchesTheListing", func(t *testing.T) {
 		conformance.RunReadyCounterEphemeralGateMatchesTheListing(t, ctx, fixture)
 	})
+	t.Run("CountsOnlyTheOpenRowsItsListingLists", func(t *testing.T) {
+		conformance.RunReadyCounterCountsOnlyTheOpenRowsItsListingLists(t, ctx, fixture)
+	})
 	t.Run("EmptyFrontIsZeroAndNil", func(t *testing.T) {
 		conformance.RunReadyCounterEmptyFrontIsZeroAndNil(t, ctx, fixture)
 	})
@@ -65,6 +68,7 @@ func newEmbeddedReadyCounterFixture(t *testing.T, te *testEnv, prefix string) co
 		CreateIssue:   kit.CreateIssue,
 		CreateWisp:    kit.CreateWisp,
 		AddDependency: kit.AddDependency,
+		QueryScalar:   kit.QueryScalar,
 		CountHistory:  kit.CountHistory,
 	}
 }

--- a/internal/storage/uow/claimer_contract_test.go
+++ b/internal/storage/uow/claimer_contract_test.go
@@ -43,6 +43,8 @@ func TestClaimerContract(t *testing.T) {
 		{name: "AcceptsAConfiguredActiveStatusAndRefusesAConfiguredWipOne", run: conformance.RunClaimerAcceptsAConfiguredActiveStatusAndRefusesAConfiguredWipOne},
 		{name: "TakesAPoolAssignedIssueButRefusesAForeignHolder", run: conformance.RunClaimerTakesAPoolAssignedIssueButRefusesAForeignHolder},
 		{name: "RefusesABuiltInIneligibleStatusWithTheStateThatRefusedIt", run: conformance.RunClaimerRefusesABuiltInIneligibleStatusWithTheStateThatRefusedIt},
+		{name: "GrantsALiveLeaseOnTheRowItWonAndLeavesARefusedOneAlone", run: conformance.RunClaimerGrantsALiveLeaseOnTheRowItWonAndLeavesARefusedOneAlone},
+		{name: "StampsStartedAtOnceAcrossTheTwoWritesItChoosesBetween", run: conformance.RunClaimerStampsStartedAtOnceAcrossTheTwoWritesItChoosesBetween},
 		{name: "RefusesAWispIDAsNotFound", run: conformance.RunClaimerRefusesAWispIDAsNotFound},
 		{name: "RefusesIncompleteRequestsAndAnAbsentIDWithoutTouchingState", run: conformance.RunClaimerRefusesIncompleteRequestsAndAnAbsentIDWithoutTouchingState},
 		{name: "RefusalMessagesCarryTheirFragments", run: conformance.RunClaimerRefusalMessagesCarryTheirFragments},

--- a/internal/storage/uow/ready_claimer_contract_test.go
+++ b/internal/storage/uow/ready_claimer_contract_test.go
@@ -36,6 +36,8 @@ func TestReadyClaimerContract(t *testing.T) {
 		{name: "ClaimsAnEphemeralRowTheFilterAdmits", run: conformance.RunReadyClaimerClaimsAnEphemeralRowTheFilterAdmits},
 		{name: "LeavesEphemeralRowsOutOfTheDefaultReadySet", run: conformance.RunReadyClaimerLeavesEphemeralRowsOutOfTheDefaultReadySet},
 		{name: "LeasesADurableWinButNotAnEphemeralOne", run: conformance.RunReadyClaimerLeasesADurableWinButNotAnEphemeralOne},
+		{name: "FencesTheClaimByEveryLabelSetAndTheParentItWasGiven", run: conformance.RunReadyClaimerFencesTheClaimByEveryLabelSetAndTheParentItWasGiven},
+		{name: "HydratesOnlyItsBlocksEdgesIntoTheCardinalities", run: conformance.RunReadyClaimerHydratesOnlyItsBlocksEdgesIntoTheCardinalities},
 		{name: "AnswersTheQuestionReaderReadyLists", run: conformance.RunReadyClaimerAnswersTheQuestionReaderReadyLists},
 		{name: "SkipsIneligibleFrontRows", run: conformance.RunReadyClaimerSkipsIneligibleFrontRows},
 		{name: "RecordsOneHistoryEntryForAWin", run: conformance.RunReadyClaimerRecordsOneHistoryEntryForAWin},

--- a/internal/storage/uow/ready_counter_contract_test.go
+++ b/internal/storage/uow/ready_counter_contract_test.go
@@ -32,6 +32,9 @@ func TestReadyCounterContract(t *testing.T) {
 	t.Run("EphemeralGateMatchesTheListing", func(t *testing.T) {
 		conformance.RunReadyCounterEphemeralGateMatchesTheListing(t, ctx, fixture)
 	})
+	t.Run("CountsOnlyTheOpenRowsItsListingLists", func(t *testing.T) {
+		conformance.RunReadyCounterCountsOnlyTheOpenRowsItsListingLists(t, ctx, fixture)
+	})
 	t.Run("EmptyFrontIsZeroAndNil", func(t *testing.T) {
 		conformance.RunReadyCounterEmptyFrontIsZeroAndNil(t, ctx, fixture)
 	})
@@ -73,6 +76,7 @@ func newUOWReadyCounterFixture(t *testing.T, ctx context.Context, prefix string)
 		CreateIssue:   kit.CreateIssue,
 		CreateWisp:    kit.CreateWisp,
 		AddDependency: kit.AddDependency,
+		QueryScalar:   kit.QueryScalar,
 		CountHistory:  kit.CountHistory,
 	}
 }


### PR DESCRIPTION
`backend/conformance/` has two tiers. Role contracts run on all three legs. The **audit tier** (`conformance.go` + `audit_*.go`, 176 leaf cases) runs through `RunAll(t, factory)` where `Factory` is `func(*testing.T) storage.DoltStorage` — and a unit-of-work provider is not one, so **uow can never run any of it**, while the two store legs share their bodies in `internal/storage/issueops`.

That blindness has already produced three separate coverage gaps. This is the claim-family half of the migration: **additive only, nothing deleted.** +669 lines, 5 cases, all three legs.

## The lease grant — the triage's top-ranked migration

`RunClaimerGrantsALiveLeaseOnTheRowItWonAndLeavesARefusedOneAlone`, from audit `testClaim`. Pins `issueops.UpsertLeaseInTx`'s invariant — *a leases row exists iff its issue is a live claim* — plus the grant itself.

Two bodies, measured separately: flipping the uow dual's wisp guard (`domain/db/issue.go`) reddens **uow, green on dolt**; flipping the same guard in `issueops/claim.go` reddens **dolt, green on uow**.

The fixture reads the `leases` row raw — holder, `lease_expires_at > granted_at`, `heartbeat_at >= granted_at` — because **no existing detector can see a lease write**: not `updated_at`, not the event count, not history. A refusal arm asserts the holder's lease is neither minted nor *transferred*.

**Correction to the triage, from the implementer:** its claim that "nothing anywhere observes it" was stale — `issueClaimStampsLease` observes the uow dual's lease at the *repository* level. What was genuinely unpinned is the lease as a **role** promise on all three legs.

## The rest

- **`StampsStartedAtOnceAcrossTheTwoWritesItChoosesBetween`** — the stamp-on-first-transition/preserve-after promise. Drives *both* UPDATE statements: every prior fixture seeded unstamped rows, so the second statement never executed. The seeded start is 2021, far enough from `now` that second-precision `DATETIME` cannot tie. Inverting the shared branch reddens dolt; inverting uow's `startedWasZero` reddens uow.
- **`FencesTheClaimByEveryLabelSetAndTheParentItWasGiven`** — OR-set alone, unsatisfiable AND∘OR, both arms of the parent clause (dotted-id *and* recursive walk), and exhausted-fence-claims-nothing with a top-priority in-scope decoy.
- **`HydratesOnlyItsBlocksEdgesIntoTheCardinalities`** — six edges, one pair per type, raw totals asserted first. Reddens on each leg's own counts body.
- **`ReadyCounterCountsOnlyTheOpenRowsItsListingLists`** — needed a `QueryScalar` hook, because excluded rows are invisible to both compared surfaces.

## A wrong-body probe, reported rather than buried

The first mutation for the cardinalities case targeted `sqlbuild`'s join and returned `INCONCLUSIVE` — claim hydration uses `GetDependencyCountsInTx`, not `SearchCountsSQL`. Re-targeted. `INCONCLUSIVE` means the measurement failed, not that the test is weak, and this is the third time in this programme that distinction has caught a wrong-body verdict before it became a false conclusion.

## Not migratable as triaged

The **ready clamp** is `domain/db`'s `GetStatistics` — stats_reporter's contract, not this slice's, and unstageable at role tier. `WorkFilter.Statuses` (the OR-set) has **no `ReadyRequest` field on any role**, so only the reachable half of that target moved.

## Verification

Eight mutation runs, each attributed to the body it broke and reported per leg. `go build ./...`, `go vet`, `golangci-lint run` clean; contracts green on all three legs; new cases confirmed executing at each leg by name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)