### PR TITLE
Make the conformance obligation true: rewire the dolt_log probes, fix the doc that lied

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -3,7 +3,7 @@
 // implement (the engine interface storage.DoltStorage and every type its
 // method signatures reach), the process-init registry that plugs an
 // implementation into bd, and — via the backend/conformance subpackage — the
-// suite that proves an implementation behaves like the Dolt reference.
+// tests that prove an implementation behaves like the Dolt reference.
 //
 // Every name here is an alias or thin wrapper over the in-tree definition, so
 // an external implementation and the in-tree consumers see IDENTICAL types:
@@ -27,13 +27,26 @@
 //	    })
 //	}
 //
-// and proves itself with the conformance suite:
+// and proves itself with the conformance package:
 //
 //	func TestConformance(t *testing.T) {
+//	    // What the backend declares it does not do.
+//	    conformance.RunUnsupportedContract(t, &Store{}, unsupported)
+//	    // What it does: the portable raw surface.
 //	    conformance.RunAll(t, func(t *testing.T) backend.DoltStorage {
 //	        return newTestStore(t)
 //	    })
 //	}
+//
+// The two halves are not interchangeable. RunAll covers the portable raw
+// surface — roughly half of core Storage plus five capability sub-interfaces —
+// and calls NO method of VersionControl, HistoryViewer, RemoteStore, SyncStore,
+// FederationStore, CompactionStore or FastStatisticsStore. Those seven are
+// proved only by the allowlist: a backend that answers them with a typed
+// ErrUnsupported and runs RunUnsupportedContract has satisfied everything the
+// suite asks of them. The conformance package doc measures the split, and the
+// role contracts in that package are the third piece, covering the issueops
+// roles the accessors on Storage return.
 //
 // Registration is init-time wiring only; see Register. bd init / bd bootstrap
 // do not provision registered backends — an external backend supplies its own
