### PR TITLE
Migrate the query-family audit cases into role contracts, with fixtures that can see what the old ones could not

### DIFF
--- a/backend/conformance/counter_contract.go
+++ b/backend/conformance/counter_contract.go
@@ -282,6 +282,147 @@ func RunCounterPrefixesPriorityBuckets(t *testing.T, ctx context.Context, fixtur
 	assertCounterBuckets(t, result.Groups, map[string]int{"P1": 1, "P3": 1})
 }
 
+// RunCounterPriorityBucketsCountZeroAndCountEveryRow strengthens the priority
+// dimension on the two axes the case above cannot reach, both of them
+// FIXTURE properties rather than assertion ones.
+//
+// A PRIORITY-ZERO ROW. The bucket key is read out of the database through
+// COALESCE(CAST(priority AS CHAR), ”) and then prefixed, and P0 is the one
+// value where the CAST and the COALESCE can disagree with each other: a body
+// that folded the column's zero into the empty string — the shape that
+// normalization is there to catch for the nullable columns — answers "P" for
+// it while every P1/P3 fixture stays green. P0 is also the priority `bd
+// create --priority 0` writes, so the bucket is not a corner case.
+//
+// A BUCKET HOLDING MORE THAN ONE ROW. Every priority bucket in this file held
+// exactly one, so a body whose GROUP BY counted DISTINCT anything, or returned
+// the row count of the group table rather than of the rows, is indistinguishable
+// from a correct one. Two rows share P1 here and the assertion is the exact map,
+// so both a 1 and a 3 fail.
+//
+// WHAT THIS FIXTURE CANNOT SEE: the wisp merge — every row is durable, so the
+// ephemeral half of the grouped count is somebody else's case
+// (RunCounterIncludeInfraMergesTheWispTier) — and the P-prefix itself, which
+// RunCounterPrefixesPriorityBuckets already owns.
+func RunCounterPriorityBucketsCountZeroAndCountEveryRow(t *testing.T, ctx context.Context, fixture CounterFixture) {
+	t.Helper()
+	zero := fixture.IssuePrefix + "-prio0"
+	firstOne := fixture.IssuePrefix + "-prio1-a"
+	secondOne := fixture.IssuePrefix + "-prio1-b"
+	two := fixture.IssuePrefix + "-prio2"
+
+	for _, seed := range []struct {
+		id       string
+		priority int
+	}{{zero, 0}, {firstOne, 1}, {secondOne, 1}, {two, 2}} {
+		issue := counterSeed(seed.id)
+		issue.Priority = seed.priority
+		seedCounterIssue(t, ctx, fixture, issue)
+	}
+
+	scope := counterScope(zero, firstOne, secondOne, two)
+	result := counterGroups(t, ctx, fixture, scope, publicops.CountGroupPriority)
+	assertCounterBuckets(t, result.Groups, map[string]int{"P0": 1, "P1": 2, "P2": 1})
+	if result.Total != 4 {
+		t.Errorf("Total = %d, want 4: priority buckets do not overlap, so they partition the scalar set", result.Total)
+	}
+}
+
+// RunCounterTheNoLabelBucketIsAbsentWhenEveryRowIsLabeled pins the half of the
+// synthesized "(no labels)" bucket that only a second act can show: it is
+// appended ONLY when it would be nonzero, so a set in which every row carries a
+// label has no such key at all — not a key with a zero behind it.
+//
+// The distinction is not cosmetic. `bd count --group-by label` renders one line
+// per key, so a bucket that is present-and-zero prints a phantom "(no labels) 0"
+// row; and every caller that reads the map to decide whether any unlabeled work
+// EXISTS tests for the key, not for its value.
+//
+// THE SECOND ACT IS A NARROWER SCOPE, not a label added to a row. This role has
+// no label-writing verb and its fixture has no label hook, but the request's own
+// IDFilter is enough: the same three rows, asked about twice, are first a set
+// that contains an unlabeled row and then a set that does not. The seam
+// recomputes the bucket per request, which is exactly the code the second act
+// has to reach.
+//
+// WHAT THIS FIXTURE CANNOT SEE: the overlap arithmetic — two labels on one row
+// is RunCounterLabelBucketsOverlapSoTotalIsNotTheirSum's job, and it is seeded
+// here only so the first act is not a one-label degenerate. A bucket of two
+// rows is pinned here because no label bucket in this file held more than one.
+func RunCounterTheNoLabelBucketIsAbsentWhenEveryRowIsLabeled(t *testing.T, ctx context.Context, fixture CounterFixture) {
+	t.Helper()
+	shared := fixture.IssuePrefix + "-shared"
+	extra := fixture.IssuePrefix + "-extra"
+
+	first := fixture.IssuePrefix + "-nolabel-first"
+	second := fixture.IssuePrefix + "-nolabel-second"
+	bare := fixture.IssuePrefix + "-nolabel-bare"
+
+	firstSeed := counterSeed(first)
+	firstSeed.Labels = []string{shared, extra}
+	seedCounterIssue(t, ctx, fixture, firstSeed)
+	secondSeed := counterSeed(second)
+	secondSeed.Labels = []string{shared}
+	seedCounterIssue(t, ctx, fixture, secondSeed)
+	seedCounterIssue(t, ctx, fixture, counterSeed(bare))
+
+	withBare := counterGroups(t, ctx, fixture, counterScope(first, second, bare), publicops.CountGroupLabel)
+	assertCounterBuckets(t, withBare.Groups, map[string]int{
+		shared:        2,
+		extra:         1,
+		"(no labels)": 1,
+	})
+
+	labeledOnly := counterGroups(t, ctx, fixture, counterScope(first, second), publicops.CountGroupLabel)
+	if count, present := labeledOnly.Groups["(no labels)"]; present {
+		t.Errorf("(no labels) is present with %d over a set in which every row is labeled; the bucket is appended only when it is nonzero, and a zero-valued key renders as a phantom line", count)
+	}
+	assertCounterBuckets(t, labeledOnly.Groups, map[string]int{shared: 2, extra: 1})
+}
+
+// RunCounterTypeBucketsAreTheRawTypeNames pins the type dimension, which had
+// no case at all: its keys are the stored issue_type strings, carried through
+// with none of the decoration the other dimensions get.
+//
+// The three dimensions around it are each normalized — priority is prefixed
+// with a P, assignee's empty string becomes "(unassigned)", label grows a
+// synthetic bucket — so "this one is passed through verbatim" is a decision,
+// and the exact-map assertion is what makes a fourth normalization (a "T"
+// prefix, a title-cased name, a plural) fail rather than quietly reshape every
+// `bd count --group-by type` line and every caller keying off it.
+//
+// It also pins that the dimension reads issue_type at all: nothing drove
+// CountGroupType before, so a seam whose dimension table sent "type" to the
+// status column answered a plausible map for a question nobody asked.
+//
+// WHAT THIS FIXTURE CANNOT SEE: a workspace-configured custom type — every
+// seed is a built-in — and the wisp tier, since both rows are durable.
+func RunCounterTypeBucketsAreTheRawTypeNames(t *testing.T, ctx context.Context, fixture CounterFixture) {
+	t.Helper()
+	firstBug := fixture.IssuePrefix + "-type-bug-a"
+	secondBug := fixture.IssuePrefix + "-type-bug-b"
+	chore := fixture.IssuePrefix + "-type-chore"
+
+	for _, seed := range []struct {
+		id        string
+		issueType types.IssueType
+	}{{firstBug, types.TypeBug}, {secondBug, types.TypeBug}, {chore, types.TypeChore}} {
+		issue := counterSeed(seed.id)
+		issue.IssueType = seed.issueType
+		seedCounterIssue(t, ctx, fixture, issue)
+	}
+
+	scope := counterScope(firstBug, secondBug, chore)
+	result := counterGroups(t, ctx, fixture, scope, publicops.CountGroupType)
+	assertCounterBuckets(t, result.Groups, map[string]int{
+		string(types.TypeBug):   2,
+		string(types.TypeChore): 1,
+	})
+	if result.Total != 3 {
+		t.Errorf("Total = %d, want 3: type buckets do not overlap, so they partition the scalar set", result.Total)
+	}
+}
+
 // RunCounterRefusesAnUnknownGroup pins counter.go:145-148 and :247: the
 // CountGroup set is closed, and a value outside it is ErrValidation rather
 // than an empty answer.

