### PR TITLE
Close the three is_blocked clauses that had no case

### DIFF
--- a/backend/conformance/deleter_contract.go
+++ b/backend/conformance/deleter_contract.go
@@ -707,7 +707,7 @@ func RunDeleterSettlesTheSurvivorsOfADeletedBlocker(t *testing.T, ctx context.Co
 	controlBlocker := deleterSeedIssue(t, ctx, fixture, "bsdel", "ctlblocker")
 	controlDepender := deleterSeedIssue(t, ctx, fixture, "bsdel", "ctldepender")
 	deleterAddEdge(t, ctx, fixture, depender, blocker)
-	deleterAddTypedEdge(t, ctx, fixture, child, depender, types.DepParentChild)
+	deleterAddParentChildEdge(t, ctx, fixture, child, depender)
 	deleterAddEdge(t, ctx, fixture, wispDepender, blocker)
 	deleterAddEdge(t, ctx, fixture, controlDepender, controlBlocker)
 
@@ -749,9 +749,9 @@ func RunDeleterSettlesTheChildrenOfADeletedParent(t *testing.T, ctx context.Cont
 	controlParent := deleterSeedIssue(t, ctx, fixture, "bsdelpc", "ctlparent")
 	controlChild := deleterSeedIssue(t, ctx, fixture, "bsdelpc", "ctlchild")
 	deleterAddEdge(t, ctx, fixture, parent, blocker)
-	deleterAddTypedEdge(t, ctx, fixture, child, parent, types.DepParentChild)
+	deleterAddParentChildEdge(t, ctx, fixture, child, parent)
 	deleterAddEdge(t, ctx, fixture, controlParent, controlBlocker)
-	deleterAddTypedEdge(t, ctx, fixture, controlChild, controlParent, types.DepParentChild)
+	deleterAddParentChildEdge(t, ctx, fixture, controlChild, controlParent)
 
 	probe := newBlockedStateProbe(ctx, fixture.QueryScalar)
 	probe.requireBlockedWithNoDirectBlockerEdges(t, blockedIssue(child), "the child is blocked only through the parent about to be deleted")
@@ -773,17 +773,99 @@ func RunDeleterSettlesTheChildrenOfADeletedParent(t *testing.T, ctx context.Cont
 	flip.requireFlippedTo(t, 0, "a child orphaned from a blocked parent inherits nothing, and the deleting transaction settles it")
 }
 
-// deleterAddTypedEdge is deleterAddEdge for an edge that is not a block. The
-// blocked-state cases need parent-child edges, which is the type that carries
-// inheritance.
-func deleterAddTypedEdge(t *testing.T, ctx context.Context, fixture DeleterFixture, source, target string, depType types.DependencyType) {
+// RunDeleterSettlesTheSurvivorsOfADeletedWispBlocker is the same obligation
+// with the deleted row in the OTHER PLANE, and it is a different query rather
+// than the same one with different data: the deletion's affected set walks the
+// two planes through two separate loads keyed on two separate columns
+// (internal/storage/issueops/blocked_state.go AffectedByDeletionInTx, which
+// asks depends_on_issue_id about the deleted issues and depends_on_wisp_id
+// about the deleted wisps). Every other Deleter case in this file names durable
+// rows only, so the second load ran against an empty list every time and could
+// have been deleted with nothing going red.
+//
+// IT IS ROLE-REACHABLE. DeleteRequest.IDs "names the rows to delete, IN EITHER
+// PLANE", and the unforced guard has "no wisp exemption at either end", so a
+// forced `bd delete <wisp>` with durable dependents is a documented mode rather
+// than an out-of-band poke — which is why blocked_state.go's wisp carve-out,
+// which covers the store's own wisp-delete entry points, does not cover this
+// one.
+//
+// The survivors span both planes and both distances: a DURABLE depender of the
+// wisp, that depender's parent-child child, and a WISP depender whose edge
+// lives in the ephemeral table. The durable depender is the sharpest — its edge
+// sits in `dependencies` with the target in depends_on_wisp_id, which is the
+// exact pairing a body that classified the affected set by the DEPENDER's plane
+// instead of the deleted row's would miss.
+//
+// Force is required for the same reason the sibling case gives, and here it is
+// also the mode the leaf calls out by name: without it the dependents outside
+// the request refuse the delete.
+func RunDeleterSettlesTheSurvivorsOfADeletedWispBlocker(t *testing.T, ctx context.Context, fixture DeleterFixture) {
+	t.Helper()
+	wispBlocker := deleterSeedWisp(t, ctx, fixture, "bsdelw", "wispblocker")
+	depender := deleterSeedIssue(t, ctx, fixture, "bsdelw", "depender")
+	child := deleterSeedIssue(t, ctx, fixture, "bsdelw", "child")
+	wispDepender := deleterSeedWisp(t, ctx, fixture, "bsdelw", "wispdep")
+	controlBlocker := deleterSeedIssue(t, ctx, fixture, "bsdelw", "ctlblocker")
+	controlDepender := deleterSeedIssue(t, ctx, fixture, "bsdelw", "ctldepender")
+	deleterAddEdge(t, ctx, fixture, depender, wispBlocker)
+	deleterAddParentChildEdge(t, ctx, fixture, child, depender)
+	deleterAddEdge(t, ctx, fixture, wispDepender, wispBlocker)
+	deleterAddEdge(t, ctx, fixture, controlDepender, controlBlocker)
+
+	probe := newBlockedStateProbe(ctx, fixture.QueryScalar)
+	// Residency is asserted on the row being deleted above all: a "wisp" that
+	// had leaked a durable row would make this case a second copy of its
+	// sibling.
+	probe.requirePlaneResidency(t, blockedWisp(wispBlocker))
+	probe.requirePlaneResidency(t, blockedWisp(wispDepender))
+	probe.requirePlaneResidency(t, blockedIssue(depender))
+	probe.requireBlockedByOpenBlocker(t, blockedIssue(depender), blockedWisp(wispBlocker),
+		"the DURABLE depender of the ephemeral row about to be deleted")
+	probe.requireBlockedByOpenBlocker(t, blockedWisp(wispDepender), blockedWisp(wispBlocker),
+		"the same-plane depender, whose edge lives in the ephemeral table")
+	probe.requireBlockedWithNoDirectBlockerEdges(t, blockedIssue(child),
+		"the child inherits across the plane boundary and holds no blocker of its own")
+	probe.requireBlockedByOpenBlocker(t, blockedIssue(controlDepender), blockedIssue(controlBlocker),
+		"the control's blocker is a durable row this delete never names")
+
+	flip := probe.watchFlip(t,
+		[]blockedStateRow{blockedIssue(depender), blockedIssue(child), blockedWisp(wispDepender)},
+		[]blockedStateRow{blockedIssue(controlDepender)})
+
+	result, err := fixture.Deleter.Delete(ctx, publicops.DeleteRequest{IDs: []string{wispBlocker}, Force: true, Actor: "deleter"})
+	if err != nil {
+		t.Fatalf("force-delete the wisp blocker %s: %v", wispBlocker, err)
+	}
+	if result.Deleted != 1 {
+		t.Fatalf("Deleted = %d, want the 1 named wisp", result.Deleted)
+	}
+	// The zeros below mean "blocked by nothing" only if the cause is really
+	// gone; a delete that reported 1 and left the row would make them describe
+	// a live blocker.
+	var survives int
+	if err := fixture.QueryScalar(ctx, "SELECT COUNT(*) FROM wisps WHERE id = ?", []any{wispBlocker}, &survives); err != nil {
+		t.Fatalf("count the deleted wisp %s: %v", wispBlocker, err)
+	}
+	if survives != 0 {
+		t.Fatalf("wisp %s still has %d row(s) after a forced delete, want it gone", wispBlocker, survives)
+	}
+
+	flip.requireFlippedTo(t, 0,
+		"a survivor whose only blocker was an erased WISP is left unblocked, in both planes, and so is everything that inherited from it")
+}
+
+// deleterAddParentChildEdge is deleterAddEdge for the one edge type that is not
+// a block: the blocked-state cases hang a child off a subject to observe
+// INHERITANCE, which parent-child is what carries.
+func deleterAddParentChildEdge(t *testing.T, ctx context.Context, fixture DeleterFixture, child, parent string) {
 	t.Helper()
 	if err := fixture.AddDependency(ctx, &types.Dependency{
-		IssueID:     source,
-		DependsOnID: target,
-		Type:        depType,
+		IssueID:     child,
+		DependsOnID: parent,
+		Type:        types.DepParentChild,
 	}, "deleter-seed"); err != nil {
-		t.Fatalf("seeding %s edge %s -> %s: %v", depType, source, target, err)
+		t.Fatalf("seeding %s edge %s -> %s: %v", types.DepParentChild, child, parent, err)
 	}
 }
 

--- a/backend/conformance/issue_operations_contract.go
+++ b/backend/conformance/issue_operations_contract.go
@@ -2696,6 +2696,91 @@ func RunIssueOperationsUpdateStatusCrossingSettlesDependers(t *testing.T, ctx co
 	probe.requireBlockedByOpenBlocker(t, blockedIssue(depender), blockedIssue(blocker), "the postcondition is the flag AND the live blocker behind it")
 }
 
+// RunIssueOperationsUpdateStatusCrossingSettlesAConditionalBlocksDepender pins
+// the HALF OF THE PREDICATE'S FIRST CLAUSE THAT NAMES A SECOND EDGE TYPE.
+// issueops.BlockedStateInvariant says a row is blocked when "it has a blocks or
+// conditional-blocks edge onto a target that is itself neither closed nor
+// pinned"; every other is_blocked case in this package seeds the first type
+// only, so the second was a word in the doc with no case behind it. The type
+// list is spelled out five times in
+// internal/storage/issueops/blocked_state.go — the two mark templates, the two
+// unmark templates, and the depender load that builds the affected set — and
+// dropping `conditional-blocks` from any of them left every case green.
+//
+// IT IS ON UPDATE, and on the same crossing the sibling case above uses, for
+// the reason that case gives: the decision that a status move counts as a
+// crossing is written TWICE (internal/storage/issueops/update.go and
+// internal/storage/domain/db's issue Update), so this is TWO GENUINE VOTES
+// rather than one body seen three times. The DependencyEditor's add path could
+// not host it — the direct-source mark there runs a type-agnostic UPDATE of its
+// own (markDirectBlockingDependencySourceInTx and its domain/db mirror) once
+// the caller's type has already passed the wiring's gate, so on that role the
+// mark template's copy of the type list is never the thing that decides.
+//
+// BOTH DIRECTIONS RUN. The mark and the unmark are separate SQL carrying
+// separate copies of the type list, and the unpinning half is the one that
+// reaches the MARK template: it must re-block a row whose only cause is a
+// conditional-blocks edge.
+//
+// WHAT THE FIXTURE MAKES OBSERVABLE. The depender carries a conditional-blocks
+// edge AND NOTHING ELSE, asserted by counting its `blocks` edges at zero and
+// its `conditional-blocks` edges at one. A depender holding both types would be
+// blocked either way and this case would pass against a predicate that had
+// never heard of the second one — which is the shape of the retired
+// fixture-defect case, a subject whose named term was not the term producing
+// its value.
+//
+// The control is blocked through a PLAIN blocks edge. It is the same shape at
+// the same moment differing in the one fact under test, so a mutation that
+// drops the conditional type reddens the subject and leaves the control exactly
+// where it was, and the failure names the term.
+func RunIssueOperationsUpdateStatusCrossingSettlesAConditionalBlocksDepender(t *testing.T, ctx context.Context, fixture IssueOperationsStagingFixture) {
+	t.Helper()
+
+	blocker := fixture.IssuePrefix + "-bscond-blocker"
+	depender := fixture.IssuePrefix + "-bscond-depender"
+	controlBlocker := fixture.IssuePrefix + "-bscond-ctlblocker"
+	controlDepender := fixture.IssuePrefix + "-bscond-ctldepender"
+	seedIssueOperationsLabeledIssue(t, ctx, fixture, blocker)
+	seedIssueOperationsLabeledIssue(t, ctx, fixture, controlBlocker)
+	createIssueOperationsTypedBlockedIssue(t, ctx, fixture, depender, blocker, types.DepConditionalBlocks)
+	createIssueOperationsBlockedIssue(t, ctx, fixture, controlDepender, controlBlocker)
+
+	probe := newBlockedStateProbe(ctx, fixture.QueryScalar)
+	// The conditional term is only observable while it is the ONLY term.
+	assertIssueOperationsEdgeTypeCount(t, ctx, fixture, depender, string(types.DepBlocks), 0)
+	assertIssueOperationsEdgeTypeCount(t, ctx, fixture, depender, string(types.DepConditionalBlocks), 1)
+	assertIssueOperationsEdgeTypeCount(t, ctx, fixture, controlDepender, string(types.DepBlocks), 1)
+	assertIssueOperationsEdgeTypeCount(t, ctx, fixture, controlDepender, string(types.DepConditionalBlocks), 0)
+	probe.requireBlockedByOpenBlocker(t, blockedIssue(depender), blockedIssue(blocker),
+		"a conditional-blocks edge onto a live target blocks its source exactly as a blocks edge does")
+	probe.requireBlockedByOpenBlocker(t, blockedIssue(controlDepender), blockedIssue(controlBlocker),
+		"the control is blocked through the edge type this suite already covered")
+
+	out := probe.watchFlip(t, []blockedStateRow{blockedIssue(depender)}, []blockedStateRow{blockedIssue(controlDepender)})
+	if _, err := fixture.Operations.Update(ctx, publicops.UpdateRequest{
+		Actor: "writer", IssueID: blocker,
+		Patch: publicops.IssuePatch{Status: publicops.Field[publicops.Status]{Set: true, Value: types.StatusPinned}},
+	}); err != nil {
+		t.Fatalf("update %s to pinned: %v", blocker, err)
+	}
+	out.requireFlippedTo(t, 0,
+		"pinning the target of a conditional-blocks edge takes it out of the active set, and the unmark template counts that type")
+
+	back := probe.watchFlip(t, []blockedStateRow{blockedIssue(depender)}, []blockedStateRow{blockedIssue(controlDepender)})
+	if _, err := fixture.Operations.Update(ctx, publicops.UpdateRequest{
+		Actor: "writer", IssueID: blocker,
+		Patch: publicops.IssuePatch{Status: publicops.Field[publicops.Status]{Set: true, Value: types.StatusOpen}},
+	}); err != nil {
+		t.Fatalf("update %s back to open: %v", blocker, err)
+	}
+	back.requireFlippedTo(t, 1,
+		"unpinning re-blocks a row whose only cause is a conditional-blocks edge — the MARK template's own copy of the type list")
+	probe.requireBlockedByOpenBlocker(t, blockedIssue(depender), blockedIssue(blocker),
+		"the postcondition is the flag AND the live conditional blocker behind it")
+	assertIssueOperationsEdgeTypeCount(t, ctx, fixture, depender, string(types.DepBlocks), 0)
+}
+
 // RunIssueOperationsCreateWithDependenciesSettlesInTheCreatingTransaction pins
 // the create half, and with it the one structural asymmetry between the two
 // bodies: the store-backed create runs ONE terminal recompute over the union of
@@ -2835,15 +2920,44 @@ func RunIssueOperationsClaimLeavesBlockedStateAlone(t *testing.T, ctx context.Co
 // carrying is EARNED by that verb; nothing in these fixtures can write it.
 func createIssueOperationsBlockedIssue(t *testing.T, ctx context.Context, fixture IssueOperationsStagingFixture, id, blockerID string) {
 	t.Helper()
+	createIssueOperationsTypedBlockedIssue(t, ctx, fixture, id, blockerID, types.DepBlocks)
+}
+
+// createIssueOperationsTypedBlockedIssue is the same create with the edge type
+// named, for the case whose subject is the OTHER type the blocking predicate
+// accepts. The type travels on the request rather than on a seeding hook so the
+// edge and the flag both come from role verbs.
+func createIssueOperationsTypedBlockedIssue(
+	t *testing.T, ctx context.Context, fixture IssueOperationsStagingFixture, id, blockerID string, depType types.DependencyType,
+) {
+	t.Helper()
 	if _, err := fixture.Operations.Create(ctx, publicops.CreateRequest{
 		Actor:         "writer",
 		ForceIDPrefix: true,
 		Issue: &types.Issue{
 			ID: id, Title: id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask,
 		},
-		Dependencies: []publicops.CreateDependency{{TargetID: blockerID, Type: types.DepBlocks}},
+		Dependencies: []publicops.CreateDependency{{TargetID: blockerID, Type: depType}},
 	}); err != nil {
-		t.Fatalf("create %s blocked by %s: %v", id, blockerID, err)
+		t.Fatalf("create %s blocked by %s through a %s edge: %v", id, blockerID, depType, err)
+	}
+}
+
+// assertIssueOperationsEdgeTypeCount counts one row's outgoing edges OF ONE
+// TYPE. The blocked-state cases that name an edge type need it: a subject whose
+// flag is attributed to a conditional-blocks edge proves nothing unless the row
+// is known to carry no plain blocks edge as well.
+func assertIssueOperationsEdgeTypeCount(
+	t *testing.T, ctx context.Context, fixture IssueOperationsStagingFixture, id, depType string, want int,
+) {
+	t.Helper()
+	var got int
+	if err := fixture.QueryScalar(ctx,
+		"SELECT COUNT(*) FROM dependencies WHERE issue_id = ? AND type = ?", []any{id, depType}, &got); err != nil {
+		t.Fatalf("count %s edges out of %s: %v", depType, id, err)
+	}
+	if got != want {
+		t.Fatalf("%s carries %d %s edges, want %d: the case attributes its blocked state to a NAMED edge type", id, got, depType, want)
 	}
 }
 

--- a/backend/conformance/lifecycle_close_reopen_contract.go
+++ b/backend/conformance/lifecycle_close_reopen_contract.go
@@ -1358,6 +1358,105 @@ func RunLifecycleCloseSettlesTheClosedRowItselfAndItsChild(t *testing.T, ctx con
 		"a closed row is never blocked, and settling it settles its own parent-child child with it")
 }
 
+// RunLifecycleCloseOnASpawnersLastChildSatisfiesAWaitsForGate pins the third
+// arm of the blocking predicate — "a waits-for edge whose gate over the
+// spawner's children is not yet satisfied" — on the side of it that no case
+// reached.
+//
+// THE ARM, BY NAME. internal/storage/issueops/blocked_state.go's
+// AffectedByStatusChangeInTx builds the affected set from three loads, and one
+// of them, loadWaitersWhoseSpawnerIsParentOfInTx, exists for exactly this
+// shape: the row whose status moved is a CHILD, and the row that has to settle
+// is a waiter on that child's PARENT — a row the other two loads cannot reach,
+// because it holds no blocking edge onto the child (so the depender load misses
+// it) and it waits on the spawner rather than on the child (so the waiter load
+// misses it too). Delete that one call and this case is the only thing that
+// goes red. The DependencyEditor's gate case covers the ADD side of a gate; it
+// runs through AffectedByDepChangeInTx and never touches this load.
+//
+// WHAT THE FIXTURE MAKES OBSERVABLE, and it is the whole design: the spawner
+// has EXACTLY ONE open child, asserted before the close in both planes. A
+// spawner with a second open child leaves an all-children gate unsatisfied
+// after the close, so the subject could not flip and the case would pass
+// against a body that never recomputed it — an unfalsifiable case wearing a
+// correct assertion, which is the defect this program already shipped once.
+//
+// TWO CONTROLS, one on each side of the affected set. edgedWaiter waits on the
+// SAME spawner, so the same recompute visits it, and stays blocked because it
+// also holds a blocks edge onto a live row: it separates "the gate was
+// re-evaluated" from "the flag was cleared". otherWaiter is gated on a
+// different spawner whose own child nobody touched, so it separates a correct
+// affected set from a blanket pass over every waiter in the workspace.
+//
+// All three legs reach ONE body here (internal/storage/issueops.closeIssueInTx),
+// so this is a wrapper and engine check rather than a third vote, exactly as
+// blocked_state.go's header says of the whole Close family.
+func RunLifecycleCloseOnASpawnersLastChildSatisfiesAWaitsForGate(t *testing.T, ctx context.Context, fixture LifecycleCloseReopenFixture) {
+	t.Helper()
+
+	spawner := fixture.IssuePrefix + "-bswait-spawner"
+	lastChild := fixture.IssuePrefix + "-bswait-lastchild"
+	waiter := fixture.IssuePrefix + "-bswait-waiter"
+	edgedWaiter := fixture.IssuePrefix + "-bswait-edgedwaiter"
+	edgeBlocker := fixture.IssuePrefix + "-bswait-edgeblocker"
+	otherSpawner := fixture.IssuePrefix + "-bswait-otherspawner"
+	otherChild := fixture.IssuePrefix + "-bswait-otherchild"
+	otherWaiter := fixture.IssuePrefix + "-bswait-otherwaiter"
+	for _, id := range []string{spawner, lastChild, waiter, edgedWaiter, edgeBlocker, otherSpawner, otherChild, otherWaiter} {
+		lifecycleCloseReopenSeedIssue(t, ctx, fixture, id, types.StatusOpen, nil)
+	}
+
+	// The hierarchies land FIRST. A gate over a spawner with no children at all
+	// is already satisfied, so a waits-for edge seeded before its spawner had a
+	// child would leave the waiter unblocked and give this case nothing to flip.
+	lifecycleCloseReopenSeedEdge(t, ctx, fixture, lastChild, spawner, types.DepParentChild)
+	lifecycleCloseReopenSeedEdge(t, ctx, fixture, otherChild, otherSpawner, types.DepParentChild)
+	lifecycleCloseReopenSeedEdge(t, ctx, fixture, edgedWaiter, edgeBlocker, types.DepBlocks)
+	for _, edge := range []struct{ waiter, spawner string }{
+		{waiter, spawner}, {edgedWaiter, spawner}, {otherWaiter, otherSpawner},
+	} {
+		lifecycleCloseReopenSeedWaitsForEdge(t, ctx, fixture, edge.waiter, edge.spawner, types.WaitsForAllChildren)
+	}
+
+	probe := newBlockedStateProbe(ctx, fixture.QueryScalar)
+	// The trap this case is built around: one open child, so closing it is the
+	// transition that satisfies the gate.
+	assertLifecycleCloseReopenOpenChildCount(t, ctx, fixture, spawner, 1)
+	assertLifecycleCloseReopenOpenChildCount(t, ctx, fixture, otherSpawner, 1)
+	probe.requireBlockedWithNoDirectBlockerEdges(t, blockedIssue(waiter),
+		"the subject's block is the GATE — the flag with no blocking edge of its own is what says so")
+	probe.requireBlockedByOpenBlocker(t, blockedIssue(edgedWaiter), blockedIssue(edgeBlocker),
+		"the in-set control is blocked by a cause this close does not touch")
+	probe.requireBlockedWithNoDirectBlockerEdges(t, blockedIssue(otherWaiter),
+		"the out-of-set control is gated on a spawner whose child nobody closes")
+	probe.requireUnblocked(t, blockedIssue(lastChild), "the row being closed carries no block of its own to confuse the flip with")
+
+	flip := probe.watchFlip(t,
+		[]blockedStateRow{blockedIssue(waiter)},
+		[]blockedStateRow{blockedIssue(edgedWaiter), blockedIssue(otherWaiter)})
+
+	closed, err := fixture.Lifecycle.Close(ctx, publicops.CloseRequest{Actor: "writer", IssueID: lastChild})
+	if err != nil {
+		t.Fatalf("close the spawner's last open child %s: %v", lastChild, err)
+	}
+	if !closed.Changed {
+		t.Fatalf("close of %s reported Changed = false, want a committed close", lastChild)
+	}
+	assertLifecycleCloseReopenOpenChildCount(t, ctx, fixture, spawner, 0)
+
+	flip.requireFlippedTo(t, 0,
+		"closing a spawner's LAST open child satisfies an all-children gate, and the closing transaction settles the waiter")
+
+	// The flip is attributable to the GATE and to nothing else: the spawner
+	// itself never moved, and the waits-for edge that gated the waiter is still
+	// there. A 0 read off a row whose edge had vanished would be a different
+	// fact wearing the same value.
+	if got := probe.rawStatus(t, blockedIssue(spawner)); got != string(types.StatusOpen) {
+		t.Fatalf("spawner %s status = %q, want it still open: the waiter's flip must come from the gate, not from its target closing", spawner, got)
+	}
+	assertLifecycleCloseReopenWaitsForEdgeCount(t, ctx, fixture, waiter, spawner, 1)
+}
+
 // RunLifecycleReopenReblocksItsDependers is the other direction, and it is what
 // makes the pair complete: the unmark template and the mark template are
 // separate SQL, so a case that only ever watches a flag fall exercises one of
@@ -1532,6 +1631,59 @@ func lifecycleCloseReopenSeedEdge(t *testing.T, ctx context.Context, fixture Lif
 		IssueID: from, DependsOnID: to, Type: kind,
 	}, "seed"); err != nil {
 		t.Fatalf("seed %s %s -> %s: %v", kind, from, to, err)
+	}
+}
+
+// lifecycleCloseReopenSeedWaitsForEdge seeds a waits-for edge carrying its GATE.
+// It goes through the constructor rather than a literal because the gate lives
+// in edge metadata whose spelling the derivation engine reads, and a hand-built
+// JSON blob here would be this file's guess at that spelling.
+func lifecycleCloseReopenSeedWaitsForEdge(t *testing.T, ctx context.Context, fixture LifecycleCloseReopenFixture, waiter, spawner, gate string) {
+	t.Helper()
+	edge, err := types.NewWaitsForDependency(waiter, spawner, gate)
+	if err != nil {
+		t.Fatalf("build the %s waits-for edge %s -> %s: %v", gate, waiter, spawner, err)
+	}
+	if err := fixture.AddDependency(ctx, edge, "seed"); err != nil {
+		t.Fatalf("seed the %s waits-for edge %s -> %s: %v", gate, waiter, spawner, err)
+	}
+}
+
+// assertLifecycleCloseReopenOpenChildCount counts a spawner's parent-child
+// children that are neither closed nor pinned, IN BOTH PLANES. The gate case
+// reads it as a fixture check on both sides of the close: a spawner with a
+// second open child would leave an all-children gate unsatisfied afterwards, so
+// the subject could not flip and the case could not fail.
+func assertLifecycleCloseReopenOpenChildCount(t *testing.T, ctx context.Context, fixture LifecycleCloseReopenFixture, spawner string, want int) {
+	t.Helper()
+	var got int
+	if err := fixture.QueryScalar(ctx, `
+		SELECT (
+		    SELECT COUNT(*) FROM dependencies d JOIN issues c ON c.id = d.issue_id
+		    WHERE d.type = 'parent-child' AND d.depends_on_issue_id = ?
+		      AND c.status <> 'closed' AND c.status <> 'pinned'
+		  ) + (
+		    SELECT COUNT(*) FROM wisp_dependencies d JOIN wisps c ON c.id = d.issue_id
+		    WHERE d.type = 'parent-child' AND d.depends_on_issue_id = ?
+		      AND c.status <> 'closed' AND c.status <> 'pinned'
+		  )`, []any{spawner, spawner}, &got); err != nil {
+		t.Fatalf("count the open children of %s: %v", spawner, err)
+	}
+	if got != want {
+		t.Fatalf("%s has %d open children, want %d: an all-children gate case is about the LAST one closing", spawner, got, want)
+	}
+}
+
+func assertLifecycleCloseReopenWaitsForEdgeCount(t *testing.T, ctx context.Context, fixture LifecycleCloseReopenFixture, waiter, spawner string, want int) {
+	t.Helper()
+	var got int
+	if err := fixture.QueryScalar(ctx,
+		"SELECT COUNT(*) FROM dependencies WHERE issue_id = ? AND depends_on_issue_id = ? AND type = ?",
+		[]any{waiter, spawner, string(types.DepWaitsFor)}, &got); err != nil {
+		t.Fatalf("count waits-for edges %s -> %s: %v", waiter, spawner, err)
+	}
+	if got != want {
+		t.Errorf("waits-for edges %s -> %s = %d, want %d", waiter, spawner, got, want)
 	}
 }
 

--- a/internal/storage/dolt/deleter_contract_test.go
+++ b/internal/storage/dolt/deleter_contract_test.go
@@ -72,6 +72,9 @@ func TestDeleterContract(t *testing.T) {
 	t.Run("SettlesTheSurvivorsOfADeletedBlocker", func(t *testing.T) {
 		conformance.RunDeleterSettlesTheSurvivorsOfADeletedBlocker(t, ctx, fixture)
 	})
+	t.Run("SettlesTheSurvivorsOfADeletedWispBlocker", func(t *testing.T) {
+		conformance.RunDeleterSettlesTheSurvivorsOfADeletedWispBlocker(t, ctx, fixture)
+	})
 	t.Run("SettlesTheChildrenOfADeletedParent", func(t *testing.T) {
 		conformance.RunDeleterSettlesTheChildrenOfADeletedParent(t, ctx, fixture)
 	})

--- a/internal/storage/dolt/issue_operations_contract_test.go
+++ b/internal/storage/dolt/issue_operations_contract_test.go
@@ -169,6 +169,12 @@ func TestIssueOperationsUpdateStatusCrossingSettlesDependers(t *testing.T) {
 	conformance.RunIssueOperationsUpdateStatusCrossingSettlesDependers(t, ctx, fixture)
 }
 
+func TestIssueOperationsUpdateStatusCrossingSettlesAConditionalBlocksDepender(t *testing.T) {
+	fixture, ctx, cleanup := newDoltIssueOperationsFixture(t)
+	defer cleanup()
+	conformance.RunIssueOperationsUpdateStatusCrossingSettlesAConditionalBlocksDepender(t, ctx, fixture)
+}
+
 func TestIssueOperationsCreateWithDependenciesSettlesInTheCreatingTransaction(t *testing.T) {
 	fixture, ctx, cleanup := newDoltIssueOperationsFixture(t)
 	defer cleanup()

--- a/internal/storage/dolt/lifecycle_close_reopen_contract_test.go
+++ b/internal/storage/dolt/lifecycle_close_reopen_contract_test.go
@@ -71,6 +71,9 @@ func TestLifecycleCloseReopenContract(t *testing.T) {
 	t.Run("CloseSettlesTheClosedRowItselfAndItsChild", func(t *testing.T) {
 		conformance.RunLifecycleCloseSettlesTheClosedRowItselfAndItsChild(t, ctx, fixture)
 	})
+	t.Run("CloseOnASpawnersLastChildSatisfiesAWaitsForGate", func(t *testing.T) {
+		conformance.RunLifecycleCloseOnASpawnersLastChildSatisfiesAWaitsForGate(t, ctx, fixture)
+	})
 	t.Run("ReopenReblocksItsDependers", func(t *testing.T) {
 		conformance.RunLifecycleReopenReblocksItsDependers(t, ctx, fixture)
 	})

--- a/internal/storage/embeddeddolt/deleter_contract_test.go
+++ b/internal/storage/embeddeddolt/deleter_contract_test.go
@@ -74,6 +74,9 @@ func TestDeleterContract(t *testing.T) {
 	t.Run("SettlesTheSurvivorsOfADeletedBlocker", func(t *testing.T) {
 		conformance.RunDeleterSettlesTheSurvivorsOfADeletedBlocker(t, ctx, fixture)
 	})
+	t.Run("SettlesTheSurvivorsOfADeletedWispBlocker", func(t *testing.T) {
+		conformance.RunDeleterSettlesTheSurvivorsOfADeletedWispBlocker(t, ctx, fixture)
+	})
 	t.Run("SettlesTheChildrenOfADeletedParent", func(t *testing.T) {
 		conformance.RunDeleterSettlesTheChildrenOfADeletedParent(t, ctx, fixture)
 	})

--- a/internal/storage/embeddeddolt/issue_operations_contract_test.go
+++ b/internal/storage/embeddeddolt/issue_operations_contract_test.go
@@ -199,6 +199,13 @@ func TestEmbeddedIssueOperationsUpdateStatusCrossingSettlesDependers(t *testing.
 	conformance.RunIssueOperationsUpdateStatusCrossingSettlesDependers(t, ctx, newEmbeddedIssueOperationsFixture(t, ctx, te, "bsupd"))
 }
 
+func TestEmbeddedIssueOperationsUpdateStatusCrossingSettlesAConditionalBlocksDepender(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	te := newTestEnv(t, "bscond")
+	ctx := t.Context()
+	conformance.RunIssueOperationsUpdateStatusCrossingSettlesAConditionalBlocksDepender(t, ctx, newEmbeddedIssueOperationsFixture(t, ctx, te, "bscond"))
+}
+
 func TestEmbeddedIssueOperationsCreateWithDependenciesSettlesInTheCreatingTransaction(t *testing.T) {
 	skipUnlessEmbeddedDolt(t)
 	te := newTestEnv(t, "bscreate")

--- a/internal/storage/embeddeddolt/lifecycle_close_reopen_contract_test.go
+++ b/internal/storage/embeddeddolt/lifecycle_close_reopen_contract_test.go
@@ -74,6 +74,9 @@ func TestLifecycleCloseReopenContract(t *testing.T) {
 	t.Run("CloseSettlesTheClosedRowItselfAndItsChild", func(t *testing.T) {
 		conformance.RunLifecycleCloseSettlesTheClosedRowItselfAndItsChild(t, ctx, fixture)
 	})
+	t.Run("CloseOnASpawnersLastChildSatisfiesAWaitsForGate", func(t *testing.T) {
+		conformance.RunLifecycleCloseOnASpawnersLastChildSatisfiesAWaitsForGate(t, ctx, fixture)
+	})
 	t.Run("ReopenReblocksItsDependers", func(t *testing.T) {
 		conformance.RunLifecycleReopenReblocksItsDependers(t, ctx, fixture)
 	})

--- a/internal/storage/uow/deleter_contract_test.go
+++ b/internal/storage/uow/deleter_contract_test.go
@@ -75,6 +75,9 @@ func TestDeleterContract(t *testing.T) {
 	t.Run("SettlesTheSurvivorsOfADeletedBlocker", func(t *testing.T) {
 		conformance.RunDeleterSettlesTheSurvivorsOfADeletedBlocker(t, ctx, fixture)
 	})
+	t.Run("SettlesTheSurvivorsOfADeletedWispBlocker", func(t *testing.T) {
+		conformance.RunDeleterSettlesTheSurvivorsOfADeletedWispBlocker(t, ctx, fixture)
+	})
 	t.Run("SettlesTheChildrenOfADeletedParent", func(t *testing.T) {
 		conformance.RunDeleterSettlesTheChildrenOfADeletedParent(t, ctx, fixture)
 	})

--- a/internal/storage/uow/issue_operations_contract_test.go
+++ b/internal/storage/uow/issue_operations_contract_test.go
@@ -147,6 +147,11 @@ func TestIssueOperationsUpdateStatusCrossingSettlesDependers(t *testing.T) {
 	conformance.RunIssueOperationsUpdateStatusCrossingSettlesDependers(t, ctx, newUOWIssueOperationsFixture(t, ctx))
 }
 
+func TestIssueOperationsUpdateStatusCrossingSettlesAConditionalBlocksDepender(t *testing.T) {
+	ctx := context.Background()
+	conformance.RunIssueOperationsUpdateStatusCrossingSettlesAConditionalBlocksDepender(t, ctx, newUOWIssueOperationsFixture(t, ctx))
+}
+
 func TestIssueOperationsCreateWithDependenciesSettlesInTheCreatingTransaction(t *testing.T) {
 	ctx := context.Background()
 	conformance.RunIssueOperationsCreateWithDependenciesSettlesInTheCreatingTransaction(t, ctx, newUOWIssueOperationsFixture(t, ctx))

--- a/internal/storage/uow/lifecycle_close_reopen_contract_test.go
+++ b/internal/storage/uow/lifecycle_close_reopen_contract_test.go
@@ -72,6 +72,9 @@ func TestLifecycleCloseReopenContract(t *testing.T) {
 	t.Run("CloseSettlesTheClosedRowItselfAndItsChild", func(t *testing.T) {
 		conformance.RunLifecycleCloseSettlesTheClosedRowItselfAndItsChild(t, ctx, fixture)
 	})
+	t.Run("CloseOnASpawnersLastChildSatisfiesAWaitsForGate", func(t *testing.T) {
+		conformance.RunLifecycleCloseOnASpawnersLastChildSatisfiesAWaitsForGate(t, ctx, fixture)
+	})
 	t.Run("ReopenReblocksItsDependers", func(t *testing.T) {
 		conformance.RunLifecycleReopenReblocksItsDependers(t, ctx, fixture)
 	})


### PR DESCRIPTION
Follow-up to #5436, which pinned `issueops.BlockedStateInvariant` with 13 postcondition cases. An adversarial review of that PR confirmed all 13 can fail and the kit's countermeasures are real, then found **clauses of the stated invariant with no case at all**. One was closed before merge; these are the remaining three.

Each is a clause the invariant states in prose and nothing tested.

## 1. Conditional-blocks edges were never seeded

The predicate names "a **blocks or conditional-blocks** edge". The kit's edge counters accept both types, but no fixture ever built one — drop `conditional_blocks` from a mark template and none of the 13 cases reddened.

`RunIssueOperationsUpdateStatusCrossingSettlesAConditionalBlocksDepender` seeds a depender with a conditional-blocks edge **and nothing else**, and asserts its plain-`blocks` edge count is **zero** — a row holding both types is blocked either way, so the conditional term would be unobservable.

**It could not live where the review assumed.** On DependencyEditor, `markDirectBlockingDependencySourceInTx` and its `domain/db` mirror mark the source with a type-agnostic UPDATE and then drop it from the affected set, so the mark template's type list never decides an add — dropping `DepConditionalBlocks` from either wiring is behaviour-equivalent today. The type list only decides anything at Update's status crossing. Found by trying it.

Mutations: dropping the type from `markBlockedTemplateForIssues` reddens all three legs while the plain-blocks sibling stays green; neutering each leg's own crossing recompute reddens that leg alone. **Two genuine votes.**

## 2. Waits-for gates were pinned only on the add side

`AffectedByStatusChangeInTx` has a dedicated waiter-expansion arm, `loadWaitersWhoseSpawnerIsParentOfInTx` — the only load that reaches a waiter on the *parent* of the row whose status moved — and no case drove it.

`RunLifecycleCloseOnASpawnersLastChildSatisfiesAWaitsForGate` seeds a spawner with **exactly one** open child, asserted in both planes before and after: a second open child would leave the gate unsatisfied and the subject unable to flip, making the case unfalsifiable on its own term. Two controls — a waiter on the same spawner still blocked by an edge of its own, and a waiter gated on an untouched spawner.

Deleting that call reddens all three legs while the three existing close/reopen cases stay green. Close is **one body** on all three legs, so this is reported as **one vote**, not three.

## 3. Wisp-blocker deletion was unpinned

The Deleter cases only ever deleted durable rows; the kit header's wisp carve-out covers store-only sites, not this one.

`RunDeleterSettlesTheSurvivorsOfADeletedWispBlocker` force-deletes a **wisp** blocker with a durable depender (edge target in `depends_on_wisp_id`), that depender's child, and a wisp depender — then counts the deleted row at zero, so the survivors' zeros describe an absent blocker rather than a coincidence.

Mutations on each leg's own affected-set call: `issueops/delete.go` reddens dolt and embedded with uow green; `domain/issue_delete.go` reddens uow with dolt green. **Two genuine votes.**

## Verification

All nine case/leg pairs confirmed executing **by name**. Every case mutation-verified against the wiring it pins, attributed per leg, with the shared-body case reported as one vote. `go build ./...`, `go vet`, `golangci-lint run` clean; all three touched contracts green on all three legs.

Lint also forced a small cleanup: `deleterAddTypedEdge` lost a parameter every caller passed the same value for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)