@@ -59,8 +72,11 @@ import (
 // DoltStorage is the full engine interface an external backend implements:
 // the core Storage interface plus every capability sub-interface. The name is
 // historical — the Dolt stores were its first implementations — but the
-// contract is backend-agnostic; the conformance suite exercises exactly this
-// surface.
+// contract is backend-agnostic.
+//
+// Implementing it is not the same as being exercised by the conformance suite,
+// which reaches roughly half of it; the rest is declared through the unsupported
+// allowlist. See the conformance package doc for which half is which.
 type DoltStorage = storage.DoltStorage
 
 // The engine interface decomposes into the core Storage interface plus these

--- a/backend/conformance/batch_closer_contract.go
+++ b/backend/conformance/batch_closer_contract.go
@@ -91,6 +91,12 @@ type BatchCloserFixture struct {
 	// entry-per-call clause. Nil means this backend cannot observe history,
 	// and the two history cases then skip loudly rather than pass quietly.
 	CountHistory func(context.Context) (int, error)
+	// CountHistoryMatching is CountHistory narrowed to the entries whose
+	// message matches a SQL LIKE pattern ("" = every entry), which is how the
+	// wisp-naming case asks whether any entry NAMES an id. Nil means this
+	// backend cannot observe history by message, and that case skips loudly.
+	// See history_matching.go for the convention.
+	CountHistoryMatching func(context.Context, string) (int, error)
 }
 
 // RunBatchCloserOutcomesMirrorItemsIndexForIndex pins the index correspondence
@@ -711,6 +717,7 @@ func RunBatchCloserDurableHistoryNeverNamesAWisp(t *testing.T, ctx context.Conte
 	t.Helper()
 	requireBatchCloserWisps(t, fixture)
 	requireBatchCloserHistory(t, fixture)
+	requireBatchCloserHistoryMatching(t, fixture)
 	durable := fixture.IssuePrefix + "-wisphistory-durable"
 	wisp := fixture.IssuePrefix + "-wisphistory-wisp"
 	seedBatchCloserIssue(t, ctx, fixture, durable)
@@ -1323,11 +1330,13 @@ func assertBatchCloserWispStatus(t *testing.T, ctx context.Context, fixture Batc
 // message mentions id anywhere. The contract asserts on the MESSAGE rather than
 // on a count alone because "an entry naming a wisp" is a claim about what
 // shipped, and only the message carries an id at all.
+//
+// The ids this is called with are the fixture's own seeded ones, which carry no
+// LIKE wildcard, so the surrounding %s are the only wildcards in the pattern.
 func batchCloserHistoryEntriesNaming(t *testing.T, ctx context.Context, fixture BatchCloserFixture, id string) int {
 	t.Helper()
-	var entries int
-	if err := fixture.QueryScalar(ctx,
-		"SELECT COUNT(*) FROM dolt_log WHERE message LIKE ?", []any{"%" + id + "%"}, &entries); err != nil {
+	entries, err := fixture.CountHistoryMatching(ctx, "%"+historyPatternForExactMessage(t, id)+"%")
+	if err != nil {
 		t.Fatalf("count history entries naming %s: %v", id, err)
 	}
 	return entries
@@ -1366,6 +1375,16 @@ func requireBatchCloserHistory(t *testing.T, fixture BatchCloserFixture) {
 	t.Helper()
 	if fixture.CountHistory == nil {
 		t.Skipf("fixture has no CountHistory: this backend cannot observe history, so batchcloser.go:119-122 is UNPINNED here")
+	}
+}
+
+// requireBatchCloserHistoryMatching is requireBatchCloserHistory for the
+// message-scoped count: a backend that can say how LONG its history is but not
+// what an entry READS leaves the wisp-naming clause unpinned, and says so.
+func requireBatchCloserHistoryMatching(t *testing.T, fixture BatchCloserFixture) {
+	t.Helper()
+	if fixture.CountHistoryMatching == nil {
+		t.Skipf("fixture has no CountHistoryMatching: this backend cannot observe history BY MESSAGE, so batchcloser.go:128-135 is UNPINNED here")
 	}
 }
 

--- a/backend/conformance/claim.go
+++ b/backend/conformance/claim.go
@@ -10,10 +10,11 @@ import (
 	"github.com/steveyegge/beads/internal/types"
 )
 
-// Claim / lease behavior (Gas Station v1.1 dead-worker recovery). Each backend
-// routes ClaimIssue/ClaimReadyIssue/HeartbeatIssue/ReclaimExpiredLeases through the
-// shared issueops implementations, so these assertions hold identically on Dolt and
-// SQLite. issueops.WithLeaseTTL pins the lease deterministically
+// Claim / lease behavior (Gas Station v1.1 dead-worker recovery). The in-tree backends
+// route ClaimIssue/ClaimReadyIssue/HeartbeatIssue/ReclaimExpiredLeases through the
+// shared issueops implementations, so they answer these assertions identically; a
+// backend with a claim path of its own is what the assertions are here to measure.
+// issueops.WithLeaseTTL pins the lease deterministically
 // so the reclaim path is testable without wall-clock waits.
 
 // testClaim: claiming an open issue stamps assignee, in_progress, started_at, and a

--- a/backend/conformance/conformance.go
+++ b/backend/conformance/conformance.go
@@ -1,10 +1,57 @@
 // Package conformance provides backend-agnostic tests for Storage
-// implementations: the suite every storage backend — in-tree or out-of-tree —
-// runs to prove it behaves like the embedded-Dolt reference.
+// implementations. It holds TWO tiers, and RunAll is one of them.
 //
-// Usage from a backend test file:
+// # What RunAll proves
+//
+// RunAll is the PORTABLE RAW-SURFACE suite. It drives the store's own methods —
+// issue CRUD, search and counts, dependencies and readiness, labels, comments,
+// config, metadata slots, statistics, staleness, iterators, transactions,
+// claim/lease/heartbeat/reclaim, promote and rekey, batch create — and for most
+// of that surface it is the ONLY conformance coverage there is: the role tier
+// reaches a store through a handful of fixture seed hooks and nothing else.
+//
+// Counting the methods invoked on the store a Factory returns (measured
+// 2026-08-09): 51 of core Storage's 98, plus 32 across five capability
+// sub-interfaces — BulkIssueStore (10/10), DependencyQueryStore,
+// ConfigMetadataStore, AnnotationStore and AdvancedQueryStore (6/6) — and
+// EventQueryStore through the Transaction that RunInTransaction yields. Most of
+// the untouched half of core Storage is the 23 role accessors, which the role
+// contracts cover instead.
+//
+// What RunAll does NOT do is exercise the version-control families its Factory
+// type names. This package makes no call to any method of VersionControl,
+// HistoryViewer, RemoteStore, SyncStore, FederationStore, CompactionStore or
+// FastStatisticsStore — not one, in either tier. Their positive behavior has no
+// conformance coverage anywhere. A backend DECLARES those families instead:
+// it answers a typed *storage.ErrUnsupported and proves that with
+// RunUnsupportedContract over its allowlist. A backend that stubs all seven
+// passes RunAll today, because the stubs are never reached.
+//
+// # Why Factory is storage.DoltStorage
+//
+// Because the registry door is (internal/storage/backends), not because this
+// suite needs the surface. For a backend the registry already admits, the type
+// asks nothing beyond registration. It is a wall only for a provider that is
+// not a store at all — the in-tree unit-of-work provider, which is why the
+// Claimer role is wired outside RunAll (see the note in RunAll's body).
+//
+// The name RunAll is historical and stays. The suite is not Dolt-specific, and
+// the name overstates only its coverage, not its portability.
+//
+// # The role tier
+//
+// The *_contract.go files hold the role contracts: the SEMANTIC obligation, one
+// contract per issueops role, driven through small per-fixture hooks rather
+// than through the store type — which is how a provider that could never enter
+// RunAll proves the same promises. Their portability class is "a store that can
+// answer single-row SQL over the canonical relational schema": QueryScalar is
+// required, while CountHistory, CountHistoryMatching, Exec and the seed hooks
+// are optional and degrade LOUDLY when nil (see history_matching.go).
+//
+// # Usage from a backend test file
 //
 //	func TestConformance(t *testing.T) {
+//	    conformance.RunUnsupportedContract(t, &Store{}, unsupported)
 //	    conformance.RunAll(t, func(t *testing.T) storage.DoltStorage {
 //	        return newTestStore(t)
 //	    })
@@ -14,8 +61,7 @@
 // its public alias, github.com/steveyegge/beads/backend.DoltStorage — the
 // identical type, so the factory literal satisfies Factory as-is. The whole
 // public contract an external backend implements (interface, signature types,
-// registry, sentinels) lives in that backend package; this package is its
-// proof obligation.
+// registry, sentinels) lives in that backend package.
 //
 // # Stability
 //
@@ -224,10 +270,15 @@ func RunAll(t *testing.T, factory Factory) {
 	t.Run("TransactionReadYourWrites", func(t *testing.T) { testTransactionReadYourWrites(t, factory) })
 }
 
-// RunDeferredReads runs the subset of the suite covering SQLite's shared
-// non-version-control reads: statistics, external-ref lookup, and staleness. RunAll
-// remains the full Dolt reference; SQLite runs this focused gate for methods supplied
-// by issueops while its Dolt-only methods fail loudly as unsupported.
+// RunDeferredReads runs a curated three-case subset — statistics, external-ref
+// lookup, staleness — for a backend whose unsupported allowlist refuses enough
+// of RunAll's subjects that the full suite is the wrong gate.
+//
+// It is the worked example the admission rule in RunSearchPaging cites. Its
+// original consumer, the in-tree SQLite backend, is gone (configfile now answers
+// that name with a RemovedBackendError), so this entry point has no caller
+// in-tree; it survives as the published precedent for composing a
+// supported-subset gate out of the per-block runners.
 func RunDeferredReads(t *testing.T, factory Factory) {
 	t.Helper()
 	t.Run("Statistics", func(t *testing.T) { testStatistics(t, factory) })

--- a/backend/conformance/history_matching.go
+++ b/backend/conformance/history_matching.go
@@ -1,0 +1,52 @@
+package conformance
+
+import (
+	"strings"
+	"testing"
+)
+
+// This file holds the shared half of the message-scoped history hook that three
+// role contracts observe through. The hook itself is declared on each fixture
+// that needs it, named and typed identically so one per-backend closure fills
+// all three:
+//
+//	CountHistoryMatching func(ctx context.Context, pattern string) (int, error)
+//
+// It counts the entries in the backend's version log whose message matches
+// pattern, where "" means every entry and anything else is a SQL LIKE pattern
+// the backend applies with its own escaping. It exists because three cases
+// assert on what an entry READS — "an entry naming this wisp", "an entry
+// reading the caller's provenance label" — which plain CountHistory cannot
+// express, and which those cases used to get by sending
+// `SELECT COUNT(*) FROM dolt_log ...` through QueryScalar. That was the only
+// Dolt-engine dependency in the role tier: a backend with no dolt_log table
+// FAILED those three cases instead of skipping them.
+//
+// CountHistoryMatching does not supersede CountHistory. The two declare
+// different capabilities — a backend can know how long its history is without
+// being able to match on the text of an entry — and 25 cases run on the narrow
+// hook alone. Where a backend has both, its fixture kit defines CountHistory as
+// CountHistoryMatching(ctx, "") so the two cannot disagree.
+//
+// A nil CountHistoryMatching means "this backend cannot observe history by
+// message", and every case that needs one SKIPS LOUDLY with that reason rather
+// than passing quietly, exactly as a nil CountHistory does.
+
+// historyPatternForExactMessage returns the LIKE pattern that matches message
+// and nothing else.
+//
+// A LIKE pattern carrying no wildcards is anchored at both ends, so the cases
+// that count entries by their EXACT message keep counting exactly those — but
+// only while the message itself carries no % or _, which LIKE would read as a
+// wildcard and quietly widen the count with. A message needing an escape fails
+// here, loudly, rather than asserting on more entries than the case means.
+func historyPatternForExactMessage(t *testing.T, message string) string {
+	t.Helper()
+	if message == "" {
+		t.Fatal("an exact-message history count needs a message: the empty pattern counts every entry")
+	}
+	if strings.ContainsAny(message, `%_\`) {
+		t.Fatalf("history message %q carries a LIKE metacharacter: CountHistoryMatching takes a pattern, so this count would reach entries the case does not mean", message)
+	}
+	return message
+}

--- a/backend/conformance/issue_operations_contract.go
+++ b/backend/conformance/issue_operations_contract.go
@@ -2987,23 +2987,30 @@ type issueOperationsHistoryCounter struct {
 	total   int
 }
 
+// newIssueOperationsHistoryCounter is the single choke point for the fixture's
+// history hook, so it is also where a backend that cannot observe history skips
+// LOUDLY rather than passing quietly — including for any case that reaches for
+// the counter later.
 func newIssueOperationsHistoryCounter(t *testing.T, ctx context.Context, fixture IssueOperationsStagingFixture) *issueOperationsHistoryCounter {
 	t.Helper()
+	if fixture.CountHistoryMatching == nil {
+		t.Skip("fixture has no CountHistoryMatching: this backend cannot observe history, so issueops.go:261-270 is UNPINNED here")
+	}
 	counter := &issueOperationsHistoryCounter{ctx: ctx, fixture: fixture}
 	counter.total = counter.count(t, "")
 	return counter
 }
 
+// count answers the entries carrying message exactly, or every entry when
+// message is empty.
 func (c *issueOperationsHistoryCounter) count(t *testing.T, message string) int {
 	t.Helper()
-	query := "SELECT COUNT(*) FROM dolt_log"
-	var args []any
+	pattern := ""
 	if message != "" {
-		query += " WHERE message = ?"
-		args = append(args, message)
+		pattern = historyPatternForExactMessage(t, message)
 	}
-	var got int
-	if err := c.fixture.QueryScalar(c.ctx, query, args, &got); err != nil {
+	got, err := c.fixture.CountHistoryMatching(c.ctx, pattern)
+	if err != nil {
 		t.Fatalf("count history entries (%q): %v", message, err)
 	}
 	return got

--- a/backend/conformance/issue_operations_staging.go
+++ b/backend/conformance/issue_operations_staging.go
@@ -21,6 +21,15 @@ type IssueOperationsStagingFixture struct {
 	Commit        func(context.Context, string) error
 	Exec          func(context.Context, string, ...any) error
 	QueryScalar   func(context.Context, string, []any, ...any) error
+	// CountHistoryMatching counts the history entries whose message matches a
+	// SQL LIKE pattern ("" = every entry). The provenance case needs both
+	// halves: the total, for "an update records one entry", and the exact
+	// message, for "the entry reads as the caller's own string".
+	//
+	// A nil CountHistoryMatching means "this backend cannot observe history",
+	// and that case SKIPS loudly with that reason rather than passing quietly.
+	// See history_matching.go for the convention.
+	CountHistoryMatching func(context.Context, string) (int, error)
 	// UpdateRaw drives the backend's generic update funnel with an untyped
 	// column map, the way an external-sync or backfill caller does. The typed
 	// patch behind Operations.Update carries no closed_at, so this is the only

--- a/backend/conformance/lifecycle_close_reopen_contract.go
+++ b/backend/conformance/lifecycle_close_reopen_contract.go
@@ -56,6 +56,15 @@ type LifecycleCloseReopenFixture struct {
 	// category cases are read against.
 	SetConfig   func(context.Context, string, string) error
 	QueryScalar func(context.Context, string, []any, ...any) error
+	// CountHistoryMatching counts the history entries whose message matches a
+	// SQL LIKE pattern ("" = every entry). Only the provenance case needs it,
+	// and it needs the message rather than a bare count: the clause it pins is
+	// that the recorded entry READS as the caller's own string.
+	//
+	// A nil CountHistoryMatching means "this backend cannot observe history by
+	// message", and that case SKIPS loudly with that reason rather than
+	// passing quietly. See history_matching.go for the convention.
+	CountHistoryMatching func(context.Context, string) (int, error)
 	// Exec runs a raw seeding script as ONE session, out of band of the role.
 	//
 	// It exists because the close policy answers to states no supported verb
@@ -1130,6 +1139,10 @@ func RunLifecycleCloseAndReopenRequireActorAndIssueID(t *testing.T, ctx context.
 func RunLifecycleReopenProvenanceLabelsHistory(t *testing.T, ctx context.Context, fixture LifecycleCloseReopenFixture) {
 	t.Helper()
 
+	if fixture.CountHistoryMatching == nil {
+		t.Skip("fixture has no CountHistoryMatching: this backend cannot observe history BY MESSAGE, so issueops.go:335-344 is UNPINNED here")
+	}
+
 	const label = "conformance: reopen provenance label"
 
 	id := fixture.IssuePrefix + "-lcr-prov"
@@ -1405,8 +1418,8 @@ func RunLifecycleReopenReblocksItsDependers(t *testing.T, ctx context.Context, f
 // would carry their commits too.
 func lifecycleCloseReopenCountHistory(t *testing.T, ctx context.Context, fixture LifecycleCloseReopenFixture, message string) int {
 	t.Helper()
-	var count int
-	if err := fixture.QueryScalar(ctx, "SELECT COUNT(*) FROM dolt_log WHERE message = ?", []any{message}, &count); err != nil {
+	count, err := fixture.CountHistoryMatching(ctx, historyPatternForExactMessage(t, message))
+	if err != nil {
 		t.Fatalf("count history entries reading %q: %v", message, err)
 	}
 	return count

--- a/backend/conformance/portable.go
+++ b/backend/conformance/portable.go
@@ -14,8 +14,8 @@ import (
 )
 
 // This file holds the behavior contract for the portable, non-version-control methods
-// that SQLite implements through shared issueops helpers: molecule rollups, repo-mtime
-// cache, event/dependency streams, dependent
+// the shared issueops helpers implement: molecule rollups, repo-mtime cache,
+// event/dependency streams, dependent
 // counts, wisp cascade discovery, comment/audit writes, id rekey, source-repo purge, and
 // batch create. Each case is validated against the embedded-Dolt reference (the oracle)
 // and, once a method is wired into a backend, must match it there too.
@@ -23,8 +23,10 @@ import (
 // Ordering that the implementations leave unspecified (map iteration, same-second event
 // ties, tie-broken "current step") is asserted as a set, never positionally.
 
-// RunPortableMethods runs the portable-method behavior contract. The Dolt reference runs
-// it via RunAll; SQLite runs it for the methods supplied by the shared layer.
+// RunPortableMethods runs the portable-method behavior contract. RunAll composes it, so
+// every backend driving the full suite runs it with no extra wiring; a backend whose
+// allowlist refuses some of these subjects composes its own supported-subset entry point
+// instead, on the RunDeferredReads precedent.
 func RunPortableMethods(t *testing.T, factory Factory) {
 	t.Helper()
 	t.Run("MoleculeProgress", func(t *testing.T) { testGetMoleculeProgress(t, factory) })

--- a/backend/conformance/reclaim_scope.go
+++ b/backend/conformance/reclaim_scope.go
@@ -14,8 +14,9 @@ import (
 // filter selects and leaving every other stale lease in_progress. The filters
 // never widen the set — an unmatched scope reclaims nothing even though a global
 // reclaim would grab everything — which is the property a federated deployment
-// partitions reclaim on. Runs identically on Dolt and SQLite because both route
-// through issueops.ReclaimExpiredLeasesInTx + sqlbuild.ReclaimScopeSQL.
+// partitions reclaim on. Any backend routing through
+// issueops.ReclaimExpiredLeasesInTx + sqlbuild.ReclaimScopeSQL answers it the
+// same way; one with a reclaim path of its own is what this case measures.
 //
 // The whole test runs one reaper cutoff (-time.Hour), so every fresh lease is
 // already "expired": scoping, not staleness, decides what each call reclaims.

--- a/internal/storage/dolt/batch_closer_contract_test.go
+++ b/internal/storage/dolt/batch_closer_contract_test.go
@@ -151,9 +151,10 @@ func newDoltBatchCloserFixture(t *testing.T, prefix string) (conformance.BatchCl
 		// Local, because the shared kit exposes no comment hook. Folding it in
 		// is an S0 follow-up (bd-kue5t); editing the frozen kit from this slice
 		// would collide with the five running beside it.
-		AddComment:   store.AddComment,
-		QueryScalar:  kit.QueryScalar,
-		CountHistory: kit.CountHistory,
+		AddComment:           store.AddComment,
+		QueryScalar:          kit.QueryScalar,
+		CountHistory:         kit.CountHistory,
+		CountHistoryMatching: kit.CountHistoryMatching,
 	}
 	return fixture, ctx, func() {
 		cancel()

--- a/internal/storage/dolt/issue_operations_contract_test.go
+++ b/internal/storage/dolt/issue_operations_contract_test.go
@@ -191,6 +191,7 @@ func newDoltIssueOperationsFixture(t *testing.T) (conformance.IssueOperationsSta
 		storeCleanup()
 		t.Fatalf("NewIssueOperations: %v", err)
 	}
+	kit := newDoltRoleFixtureKit(store, "test")
 	fixture := conformance.IssueOperationsStagingFixture{
 		IssuePrefix: "test",
 		Operations:  operations,
@@ -200,6 +201,7 @@ func newDoltIssueOperationsFixture(t *testing.T) (conformance.IssueOperationsSta
 		QueryScalar: func(ctx context.Context, query string, args []any, dest ...any) error {
 			return store.db.QueryRowContext(ctx, query, args...).Scan(dest...)
 		},
+		CountHistoryMatching: kit.CountHistoryMatching,
 	}
 	return fixture, ctx, func() {
 		cancel()

--- a/internal/storage/dolt/lifecycle_close_reopen_contract_test.go
+++ b/internal/storage/dolt/lifecycle_close_reopen_contract_test.go
@@ -91,13 +91,14 @@ func newDoltLifecycleCloseReopenFixture(t *testing.T, prefix string) (conformanc
 	}
 	kit := newDoltRoleFixtureKit(store, prefix)
 	fixture := conformance.LifecycleCloseReopenFixture{
-		IssuePrefix:   kit.IssuePrefix,
-		Lifecycle:     lifecycle,
-		CreateIssue:   kit.CreateIssue,
-		CreateWisp:    kit.CreateWisp,
-		AddDependency: kit.AddDependency,
-		SetConfig:     kit.SetConfig,
-		QueryScalar:   kit.QueryScalar,
+		IssuePrefix:          kit.IssuePrefix,
+		Lifecycle:            lifecycle,
+		CreateIssue:          kit.CreateIssue,
+		CreateWisp:           kit.CreateWisp,
+		AddDependency:        kit.AddDependency,
+		SetConfig:            kit.SetConfig,
+		QueryScalar:          kit.QueryScalar,
+		CountHistoryMatching: kit.CountHistoryMatching,
 		// The frozen kit exposes reads only, so the raw writes the close-policy
 		// cases need are supplied here — over the same *sql.DB its QueryScalar
 		// reads through, on ONE PINNED CONNECTION so a multi-statement seed

--- a/internal/storage/dolt/role_fixture_kit_test.go
+++ b/internal/storage/dolt/role_fixture_kit_test.go
@@ -79,6 +79,24 @@ type roleFixtureKit struct {
 	// pass quietly. It is non-nil on all three backends today; see
 	// uow/role_fixture_kit_test.go for the evidence on the awkward one.
 	CountHistory func(context.Context) (int, error)
+	// CountHistoryMatching is CountHistory scoped to what the entries READ: it
+	// counts the entries whose message matches pattern, where "" means every
+	// entry and anything else is a SQL LIKE pattern the backend applies with
+	// its own escaping.
+	//
+	// Three role cases assert on a MESSAGE rather than on a bare count — "an
+	// entry naming this wisp", "an entry reading the caller's provenance
+	// label" — and before this hook existed they reached past the fixture into
+	// `dolt_log` through QueryScalar to get one. That was the only Dolt-engine
+	// dependency left in the role contracts.
+	//
+	// It does NOT replace CountHistory: a backend can know how long its
+	// history is without being able to match on the text of an entry, and 25
+	// cases run on the narrow hook alone. Where both are available CountHistory
+	// is DEFINED as CountHistoryMatching(ctx, "") so the two cannot disagree.
+	// Nil carries the same meaning as a nil CountHistory, and the cases that
+	// need it skip LOUDLY.
+	CountHistoryMatching func(context.Context, string) (int, error)
 }
 
 // roleFixtureKitComposesConformanceFixtures is the compile-time half of the
@@ -105,6 +123,17 @@ var roleFixtureKitComposesConformanceFixtures = func(kit roleFixtureKit) (confor
 // store's own create routes an ephemeral issue to the wisps plane, so the two
 // seed verbs differ only by the flag already on the issue.
 func newDoltRoleFixtureKit(store *DoltStore, prefix string) roleFixtureKit {
+	countHistoryMatching := func(ctx context.Context, pattern string) (int, error) {
+		query := "SELECT COUNT(*) FROM dolt_log"
+		var args []any
+		if pattern != "" {
+			query += " WHERE message LIKE ?"
+			args = append(args, pattern)
+		}
+		var entries int
+		err := store.db.QueryRowContext(ctx, query, args...).Scan(&entries)
+		return entries, err
+	}
 	return roleFixtureKit{
 		IssuePrefix: prefix,
 		CreateIssue: store.CreateIssue,
@@ -116,10 +145,9 @@ func newDoltRoleFixtureKit(store *DoltStore, prefix string) roleFixtureKit {
 		QueryScalar: func(ctx context.Context, query string, args []any, dest ...any) error {
 			return store.db.QueryRowContext(ctx, query, args...).Scan(dest...)
 		},
+		CountHistoryMatching: countHistoryMatching,
 		CountHistory: func(ctx context.Context) (int, error) {
-			var entries int
-			err := store.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM dolt_log").Scan(&entries)
-			return entries, err
+			return countHistoryMatching(ctx, "")
 		},
 	}
 }
@@ -208,6 +236,26 @@ func assertRoleFixtureKitHooksAreUsable(t *testing.T, ctx context.Context, kit r
 	}
 	if entries < 1 {
 		t.Fatalf("history entries = %d, want at least the initializing commit", entries)
+	}
+
+	if kit.CountHistoryMatching == nil {
+		t.Fatal("kit.CountHistoryMatching is nil — this backend cannot observe history BY MESSAGE, which the role contracts' provenance and wisp-naming clauses need")
+	}
+	all, err := kit.CountHistoryMatching(ctx, "")
+	if err != nil {
+		t.Fatalf("kit.CountHistoryMatching(all): %v", err)
+	}
+	if all != entries {
+		t.Fatalf("CountHistoryMatching with an empty pattern = %d, want the %d CountHistory reports — the empty pattern means every entry", all, entries)
+	}
+	// The pattern has to FILTER. A hook that accepted one and answered the
+	// total anyway would leave every message-scoped assertion vacuous.
+	none, err := kit.CountHistoryMatching(ctx, "%no entry in this fixture reads this%")
+	if err != nil {
+		t.Fatalf("kit.CountHistoryMatching(miss): %v", err)
+	}
+	if none != 0 {
+		t.Fatalf("CountHistoryMatching of a message no entry carries = %d, want 0 — the pattern must narrow the count", none)
 	}
 }
 

--- a/internal/storage/embeddeddolt/batch_closer_contract_test.go
+++ b/internal/storage/embeddeddolt/batch_closer_contract_test.go
@@ -150,8 +150,9 @@ func newEmbeddedBatchCloserFixture(t *testing.T, prefix string) conformance.Batc
 		// Local, because the shared kit exposes no comment hook. Folding it in
 		// is an S0 follow-up (bd-kue5t); editing the frozen kit from this slice
 		// would collide with the five running beside it.
-		AddComment:   te.store.AddComment,
-		QueryScalar:  kit.QueryScalar,
-		CountHistory: kit.CountHistory,
+		AddComment:           te.store.AddComment,
+		QueryScalar:          kit.QueryScalar,
+		CountHistory:         kit.CountHistory,
+		CountHistoryMatching: kit.CountHistoryMatching,
 	}
 }

--- a/internal/storage/embeddeddolt/issue_operations_contract_test.go
+++ b/internal/storage/embeddeddolt/issue_operations_contract_test.go
@@ -219,6 +219,7 @@ func newEmbeddedIssueOperationsFixture(t *testing.T, ctx context.Context, te *te
 	if err != nil {
 		t.Fatalf("NewIssueOperations: %v", err)
 	}
+	kit := newEmbeddedRoleFixtureKit(te, prefix)
 	return conformance.IssueOperationsStagingFixture{
 		IssuePrefix: prefix,
 		Operations:  operations,
@@ -229,5 +230,6 @@ func newEmbeddedIssueOperationsFixture(t *testing.T, ctx context.Context, te *te
 			te.queryScalar(t, ctx, query, args, dest...)
 			return nil
 		},
+		CountHistoryMatching: kit.CountHistoryMatching,
 	}
 }

--- a/internal/storage/embeddeddolt/lifecycle_close_reopen_contract_test.go
+++ b/internal/storage/embeddeddolt/lifecycle_close_reopen_contract_test.go
@@ -90,13 +90,14 @@ func newEmbeddedLifecycleCloseReopenFixture(t *testing.T, te *testEnv, prefix st
 	}
 	kit := newEmbeddedRoleFixtureKit(te, prefix)
 	return conformance.LifecycleCloseReopenFixture{
-		IssuePrefix:   kit.IssuePrefix,
-		Lifecycle:     lifecycle,
-		CreateIssue:   kit.CreateIssue,
-		CreateWisp:    kit.CreateWisp,
-		AddDependency: kit.AddDependency,
-		SetConfig:     kit.SetConfig,
-		QueryScalar:   kit.QueryScalar,
+		IssuePrefix:          kit.IssuePrefix,
+		Lifecycle:            lifecycle,
+		CreateIssue:          kit.CreateIssue,
+		CreateWisp:           kit.CreateWisp,
+		AddDependency:        kit.AddDependency,
+		SetConfig:            kit.SetConfig,
+		QueryScalar:          kit.QueryScalar,
+		CountHistoryMatching: kit.CountHistoryMatching,
 		// The frozen kit exposes reads only, so this is the write half of the
 		// same short-lived raw connection its QueryScalar opens, pinned for the
 		// whole script so a multi-statement seed stays in one session.

--- a/internal/storage/embeddeddolt/role_fixture_kit_test.go
+++ b/internal/storage/embeddeddolt/role_fixture_kit_test.go
@@ -81,6 +81,24 @@ type roleFixtureKit struct {
 	// pass quietly. It is non-nil on all three backends today; see
 	// uow/role_fixture_kit_test.go for the evidence on the awkward one.
 	CountHistory func(context.Context) (int, error)
+	// CountHistoryMatching is CountHistory scoped to what the entries READ: it
+	// counts the entries whose message matches pattern, where "" means every
+	// entry and anything else is a SQL LIKE pattern the backend applies with
+	// its own escaping.
+	//
+	// Three role cases assert on a MESSAGE rather than on a bare count — "an
+	// entry naming this wisp", "an entry reading the caller's provenance
+	// label" — and before this hook existed they reached past the fixture into
+	// `dolt_log` through QueryScalar to get one. That was the only Dolt-engine
+	// dependency left in the role contracts.
+	//
+	// It does NOT replace CountHistory: a backend can know how long its
+	// history is without being able to match on the text of an entry, and 25
+	// cases run on the narrow hook alone. Where both are available CountHistory
+	// is DEFINED as CountHistoryMatching(ctx, "") so the two cannot disagree.
+	// Nil carries the same meaning as a nil CountHistory, and the cases that
+	// need it skip LOUDLY.
+	CountHistoryMatching func(context.Context, string) (int, error)
 }
 
 // roleFixtureKitComposesConformanceFixtures is the compile-time half of the
@@ -120,6 +138,17 @@ func newEmbeddedRoleFixtureKit(te *testEnv, prefix string) roleFixtureKit {
 		defer func() { _ = cleanup() }()
 		return db.QueryRowContext(ctx, query, args...).Scan(dest...)
 	}
+	countHistoryMatching := func(ctx context.Context, pattern string) (int, error) {
+		query := "SELECT COUNT(*) FROM dolt_log"
+		var args []any
+		if pattern != "" {
+			query += " WHERE message LIKE ?"
+			args = append(args, pattern)
+		}
+		var entries int
+		err := queryScalar(ctx, query, args, &entries)
+		return entries, err
+	}
 	return roleFixtureKit{
 		IssuePrefix: prefix,
 		CreateIssue: te.store.CreateIssue,
@@ -127,12 +156,11 @@ func newEmbeddedRoleFixtureKit(te *testEnv, prefix string) roleFixtureKit {
 		AddDependency: func(ctx context.Context, dep *types.Dependency, actor string) error {
 			return te.store.AddDependencyWithOptions(ctx, dep, actor, storage.DependencyAddOptions{EmitEvent: true})
 		},
-		SetConfig:   te.store.SetConfig,
-		QueryScalar: queryScalar,
+		SetConfig:            te.store.SetConfig,
+		QueryScalar:          queryScalar,
+		CountHistoryMatching: countHistoryMatching,
 		CountHistory: func(ctx context.Context) (int, error) {
-			var entries int
-			err := queryScalar(ctx, "SELECT COUNT(*) FROM dolt_log", nil, &entries)
-			return entries, err
+			return countHistoryMatching(ctx, "")
 		},
 	}
 }
@@ -220,6 +248,26 @@ func assertRoleFixtureKitHooksAreUsable(t *testing.T, ctx context.Context, kit r
 	}
 	if entries < 1 {
 		t.Fatalf("history entries = %d, want at least the initializing commit", entries)
+	}
+
+	if kit.CountHistoryMatching == nil {
+		t.Fatal("kit.CountHistoryMatching is nil — this backend cannot observe history BY MESSAGE, which the role contracts' provenance and wisp-naming clauses need")
+	}
+	all, err := kit.CountHistoryMatching(ctx, "")
+	if err != nil {
+		t.Fatalf("kit.CountHistoryMatching(all): %v", err)
+	}
+	if all != entries {
+		t.Fatalf("CountHistoryMatching with an empty pattern = %d, want the %d CountHistory reports — the empty pattern means every entry", all, entries)
+	}
+	// The pattern has to FILTER. A hook that accepted one and answered the
+	// total anyway would leave every message-scoped assertion vacuous.
+	none, err := kit.CountHistoryMatching(ctx, "%no entry in this fixture reads this%")
+	if err != nil {
+		t.Fatalf("kit.CountHistoryMatching(miss): %v", err)
+	}
+	if none != 0 {
+		t.Fatalf("CountHistoryMatching of a message no entry carries = %d, want 0 — the pattern must narrow the count", none)
 	}
 }
 

--- a/internal/storage/uow/batch_closer_contract_test.go
+++ b/internal/storage/uow/batch_closer_contract_test.go
@@ -80,7 +80,8 @@ func newUOWBatchCloserFixture(t *testing.T, provider UnitOfWorkProvider, prefix 
 				return "seed comment on " + issueID, err
 			})
 		},
-		QueryScalar:  kit.QueryScalar,
-		CountHistory: kit.CountHistory,
+		QueryScalar:          kit.QueryScalar,
+		CountHistory:         kit.CountHistory,
+		CountHistoryMatching: kit.CountHistoryMatching,
 	}
 }

--- a/internal/storage/uow/issue_operations_contract_test.go
+++ b/internal/storage/uow/issue_operations_contract_test.go
@@ -160,6 +160,7 @@ func TestIssueOperationsClaimLeavesBlockedStateAlone(t *testing.T) {
 func newUOWIssueOperationsFixture(t *testing.T, ctx context.Context) conformance.IssueOperationsStagingFixture {
 	t.Helper()
 	operations, provider := newRealIssueOperationsWithProvider(t, ctx)
+	kit := newUOWRoleFixtureKit(provider, "bd")
 	return conformance.IssueOperationsStagingFixture{
 		IssuePrefix: "bd",
 		Operations:  operations,
@@ -208,6 +209,7 @@ func newUOWIssueOperationsFixture(t *testing.T, ctx context.Context) conformance
 			}
 			return nil
 		},
+		CountHistoryMatching: kit.CountHistoryMatching,
 	}
 }
 

--- a/internal/storage/uow/lifecycle_close_reopen_contract_test.go
+++ b/internal/storage/uow/lifecycle_close_reopen_contract_test.go
@@ -93,13 +93,14 @@ func newUOWLifecycleCloseReopenFixture(t *testing.T, ctx context.Context, prefix
 	}
 	kit := newUOWRoleFixtureKit(provider, prefix)
 	return conformance.LifecycleCloseReopenFixture{
-		IssuePrefix:   kit.IssuePrefix,
-		Lifecycle:     lifecycle,
-		CreateIssue:   kit.CreateIssue,
-		CreateWisp:    kit.CreateWisp,
-		AddDependency: kit.AddDependency,
-		SetConfig:     kit.SetConfig,
-		QueryScalar:   kit.QueryScalar,
+		IssuePrefix:          kit.IssuePrefix,
+		Lifecycle:            lifecycle,
+		CreateIssue:          kit.CreateIssue,
+		CreateWisp:           kit.CreateWisp,
+		AddDependency:        kit.AddDependency,
+		SetConfig:            kit.SetConfig,
+		QueryScalar:          kit.QueryScalar,
+		CountHistoryMatching: kit.CountHistoryMatching,
 		// The frozen kit exposes reads only. This is the write half of the same
 		// raw-SQL pass-through, inside ONE committing unit of work — which also
 		// gives the whole script one session.

--- a/internal/storage/uow/role_fixture_kit_test.go
+++ b/internal/storage/uow/role_fixture_kit_test.go
@@ -81,6 +81,24 @@ type roleFixtureKit struct {
 	// pass quietly. It is non-nil here: see
 	// TestUOWRoleFixtureKitCountHistoryMovesWithACommit for the evidence.
 	CountHistory func(context.Context) (int, error)
+	// CountHistoryMatching is CountHistory scoped to what the entries READ: it
+	// counts the entries whose message matches pattern, where "" means every
+	// entry and anything else is a SQL LIKE pattern the backend applies with
+	// its own escaping.
+	//
+	// Three role cases assert on a MESSAGE rather than on a bare count — "an
+	// entry naming this wisp", "an entry reading the caller's provenance
+	// label" — and before this hook existed they reached past the fixture into
+	// `dolt_log` through QueryScalar to get one. That was the only Dolt-engine
+	// dependency left in the role contracts.
+	//
+	// It does NOT replace CountHistory: a backend can know how long its
+	// history is without being able to match on the text of an entry, and 25
+	// cases run on the narrow hook alone. Where both are available CountHistory
+	// is DEFINED as CountHistoryMatching(ctx, "") so the two cannot disagree.
+	// Nil carries the same meaning as a nil CountHistory, and the cases that
+	// need it skip LOUDLY.
+	CountHistoryMatching func(context.Context, string) (int, error)
 }
 
 // roleFixtureKitComposesConformanceFixtures is the compile-time half of the
@@ -175,6 +193,17 @@ func newUOWRoleFixtureKit(provider UnitOfWorkProvider, prefix string) roleFixtur
 		}
 		return nil
 	}
+	countHistoryMatching := func(ctx context.Context, pattern string) (int, error) {
+		query := "SELECT COUNT(*) FROM dolt_log"
+		var args []any
+		if pattern != "" {
+			query += " WHERE message LIKE ?"
+			args = append(args, pattern)
+		}
+		var entries int
+		err := queryScalar(ctx, query, args, &entries)
+		return entries, err
+	}
 	return roleFixtureKit{
 		IssuePrefix: prefix,
 		CreateIssue: seed(false),
@@ -193,11 +222,10 @@ func newUOWRoleFixtureKit(provider UnitOfWorkProvider, prefix string) roleFixtur
 				return "set " + key, uw.ConfigUseCase().SetConfig(ctx, key, value)
 			})
 		},
-		QueryScalar: queryScalar,
+		QueryScalar:          queryScalar,
+		CountHistoryMatching: countHistoryMatching,
 		CountHistory: func(ctx context.Context) (int, error) {
-			var entries int
-			err := queryScalar(ctx, "SELECT COUNT(*) FROM dolt_log", nil, &entries)
-			return entries, err
+			return countHistoryMatching(ctx, "")
 		},
 	}
 }
@@ -354,6 +382,26 @@ func assertRoleFixtureKitHooksAreUsable(t *testing.T, ctx context.Context, kit r
 	}
 	if entries < 1 {
 		t.Fatalf("history entries = %d, want at least the initializing commit", entries)
+	}
+
+	if kit.CountHistoryMatching == nil {
+		t.Fatal("kit.CountHistoryMatching is nil — this backend cannot observe history BY MESSAGE, which the role contracts' provenance and wisp-naming clauses need")
+	}
+	all, err := kit.CountHistoryMatching(ctx, "")
+	if err != nil {
+		t.Fatalf("kit.CountHistoryMatching(all): %v", err)
+	}
+	if all != entries {
+		t.Fatalf("CountHistoryMatching with an empty pattern = %d, want the %d CountHistory reports — the empty pattern means every entry", all, entries)
+	}
+	// The pattern has to FILTER. A hook that accepted one and answered the
+	// total anyway would leave every message-scoped assertion vacuous.
+	none, err := kit.CountHistoryMatching(ctx, "%no entry in this fixture reads this%")
+	if err != nil {
+		t.Fatalf("kit.CountHistoryMatching(miss): %v", err)
+	}
+	if none != 0 {
+		t.Fatalf("CountHistoryMatching of a message no entry carries = %d, want 0 — the pattern must narrow the count", none)
 	}
 }
 


### PR DESCRIPTION
`conformance.go` documents `RunAll` as the proof obligation an external backend must satisfy. Two things about that were false, in opposite directions, and the *widely assumed* one was false too — including in my own review comments on earlier PRs.

## The assumption that was wrong

`RunAll`'s `Factory` is `func(*testing.T) storage.DoltStorage` — ten interfaces, 100 methods, including `VersionControl`, `SyncStore` and `FederationStore`. It is natural to conclude the suite demands Dolt version control.

**That is inferred from the type and is false of the content.** A scan of every call site in the package finds RunAll's body makes **zero** calls to `VersionControl`, `HistoryViewer`, `RemoteStore`, `SyncStore`, `FederationStore`, `CompactionStore` or `FastStatisticsStore`. A backend that stubs those families with `*ErrUnsupported` passes RunAll today, because the stubs are never invoked.

The genuine Dolt-engine dependency was in the **role tier** — the one usually called portable.

## What actually broke portability: three `dolt_log` probes

`batch_closer_contract.go`, `lifecycle_close_reopen_contract.go` and `issue_operations_contract.go` each read `dolt_log` directly through `QueryScalar`. A backend without a Dolt version log does not *skip* those cases — it **fails** them.

Rewired through a new nil-able `CountHistoryMatching(ctx, pattern)` hook, so such a backend loudly skips instead. That matches the established convention: 25 `CountHistory == nil` and 5 `Exec == nil` loud-skip guards already exist.

**`CountHistory` is kept beside it, and derived from it.** It declares a strictly narrower capability — know history's *length* without being able to read an entry's *text* — and 25 cases run on that narrow hook alone. Superseding it would churn 19 fixtures and ~57 wiring sites for no behaviour change. Instead each kit defines `CountHistory` as `CountHistoryMatching(ctx, "")`, so the two cannot disagree and each leg holds one `dolt_log` literal instead of two.

**The hook has a tripwire.** The kit test asserts a pattern *narrows* the count — a hook that ignored its pattern would make every message-scoped assertion silently vacuous, which is precisely the failure class this suite keeps producing. `historyPatternForExactMessage` additionally fatals on a message containing `%`, `_` or `\`, because the two exact-match probes express "exact" as "LIKE with no wildcards" and that is only true while it holds.

All three rewired cases verified red on all three legs, with mutations chosen so the *only* reddening assertion is the rewired probe. 404 passes, zero skips.

## The doc, corrected

It said RunAll is "the suite every storage backend runs to prove it behaves like the embedded-Dolt reference."

It now says what the code does: RunAll is the **portable raw-surface tier**, the sole proof of **51 of core `Storage`'s 98 methods plus 32 across five sub-interfaces** — labels, slots, iterators, transactions, leases, promote/rekey. It does not exercise the version-control families its `Factory` type names; those are declared through the unsupported allowlist. The `Factory` type is `DoltStorage` because the **registry door** is, not because the suite needs it — which is why the unit-of-work provider cannot run it.

`RunAll` is **not** renamed. The name was fine; the doc was what lied.

## Two more falsehoods, found beyond the brief

- `backend.go`'s `DoltStorage` doc claimed "the conformance suite exercises exactly this surface" — sharper than the one I sent the implementer to fix.
- `claim.go`'s header claimed its assertions "hold identically on Dolt and SQLite"; SQLite is tombstoned via `RemovedBackendError`. Historical SQLite notes in the audit files were deliberately left — they record *why* a case exists.

## A number with its counting rule

The design said 54 and 33; measuring methods actually invoked on the store a `Factory` returns gives **51 and 32** (54/33 appears if `Transaction`-surface calls are credited). The doc states the counting rule alongside the number, so the next reader can re-measure rather than trust it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)