--- a/backend/conformance/querier_contract.go
+++ b/backend/conformance/querier_contract.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/steveyegge/beads/internal/types"
 	publicops "github.com/steveyegge/beads/issueops"
@@ -196,6 +197,236 @@ func RunQuerierSortBoundsThePageInOrder(t *testing.T, ctx context.Context, fixtu
 	}
 	if want := []string{fourth.ID, third.ID}; !slices.Equal(querierPageIDs(reversed), want) {
 		t.Errorf("reversed page = %v, want %v", querierPageIDs(reversed), want)
+	}
+}
+
+// RunQuerierSortByTitleFoldsCaseBeforeItCutsThePage pins the title order's
+// COLLATION, which the case above is structurally unable to observe.
+//
+// THE DEFECT IS IN THE FIXTURE, not in the assertion. The case above titles
+// every row with its own id, so every title is lower-case: byte order, folded
+// order and linguistic order are the same sequence over `a b y z`, and an
+// engine whose text comparison is byte-wise satisfies it exactly. That is the
+// ordering-fixture trap ADDING_AN_ISSUEOPS_ROLE.md names by name. The five
+// titles here are chosen so the three orders disagree — byte order is
+// APPLE2 < Apple < Zebra < apple < banana, folded order is
+// apple = Apple < APPLE2 < banana < Zebra — so which rows survive a cut of two
+// is a different answer under each.
+//
+// THE CUT IS WHERE IT IS OBSERVABLE, and the case has both arms because the two
+// arms fail on different legs. A bounded page is the rows the DATABASE kept, so
+// a collation break changes the page on every leg. An unbounded answer is
+// re-sorted after the fact by the shared Go comparator, which folds — and the
+// one thing that comparator cannot restore is the order INSIDE a folded tie,
+// which it reports as equal and a stable sort therefore leaves in the order the
+// query returned. So the unbounded arm pins the tie leg, and on the unit-of-work
+// leg — whose page order comes straight out of the UNION's ORDER BY — that is
+// the collation's own answer.
+//
+// WHAT THIS FIXTURE CANNOT SEE: the store legs' unbounded tie. Those two
+// backends re-order the merged rows with sqlbuild.Less before the page is cut,
+// and its tie-break is id ASC in Go, so the unbounded arm cannot fail there
+// however the engine collates. The bounded arm is the one that speaks on all
+// three legs.
+//
+// The two winners carry the WORST priorities, so the default engine order puts
+// them last: a body that bounded in storage order and sorted afterwards returns
+// neither of them, which is the property this case inherits from the one above.
+func RunQuerierSortByTitleFoldsCaseBeforeItCutsThePage(t *testing.T, ctx context.Context, fixture QuerierFixture) {
+	t.Helper()
+	scope := querierLabel(fixture, "titlefold")
+	// The ids ascend with the tags, so the two rows that fold to the same title
+	// pin the id-ASC tie leg in a known direction.
+	lower := querierTitledIssue(querierID(fixture, "titlefold", "1"), "apple", 3, scope)
+	upper := querierTitledIssue(querierID(fixture, "titlefold", "2"), "Apple", 3, scope)
+	shouted := querierTitledIssue(querierID(fixture, "titlefold", "3"), "APPLE2", 2, scope)
+	fruit := querierTitledIssue(querierID(fixture, "titlefold", "4"), "banana", 1, scope)
+	animal := querierTitledIssue(querierID(fixture, "titlefold", "5"), "Zebra", 0, scope)
+	for _, issue := range []*types.Issue{lower, upper, shouted, fruit, animal} {
+		seedQuerierIssue(t, ctx, fixture, issue)
+	}
+
+	// A conjunction the filter vocabulary expresses exactly, so the database
+	// carries both the order and the bound.
+	expression := fmt.Sprintf("type=bug AND label=%s", scope)
+	want := []string{lower.ID, upper.ID, shouted.ID, fruit.ID, animal.ID}
+
+	whole := querierIDs(t, ctx, fixture, publicops.QueryRequest{
+		Expression: expression, SortBy: "title", Limit: querierLimit(0),
+	})
+	if !slices.Equal(whole, want) {
+		t.Errorf("title order = %v, want %v: titles compare case-folded, and two titles that fold alike break by id ASC",
+			whole, want)
+	}
+
+	page := querierIDs(t, ctx, fixture, publicops.QueryRequest{
+		Expression: expression, SortBy: "title", Limit: querierLimit(2),
+	})
+	if !slices.Equal(page, want[:2]) {
+		t.Errorf("bounded page = %v, want %v: the cut keeps the first rows of the CASE-FOLDED order, so a byte-wise "+
+			"collation hands back a different page and no error", page, want[:2])
+	}
+}
+
+// RunQuerierSortByClosedPutsTheUnclosedRowsAtTheFarEnd pins the nullable sort
+// key's placement — the promise sqlbuild leads its clause with an explicit
+// (col IS NULL) term to keep: a row with no value for the key sorts LAST under
+// the key's own direction and FIRST when the direction is reversed, whatever
+// the driver's native NULL ordering happens to be.
+//
+// No contract case drove the closed sort at all before this one, in either
+// direction.
+//
+// EVERY ARM IS BOUNDED, and that is the whole design of the case. Unbounded,
+// the answer is re-sorted by the shared Go comparator, which has its own
+// nil-handling — so an unbounded assertion is one body checking itself and
+// passes with the SQL term deleted or inverted. Under a cut of two it is the
+// DATABASE that decides which rows reach the epilogue at all, and no Go
+// comparator can put back a row the query left behind. Each arm therefore
+// carries a limit smaller than the match count, and the unbounded reads are
+// kept only as the baseline the pages must be prefixes of.
+//
+// WHAT THIS FIXTURE CANNOT SEE: which encoding "no value" takes. closed_at is
+// genuinely NULL on an open row, so this key exercises the NULL term; the
+// assignee key does not, because an unassigned row's column holds the empty
+// string — that key's placement is ordinary string order and is pinned in
+// RunQuerierSortTieBreaksByIDInBothDirections instead. Nor does it see the
+// closed-row DEFAULT: IncludeClosed is set on every request here, so the
+// conditional hiding is somebody else's case.
+func RunQuerierSortByClosedPutsTheUnclosedRowsAtTheFarEnd(t *testing.T, ctx context.Context, fixture QuerierFixture) {
+	t.Helper()
+	scope := querierLabel(fixture, "closedsort")
+	older := querierWholeSecond(2021)
+	newer := querierWholeSecond(2022)
+
+	openFirst := querierTitledIssue(querierID(fixture, "closedsort", "1"), "open first", 1, scope)
+	openSecond := querierTitledIssue(querierID(fixture, "closedsort", "2"), "open second", 1, scope)
+	shutOld := querierTitledIssue(querierID(fixture, "closedsort", "3"), "shut old", 1, scope)
+	shutOld.Status = types.StatusClosed
+	shutOld.ClosedAt = &older
+	shutNew := querierTitledIssue(querierID(fixture, "closedsort", "4"), "shut new", 1, scope)
+	shutNew.Status = types.StatusClosed
+	shutNew.ClosedAt = &newer
+	for _, issue := range []*types.Issue{openFirst, openSecond, shutOld, shutNew} {
+		seedQuerierIssue(t, ctx, fixture, issue)
+	}
+
+	expression := fmt.Sprintf("type=bug AND label=%s", scope)
+	request := func(reverse bool, limit int) publicops.QueryRequest {
+		return publicops.QueryRequest{
+			Expression: expression, IncludeClosed: true,
+			SortBy: "closed", Reverse: reverse, Limit: querierLimit(limit),
+		}
+	}
+
+	// The key's own direction is newest-closed first, and the two rows that
+	// were never closed follow every row that was.
+	forward := []string{shutNew.ID, shutOld.ID, openFirst.ID, openSecond.ID}
+	if got := querierIDs(t, ctx, fixture, request(false, 0)); !slices.Equal(got, forward) {
+		t.Errorf("closed order = %v, want %v: newest close first, and the rows with no close last", got, forward)
+	}
+	if got := querierIDs(t, ctx, fixture, request(false, 2)); !slices.Equal(got, forward[:2]) {
+		t.Errorf("bounded closed page = %v, want %v: an unclosed row must not displace a closed one from the page",
+			got, forward[:2])
+	}
+
+	// Reversed, the unclosed rows lead — the placement flips with the
+	// direction rather than staying pinned to one end of the answer.
+	reversed := []string{openFirst.ID, openSecond.ID, shutOld.ID, shutNew.ID}
+	if got := querierIDs(t, ctx, fixture, request(true, 0)); !slices.Equal(got, reversed) {
+		t.Errorf("reversed closed order = %v, want %v: the rows with no close lead, then the oldest close",
+			got, reversed)
+	}
+	if got := querierIDs(t, ctx, fixture, request(true, 2)); !slices.Equal(got, reversed[:2]) {
+		t.Errorf("bounded reversed closed page = %v, want %v: reversing moves the unclosed rows INTO the page, "+
+			"which is the half a driver's native NULL order gets wrong", got, reversed[:2])
+	}
+}
+
+// RunQuerierSortTieBreaksByIDInBothDirections pins the other half of every
+// non-default sort clause: rows the key cannot separate are ordered by id
+// ASC, and reversing the request flips the KEY only — the tie-break never
+// turns around.
+//
+// It is what makes a sorted page reproducible. Two rows updated in the same
+// second, or sharing a status, are a tie at the key; if the tie-break flipped
+// with the key, the same request answered twice around a reversal would visit
+// the tied rows in two different orders and a caller paging through them would
+// see rows move under it.
+//
+// THREE KEYS, BECAUSE THE TIE ARRIVES THREE DIFFERENT WAYS: a timestamp column
+// (whole-second stamps that collide), an enumerated string column (a status
+// two rows share), and a column that is EMPTY on every row here — the
+// unassigned case, where the tied group is the entire answer and reversing the
+// request must therefore change nothing at all.
+//
+// WHERE THE ANSWER COMES FROM DIFFERS BY LEG, which is why this is worth
+// running on all three. The role's own epilogue reports a tie as equal and
+// sorts stably, so it hands the decision back to whatever produced the rows:
+// the unit-of-work leg's UNION ORDER BY, and the store legs' Go mirror of it
+// (sqlbuild.Less). Two bodies, one promise.
+//
+// WHAT THIS FIXTURE CANNOT SEE: the direction of the KEY on a nullable column —
+// no row here has a NULL sort key, so
+// RunQuerierSortByClosedPutsTheUnclosedRowsAtTheFarEnd owns that — and any
+// order below a page cut, since every read here is unbounded so that the tied
+// group is visible whole.
+func RunQuerierSortTieBreaksByIDInBothDirections(t *testing.T, ctx context.Context, fixture QuerierFixture) {
+	t.Helper()
+	scope := querierLabel(fixture, "tiebreak")
+	tied := querierWholeSecond(2020)
+	fresh := querierWholeSecond(2022)
+
+	first := querierTitledIssue(querierID(fixture, "tiebreak", "1"), "tied first", 1, scope)
+	first.UpdatedAt = tied
+	first.CreatedAt = tied
+	second := querierTitledIssue(querierID(fixture, "tiebreak", "2"), "tied second", 1, scope)
+	second.UpdatedAt = tied
+	second.CreatedAt = tied
+	shut := querierTitledIssue(querierID(fixture, "tiebreak", "3"), "tied closed", 1, scope)
+	shut.Status = types.StatusClosed
+	shut.UpdatedAt = tied
+	shut.CreatedAt = tied
+	moving := querierTitledIssue(querierID(fixture, "tiebreak", "4"), "moved lately", 1, scope)
+	moving.Status = types.StatusInProgress
+	moving.UpdatedAt = fresh
+	moving.CreatedAt = fresh
+	for _, issue := range []*types.Issue{first, second, shut, moving} {
+		seedQuerierIssue(t, ctx, fixture, issue)
+	}
+
+	expression := fmt.Sprintf("type=bug AND label=%s", scope)
+	answer := func(sortBy string, reverse bool) []string {
+		return querierIDs(t, ctx, fixture, publicops.QueryRequest{
+			Expression: expression, IncludeClosed: true,
+			SortBy: sortBy, Reverse: reverse, Limit: querierLimit(0),
+		})
+	}
+
+	for _, test := range []struct {
+		name    string
+		sortBy  string
+		reverse bool
+		want    []string
+	}{
+		// Most recently updated first; the three same-second rows are a tie.
+		{"updated", "updated", false, []string{moving.ID, first.ID, second.ID, shut.ID}},
+		// Reversed, the tied group moves to the front UNCHANGED.
+		{"updated reversed", "updated", true, []string{first.ID, second.ID, shut.ID, moving.ID}},
+		// closed < in_progress < open, and the two open rows tie.
+		{"status", "status", false, []string{shut.ID, moving.ID, first.ID, second.ID}},
+		{"status reversed", "status", true, []string{first.ID, second.ID, moving.ID, shut.ID}},
+		// Nothing here is assigned, so the tie is the whole answer and
+		// reversing it is a no-op.
+		{"assignee", "assignee", false, []string{first.ID, second.ID, shut.ID, moving.ID}},
+		{"assignee reversed", "assignee", true, []string{first.ID, second.ID, shut.ID, moving.ID}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := answer(test.sortBy, test.reverse); !slices.Equal(got, test.want) {
+				t.Errorf("sort by %q reverse=%v = %v, want %v: ties break by id ASC, and a reversal flips the key alone",
+					test.sortBy, test.reverse, got, test.want)
+			}
+		})
 	}
 }
 
