### PR TITLE
Retire 19 audit cases the role contracts dominate, and say why 9 stay

### DIFF
--- a/backend/conformance/audit_config_metadata_slots_repomtime.go
+++ b/backend/conformance/audit_config_metadata_slots_repomtime.go
@@ -92,6 +92,17 @@ func testAuditCustomStatusesOrder(t *testing.T, f Factory) {
 // value and returns an error for an invalid one, rolling back the whole write tx.
 // So SetConfig returns an error AND nothing is stored (GetConfig empty). A backend
 // that skips the sync would silently store the invalid value and return nil.
+//
+// NOT DOMINATED by RunWorkspaceConfigRefusesAnUnparseableCustomStatus, however
+// alike the two read. The role refuses in workapi.ValidateSettingWrite, which
+// parses the value BEFORE calling the store at all ("Checking here rather than
+// leaving it to SyncCustomStatusesTable is what makes the refusal a validation
+// error rather than a storage failure"). The store's own in-transaction refusal
+// is therefore reachable only from this seam: make the store swallow the sync
+// error and the whole workspaceconfig contract stays green while this case goes
+// red (measured with scripts/mutation-equivalence.sh). The two also drive
+// different parser branches — a name-shaped refusal here, a built-in collision
+// there.
 func testAuditSetConfigInvalidStatusRollsBack(t *testing.T, f Factory) {
 	s := f(t)
 	c := ctx()
@@ -128,6 +139,12 @@ func testAuditCustomTypesOrder(t *testing.T, f Factory) {
 // earlier SetConfig populated. So after deleting status.custom the reference still
 // reports the custom statuses (stale table). A backend that never synced the table
 // would instead report empty.
+//
+// RunWorkspaceConfigUnsetLeavesTheProjectionBehind pins the same bd-yby99.33
+// clause on three legs and reads the projection table raw rather than through
+// GetCustomStatuses, so on promises alone this case is dominated. It survives
+// because it is the only call to DoltStorage.DeleteConfig anywhere in RunAll,
+// the gate an out-of-tree backend proves itself with.
 func testAuditDeleteConfigLeavesNormalizedTable(t *testing.T, f Factory) {
 	s := f(t)
 	c := ctx()

--- a/backend/conformance/audit_dependencies_readiness.go
+++ b/backend/conformance/audit_dependencies_readiness.go
@@ -306,6 +306,13 @@ func testAuditDetectCyclesBlocksOnly(t *testing.T, f Factory) {
 	}
 }
 
+// testAuditDependencyTree survives a retirement pass despite tree_walker_contract.go
+// pinning the same GetDependencyTreeInTx body harder (Depth/ParentID/EdgeFromParent,
+// title hydration, `related` included as well as relates-to excluded). It is the
+// only call to DoltStorage.GetDependencyTree anywhere in RunAll, and RunAll is
+// what an out-of-tree backend proves itself with — the role contracts are wired
+// per-backend and are not part of that gate. Deleting this leaves the method
+// uncalled by the suite that exists to call it.
 func testAuditDependencyTree(t *testing.T, f Factory) {
 	s := f(t)
 	for _, id := range []string{"g1", "g2", "g3", "g4"} {

--- a/backend/conformance/audit_dependencies_readiness.go
+++ b/backend/conformance/audit_dependencies_readiness.go
@@ -15,10 +15,40 @@ import (
 // issueops reference (validated against the embedded-Dolt oracle). Every case here
 // is deliberately absent from conformance.go/portable.go: self-dep and cycle
 // rejection, the hierarchy blocking-deadlock guard, idempotency vs type-conflict,
-// external targets, the blocks-only vs all-types count split, ready-work type/pinned/
-// deferred exclusions, hybrid sort ordering, transitive ParentID descendants,
-// inherited parent blocking, typed blocker descriptions, and hypothetical
-// unblock-by-close. Ordering that the SQL leaves unspecified is asserted as a set.
+// the blocks-only vs all-types count split, ready-work type/pinned exclusions,
+// hybrid sort ordering, transitive ParentID descendants, inherited parent
+// blocking, typed blocker descriptions, and hypothetical unblock-by-close.
+// Ordering that the SQL leaves unspecified is asserted as a set.
+//
+// FOUR CASES WERE RETIRED against dependency_editor_contract.go and
+// reader_contract.go, which reach the same bodies and read them at a stronger
+// plane on three legs instead of two:
+//
+//	a ghost endpoint refuses     RunDependencyEditorRefusesAGhostSource /
+//	                             RefusesAMissingLocalTarget (typed
+//	                             *DependencyEndpointNotFoundError, and raw
+//	                             no-edge rollback in BOTH planes)
+//	an external: target lands     RunDependencyEditorAcceptsAnExternalTarget +
+//	                             WritesTheTargetIntoItsTypedColumn (the typed
+//	                             COLUMN, where this file read the COALESCE
+//	                             expression back)
+//	removing an absent edge is    RunDependencyEditorRemoveIsIdempotent
+//	a no-op, removing the real
+//	one unblocks                  RunDependencyEditorRemoveUnmarksItsSourceAndDescendants
+//	                             (raw is_blocked with a falsifiability
+//	                             pre-check, where this file asked GetReadyWork
+//	                             and IsBlocked — the role-answer anti-pattern
+//	                             ADDING_AN_ISSUEOPS_ROLE.md names)
+//	defer_until hides a row       RunReaderReadyDeferredAndEphemeralGates (same
+//	                             sqlbuild.BuildReadyWorkWhere clause, plus the
+//	                             cross-gate independence with IncludeEphemeral)
+//
+// testAuditSelfDependencyRejected stayed: its guard is a DIFFERENT body. The
+// role refuses a self-edge in issueops.ValidateAddDependenciesRequest before the
+// transaction opens; the raw verb reaches the guard inside
+// CheckDependencyCycleInTx, which is the one that fires ahead of the
+// scheduling-edge early return and so refuses a relates-to self-edge too.
+// Deleting that guard leaves the whole editor contract green.
 
 // RunAudit_dependencies_readiness runs the dependencies-readiness audit cases.
 func RunAudit_dependencies_readiness(t *testing.T, f Factory) {
@@ -28,14 +58,10 @@ func RunAudit_dependencies_readiness(t *testing.T, f Factory) {
 	t.Run("CycleScopeByDependencyType", func(t *testing.T) { testAuditCycleScopeByDependencyType(t, f) })
 	t.Run("IdempotencyVsTypeConflict", func(t *testing.T) { testAuditIdempotencyVsTypeConflict(t, f) })
 	t.Run("CrossTypeEpicTaskBlocking", func(t *testing.T) { testAuditCrossTypeEpicTaskBlocking(t, f) })
-	t.Run("MissingSourceTarget", func(t *testing.T) { testAuditMissingSourceTarget(t, f) })
-	t.Run("ExternalTarget", func(t *testing.T) { testAuditExternalTarget(t, f) })
-	t.Run("RemoveMissingAndUnblock", func(t *testing.T) { testAuditRemoveMissingAndUnblock(t, f) })
 	t.Run("DependencyCountsBlocksOnly", func(t *testing.T) { testAuditDependencyCountsBlocksOnly(t, f) })
 	t.Run("DetectCyclesBlocksOnly", func(t *testing.T) { testAuditDetectCyclesBlocksOnly(t, f) })
 	t.Run("DependencyTree", func(t *testing.T) { testAuditDependencyTree(t, f) })
 	t.Run("ReadyTypeAndPinnedExclusions", func(t *testing.T) { testAuditReadyTypeAndPinnedExclusions(t, f) })
-	t.Run("ReadyDeferredExclusion", func(t *testing.T) { testAuditReadyDeferredExclusion(t, f) })
 	t.Run("ReadyMultiStatusFilter", func(t *testing.T) { testAuditReadyMultiStatusFilter(t, f) })
 	t.Run("ReadyHybridSortAndOldest", func(t *testing.T) { testAuditReadyHybridSortAndOldest(t, f) })
 	t.Run("ReadyParentTransitiveDescendants", func(t *testing.T) { testAuditReadyParentTransitiveDescendants(t, f) })
@@ -229,65 +255,6 @@ func testAuditCrossTypeEpicTaskBlocking(t *testing.T, f Factory) {
 	}
 }
 
-func testAuditMissingSourceTarget(t *testing.T, f Factory) {
-	s := f(t)
-	must(t, s.CreateIssue(ctx(), withDefaults(&types.Issue{ID: "me", Title: "Me"}), "a"))
-
-	errTarget := s.AddDependency(ctx(), &types.Dependency{IssueID: "me", DependsOnID: "ghost", Type: types.DepBlocks}, "a")
-	if errTarget == nil || !strings.Contains(errTarget.Error(), "ghost") || !strings.Contains(errTarget.Error(), "not found") {
-		t.Errorf("missing-target err = %v, want to mention 'ghost' and 'not found'", errTarget)
-	}
-	errSource := s.AddDependency(ctx(), &types.Dependency{IssueID: "ghost", DependsOnID: "me", Type: types.DepBlocks}, "a")
-	if errSource == nil || !strings.Contains(errSource.Error(), "ghost") || !strings.Contains(errSource.Error(), "not found") {
-		t.Errorf("missing-source err = %v, want to mention 'ghost' and 'not found'", errSource)
-	}
-	deps, _ := s.GetDependencies(ctx(), "me")
-	if len(deps) != 0 {
-		t.Errorf("GetDependencies(me) = %v, want empty", issueIDs(deps))
-	}
-}
-
-func testAuditExternalTarget(t *testing.T, f Factory) {
-	s := f(t)
-	must(t, s.CreateIssue(ctx(), withDefaults(&types.Issue{ID: "ex1", Title: "Ext"}), "a"))
-
-	// An external: target skips existence validation and is written to depends_on_external.
-	must(t, s.AddDependency(ctx(), &types.Dependency{IssueID: "ex1", DependsOnID: "external:PROJ-9", Type: types.DepBlocks}, "a"))
-
-	// GetDependencies hydrates issues/wisps only, so the external target is dropped.
-	deps, _ := s.GetDependencies(ctx(), "ex1")
-	if len(deps) != 0 {
-		t.Errorf("GetDependencies(ex1) = %v, want empty (external target is not an issue)", issueIDs(deps))
-	}
-	// GetDependencyRecords surfaces the raw edge via the COALESCE target expression.
-	recs, _ := s.GetDependencyRecords(ctx(), "ex1")
-	if got := depTargets(recs); !slices.Equal(got, []string{"external:PROJ-9"}) {
-		t.Errorf("GetDependencyRecords(ex1) targets = %v, want [external:PROJ-9]", got)
-	}
-}
-
-func testAuditRemoveMissingAndUnblock(t *testing.T, f Factory) {
-	s := f(t)
-	must(t, s.CreateIssue(ctx(), withDefaults(&types.Issue{ID: "rb1", Title: "Blocker", Status: types.StatusOpen}), "a"))
-	must(t, s.CreateIssue(ctx(), withDefaults(&types.Issue{ID: "rb2", Title: "Blocked", Status: types.StatusOpen}), "a"))
-	must(t, s.AddDependency(ctx(), &types.Dependency{IssueID: "rb2", DependsOnID: "rb1", Type: types.DepBlocks}, "a"))
-
-	// Removing a non-existent edge is a silent no-op.
-	must(t, s.RemoveDependency(ctx(), "rb2", "nope", "a"))
-	// Removing the real sole blocks edge recomputes is_blocked; rb2 becomes ready.
-	must(t, s.RemoveDependency(ctx(), "rb2", "rb1", "a"))
-
-	ready, _ := s.GetReadyWork(ctx(), types.WorkFilter{})
-	if !contains(issueIDs(ready), "rb2") {
-		t.Errorf("ready after remove = %v, want to contain rb2", issueIDs(ready))
-	}
-	blocked, _, err := s.IsBlocked(ctx(), "rb2")
-	must(t, err)
-	if blocked {
-		t.Error("IsBlocked(rb2) = true after removing sole blocker, want false")
-	}
-}
-
 func testAuditDependencyCountsBlocksOnly(t *testing.T, f Factory) {
 	s := f(t)
 	for _, id := range []string{"t", "c", "r", "b"} {
@@ -402,22 +369,6 @@ func testAuditReadyTypeAndPinnedExclusions(t *testing.T, f Factory) {
 	ready, _ := s.GetReadyWork(ctx(), types.WorkFilter{})
 	if got := issueIDs(ready); !slices.Equal(got, []string{"rk1"}) {
 		t.Errorf("ready = %v, want [rk1] (gate/molecule/pinned excluded)", got)
-	}
-}
-
-func testAuditReadyDeferredExclusion(t *testing.T, f Factory) {
-	s := f(t)
-	future := time.Now().UTC().Add(24 * time.Hour).Truncate(time.Second)
-	must(t, s.CreateIssue(ctx(), withDefaults(&types.Issue{ID: "df1", Title: "deferred", Status: types.StatusOpen, DeferUntil: &future}), "a"))
-	must(t, s.CreateIssue(ctx(), withDefaults(&types.Issue{ID: "df2", Title: "ready", Status: types.StatusOpen}), "a"))
-
-	ready, _ := s.GetReadyWork(ctx(), types.WorkFilter{})
-	if got := issueIDs(ready); !slices.Equal(got, []string{"df2"}) {
-		t.Errorf("ready = %v, want [df2] (df1 deferred out)", got)
-	}
-	withDeferred, _ := s.GetReadyWork(ctx(), types.WorkFilter{IncludeDeferred: true})
-	if got := issueIDs(withDeferred); !slices.Equal(got, []string{"df1", "df2"}) {
-		t.Errorf("ready(IncludeDeferred) = %v, want [df1 df2]", got)
 	}
 }
 

--- a/backend/conformance/audit_issue-lifecycle.go
+++ b/backend/conformance/audit_issue-lifecycle.go
@@ -10,112 +10,49 @@ import (
 	"github.com/steveyegge/beads/internal/types"
 )
 
-// This file encodes audit findings for the "issue-lifecycle" slice: close/reopen
-// idempotency, batch delete (cascade/force/orphan-guard/dry-run), FK child-row
-// cleanup, derived timestamps (closed_at, started_at), metadata JSON round-trip,
-// and the external-ref wisp fallthrough. Every case is validated against the
-// embedded-Dolt reference (the oracle); they pin real reference behavior so a SQL
-// backend that diverges fails loudly.
-
-// auditCountEventType counts how many of the issue's audit events have the given type.
-func auditCountEventType(events []*types.Event, want types.EventType) int {
-	n := 0
-	for _, e := range events {
-		if e.EventType == want {
-			n++
-		}
-	}
-	return n
-}
+// This file encodes audit findings for the "issue-lifecycle" slice: batch delete
+// (cascade/force/orphan-guard/dry-run), FK child-row cleanup, derived timestamps
+// (closed_at, started_at), metadata JSON round-trip, and the external-ref wisp
+// fallthrough. Every case is validated against the embedded-Dolt reference (the
+// oracle); they pin real reference behavior so a SQL backend that diverges fails
+// loudly.
+//
+// THE CLOSE/REOPEN CASES ARE GONE, and deliberately. Close, reopen and the
+// is_blocked recompute they trigger reach ONE body from either seam
+// (issueops.closeIssueInTx / ReopenIssueInTx; the store verbs and the Lifecycle
+// role both land there), and lifecycle_close_reopen_contract.go pins each of the
+// four promises they held with a strictly stronger observation:
+//
+//	first-close attribution wins   RunLifecycleCloseIsIdempotentAndKeepsTheFirstClose
+//	                               (raw closed_at/close_reason/session + a raw
+//	                               event delta, where this file read GetIssue)
+//	reopen is a strict no-op       RunLifecycleReopenLeavesNonDoneStatusesUnchanged
+//	                               (three non-done statuses, whole-row compare)
+//	reopen mints exactly one event RunLifecycleReopenRecordsItsReason
+//	a missing id is ErrNotFound    RunLifecycleExpectedVersionIsCheckedBeforeTheNoOps
+//	                               (guarded and unguarded, and NOT ErrVersionMismatch)
+//	the recompute leaves           RunLifecycleCloseSettlesItsTransitiveAndCrossPlaneDependers
+//	updated_at alone               (raw is_blocked flip + raw updated_at, with a
+//	                               falsifiability pre-check, a cross-plane wisp
+//	                               depender, an inherited child and a control)
+//
+// and each runs on the unit-of-work leg as well, which this suite's Factory type
+// cannot reach. Same for UpdateIssueTypeRejectsInvalid against
+// RunIssueOperationsUpdateRefusesATypeOutsideTheWorkspaceVocabulary, which adds
+// the CONFIGURED-vocabulary positive half a guard hardcoding the built-ins would
+// pass here. The store verbs keep their seats in this suite through
+// testCloseAndReopen, testUpdateIssueType and the ready/blocked cases.
 
 // RunAudit_issue_lifecycle runs the issue-lifecycle audit cases.
 func RunAudit_issue_lifecycle(t *testing.T, f Factory) {
 	t.Helper()
-	t.Run("CloseIdempotentKeepsFirstReason", func(t *testing.T) { testAuditCloseIdempotentKeepsFirstReason(t, f) })
-	t.Run("ReopenEventSemantics", func(t *testing.T) { testAuditReopenEventSemantics(t, f) })
-	t.Run("ReopenNotFoundIsSentinel", func(t *testing.T) { testAuditReopenNotFoundIsSentinel(t, f) })
 	t.Run("DeleteIssuesBatchModes", func(t *testing.T) { testAuditDeleteIssuesBatchModes(t, f) })
 	t.Run("DeleteIssuesDryRunCounts", func(t *testing.T) { testAuditDeleteIssuesDryRunCounts(t, f) })
 	t.Run("DeleteIssueCascadesChildRows", func(t *testing.T) { testAuditDeleteIssueCascadesChildRows(t, f) })
-	t.Run("CloseDependentUpdatedAtPreserved", func(t *testing.T) { testAuditCloseDependentUpdatedAtPreserved(t, f) })
 	t.Run("CreateClosedDerivesClosedAt", func(t *testing.T) { testAuditCreateClosedDerivesClosedAt(t, f) })
 	t.Run("MetadataJSONRoundTrip", func(t *testing.T) { testAuditMetadataJSONRoundTrip(t, f) })
 	t.Run("StartedAtStampedOnceOnInProgress", func(t *testing.T) { testAuditStartedAtStampedOnceOnInProgress(t, f) })
 	t.Run("ExternalRefResolvesWispTier", func(t *testing.T) { testAuditExternalRefResolvesWispTier(t, f) })
-	t.Run("UpdateIssueTypeRejectsInvalid", func(t *testing.T) { testAuditUpdateIssueTypeRejectsInvalid(t, f) })
-}
-
-// A second close of an already-closed issue is a no-op: it returns nil, does not
-// overwrite the original close_reason/closed_at, and mints no second EventClosed.
-func testAuditCloseIdempotentKeepsFirstReason(t *testing.T, f Factory) {
-	s := f(t)
-	must(t, s.CreateIssue(ctx(), withDefaults(&types.Issue{ID: "cl-1", Title: "T", Status: types.StatusOpen}), "a"))
-	must(t, s.CloseIssue(ctx(), "cl-1", "first", "a", "s1"))
-
-	afterFirst, err := s.GetIssue(ctx(), "cl-1")
-	must(t, err)
-	if afterFirst.ClosedAt == nil {
-		t.Fatal("ClosedAt nil after first close")
-	}
-	firstClosedAt := *afterFirst.ClosedAt
-
-	// Second close with a different reason/session must be silently dropped.
-	if err := s.CloseIssue(ctx(), "cl-1", "second", "b", "s2"); err != nil {
-		t.Fatalf("second CloseIssue: %v", err)
-	}
-
-	got, err := s.GetIssue(ctx(), "cl-1")
-	must(t, err)
-	if got.CloseReason != "first" {
-		t.Errorf("CloseReason = %q, want %q (first close wins)", got.CloseReason, "first")
-	}
-	if got.ClosedAt == nil || !got.ClosedAt.Equal(firstClosedAt) {
-		t.Errorf("ClosedAt = %v, want %v (unchanged by second close)", got.ClosedAt, firstClosedAt)
-	}
-
-	events, err := s.GetEvents(ctx(), "cl-1", 0)
-	must(t, err)
-	if n := auditCountEventType(events, types.EventClosed); n != 1 {
-		t.Errorf("EventClosed count = %d, want 1", n)
-	}
-}
-
-// Reopening an already-open issue is a strict no-op. Reopening the same issue
-// after a genuine close mints exactly one reopened event.
-func testAuditReopenEventSemantics(t *testing.T, f Factory) {
-	s := f(t)
-	must(t, s.CreateIssue(ctx(), withDefaults(&types.Issue{ID: "ro-1", Title: "T", Status: types.StatusOpen}), "a"))
-
-	before, err := s.GetEvents(ctx(), "ro-1", 0)
-	must(t, err)
-
-	must(t, s.ReopenIssue(ctx(), "ro-1", "", "a"))
-
-	after, err := s.GetEvents(ctx(), "ro-1", 0)
-	must(t, err)
-	if len(after) != len(before) {
-		t.Errorf("events after reopen-on-open = %d, want %d (strict no-op)", len(after), len(before))
-	}
-
-	must(t, s.CloseIssue(ctx(), "ro-1", "done", "a", "session"))
-	must(t, s.ReopenIssue(ctx(), "ro-1", "", "a"))
-	afterClosedReopen, err := s.GetEvents(ctx(), "ro-1", 0)
-	must(t, err)
-	if n := auditCountEventType(afterClosedReopen, types.EventReopened); n != 1 {
-		t.Errorf("EventReopened count after closed reopen = %d, want 1", n)
-	}
-}
-
-// Reopening a non-existent id returns a wrapped storage.ErrNotFound on the reference.
-func testAuditReopenNotFoundIsSentinel(t *testing.T, f Factory) {
-	s := f(t)
-	err := s.ReopenIssue(ctx(), "nonexistent", "", "a")
-	if err == nil {
-		t.Fatal("expected error reopening a missing issue")
-	}
-	if !errors.Is(err, storage.ErrNotFound) {
-		t.Errorf("err = %v, want errors.Is(storage.ErrNotFound)", err)
-	}
 }
 
 // Batch DeleteIssues: non-cascade/non-force with an external dependent is a guarded
@@ -229,29 +166,6 @@ func testAuditDeleteIssueCascadesChildRows(t *testing.T, f Factory) {
 	}
 }
 
-// Closing a blocker reprojects is_blocked on its dependent WITHOUT bumping the
-// dependent's updated_at (the recompute uses `updated_at = updated_at`).
-func testAuditCloseDependentUpdatedAtPreserved(t *testing.T, f Factory) {
-	s := f(t)
-	frozen := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
-	must(t, s.CreateIssue(ctx(), withDefaults(&types.Issue{ID: "cd-blk", Title: "Blocker", Status: types.StatusOpen}), "a"))
-	must(t, s.CreateIssue(ctx(), withDefaults(&types.Issue{ID: "cd-dep", Title: "Dep", Status: types.StatusOpen, CreatedAt: frozen, UpdatedAt: frozen}), "a"))
-	must(t, s.AddDependency(ctx(), &types.Dependency{IssueID: "cd-dep", DependsOnID: "cd-blk", Type: types.DepBlocks}, "a"))
-	must(t, s.CloseIssue(ctx(), "cd-blk", "done", "a", "s"))
-
-	got, err := s.GetIssue(ctx(), "cd-dep")
-	must(t, err)
-	if !got.UpdatedAt.Equal(frozen) {
-		t.Errorf("dependent UpdatedAt = %v, want %v (is_blocked reprojection must not bump it)", got.UpdatedAt, frozen)
-	}
-
-	ready, err := s.GetReadyWork(ctx(), types.WorkFilter{})
-	must(t, err)
-	if !contains(issueIDs(ready), "cd-dep") {
-		t.Errorf("ready = %v, want it to include cd-dep after blocker closed", issueIDs(ready))
-	}
-}
-
 // Creating an issue Status=closed with no ClosedAt derives closed_at = max(created,updated)+1s.
 func testAuditCreateClosedDerivesClosedAt(t *testing.T, f Factory) {
 	s := f(t)
@@ -355,19 +269,5 @@ func testAuditExternalRefResolvesWispTier(t *testing.T, f Factory) {
 	_, err = s.GetIssueByExternalRef(ctx(), "gh-absent")
 	if !errors.Is(err, storage.ErrNotFound) {
 		t.Errorf("missing ref: %v, want ErrNotFound", err)
-	}
-}
-
-// UpdateIssueType rejects an unknown type and leaves the row unchanged.
-func testAuditUpdateIssueTypeRejectsInvalid(t *testing.T, f Factory) {
-	s := f(t)
-	must(t, s.CreateIssue(ctx(), withDefaults(&types.Issue{ID: "it-1", Title: "T", IssueType: "task"}), "a"))
-	if err := s.UpdateIssueType(ctx(), "it-1", "not-a-type", "a"); err == nil {
-		t.Error("expected error for invalid issue type")
-	}
-	got, err := s.GetIssue(ctx(), "it-1")
-	must(t, err)
-	if got.IssueType != "task" {
-		t.Errorf("IssueType = %q, want task (unchanged)", got.IssueType)
 	}
 }

--- a/backend/conformance/audit_search-counts-stats.go
+++ b/backend/conformance/audit_search-counts-stats.go
@@ -527,6 +527,14 @@ func testAuditSearchSortNullsDirectional(t *testing.T, f Factory) {
 // own byte order would break the id sort for every caller. Sequence is not asserted:
 // the natural-numeric display order is owned above the store (internal/workapi/sort.go
 // CompareIssuesBy via utils.NaturalCompareIDs), which is why callers push Limit 0 here.
+//
+// RunReaderListNaturalNumericIDSortTrimsAfterTheFetch looks like a dominator and
+// is not: it drives the Reader, which rides SearchIssuesWithCountsInTx (and the
+// unit-of-work UNION), while this drives the PLAIN SearchIssues verb over
+// searchInTx. Those are separate bodies — make searchInTx refuse the go-side sort
+// key and the reader case stays green while this one goes red (measured with
+// scripts/mutation-equivalence.sh). This is the only place the go-side sort key
+// meets the plain search projection.
 func testAuditSearchSortByIDCompleteSet(t *testing.T, f Factory) {
 	s := f(t)
 	c := ctx()

--- a/backend/conformance/claim.go
+++ b/backend/conformance/claim.go
@@ -44,75 +44,22 @@ func testClaim(t *testing.T, f Factory) {
 	}
 }
 
-// testClaimIdempotent: re-claiming an in_progress issue by the SAME actor is a no-op
-// success (supports agent retry workflows).
-func testClaimIdempotent(t *testing.T, f Factory) {
-	s := f(t)
-	must(t, s.CreateIssue(ctx(), withDefaults(&types.Issue{ID: "cl-2", Title: "T"}), "a"))
-	must(t, s.ClaimIssue(ctx(), "cl-2", "worker"))
-	if err := s.ClaimIssue(ctx(), "cl-2", "worker"); err != nil {
-		t.Errorf("idempotent re-claim by same actor: %v", err)
-	}
-}
-
-// testClaimAlreadyClaimed: claiming an issue held by a different actor is ErrAlreadyClaimed.
-func testClaimAlreadyClaimed(t *testing.T, f Factory) {
-	s := f(t)
-	must(t, s.CreateIssue(ctx(), withDefaults(&types.Issue{ID: "cl-3", Title: "T"}), "a"))
-	must(t, s.ClaimIssue(ctx(), "cl-3", "worker1"))
-	err := s.ClaimIssue(ctx(), "cl-3", "worker2")
-	if !errors.Is(err, storage.ErrAlreadyClaimed) {
-		t.Errorf("claim by different actor: err = %v, want ErrAlreadyClaimed", err)
-	}
-}
-
-// testClaimOpenForeignAssignee: an OPEN issue pre-assigned to a different real
-// actor (a dispatcher set the assignee but nobody claimed it, so status stays
-// open) is still an ErrAlreadyClaimed conflict when another actor tries to claim
-// it. The open-but-assigned refusal branch wraps the sentinel so the public
-// IssueClaimer contract (errors.Is / ParseClaimConflict) holds identically on
-// both backends, matching the already-claimed (in_progress) path above.
-func testClaimOpenForeignAssignee(t *testing.T, f Factory) {
-	s := f(t)
-	must(t, s.CreateIssue(ctx(), withDefaults(&types.Issue{ID: "cl-fa1", Title: "T", Assignee: "alice", Status: types.StatusOpen}), "dispatcher"))
-	pre, err := s.GetIssue(ctx(), "cl-fa1")
-	must(t, err)
-	if pre.Status != types.StatusOpen || pre.Assignee != "alice" {
-		t.Fatalf("precondition: want open+assigned-to-alice, got status=%q assignee=%q", pre.Status, pre.Assignee)
-	}
-	err = s.ClaimIssue(ctx(), "cl-fa1", "bob")
-	if !errors.Is(err, storage.ErrAlreadyClaimed) {
-		t.Errorf("claim of open issue pre-assigned to another actor: err = %v, want ErrAlreadyClaimed", err)
-	}
-}
-
-// testClaimNotClaimable: claiming a closed issue is ErrNotClaimable.
-func testClaimNotClaimable(t *testing.T, f Factory) {
-	s := f(t)
-	must(t, s.CreateIssue(ctx(), withDefaults(&types.Issue{ID: "cl-4", Title: "T"}), "a"))
-	must(t, s.CloseIssue(ctx(), "cl-4", "done", "closer", "sess"))
-	err := s.ClaimIssue(ctx(), "cl-4", "worker")
-	if !errors.Is(err, storage.ErrNotClaimable) {
-		t.Errorf("claim closed issue: err = %v, want ErrNotClaimable", err)
-	}
-}
-
-// testClaimReadyIssue: ClaimReadyIssue picks and claims a ready issue.
-func testClaimReadyIssue(t *testing.T, f Factory) {
-	s := f(t)
-	must(t, s.CreateIssue(ctx(), withDefaults(&types.Issue{ID: "cl-r1", Title: "ready", Priority: 1}), "a"))
-	claimed, err := s.ClaimReadyIssue(ctx(), types.WorkFilter{}, "worker")
-	must(t, err)
-	if claimed == nil {
-		t.Fatal("ClaimReadyIssue returned nil, expected a ready issue to claim")
-	}
-	if claimed.ID != "cl-r1" {
-		t.Errorf("claimed id = %q, want cl-r1", claimed.ID)
-	}
-	if claimed.Assignee != "worker" || claimed.Status != types.StatusInProgress {
-		t.Errorf("ready issue not properly claimed: assignee=%q status=%q", claimed.Assignee, claimed.Status)
-	}
-}
+// The claim REFUSALS that used to live here — same-actor idempotence, a foreign
+// holder in progress, a foreign holder on an open row, and an ineligible status
+// — are retired. claimer_contract.go pins every one of them at the role seam
+// against the same issueops.ClaimIssueInTx CAS, and pins more of each: the typed
+// *ClaimConflictError, the raw row read back unchanged, and a zero history
+// delta, on the unit-of-work dual this suite's Factory type cannot reach.
+// storage.ErrAlreadyClaimed and storage.ErrNotClaimable are ALIASES of the
+// issueops sentinels the contract matches (internal/storage/storage.go), so the
+// two seams assert one identity, not two. ClaimIssue itself stays exercised here
+// by testClaim and by the whole lease-recovery block below.
+//
+// testClaimReadyIssue is retired for the same reason against
+// RunReadyClaimerClaimsTheFrontRowAndReturnsThePostClaimState, which additionally
+// pins winner selection, the post-claim snapshot against the stored row and the
+// runner-up left alone; ClaimReadyIssue keeps its seat here through
+// testClaimReadyIssueLabelFilters.
 
 // testClaimReadyIssueLabelFilters: the claim path is FENCED by the label filters it is
 // given. --label-any (LabelsAny, OR-set) used to be dropped on the ready/claim path, so a

--- a/backend/conformance/conformance.go
+++ b/backend/conformance/conformance.go
@@ -172,7 +172,6 @@ func RunAll(t *testing.T, factory Factory) {
 	t.Run("GetNotFound", func(t *testing.T) { testGetNotFound(t, factory) })
 	t.Run("GetByExternalRef", func(t *testing.T) { testGetByExternalRef(t, factory) })
 	t.Run("GetByIDs", func(t *testing.T) { testGetByIDs(t, factory) })
-	t.Run("Update", func(t *testing.T) { testUpdate(t, factory) })
 	t.Run("UpdatePreservesCreatedAt", func(t *testing.T) { testUpdatePreservesCreatedAt(t, factory) })
 	t.Run("UpdateNotFound", func(t *testing.T) { testUpdateNotFound(t, factory) })
 	t.Run("UpdateIssueType", func(t *testing.T) { testUpdateIssueType(t, factory) })
@@ -188,8 +187,6 @@ func RunAll(t *testing.T, factory Factory) {
 	t.Run("SearchLimit", func(t *testing.T) { testSearchLimit(t, factory) })
 	t.Run("SearchByIDsFilter", func(t *testing.T) { testSearchByIDsFilter(t, factory) })
 	t.Run("SearchIssueIDsProjection", func(t *testing.T) { testSearchIssueIDsProjection(t, factory) })
-	t.Run("CountIssues", func(t *testing.T) { testCountIssues(t, factory) })
-	t.Run("CountByGroup", func(t *testing.T) { testCountByGroup(t, factory) })
 	t.Run("CountByGroupIsBlockedFilter", func(t *testing.T) { testCountByGroupIsBlockedFilter(t, factory) })
 
 	// Keyset paging and the defensive row cap
@@ -197,7 +194,6 @@ func RunAll(t *testing.T, factory Factory) {
 
 	// Dependencies
 	t.Run("AddAndGetDeps", func(t *testing.T) { testAddAndGetDeps(t, factory) })
-	t.Run("RemoveDep", func(t *testing.T) { testRemoveDep(t, factory) })
 	t.Run("DepCounts", func(t *testing.T) { testDepCounts(t, factory) })
 
 	// Ready/Blocked
@@ -212,11 +208,6 @@ func RunAll(t *testing.T, factory Factory) {
 
 	// Claim / lease (dead-worker recovery)
 	t.Run("Claim", func(t *testing.T) { testClaim(t, factory) })
-	t.Run("ClaimIdempotent", func(t *testing.T) { testClaimIdempotent(t, factory) })
-	t.Run("ClaimAlreadyClaimed", func(t *testing.T) { testClaimAlreadyClaimed(t, factory) })
-	t.Run("ClaimOpenForeignAssignee", func(t *testing.T) { testClaimOpenForeignAssignee(t, factory) })
-	t.Run("ClaimNotClaimable", func(t *testing.T) { testClaimNotClaimable(t, factory) })
-	t.Run("ClaimReadyIssue", func(t *testing.T) { testClaimReadyIssue(t, factory) })
 	t.Run("ClaimReadyIssueLabelFilters", func(t *testing.T) { testClaimReadyIssueLabelFilters(t, factory) })
 	t.Run("HeartbeatRenewsLease", func(t *testing.T) { testHeartbeatRenewsLease(t, factory) })
 	t.Run("HeartbeatWisp", func(t *testing.T) { testHeartbeatWisp(t, factory) })
@@ -241,7 +232,6 @@ func RunAll(t *testing.T, factory Factory) {
 	t.Run("CommentCount", func(t *testing.T) { testCommentCount(t, factory) })
 
 	// Config
-	t.Run("Config", func(t *testing.T) { testConfig(t, factory) })
 	t.Run("LocalMetadata", func(t *testing.T) { testLocalMetadata(t, factory) })
 
 	// Slots
@@ -361,6 +351,18 @@ func testCreateAndGet(t *testing.T, f Factory) {
 	}
 }
 
+// testCreateDuplicate and RunIssueOperationsCreateRefusesAnOccupiedID
+// (issue_operations_contract.go) PIN OPPOSITE SEMANTICS OF THE SAME CORE, and
+// both are load-bearing. Do not retire either against the other.
+//
+// The raw CreateIssue verb is an UPSERT: a second write to an occupied ID
+// reconciles into the one row. The Operations role is CREATE-ONLY: the same
+// second write is refused with ErrAlreadyExists and the stored row must come
+// back byte-identical. This is a deliberate divergence, not drift — `bd create
+// --id <occupied>` used to reach the upsert through the proxied server and
+// silently overwrite a bead while the direct route refused, which is the
+// regression that contract case exists for. This case is the only observer of
+// the unguarded path, which is still what import and reconcile callers ride.
 func testCreateDuplicate(t *testing.T, f Factory) {
 	s := f(t)
 	must(t, s.CreateIssue(ctx(), withDefaults(&types.Issue{ID: "d-1", Title: "First"}), "actor"))
@@ -418,18 +420,11 @@ func testGetByIDs(t *testing.T, f Factory) {
 	}
 }
 
-func testUpdate(t *testing.T, f Factory) {
-	s := f(t)
-	must(t, s.CreateIssue(ctx(), withDefaults(&types.Issue{ID: "u-1", Title: "Old", Priority: 1}), "a"))
-	must(t, s.UpdateIssue(ctx(), "u-1", map[string]interface{}{"title": "New", "priority": 3}, "a"))
-	got, _ := s.GetIssue(ctx(), "u-1")
-	if got.Title != "New" {
-		t.Errorf("Title = %q", got.Title)
-	}
-	if got.Priority != 3 {
-		t.Errorf("Priority = %d", got.Priority)
-	}
-}
+// The plain patch-and-read-back case that used to sit here is retired: the raw
+// map funnel and the Lifecycle role both land in issueops.UpdateIssueInTx, and
+// RunLifecycleUpdatePersistsThePatchAndHydratesTheResult patches seven members
+// and asserts the RESULT and the stored row where this one asserted two fields
+// through GetIssue. testUpdateNotFound below is NOT retired — see its comment.
 
 func testUpdatePreservesCreatedAt(t *testing.T, f Factory) {
 	s := f(t)
@@ -445,6 +440,18 @@ func testUpdatePreservesCreatedAt(t *testing.T, f Factory) {
 	}
 }
 
+// testUpdateNotFound survives the retirement pass, and the reason is not that
+// its assertion is strong — it is the weakest one in this file. It is that the
+// two seams REFUSE IN DIFFERENT PLACES. The Lifecycle role resolves the id
+// itself (issueops/execution.go ExecuteUpdate, ahead of any write) and never
+// reaches the raw funnel's own refusal, which lives in
+// issueops.updateIssueInTx's read-and-resolve step. Making that step swallow a
+// missing row leaves RunLifecycleUpdateRefusesUnknownIDsAndActorlessRequests
+// green and only this case red (measured with scripts/mutation-equivalence.sh).
+//
+// Worth strengthening in place rather than deleting: `err != nil` is also
+// satisfied by the foreign-key violation the event write raises on a row that
+// does not exist, so this case cannot today tell a refusal from a crash.
 func testUpdateNotFound(t *testing.T, f Factory) {
 	s := f(t)
 	err := s.UpdateIssue(ctx(), "missing", map[string]interface{}{"title": "x"}, "a")
@@ -624,29 +631,16 @@ func testSearchIssueIDsProjection(t *testing.T, f Factory) {
 	}
 }
 
-func testCountIssues(t *testing.T, f Factory) {
-	s := f(t)
-	seedStore(t, s)
-	count, err := s.CountIssues(ctx(), "", types.IssueFilter{})
-	if err != nil {
-		t.Fatalf("CountIssues: %v", err)
-	}
-	if count != 4 {
-		t.Errorf("count = %d, want 4", count)
-	}
-}
-
-func testCountByGroup(t *testing.T, f Factory) {
-	s := f(t)
-	seedStore(t, s)
-	counts, _ := s.CountIssuesByGroup(ctx(), types.IssueFilter{}, "status")
-	if counts["open"] != 2 {
-		t.Errorf("open = %d, want 2", counts["open"])
-	}
-	if counts["closed"] != 1 {
-		t.Errorf("closed = %d, want 1", counts["closed"])
-	}
-}
+// The bare scalar count and the bare group-by-status count are retired.
+// counter_contract.go rides the same store.CountIssues / CountIssuesByGroup
+// through internal/workapi/storecounter and asserts more of them:
+// RunCounterCountsClosedRows pins the unfiltered total over open, closed AND
+// in_progress (that third seed moved there from this case's fixture), and
+// RunCounterGroupsPartitionTheScalarSet compares the WHOLE bucket map — an
+// extra bucket fails — and ties the grouped total back to the scalar one.
+// The zero-predicate shape those contract cases cannot issue (they scope every
+// request with IDFilter because their fixtures share one database) is still
+// issued here by testAuditWispMergeSearchCount, on both verbs.
 
 // testCountByGroupIsBlockedFilter proves the additive IssueFilter.IsBlocked predicate honors the
 // denormalized is_blocked column in the grouped-count path on every backend: IsBlocked=&true returns
@@ -725,18 +719,18 @@ func testAddAndGetDeps(t *testing.T, f Factory) {
 	}
 }
 
-func testRemoveDep(t *testing.T, f Factory) {
-	s := f(t)
-	must(t, s.CreateIssue(ctx(), withDefaults(&types.Issue{ID: "rd-a", Title: "A"}), "a"))
-	must(t, s.CreateIssue(ctx(), withDefaults(&types.Issue{ID: "rd-b", Title: "B"}), "a"))
-	must(t, s.AddDependency(ctx(), &types.Dependency{IssueID: "rd-b", DependsOnID: "rd-a", Type: types.DepBlocks}, "a"))
-	must(t, s.RemoveDependency(ctx(), "rd-b", "rd-a", "a"))
-	deps, _ := s.GetDependencies(ctx(), "rd-b")
-	if len(deps) != 0 {
-		t.Errorf("after remove: len = %d", len(deps))
-	}
-}
-
+// The single-edge removal case is retired: the raw verb and the
+// DependencyEditor role share issueops.RemoveDependencyInTx, and
+// RunDependencyEditorRemovesOnlyTheNamedEdge seeds SEVERAL edges and asserts
+// that only the named one goes — where this case could not tell a targeted
+// delete from a delete-them-all. RemoveDependency keeps its seat in this suite
+// through testGetAllDependencyRecords.
+//
+// testDepCounts below is NOT retired even though reader_contract.go asserts the
+// same two numbers through the detail source: this suite is the ONLY caller of
+// CountDependencies anywhere in RunAll, and RunAll is what an out-of-tree
+// backend proves itself with (see this file's package doc). Deleting it would
+// leave that method uncalled by the gate.
 func testDepCounts(t *testing.T, f Factory) {
 	s := f(t)
 	must(t, s.CreateIssue(ctx(), withDefaults(&types.Issue{ID: "dc-a", Title: "A"}), "a"))
@@ -890,19 +884,13 @@ func testCommentCount(t *testing.T, f Factory) {
 
 // --- Config ---
 
-func testConfig(t *testing.T, f Factory) {
-	s := f(t)
-	must(t, s.SetConfig(ctx(), "key1", "val1"))
-	must(t, s.SetConfig(ctx(), "key2", "val2"))
-	v, _ := s.GetConfig(ctx(), "key1")
-	if v != "val1" {
-		t.Errorf("GetConfig = %q", v)
-	}
-	all, _ := s.GetAllConfig(ctx())
-	if len(all) < 2 {
-		t.Errorf("GetAllConfig len = %d", len(all))
-	}
-}
+// The set/get/list roundtrip is retired. The WorkspaceConfig role rides the same
+// store.SetConfig / GetConfig / GetAllConfig (internal/workapi/storeworkspaceconfig)
+// and pins them harder: RunWorkspaceConfigStoresAValueVerbatim writes a value
+// carrying surrounding space and an inner comma, and
+// RunWorkspaceConfigListsEveryStoredSetting compares the whole enumeration
+// against what it wrote instead of asserting a length floor. All three verbs stay
+// exercised in this suite by the audit-tier config cases.
 
 func testLocalMetadata(t *testing.T, f Factory) {
 	s := f(t)

--- a/backend/conformance/conformance.go
+++ b/backend/conformance/conformance.go
@@ -928,6 +928,15 @@ func testMetadataSlots(t *testing.T, f Factory) {
 
 // --- Statistics ---
 
+// testStatistics is dominated on its own terms —
+// RunStatsReporterCountsEveryDurableRowByStatus rides the same
+// store.GetStatistics through internal/workapi/storestats, which passes the
+// struct through verbatim, and asserts per-bucket deltas over five statuses
+// where this asserts a total and a closed count. It stays anyway, because it is
+// one of the three arms of RunDeferredReads, a SECOND exported entry point with
+// no in-tree caller: retiring it would silently narrow a published gate to two
+// of the three reads its doc names, which is an API decision rather than a
+// cleanup. If that gate is ever blessed for shrinking, this case goes with it.
 func testStatistics(t *testing.T, f Factory) {
 	s := f(t)
 	seedStore(t, s)

--- a/backend/conformance/counter_contract.go
+++ b/backend/conformance/counter_contract.go
@@ -131,20 +131,30 @@ func RunCounterCountsClosedRows(t *testing.T, ctx context.Context, fixture Count
 	t.Helper()
 	open := fixture.IssuePrefix + "-status-open"
 	closed := fixture.IssuePrefix + "-status-closed"
+	wip := fixture.IssuePrefix + "-status-wip"
 	seedCounterIssue(t, ctx, fixture, counterSeed(open))
 	closedSeed := counterSeed(closed)
 	closedSeed.Status = types.StatusClosed
 	seedCounterIssue(t, ctx, fixture, closedSeed)
+	// The in-progress row is the third status class, and it is here because the
+	// unfiltered count is the one assertion that says which statuses the default
+	// admits. With only open and closed seeded, a body defaulting to
+	// `status IN ('open','closed')` answers every number below correctly. This
+	// seed came off the retired audit case conformance.go testCountIssues, whose
+	// fixture carried it.
+	wipSeed := counterSeed(wip)
+	wipSeed.Status = types.StatusInProgress
+	seedCounterIssue(t, ctx, fixture, wipSeed)
 
-	scope := counterScope(open, closed)
-	assertCounterTotal(t, ctx, fixture, scope, 2)
+	scope := counterScope(open, closed, wip)
+	assertCounterTotal(t, ctx, fixture, scope, 3)
 
 	scope.Status = "closed"
 	assertCounterTotal(t, ctx, fixture, scope, 1)
 
 	// "all" is the other spelling of every status, and it must not narrow.
 	scope.Status = "all"
-	assertCounterTotal(t, ctx, fixture, scope, 2)
+	assertCounterTotal(t, ctx, fixture, scope, 3)
 }
 
 // RunCounterAnUnknownStatusMatchesNothing pins counter.go:50-56 and :237-241:

--- a/backend/conformance/issue_operations_contract.go
+++ b/backend/conformance/issue_operations_contract.go
@@ -166,6 +166,13 @@ func RunIssueOperationsCreateRejectsMissingDependencyTargets(t *testing.T, ctx c
 // The proxied-server `bd create` route asked its use case for a plain create
 // with no create-only guard, so `bd create --id <occupied>` silently UPSERTED
 // the stored row and reported success while the direct route refused.
+//
+// THIS CASE AND conformance.go's testCreateDuplicate PIN OPPOSITE SEMANTICS OF
+// THE SAME CORE. That one drives the raw CreateIssue verb, which UPSERTS, and
+// asserts only that the second write leaves exactly one row; this one drives
+// the create-only role and asserts a typed refusal with the stored row
+// unchanged. They read like duplicates and are not: retiring either against
+// the other deletes the only proof of one of the two behaviors.
 func RunIssueOperationsCreateRefusesAnOccupiedID(t *testing.T, ctx context.Context, fixture IssueOperationsStagingFixture) {
 	t.Helper()
 

--- a/backend/conformance/search_paging.go
+++ b/backend/conformance/search_paging.go
@@ -287,8 +287,17 @@ func pagingCapFilter(maxRows int, source string) types.IssueFilter {
 // backend answering any other shape silently loses the circuit breaker while
 // every row-count assertion still passes.
 //
-// This is the STORAGE layer's obligation, which is stricter than the reader
-// role's honored-or-refused case: refusing the cap is not an option here.
+// WHY THIS SURVIVES BESIDE RunReaderListMaxRowsIsHonored, which is stricter on
+// every assertion and runs a third leg: it is a DIFFERENT BODY. The Reader role
+// rides SearchIssuesWithCountsInTx, which enforces the cap once
+// (issueops/search_counts.go). The raw SearchIssues verb rides searchInTx, which
+// has FOUR terminal exit paths and enforces the cap on each one separately —
+// ephemeral-only, SkipWisps, empty-wisps-table, and the merged set. This case
+// drives the SkipWisps exit; deleting that exit's EnforceMaxRowsCap call leaves
+// the whole reader contract green and only this case red (measured with
+// scripts/mutation-equivalence.sh). Any earlier claim that this case is merely
+// "stricter than the reader role" is stale: the reader case is strict now, and
+// strictness was never the reason.
 func testSearchPagingMaxRows(t *testing.T, f Factory) {
 	t.Run("UnderTheCapIsAnOrdinaryResult", func(t *testing.T) {
 		s := f(t)


### PR DESCRIPTION
A triage bucketed the audit tier's 176 leaf cases as 28 DOMINATED / 47 MIGRATE / 101 AUDIT-ONLY. The MIGRATE half landed in #5447 and #5448. This takes the 28 dominated candidates — and retires **19**, declining 9.

**−147 net.** Every retirement carries a mutation verdict against the body the audit assertion observed, per the retirement protocol: a red/red against the shared `internal/storage/issueops` proves the contract sees the break through the same code and says nothing about a store wrapper or the uow body — which is exactly how three coverage losses happened earlier in this programme.

## What was declined, and why — the part worth reading

| kept | what the contract does not cover |
| --- | --- |
| `testAuditSelfDependencyRejected` | **Two different guards.** The role refuses in `ValidateAddDependenciesRequest` *pre-transaction*; the raw verb reaches `CheckDependencyCycleInTx`, the one firing *before* the scheduling-edge return. Deleting it leaves the editor contract green. |
| `testAuditSetConfigInvalidStatusRollsBack` | The role refuses in `workapi.ValidateSettingWrite` **before calling the store at all**. The store's in-transaction `SyncCustomStatusesTable` rollback has exactly one observer, and different parser branches besides. |
| `testSearchPagingMaxRows` | The reader rides `search_counts.go`; this rides `searchInTx`, which enforces the cap at **four** exits. It drives the `SkipWisps` exit. |
| `testAuditSearchSortByIDCompleteSet` | Same body split — plain `searchInTx` vs the reader's counts body. |
| `testUpdateNotFound` | **The triage was wrong.** The seams refuse in different places: role at `ExecuteUpdate`, raw at `updateIssueInTx`'s read step. |
| `testDepCounts`, `testAuditDependencyTree`, `testAuditDeleteConfigLeavesNormalizedTable` | Sole callers of `CountDependencies` / `GetDependencyTree` / `DeleteConfig` **in RunAll**, which is the surface an out-of-tree backend implements against. **Promises dominated; method calls not.** |
| `testStatistics` | Dominated on promises, but an arm of `RunDeferredReads` — narrowing a published entry point is an API change, not cleanup. |

That third-from-last row is a distinction the role contracts structurally cannot cover: a role reaches removal or counting through its own body, so retiring the raw case would leave a `DoltStorage` method the gate never invokes. Verified over the whole tier: **83 storage methods called before, 83 after.**

## Retired

**`claim.go`** — Idempotent, AlreadyClaimed, OpenForeignAssignee, NotClaimable, ReadyIssue → the claimer and ready_claimer contracts (mutations in `ClaimIssueInTx`'s assignee predicate, claimable-status set and idempotence branch; `ClaimReadyIssueInTx`'s post-claim read).

**`conformance.go`** — Update (`updateIssueInTx` columns), CountIssues + CountByGroup (`countTableInTx`, `countGroupForTablesInTx`), RemoveDep (`RemoveDependencyInTx`'s DELETE), Config (`SetConfigInTx`).

**`audit_dependencies_readiness.go`** — MissingSourceTarget + ExternalTarget (`AddDependencyInTx`'s target-existence arm), RemoveMissingAndUnblock, ReadyDeferredExclusion (`sqlbuild/ready.go`'s defer clause).

**`audit_issue-lifecycle.go`** — CloseIdempotent, ReopenEventSemantics, ReopenNotFound, CloseDependentUpdatedAt (`unmarkBlockedTemplateForIssues`' `updated_at = updated_at`), UpdateIssueTypeRejectsInvalid.

## A seed ported rather than deleted

`testCountIssues` seeded an `in_progress` row; the contract seeded only open and closed, so a body defaulting to `status IN ('open','closed')` passed it. The row now lives in `RunCounterCountsClosedRows`. That fixture gap was found *by* the retirement work.

## Other findings

**`testCreateDuplicate`'s opposition is real.** Raw `CreateIssue` upserts; role `Create` refuses with `ErrAlreadyExists` and leaves the row unchanged. They read as duplicates and pin opposite semantics — both survive, with cross-referencing comments on each side so the next reader doesn't retire one.

**Dead branches confirmed, not removed.** Every production `BatchCreateOptions` passes `OrphanAllow`; the `OrphanStrict`, `OrphanSkip` and `OrphanResurrect` branches in `CheckOrphan` are reachable only from `testAuditCreateOrphanHandling`.

**Two triage errors corrected.** The claimed "sentinel plane split" is false — `storage.ErrAlreadyClaimed` *is* `issueops.ErrAlreadyClaimed`, an alias. And `ExternalTarget`'s `COALESCE` read hides the dolt store's `TargetKind` switch, which has no observer — noted; the observable outcome is covered by `RunDependencyEditorWritesTheTargetIntoItsTypedColumn`, which reads the typed columns individually.

## Verification

`go build ./...`, `go vet`, `golangci-lint` clean; `TestConformance` green on both store legs; the counter, lifecycle, claimer, reader, editor, config and issue-ops contracts green on all three; helper-reachability sweep clean; no `.github` manifest names a deleted subtest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)