@@ -482,6 +713,22 @@ func querierIssue(id string, issueType types.IssueType, priority int, labels ...
 		IssueType: issueType,
 		Labels:    labels,
 	}
+}
+
+// querierTitledIssue is querierIssue for the ordering cases, which need a
+// title that is not the row's own id: an id-titled fixture can only carry the
+// lower-case, seed-ordered titles that make a collation break invisible.
+func querierTitledIssue(id, title string, priority int, labels ...string) *types.Issue {
+	issue := querierIssue(id, types.TypeBug, priority, labels...)
+	issue.Title = title
+	return issue
+}
+
+// querierWholeSecond is a fixed timestamp with no sub-second part, so a column
+// stored at DATETIME(0) round-trips it exactly and two rows given the same one
+// are a genuine tie rather than a truncation artifact.
+func querierWholeSecond(year int) time.Time {
+	return time.Date(year, time.June, 1, 12, 0, 0, 0, time.UTC)
 }
 
 func seedQuerierIssue(t *testing.T, ctx context.Context, fixture QuerierFixture, issue *types.Issue) {

--- a/backend/conformance/stats_reporter_contract.go
+++ b/backend/conformance/stats_reporter_contract.go
@@ -182,6 +182,56 @@ func RunStatsReporterBlockedExcludesByStatusNotByThePinnedFlag(t *testing.T, ctx
 	})
 }
 
+// RunStatsReporterBlockedCountsEveryUnfinishedStatusNotJustOpen pins the
+// POSITIVE half of the same clause the case above pins from the exclusion
+// side: BlockedIssues counts a blocked row whose status is anything other
+// than closed or pinned, not only an open one.
+//
+// IT EXISTS BECAUSE OF THE FIXTURES, not because of the assertions. Every
+// blocked row any other case in this file seeds is status OPEN — the graph
+// case, the exclusion case and the arithmetic case all seed `open`. So a body
+// that spelled the clause `is_blocked = 1 AND status = 'open'` answers all
+// three of them correctly and is wrong for every workspace where somebody has
+// claimed a blocked bead. This is the one fixture in which nothing blocked is
+// open.
+//
+// THE BLOCKER IS THE ONLY OPEN ROW HERE, deliberately: OpenIssues moves by one
+// while BlockedIssues moves by two, so a body that read the blocked count off
+// the open tally cannot land on the right number by accident. The deferred row
+// is the second arm — "not open" is not a synonym for "in progress" either.
+//
+// It is worth its own case rather than a seed on the exclusion case because
+// the query is written out THREE times (dolt/queries.go,
+// embeddeddolt/statistics.go, domain/db/issue.go), so this is three votes and
+// not one; and because `bd status`'s headline ReadyIssues is OpenIssues minus
+// this number, so a body that under-counts here reports work as ready that no
+// agent can start.
+//
+// WHAT THIS FIXTURE CANNOT SEE: the exclusion side. Nothing here is closed or
+// pinned, so a body that dropped both status terms entirely still passes —
+// RunStatsReporterBlockedExcludesByStatusNotByThePinnedFlag is the half that
+// fails then. The two cases are one clause read from its two ends.
+func RunStatsReporterBlockedCountsEveryUnfinishedStatusNotJustOpen(t *testing.T, ctx context.Context, fixture StatsReporterFixture) {
+	t.Helper()
+	before := statsReporterSummary(t, ctx, fixture, publicops.StatsRequest{})
+
+	blocker := statsReporterSeed(fixture, "unfinished-blocker", types.StatusOpen)
+	seedStatsReporterIssue(t, ctx, fixture, blocker)
+
+	claimed := statsReporterSeed(fixture, "unfinished-wip", types.StatusInProgress)
+	seedStatsReporterIssue(t, ctx, fixture, claimed)
+	blockStatsReporterIssue(t, ctx, fixture, claimed.ID, blocker.ID)
+
+	deferred := statsReporterSeed(fixture, "unfinished-deferred", types.StatusDeferred)
+	seedStatsReporterIssue(t, ctx, fixture, deferred)
+	blockStatsReporterIssue(t, ctx, fixture, deferred.ID, blocker.ID)
+
+	after := statsReporterSummary(t, ctx, fixture, publicops.StatsRequest{})
+	assertStatsReporterDelta(t, before, after, statsReporterCounts{
+		total: 3, open: 1, inProgress: 1, deferred: 1, blocked: 2,
+	})
+}
+
 // RunStatsReporterReadyIsOpenMinusBlocked pins statsreporter.go:103-108:
 // ReadyIssues is arithmetic over two numbers in the same answer, not a query.
 // The identity is asserted on the ABSOLUTE summary because it is a property of

--- a/internal/storage/dolt/counter_contract_test.go
+++ b/internal/storage/dolt/counter_contract_test.go
@@ -47,6 +47,15 @@ func TestCounterContract(t *testing.T) {
 	t.Run("PrefixesPriorityBuckets", func(t *testing.T) {
 		conformance.RunCounterPrefixesPriorityBuckets(t, ctx, fixture)
 	})
+	t.Run("PriorityBucketsCountZeroAndCountEveryRow", func(t *testing.T) {
+		conformance.RunCounterPriorityBucketsCountZeroAndCountEveryRow(t, ctx, fixture)
+	})
+	t.Run("TheNoLabelBucketIsAbsentWhenEveryRowIsLabeled", func(t *testing.T) {
+		conformance.RunCounterTheNoLabelBucketIsAbsentWhenEveryRowIsLabeled(t, ctx, fixture)
+	})
+	t.Run("TypeBucketsAreTheRawTypeNames", func(t *testing.T) {
+		conformance.RunCounterTypeBucketsAreTheRawTypeNames(t, ctx, fixture)
+	})
 	t.Run("RefusesAnUnknownGroup", func(t *testing.T) {
 		conformance.RunCounterRefusesAnUnknownGroup(t, ctx, fixture)
 	})

--- a/internal/storage/dolt/querier_contract_test.go
+++ b/internal/storage/dolt/querier_contract_test.go
@@ -29,6 +29,15 @@ func TestQuerierContract(t *testing.T) {
 	t.Run("SortBoundsThePageInOrder", func(t *testing.T) {
 		conformance.RunQuerierSortBoundsThePageInOrder(t, ctx, fixture)
 	})
+	t.Run("SortByTitleFoldsCaseBeforeItCutsThePage", func(t *testing.T) {
+		conformance.RunQuerierSortByTitleFoldsCaseBeforeItCutsThePage(t, ctx, fixture)
+	})
+	t.Run("SortByClosedPutsTheUnclosedRowsAtTheFarEnd", func(t *testing.T) {
+		conformance.RunQuerierSortByClosedPutsTheUnclosedRowsAtTheFarEnd(t, ctx, fixture)
+	})
+	t.Run("SortTieBreaksByIDInBothDirections", func(t *testing.T) {
+		conformance.RunQuerierSortTieBreaksByIDInBothDirections(t, ctx, fixture)
+	})
 	t.Run("SortSeesTheWholeMatchingSet", func(t *testing.T) {
 		conformance.RunQuerierSortSeesTheWholeMatchingSet(t, ctx, fixture)
 	})

--- a/internal/storage/dolt/stats_reporter_contract_test.go
+++ b/internal/storage/dolt/stats_reporter_contract_test.go
@@ -36,6 +36,9 @@ func TestStatsReporterContract(t *testing.T) {
 	t.Run("BlockedExcludesByStatusNotByThePinnedFlag", func(t *testing.T) {
 		conformance.RunStatsReporterBlockedExcludesByStatusNotByThePinnedFlag(t, ctx, fixture)
 	})
+	t.Run("BlockedCountsEveryUnfinishedStatusNotJustOpen", func(t *testing.T) {
+		conformance.RunStatsReporterBlockedCountsEveryUnfinishedStatusNotJustOpen(t, ctx, fixture)
+	})
 	t.Run("ReadyIsOpenMinusBlocked", func(t *testing.T) {
 		conformance.RunStatsReporterReadyIsOpenMinusBlocked(t, ctx, fixture)
 	})

--- a/internal/storage/embeddeddolt/counter_contract_test.go
+++ b/internal/storage/embeddeddolt/counter_contract_test.go
@@ -50,6 +50,15 @@ func TestCounterContract(t *testing.T) {
 	t.Run("PrefixesPriorityBuckets", func(t *testing.T) {
 		conformance.RunCounterPrefixesPriorityBuckets(t, ctx, fixture)
 	})
+	t.Run("PriorityBucketsCountZeroAndCountEveryRow", func(t *testing.T) {
+		conformance.RunCounterPriorityBucketsCountZeroAndCountEveryRow(t, ctx, fixture)
+	})
+	t.Run("TheNoLabelBucketIsAbsentWhenEveryRowIsLabeled", func(t *testing.T) {
+		conformance.RunCounterTheNoLabelBucketIsAbsentWhenEveryRowIsLabeled(t, ctx, fixture)
+	})
+	t.Run("TypeBucketsAreTheRawTypeNames", func(t *testing.T) {
+		conformance.RunCounterTypeBucketsAreTheRawTypeNames(t, ctx, fixture)
+	})
 	t.Run("RefusesAnUnknownGroup", func(t *testing.T) {
 		conformance.RunCounterRefusesAnUnknownGroup(t, ctx, fixture)
 	})

--- a/internal/storage/embeddeddolt/querier_contract_test.go
+++ b/internal/storage/embeddeddolt/querier_contract_test.go
@@ -32,6 +32,15 @@ func TestQuerierContract(t *testing.T) {
 	t.Run("SortBoundsThePageInOrder", func(t *testing.T) {
 		conformance.RunQuerierSortBoundsThePageInOrder(t, ctx, fixture)
 	})
+	t.Run("SortByTitleFoldsCaseBeforeItCutsThePage", func(t *testing.T) {
+		conformance.RunQuerierSortByTitleFoldsCaseBeforeItCutsThePage(t, ctx, fixture)
+	})
+	t.Run("SortByClosedPutsTheUnclosedRowsAtTheFarEnd", func(t *testing.T) {
+		conformance.RunQuerierSortByClosedPutsTheUnclosedRowsAtTheFarEnd(t, ctx, fixture)
+	})
+	t.Run("SortTieBreaksByIDInBothDirections", func(t *testing.T) {
+		conformance.RunQuerierSortTieBreaksByIDInBothDirections(t, ctx, fixture)
+	})
 	t.Run("SortSeesTheWholeMatchingSet", func(t *testing.T) {
 		conformance.RunQuerierSortSeesTheWholeMatchingSet(t, ctx, fixture)
 	})

--- a/internal/storage/embeddeddolt/stats_reporter_contract_test.go
+++ b/internal/storage/embeddeddolt/stats_reporter_contract_test.go
@@ -41,6 +41,9 @@ func TestStatsReporterContract(t *testing.T) {
 	t.Run("BlockedExcludesByStatusNotByThePinnedFlag", func(t *testing.T) {
 		conformance.RunStatsReporterBlockedExcludesByStatusNotByThePinnedFlag(t, ctx, fixture)
 	})
+	t.Run("BlockedCountsEveryUnfinishedStatusNotJustOpen", func(t *testing.T) {
+		conformance.RunStatsReporterBlockedCountsEveryUnfinishedStatusNotJustOpen(t, ctx, fixture)
+	})
 	t.Run("ReadyIsOpenMinusBlocked", func(t *testing.T) {
 		conformance.RunStatsReporterReadyIsOpenMinusBlocked(t, ctx, fixture)
 	})

--- a/internal/storage/uow/counter_contract_test.go
+++ b/internal/storage/uow/counter_contract_test.go
@@ -47,6 +47,15 @@ func TestCounterContract(t *testing.T) {
 	t.Run("PrefixesPriorityBuckets", func(t *testing.T) {
 		conformance.RunCounterPrefixesPriorityBuckets(t, ctx, fixture)
 	})
+	t.Run("PriorityBucketsCountZeroAndCountEveryRow", func(t *testing.T) {
+		conformance.RunCounterPriorityBucketsCountZeroAndCountEveryRow(t, ctx, fixture)
+	})
+	t.Run("TheNoLabelBucketIsAbsentWhenEveryRowIsLabeled", func(t *testing.T) {
+		conformance.RunCounterTheNoLabelBucketIsAbsentWhenEveryRowIsLabeled(t, ctx, fixture)
+	})
+	t.Run("TypeBucketsAreTheRawTypeNames", func(t *testing.T) {
+		conformance.RunCounterTypeBucketsAreTheRawTypeNames(t, ctx, fixture)
+	})
 	t.Run("RefusesAnUnknownGroup", func(t *testing.T) {
 		conformance.RunCounterRefusesAnUnknownGroup(t, ctx, fixture)
 	})

--- a/internal/storage/uow/querier_contract_test.go
+++ b/internal/storage/uow/querier_contract_test.go
@@ -32,6 +32,15 @@ func TestQuerierContract(t *testing.T) {
 	t.Run("SortBoundsThePageInOrder", func(t *testing.T) {
 		conformance.RunQuerierSortBoundsThePageInOrder(t, ctx, fixture)
 	})
+	t.Run("SortByTitleFoldsCaseBeforeItCutsThePage", func(t *testing.T) {
+		conformance.RunQuerierSortByTitleFoldsCaseBeforeItCutsThePage(t, ctx, fixture)
+	})
+	t.Run("SortByClosedPutsTheUnclosedRowsAtTheFarEnd", func(t *testing.T) {
+		conformance.RunQuerierSortByClosedPutsTheUnclosedRowsAtTheFarEnd(t, ctx, fixture)
+	})
+	t.Run("SortTieBreaksByIDInBothDirections", func(t *testing.T) {
+		conformance.RunQuerierSortTieBreaksByIDInBothDirections(t, ctx, fixture)
+	})
 	t.Run("SortSeesTheWholeMatchingSet", func(t *testing.T) {
 		conformance.RunQuerierSortSeesTheWholeMatchingSet(t, ctx, fixture)
 	})

--- a/internal/storage/uow/stats_reporter_contract_test.go
+++ b/internal/storage/uow/stats_reporter_contract_test.go
@@ -36,6 +36,9 @@ func TestStatsReporterContract(t *testing.T) {
 	t.Run("BlockedExcludesByStatusNotByThePinnedFlag", func(t *testing.T) {
 		conformance.RunStatsReporterBlockedExcludesByStatusNotByThePinnedFlag(t, ctx, fixture)
 	})
+	t.Run("BlockedCountsEveryUnfinishedStatusNotJustOpen", func(t *testing.T) {
+		conformance.RunStatsReporterBlockedCountsEveryUnfinishedStatusNotJustOpen(t, ctx, fixture)
+	})
 	t.Run("ReadyIsOpenMinusBlocked", func(t *testing.T) {
 		conformance.RunStatsReporterReadyIsOpenMinusBlocked(t, ctx, fixture)
 	})


### PR DESCRIPTION
The audit tier (`conformance.go` + `audit_*.go`) runs through `RunAll(t, factory)` where `Factory` is `func(*testing.T) storage.DoltStorage`. A unit-of-work provider is not one, so **uow can never run any of it**, and the two store legs share `internal/storage/issueops` — ~176 cases largely comparing an implementation against itself.

This is the query-family half: **additive only, nothing deleted.** +501 lines, 7 cases, 8 triage rows, all three legs.

Every one of these existed because a *fixture* could not see a defect, not because an assertion was wrong. That is the through-line.

## The clearest vindication: blocked statistics

`RunStatsReporterBlockedCountsEveryUnfinishedStatusNotJustOpen`. The blocked query is written **three times** across the implementations, and **every existing blocked seed in the file is `status=open`** — so a body computing `is_blocked AND status='open'` passed everything.

Mutation applied separately to each spelling: `dolt/queries.go` → audit FAIL / contract FAIL; `embeddeddolt/statistics.go` → FAIL/FAIL; **`domain/db/issue.go` → dolt contract PASS, uow contract FAIL**. The uow body is unreachable from the audit tier entirely — which is the whole argument for this migration in one measurement.

The new fixture makes the blocker the only open row, with an `in_progress` and a `deferred` row blocked, so Blocked moves by 2 while Open moves by 1.

## Ordering cases whose old fixtures were structurally blind

- **`SortByTitleFoldsCaseBeforeItCutsThePage`** — the existing case titles each row with its own id, so byte, folded and linguistic order all coincide and the `LOWER(title)` term is unobservable. New fixture: apple/Apple/APPLE2/banana/Zebra, plus a **bounded** arm.
- **`SortByClosedPutsTheUnclosedRowsAtTheFarEnd`** — every arm is bounded *below* the match count, because unbounded the shared Go comparator re-sorts and the SQL `(col IS NULL)` lead term cannot be seen.
- **`SortTieBreaksByIDInBothDirections`** — ties arrive three ways (colliding timestamps, shared status, an empty column where the tie *is* the answer). Two bodies measured separately: the SQL tie leg reddens uow with dolt green; the Go mirror `sqlbuild.Less` reddens both stores with uow green.

**New coverage the audit tier never had:** `sqlbuild.Less` — the Go comparator the store legs re-sort a page with before the cut — had **no tie-break pin anywhere**. `testAuditSearchSortTieBreakSurvivesReversal` goes green under that mutation; the new contract case does not.

## Counter

`PriorityBucketsCountZeroAndCountEveryRow` (P0 folded to `''`, plus bucket cardinality), `TheNoLabelBucketIsAbsentWhenEveryRowIsLabeled` (staged by narrowing `IDFilter`, so no label-write hook was needed), and `TypeBucketsAreTheRawTypeNames` — the type dimension had **no case at all**. These are one shared body: engine legs, not a third vote, and reported as such.

## Scope corrections

The counts-split row is **not this slice's** — the triage targets it at `reader_contract.go` and `ready_claimer_contract.go`; Counter has no dependents-of-a-target verb. Rows #10/#12/#13 were "querier *or* reader" and were taken into querier, so the reader slice should not duplicate them.

## Verification

Every case mutation-verified against the body implementing it, per leg. `go build ./...`, `go vet`, `golangci-lint run` clean; contracts green on all three legs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)