### PR TITLE
feat(httpapi): publish the events journal on the v0 surface (bd-opisf)

### DIFF
--- a/cmd/bd/events.go
+++ b/cmd/bd/events.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/eventsjournal"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/uow"
 )
@@ -199,18 +200,6 @@ func init() {
 	rootCmd.AddCommand(eventsCmd)
 }
 
-// eventRecord is one journal line rendered to callers. Issue, Dep and Comment
-// are raw JSON so the stored payloads are not re-encoded.
-type eventRecord struct {
-	Seq     int64           `json:"seq"`
-	TS      string          `json:"ts"`
-	Op      string          `json:"op"`
-	IssueID string          `json:"issue_id"`
-	Issue   json.RawMessage `json:"issue"`
-	Dep     json.RawMessage `json:"dep,omitempty"`
-	Comment json.RawMessage `json:"comment,omitempty"`
-}
-
 // reportEventsTruncated renders a pruned-past checkpoint as a machine-readable
 // failure. A consumer must be able to branch on this without parsing prose, so
 // JSON mode carries the code and the window it can still serve; the caller then
@@ -328,7 +317,11 @@ func journalAccessor() (storage.EventsJournalAccessor, error) {
 // readJournal reads records with seq greater than since from the active
 // storage seam. Proxied-server mode uses its transaction-bound UOW journal
 // capability; direct stores use EventsJournalAccessor.
-func readJournal(ctx context.Context, since int64, limit int) ([]eventRecord, error) {
+//
+// The projection onto the published envelope is eventsjournal.Records, the same
+// one GET /v0/beads/events serves from — see the note on eventsjournal.Record
+// for why there is exactly one.
+func readJournal(ctx context.Context, since int64, limit int) ([]eventsjournal.Record, error) {
 	var rows []storage.EventsJournalRow
 	if usesProxiedServer() {
 		if uowProvider == nil {
@@ -353,11 +346,7 @@ func readJournal(ctx context.Context, since int64, limit int) ([]eventRecord, er
 			return nil, err
 		}
 	}
-	out := make([]eventRecord, 0, len(rows))
-	for _, r := range rows {
-		out = append(out, buildRecord(r.Seq, r.TS, r.Op, r.IssueID, r.IssueJSON, r.DepJSON, r.CommentJSON))
-	}
-	return out, nil
+	return eventsjournal.Records(rows), nil
 }
 
 // pruneJournal deletes records below before honoring the retain floors.
@@ -378,18 +367,4 @@ func pruneJournal(ctx context.Context, before int64, retainDays, retainRows int)
 		return 0, err
 	}
 	return acc.PruneEventsJournal(ctx, before, retainDays, retainRows)
-}
-
-func buildRecord(seq int64, ts, op, issueID, issueJS, depJS, commentJS string) eventRecord {
-	rec := eventRecord{Seq: seq, TS: ts, Op: op, IssueID: issueID, Issue: json.RawMessage("null")}
-	if issueJS != "" {
-		rec.Issue = json.RawMessage(issueJS)
-	}
-	if depJS != "" {
-		rec.Dep = json.RawMessage(depJS)
-	}
-	if commentJS != "" {
-		rec.Comment = json.RawMessage(commentJS)
-	}
-	return rec
 }

--- a/cmd/bd/events_golden_test.go
+++ b/cmd/bd/events_golden_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/steveyegge/beads/internal/eventsjournal"
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -19,7 +21,8 @@ const goldenPath = "testdata/events_journal_records.jsonl"
 
 // TestEventsJournalGolden pins the external record contract for the durable
 // events journal. It marshals REAL beads types.Issue, EventDep and EventComment
-// values through the same buildRecord path `bd events tail` uses, so the golden
+// values through the same eventsjournal.NewRecord projection `bd events tail`
+// and GET /v0/beads/events both serve from, so the golden
 // captures bd's actual field marshaling — issue_type, omitempty elision, the
 // top-level dep edge (kind/target/metadata), and the replayable comment payload
 // — that external consumers parse. A change to the wire shape (a renamed/added/
@@ -75,7 +78,7 @@ func TestEventsJournalGoldenIsDeterministic(t *testing.T) {
 }
 
 // renderGoldenLines builds the fixture records and returns them as JSONL exactly
-// as buildRecord + the tail encoder would emit them.
+// as eventsjournal.NewRecord + the tail encoder would emit them.
 func renderGoldenLines(t *testing.T) []byte {
 	t.Helper()
 	ts := "2026-01-02T03:04:05Z" // normalized UTC insert time, as the read seam yields
@@ -148,20 +151,20 @@ func renderGoldenLines(t *testing.T) []byte {
 		CreatedAt: updated, Source: issueops.CommentSourceAudit,
 	}
 
-	records := []eventRecord{
-		buildRecord(1, ts, string(issueops.EventCreate), minimal.ID, mustJSON(t, minimal), "", ""),
-		buildRecord(2, ts, string(issueops.EventCreate), full.ID, mustJSON(t, full), "", ""),
-		buildRecord(3, ts, string(issueops.EventDepAdd), "bd-101", mustJSON(t, full),
+	records := []eventsjournal.Record{
+		goldenRecord(1, ts, string(issueops.EventCreate), minimal.ID, mustJSON(t, minimal), "", ""),
+		goldenRecord(2, ts, string(issueops.EventCreate), full.ID, mustJSON(t, full), "", ""),
+		goldenRecord(3, ts, string(issueops.EventDepAdd), "bd-101", mustJSON(t, full),
 			mustJSON(t, &issueops.EventDep{Kind: string(types.DepBlocks), Target: "bd-100"}), ""),
-		buildRecord(4, ts, string(issueops.EventUpdate), blocked.ID, mustJSON(t, blocked), "", ""),
-		buildRecord(5, ts, string(issueops.EventDepRemove), "bd-101", mustJSON(t, full),
+		goldenRecord(4, ts, string(issueops.EventUpdate), blocked.ID, mustJSON(t, blocked), "", ""),
+		goldenRecord(5, ts, string(issueops.EventDepRemove), "bd-101", mustJSON(t, full),
 			mustJSON(t, &issueops.EventDep{Kind: string(types.DepBlocks), Target: "bd-100", Metadata: `{"note":"unblocked"}`}), ""),
-		buildRecord(6, ts, string(issueops.EventUpdate), claimed.ID, mustJSON(t, claimed), "", ""),
-		buildRecord(7, ts, string(issueops.EventCommentWrite), claimed.ID, mustJSON(t, claimed), "", mustJSON(t, structuredComment)),
-		buildRecord(8, ts, string(issueops.EventCommentWrite), claimed.ID, mustJSON(t, claimed), "", mustJSON(t, auditComment)),
-		buildRecord(9, ts, string(issueops.EventClose), closedIssue.ID, mustJSON(t, closedIssue), "", ""),
-		buildRecord(10, ts, string(issueops.EventCreate), wisp.ID, mustJSON(t, wisp), "", ""),
-		buildRecord(11, ts, string(issueops.EventDelete), "bd-100", "", "", ""), // null issue on delete
+		goldenRecord(6, ts, string(issueops.EventUpdate), claimed.ID, mustJSON(t, claimed), "", ""),
+		goldenRecord(7, ts, string(issueops.EventCommentWrite), claimed.ID, mustJSON(t, claimed), "", mustJSON(t, structuredComment)),
+		goldenRecord(8, ts, string(issueops.EventCommentWrite), claimed.ID, mustJSON(t, claimed), "", mustJSON(t, auditComment)),
+		goldenRecord(9, ts, string(issueops.EventClose), closedIssue.ID, mustJSON(t, closedIssue), "", ""),
+		goldenRecord(10, ts, string(issueops.EventCreate), wisp.ID, mustJSON(t, wisp), "", ""),
+		goldenRecord(11, ts, string(issueops.EventDelete), "bd-100", "", "", ""), // null issue on delete
 	}
 
 	var buf bytes.Buffer
@@ -172,6 +175,21 @@ func renderGoldenLines(t *testing.T) []byte {
 		}
 	}
 	return buf.Bytes()
+}
+
+// goldenRecord spells one stored row positionally, so the fixture below reads
+// as a table. The projection it runs through is the shipped one — the fixture
+// must not be able to construct a record shape no reader can produce.
+func goldenRecord(seq int64, ts, op, issueID, issueJS, depJS, commentJS string) eventsjournal.Record {
+	return eventsjournal.NewRecord(storage.EventsJournalRow{
+		Seq:         seq,
+		TS:          ts,
+		Op:          op,
+		IssueID:     issueID,
+		IssueJSON:   issueJS,
+		DepJSON:     depJS,
+		CommentJSON: commentJS,
+	})
 }
 
 // assertNoInlineDependencies fails if any record's issue snapshot carries a

--- a/cmd/bd/events_http_e2e_test.go
+++ b/cmd/bd/events_http_e2e_test.go
@@ -1,0 +1,251 @@
+//go:build cgo && unix
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+// The events journal over HTTP, end to end through a real `bd serve`.
+//
+// The handler tests in internal/httpapi drive fakes, which is the right shape
+// for the refusal vocabulary and cannot answer the question this file exists
+// for: does a mutation that arrives over the HTTP surface actually reach the
+// journal the same surface then serves? Every layer between those two facts is
+// real here — the server-mode provider serve builds for itself, the activation
+// it resolves from the workspace, the journal writes inside the mutation's own
+// transaction, and the read plumbing that pages them back out.
+//
+// It is the composition that has failed before (see the note on
+// TestServeActivatesTheEventsJournal): each half looked correct in isolation
+// while the server committed with an empty journal and every response looked
+// normal.
+
+// TestServeReadsTheJournalItJustWrote: mutate over HTTP, then read the journal
+// over HTTP, and require the records to be there, gapless, and paced by a head
+// that matches.
+func TestServeReadsTheJournalItJustWrote(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+	p := newServerModeProject(t, bd, "hje")
+	p.env = append(p.env, "BD_EVENTS_JOURNAL=1")
+
+	sp := startServe(t, bd, p.dir, p.env)
+
+	// Nothing has been mutated yet: an ENABLED but untouched journal is a 200
+	// with an empty page and a head of zero, which is the answer a disabled
+	// workspace must never give.
+	status, body, _ := sp.get(t, "/v0/beads/events?since=0")
+	if status != http.StatusOK {
+		t.Fatalf("GET /v0/beads/events on a fresh workspace = %d: %v\nstderr:\n%s", status, body, sp.stderr.String())
+	}
+	if head, _ := body["head"].(float64); head != 0 {
+		t.Errorf("head on a fresh workspace = %v, want 0", body["head"])
+	}
+	if records, _ := body["records"].([]any); len(records) != 0 {
+		t.Errorf("records on a fresh workspace = %v, want none", records)
+	}
+
+	const created = 4
+	for i := range created {
+		status, body := sp.postJSON(t, "/v0/beads/issues:batchCreate",
+			fmt.Sprintf(`{"actor":"tester","items":[{"title":"served mutation %d","issue_type":"task"}]}`, i))
+		if status != http.StatusOK {
+			t.Fatalf("POST batchCreate %d = %d: %v\nstderr:\n%s", i, status, body, sp.stderr.String())
+		}
+	}
+
+	status, body, _ = sp.get(t, "/v0/beads/events?since=0")
+	if status != http.StatusOK {
+		t.Fatalf("GET /v0/beads/events = %d: %v\nstderr:\n%s", status, body, sp.stderr.String())
+	}
+	records, _ := body["records"].([]any)
+	if len(records) != created {
+		t.Fatalf("records = %d, want %d — the HTTP mutations did not reach the journal this surface serves: %v",
+			len(records), created, body)
+	}
+
+	// GAPLESS AND IN ORDER, from 1. A consumer's whole contract is that it can
+	// resume from the last seq it processed, which is only true if the sequence
+	// it sees has no holes.
+	for i, raw := range records {
+		rec, ok := raw.(map[string]any)
+		if !ok {
+			t.Fatalf("records[%d] is not an object: %v", i, raw)
+		}
+		if seq, _ := rec["seq"].(float64); int(seq) != i+1 {
+			t.Fatalf("records[%d].seq = %v, want %d — the journal has a gap", i, rec["seq"], i+1)
+		}
+		if op, _ := rec["op"].(string); op != "create" {
+			t.Errorf("records[%d].op = %v, want create", i, rec["op"])
+		}
+		// The published envelope, not a shape this surface invented: `issue` is
+		// always present, and a create carries no dependency half.
+		if _, ok := rec["issue"]; !ok {
+			t.Errorf("records[%d] has no `issue` member", i)
+		}
+		if _, ok := rec["dep"]; ok {
+			t.Errorf("records[%d] carries `dep` on a create", i)
+		}
+	}
+
+	// The head paces the consumer: caught up means last seq == head.
+	head, _ := body["head"].(float64)
+	if int(head) != created {
+		t.Fatalf("head = %v, want %d", body["head"], created)
+	}
+
+	// Resuming from the head is the steady state of a poller, and it must be an
+	// ordinary empty 200 rather than any kind of miss.
+	status, body, _ = sp.get(t, fmt.Sprintf("/v0/beads/events?since=%d", int(head)))
+	if status != http.StatusOK {
+		t.Fatalf("caught-up GET = %d: %v", status, body)
+	}
+	if records, _ := body["records"].([]any); len(records) != 0 {
+		t.Errorf("caught-up records = %v, want none", records)
+	}
+
+	// A bounded page still reports the JOURNAL's head, not the page's — that is
+	// how the consumer knows to keep reading.
+	status, body, _ = sp.get(t, "/v0/beads/events?since=0&limit=2")
+	if status != http.StatusOK {
+		t.Fatalf("bounded GET = %d: %v", status, body)
+	}
+	if records, _ := body["records"].([]any); len(records) != 2 {
+		t.Fatalf("bounded records = %d, want 2", len(records))
+	}
+	if h, _ := body["head"].(float64); int(h) != created {
+		t.Errorf("bounded page head = %v, want %d — the head must describe the journal", body["head"], created)
+	}
+
+	sp.shutdown(t)
+
+	// The same records, through the CLI, on the same workspace. This is the
+	// claim the shared record projection makes and the reason it is shared: an
+	// operator debugging a consumer must be able to reach for `bd events export`
+	// and see what the consumer saw.
+	exported := decodeEventRecords(t, p.run(t, bd, "events", "export"))
+	if len(exported) != created {
+		t.Fatalf("bd events export returned %d records, want %d — the CLI and HTTP reads disagree", len(exported), created)
+	}
+	for i, rec := range exported {
+		if rec.Seq != int64(i+1) {
+			t.Errorf("exported[%d].seq = %d, want %d", i, rec.Seq, i+1)
+		}
+	}
+}
+
+// TestServeRefusesAStaleCheckpointWithGone is the retention boundary over HTTP.
+// A consumer whose checkpoint was pruned past must be TOLD, with the window the
+// server can still serve — not handed the surviving suffix as though it were a
+// complete history, and not handed an empty success it would read as "caught
+// up" and stall on forever.
+//
+// Both retention floors are zeroed so the prune can actually cut: the shipped
+// defaults (7 days / 100k rows) protect everything a test could create, which
+// is the point of them and the reason this has to say so explicitly.
+func TestServeRefusesAStaleCheckpointWithGone(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+	p := newServerModeProject(t, bd, "hjt")
+	p.env = append(p.env,
+		"BD_EVENTS_JOURNAL=1",
+		"BD_EVENTS_JOURNAL_RETAIN_DAYS=0",
+		"BD_EVENTS_JOURNAL_RETAIN_ROWS=0",
+		// The prune below is the one this test performs. A maintenance ticker
+		// cutting on its own schedule would make the window nondeterministic.
+		"BD_EVENTS_JOURNAL_AUTO_PRUNE=0",
+	)
+
+	sp := startServe(t, bd, p.dir, p.env)
+
+	const created = 5
+	for i := range created {
+		status, body := sp.postJSON(t, "/v0/beads/issues:batchCreate",
+			fmt.Sprintf(`{"actor":"tester","items":[{"title":"pruned mutation %d","issue_type":"task"}]}`, i))
+		if status != http.StatusOK {
+			t.Fatalf("POST batchCreate %d = %d: %v\nstderr:\n%s", i, status, body, sp.stderr.String())
+		}
+	}
+
+	// Cut the first three records out from under a consumer sitting at 0.
+	p.run(t, bd, "events", "prune", "--before", "4")
+
+	status, body, _ := sp.get(t, "/v0/beads/events?since=0")
+	if status != http.StatusGone {
+		t.Fatalf("GET /v0/beads/events?since=0 after a prune = %d, want 410: %v\nstderr:\n%s",
+			status, body, sp.stderr.String())
+	}
+	if code, _ := body["code"].(string); code != "events_journal_truncated" {
+		t.Errorf("code = %v, want events_journal_truncated", body["code"])
+	}
+	// The window, which is the whole payload of this refusal: the consumer's two
+	// recoveries are both computed from these numbers.
+	for _, tc := range []struct {
+		member string
+		want   int
+	}{{"since", 0}, {"floor", 4}, {"head", created}} {
+		got, _ := body[tc.member].(float64)
+		if int(got) != tc.want {
+			t.Errorf("%s = %v, want %d", tc.member, body[tc.member], tc.want)
+		}
+	}
+
+	// The documented recovery actually works: resume from floor-1 and the read
+	// succeeds with the surviving suffix, gap explicitly accepted.
+	floor, _ := body["floor"].(float64)
+	status, body, _ = sp.get(t, fmt.Sprintf("/v0/beads/events?since=%d", int(floor)-1))
+	if status != http.StatusOK {
+		t.Fatalf("resume from floor-1 = %d, want 200: %v", status, body)
+	}
+	records, _ := body["records"].([]any)
+	if len(records) != created-int(floor)+1 {
+		t.Fatalf("resumed records = %d, want %d", len(records), created-int(floor)+1)
+	}
+	first, _ := records[0].(map[string]any)
+	if seq, _ := first["seq"].(float64); int(seq) != int(floor) {
+		t.Errorf("resumed records[0].seq = %v, want the floor %d", first["seq"], int(floor))
+	}
+
+	sp.shutdown(t)
+}
+
+// TestServeRefusesTheJournalWhenItIsDisabled is the distinction the data cannot
+// make. This workspace never enabled the journal, so it records nothing and
+// never will — and the read has to say so rather than answer the empty page an
+// enabled-but-untouched workspace answers, which a consumer would poll against
+// forever.
+func TestServeRefusesTheJournalWhenItIsDisabled(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+	p := newServerModeProject(t, bd, "hjd")
+	// Deliberately NOT enabling the journal. The default is off.
+
+	sp := startServe(t, bd, p.dir, p.env)
+
+	// A mutation lands, and is not journaled, because nothing is journaling.
+	status, postBody := sp.postJSON(t, "/v0/beads/issues:batchCreate",
+		`{"actor":"tester","items":[{"title":"unjournaled","issue_type":"task"}]}`)
+	if status != http.StatusOK {
+		t.Fatalf("POST batchCreate = %d: %v\nstderr:\n%s", status, postBody, sp.stderr.String())
+	}
+
+	status, body, _ := sp.get(t, "/v0/beads/events?since=0")
+	if status != http.StatusConflict {
+		t.Fatalf("GET /v0/beads/events on a disabled workspace = %d, want 409: %v\nstderr:\n%s",
+			status, body, sp.stderr.String())
+	}
+	if code, _ := body["code"].(string); code != "events_journal_disabled" {
+		t.Errorf("code = %v, want events_journal_disabled", body["code"])
+	}
+	if detail, _ := body["detail"].(string); detail == "" {
+		t.Error("no detail on the disabled refusal")
+	}
+
+	sp.shutdown(t)
+}

--- a/cmd/bd/events_journal_activation_e2e_test.go
+++ b/cmd/bd/events_journal_activation_e2e_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/eventsjournal"
 )
 
 // The two plumbings the root pre-run never reached. Both are end-to-end on
@@ -149,7 +151,7 @@ func TestRoutedCreateHonorsTheEnvOverrideOverTheTargetsConfig(t *testing.T) {
 	}
 }
 
-func hasEventOp(records []eventRecord, op string) bool {
+func hasEventOp(records []eventsjournal.Record, op string) bool {
 	for _, r := range records {
 		if r.Op == op {
 			return true

--- a/cmd/bd/events_proxied_server_test.go
+++ b/cmd/bd/events_proxied_server_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/steveyegge/beads/internal/eventsjournal"
 	"github.com/steveyegge/beads/internal/storage"
 )
 
@@ -144,15 +145,15 @@ func TestEventsJournalProxiedServerOffByDefault(t *testing.T) {
 	}
 }
 
-func decodeEventRecords(t *testing.T, out string) []eventRecord {
+func decodeEventRecords(t *testing.T, out string) []eventsjournal.Record {
 	t.Helper()
-	var records []eventRecord
+	var records []eventsjournal.Record
 	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
 		line = strings.TrimSpace(line)
 		if !strings.HasPrefix(line, "{") {
 			continue
 		}
-		var rec eventRecord
+		var rec eventsjournal.Record
 		if err := json.Unmarshal([]byte(line), &rec); err != nil {
 			t.Fatalf("decode journal record %q: %v", line, err)
 		}

--- a/cmd/bd/serve.go
+++ b/cmd/bd/serve.go
@@ -173,7 +173,8 @@ func runServe() error {
 		// runs after this function returns, which is after the server has
 		// fully drained, so no request can reach a closed store. runServe must
 		// not close it.
-		roles, err := serveIssueRoles(store)
+		journalEnabled := eventsjournal.EnabledFor(info.BeadsDir)
+		roles, err := serveIssueRoles(store, journalEnabled)
 		if err != nil {
 			return HandleError("bd serve: %v", err)
 		}
@@ -197,9 +198,19 @@ func runServe() error {
 			BatchCreator:      roles.batchCreator,
 			DependencyEditor:  roles.dependencyEditor,
 			Memories:          roles.memories,
-			Workspace:         info,
-			SchemaVersion:     JSONSchemaVersion,
-			Mode:              serveResolvedMode(info, db),
+			// Nil when this backend has no journal seam and the workspace never
+			// asked for one; Listen requires it exactly when the flag below is
+			// set, and serveIssueRoles has already refused the enabled case.
+			EventsJournal: roles.eventsJournal,
+			// GET /v0/beads/events refuses outright on a workspace that records
+			// nothing, because a disabled journal and an empty one are one
+			// answer at the data level. Resolved ONCE above, so the role
+			// extraction, this flag and the maintenance ticker cannot disagree
+			// about whether this workspace journals.
+			EventsJournalEnabled: journalEnabled,
+			Workspace:            info,
+			SchemaVersion:        JSONSchemaVersion,
+			Mode:                 serveResolvedMode(info, db),
 		})
 	}
 
@@ -256,9 +267,16 @@ func runServe() error {
 		Addr:             serveAddr,
 		AllowNonLoopback: serveAllowNonLoopback,
 		Provider:         provider,
-		Workspace:        info,
-		SchemaVersion:    JSONSchemaVersion,
-		Mode:             serveResolvedMode(info, db),
+		// No EventsJournal field on this arm: the provider carries the journal
+		// read as one of its own capability accessors, exactly as it carries
+		// every other role Listen would otherwise need spelled out. Activation
+		// is still the workspace's answer and still has to be handed in — the
+		// provider knows how to READ the journal, not whether this workspace has
+		// one.
+		EventsJournalEnabled: eventsjournal.EnabledFor(info.BeadsDir),
+		Workspace:            info,
+		SchemaVersion:        JSONSchemaVersion,
+		Mode:                 serveResolvedMode(info, db),
 	})
 }
 
@@ -460,7 +478,7 @@ func errServeEmbedded() error {
 // It returns the WHOLE set httpapi.Config requires; Listen refuses a partial
 // set (see checkDatabaseSource), so a role missing here is a startup failure
 // rather than a nil dereference on the first request that reaches it.
-func serveIssueRoles(src storage.DoltStorage) (serveRoles, error) {
+func serveIssueRoles(src storage.DoltStorage, journalEnabled bool) (serveRoles, error) {
 	var roles serveRoles
 	if src == nil {
 		// A set of nil roles would reach Listen as "no database source" —
@@ -494,6 +512,30 @@ func serveIssueRoles(src storage.DoltStorage) (serveRoles, error) {
 		{"batch creator", func() (err error) { roles.batchCreator, err = src.BatchCreator(); return }},
 		{"dependency editor", func() (err error) { roles.dependencyEditor, err = src.DependencyEditor(); return }},
 		{"memories", func() (err error) { roles.memories, err = src.Memories(); return }},
+		{"events journal", func() error {
+			// storage.UnwrapStore rather than the ONE peel above, and that is not
+			// an exception to this function's rule — it is the rule applied to a
+			// capability that no decorator publishes. The hook and telemetry
+			// layers wrap ROLES; neither implements the journal seam, so the
+			// assertion has to reach the concrete store or it finds nothing at
+			// all. Nothing is skipped by going the whole way: there is no
+			// journal decorator to peel past.
+			cursor, ok := storage.UnwrapStore(src).(storage.EventsJournalCursor)
+			if ok {
+				roles.eventsJournal = cursor
+				return nil
+			}
+			// A backend that cannot read the journal is an ordinary backend
+			// while the workspace records nothing — the journal is off by
+			// default, and eventsjournal.Apply takes exactly this deal when it
+			// binds activation at open time. Only an ENABLED workspace has
+			// asked for something this backend cannot do, and the message is
+			// the one `bd events` prints for the same condition.
+			if journalEnabled {
+				return fmt.Errorf("storage backend does not support the events journal")
+			}
+			return nil
+		}},
 	} {
 		if err := b.get(); err != nil {
 			return serveRoles{}, fmt.Errorf("%s: %w", b.name, err)
@@ -530,6 +572,13 @@ type serveRoles struct {
 	// plane is user data riding in the config table under its own merge class,
 	// so it has its own leaf package.
 	memories memoryops.Memories
+	// eventsJournal is the only role here that comes from a TYPE ASSERTION
+	// rather than an accessor, because the journal is not part of DoltStorage's
+	// published surface: it is engine state on a dolt_ignored table that the two
+	// concrete stores implement and a backend may not. Missing it is a startup
+	// error rather than a route that 500s, which is the same deal every other
+	// role here takes.
+	eventsJournal storage.EventsJournalCursor
 }
 
 // serveResolvedMode labels the topology for the startup log line. Cosmetic —

--- a/cmd/bd/serve_proxied_integration_test.go
+++ b/cmd/bd/serve_proxied_integration_test.go
@@ -146,6 +146,7 @@ var servedCapabilities = []any{
 	"config.get", "config.list",
 	"dependencies.add", "dependencies.blocking", "dependencies.cycles",
 	"dependencies.list", "dependencies.remove", "dependencies.tree",
+	"events.list",
 	"issues.batchCreate", "issues.claim", "issues.close", "issues.delete",
 	"issues.get", "issues.list", "issues.query", "issues.reopen", "issues.sweep",
 	"issues.update",

--- a/cmd/bd/serve_source_test.go
+++ b/cmd/bd/serve_source_test.go
@@ -137,7 +137,7 @@ func TestServeIssueRolesComeFromBeneathTheHookDecorator(t *testing.T) {
 		t.Fatal("the store's own accessor no longer returns a hook-firing dependency editor; this test proves nothing")
 	}
 
-	roles, err := serveIssueRoles(chained)
+	roles, err := serveIssueRoles(chained, false)
 	if err != nil {
 		t.Fatalf("serveIssueRoles: %v", err)
 	}
@@ -179,7 +179,7 @@ func TestServeIssueRolesComeFromBeneathTheHookDecorator(t *testing.T) {
 		// BD_NO_HOOKS=1 wires no hook decorator at all, so the roles are the
 		// store's own and the peel must be conditional.
 		bare := wireStorageDecorators(middle, hooks.NewRunner(t.TempDir()), true)
-		roles, err := serveIssueRoles(bare)
+		roles, err := serveIssueRoles(bare, false)
 		if err != nil {
 			t.Fatalf("serveIssueRoles: %v", err)
 		}
@@ -192,8 +192,35 @@ func TestServeIssueRolesComeFromBeneathTheHookDecorator(t *testing.T) {
 		// httpapi.Listen refuses a partial role set, but a nil store reaching
 		// it as an all-nil set would report "no database source" — true, and
 		// useless. Name the real condition here.
-		if _, err := serveIssueRoles(nil); err == nil {
+		if _, err := serveIssueRoles(nil, false); err == nil {
 			t.Fatal("serveIssueRoles(nil) = nil error; want a refusal naming the missing store")
+		}
+	})
+
+	// The events journal is the one CONDITIONAL role, and both polarities
+	// matter. A backend that cannot read the journal is an ordinary backend —
+	// the journal is off by default, and a registered third-party backend has
+	// no obligation to implement a Dolt-shaped seam — so requiring it
+	// unconditionally would refuse to start servers that have no use for it.
+	// Requiring it for a workspace that DID enable one is the other half: a
+	// server that bound anyway would answer that route with a nil dereference.
+	t.Run("the journal role is required only when the workspace has one", func(t *testing.T) {
+		// serveRolesStore implements no journal seam, which is the case under
+		// test: assert that rather than assume it.
+		if _, ok := storage.UnwrapStore(chained).(storage.EventsJournalCursor); ok {
+			t.Fatal("the fixture store reads the journal; this test proves nothing")
+		}
+
+		roles, err := serveIssueRoles(chained, false)
+		if err != nil {
+			t.Fatalf("serveIssueRoles with the journal off: %v", err)
+		}
+		if roles.eventsJournal != nil {
+			t.Error("a store that cannot read the journal produced a reader")
+		}
+
+		if _, err := serveIssueRoles(chained, true); err == nil {
+			t.Fatal("serveIssueRoles accepted a journal-enabled workspace on a backend that cannot read the journal")
 		}
 	})
 }

--- a/docs/reference/events-journal.md
+++ b/docs/reference/events-journal.md
@@ -77,6 +77,72 @@ Output is JSON Lines, one record per line, in sequence order:
 A consumer advances its checkpoint to the highest `seq` it has durably
 processed, and passes that as the next `--since`.
 
+### Over HTTP
+
+A consumer that already talks to a workspace over `bd serve` reads the same
+journal at `GET /v0/beads/events` instead of shelling out:
+
+```bash
+curl 'http://127.0.0.1:8080/v0/beads/events?since=4211&limit=500'
+```
+
+```json
+{
+  "records": [
+    {"seq":4212,"ts":"2026-01-02T03:04:05Z","op":"create","issue_id":"bd-100","issue":{"id":"bd-100","title":"wire the seam","status":"open","priority":1,"issue_type":"task","created_at":"2026-01-02T03:00:00Z","updated_at":"2026-01-02T03:04:05Z"}}
+  ],
+  "head": 4980
+}
+```
+
+The `records` are the records above — the same fields, the same encoding, the
+same [record contract](#the-record-contract) — so an HTTP mirror and a
+`bd events export` on the same workspace can be reconciled directly.
+
+- `since` is **required**, and it is the same checkpoint `--since` takes. A
+  missing or negative value is a `400`, never a read from the beginning.
+- `limit` runs from 1 to 10000 and defaults to 1000. There is no unlimited
+  read here: `limit=0` is refused rather than meaning "everything" as it does
+  on `GET /v0/beads/issues`.
+- `head` is the highest sequence number ever assigned, so a consumer knows
+  whether to keep reading or back off. When the last record's `seq` equals
+  `head` you are caught up — a full page proves nothing on its own.
+- **Poll; there is no streaming or `--follow` equivalent.** Read with your
+  checkpoint on your own interval.
+- The journal is read-only over HTTP. Pruning stays a workspace decision made
+  with `bd events prune` and the retention floors.
+
+<Warning>
+Publishing the journal publishes the workspace's **history**, not its current
+state: every retained record carries the full issue snapshot as it was at that
+mutation, including titles and descriptions since edited and issues since
+deleted. Pruning and the retention floors are the only thing that removes a
+record — editing or deleting a bead does not redact it from the journal. And
+because this is an HTTP read, any process that can reach the address gets that
+history without the filesystem permissions on `.beads/` that `bd events tail`
+requires. Weigh both before binding a journal-enabled workspace with
+`--allow-non-loopback`; `bd serve` has no authentication.
+</Warning>
+
+Two refusals are worth wiring into a consumer before it ships. A checkpoint
+below the retained window is a `410 Gone` carrying the same
+`events_journal_truncated` code and the same `since` / `floor` / `head` window
+[the CLI reports](#resuming-and-the-truncation-error) — with the same ways
+forward. And a workspace whose journal is **off** answers `409` with
+`events_journal_disabled` rather than an empty page, because a disabled journal
+and an empty one look identical in the data and a consumer given the empty page
+would poll a workspace that will never produce a record. That 409 is workspace
+state, not a missing feature: `events.list` appears in `/v0/beads/context`'s
+capabilities on every build, so treat the capability as "this server speaks it"
+and the 409 as "not on this workspace". (A workspace that has enabled the
+journal on a storage backend with no journal support never gets this far —
+`bd serve` refuses to start, the same refusal opening that workspace already
+gives.)
+
+The journal is per replica, which matters more over HTTP than on the command
+line: a checkpoint is meaningful only against the server URL that issued it.
+Track one per server, and re-baseline rather than carry one across.
+
 ## The record contract
 
 | Field | Type | Meaning |
@@ -199,6 +265,21 @@ A hole in the *middle* of the retained window refuses the same way, with
 from your checkpoint. Nothing bd does produces such a hole — pruning only ever
 removes a prefix — but a restored, hand-edited, or half-copied journal table
 can, and a consumer must never be handed one silently.
+
+That case has a **third way forward**, and it is worth taking before the other
+two: everything between your checkpoint and the reported `since` is intact and
+servable, and the refusal did not hand it over. Drain it explicitly by asking
+for exactly that span — the same `--since` you already passed, with `--limit`
+set to `response.since - your since` — which stops the batch at the hole and
+succeeds:
+
+```bash
+# refused with since 40 (your checkpoint was 12), floor 61
+bd events tail --since 12 --limit 28   # records 13..40, the intact stretch
+bd events tail --since 60              # then take the gap, or re-baseline
+```
+
+Skipping straight to `floor - 1` loses records you could have had.
 
 ## Retention and pruning
 

--- a/internal/eventsjournal/record.go
+++ b/internal/eventsjournal/record.go
@@ -1,0 +1,88 @@
+package eventsjournal
+
+import (
+	"encoding/json"
+
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+// The record envelope every consumer of the journal receives, in ONE place.
+//
+// It started in cmd/bd as the shape `bd events tail` printed, and moved here
+// when GET /v0/beads/events published the same records over HTTP. Two encoders
+// of the same journal row is exactly the drift this package exists to prevent:
+// the CLI's JSONL output is byte-pinned by the protocol corpus, so a second
+// struct in internal/httpapi would have satisfied its own tests while quietly
+// serving a different `ts` shape, a `dep` that was emitted when empty, or an
+// `issue` that was `{}` where the CLI says `null`. A consumer that mirrors a
+// workspace over HTTP and reconciles against a CLI export has to see one
+// contract, not two that agree today.
+//
+// The storage row is deliberately NOT this type. storage.EventsJournalRow is
+// the substrate's shape — three payload columns as strings, one of which is
+// empty most of the time — and Record is the published one. The projection
+// between them is the whole content of this file.
+
+// Record is one journal line as a consumer receives it, on the CLI's stdout and
+// in a GET /v0/beads/events body alike.
+//
+// Issue, Dep and Comment are raw JSON so the stored payloads travel unchanged:
+// re-encoding them here would reorder members and renormalize numbers against a
+// contract that promises the issue exactly as the mutation left it.
+type Record struct {
+	// Seq is counter-assigned inside the mutation's transaction: gapless,
+	// strictly increasing in commit order, never reused or reset.
+	Seq int64 `json:"seq"`
+	// TS is the UTC insert time stamped inside the committing transaction,
+	// normalized to RFC 3339 at the read seam (normalizeEventsTimestamp).
+	TS string `json:"ts"`
+	// Op is one of create, update, close, delete, dep_add, dep_remove, comment.
+	Op string `json:"op"`
+	// IssueID is the mutated issue's id.
+	IssueID string `json:"issue_id"`
+	// Issue is the full issue state AFTER the mutation, and the literal JSON
+	// `null` on a delete — never absent. A delete has no surviving row, and a
+	// consumer must be able to tell that from a payload this server failed to
+	// record, so the member is always present and omitempty is deliberately not
+	// set on it.
+	Issue json.RawMessage `json:"issue"`
+	// Dep is {"kind","target","metadata"} on dep_add and dep_remove, and absent
+	// otherwise. Absence rather than null: it says the op has no dependency
+	// half at all, which is a different statement from a delete's null issue.
+	Dep json.RawMessage `json:"dep,omitempty"`
+	// Comment is {"id","author","text","created_at","source"} on comment, and
+	// absent otherwise, for Dep's reason.
+	Comment json.RawMessage `json:"comment,omitempty"`
+}
+
+// NewRecord projects one stored row onto the published envelope.
+func NewRecord(row storage.EventsJournalRow) Record {
+	rec := Record{
+		Seq:     row.Seq,
+		TS:      row.TS,
+		Op:      row.Op,
+		IssueID: row.IssueID,
+		Issue:   json.RawMessage("null"),
+	}
+	if row.IssueJSON != "" {
+		rec.Issue = json.RawMessage(row.IssueJSON)
+	}
+	if row.DepJSON != "" {
+		rec.Dep = json.RawMessage(row.DepJSON)
+	}
+	if row.CommentJSON != "" {
+		rec.Comment = json.RawMessage(row.CommentJSON)
+	}
+	return rec
+}
+
+// Records projects a whole page. It returns a non-nil empty slice for an empty
+// page, so an HTTP body carries `"records": []` rather than `"records": null` —
+// a caught-up consumer reads an empty list, not a missing one.
+func Records(rows []storage.EventsJournalRow) []Record {
+	out := make([]Record, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, NewRecord(row))
+	}
+	return out
+}

--- a/internal/httpapi/apigen/types.gen.go
+++ b/internal/httpapi/apigen/types.gen.go
@@ -6,6 +6,7 @@ package apigen
 import (
 	"time"
 
+	eventsjournal "github.com/steveyegge/beads/internal/eventsjournal"
 	types "github.com/steveyegge/beads/internal/types"
 	issueops "github.com/steveyegge/beads/issueops"
 )
@@ -264,7 +265,9 @@ type ContextResponse struct {
 	// BeadsDir Absolute path of the served workspace's `.beads` directory. A host path, kept because it is the single-workspace server's only workspace-identity handshake; disclosing it to network peers is part of what an operator accepts when binding beyond loopback.
 	BeadsDir string `json:"beads_dir"`
 
-	// Capabilities The operations this server actually implements, derived from its route table. v0's vocabulary is `ready.list`, `ready.count`, `issues.list`, `issues.query`, `issues.get`, `issues.claim`, `issues.close`, `issues.reopen`, `issues.update`, `issues.sweep`, `issues.delete`, `issues.batchCreate`, `stats.get`, `config.list`, `config.get`, `dependencies.cycles`, `dependencies.list`, `dependencies.blocking`, `dependencies.tree`, `dependencies.add`, `dependencies.remove`, `memories.list`, `memories.get`, `memories.remember`, `memories.forget`; it grows additively, and an operation never appears here unless it is fully implemented. This is how a client checks for an operation — never the version string.
+	// Capabilities The operations this server actually implements, derived from its route table. v0's vocabulary is `ready.list`, `ready.count`, `issues.list`, `issues.query`, `issues.get`, `issues.claim`, `issues.close`, `issues.reopen`, `issues.update`, `issues.sweep`, `issues.delete`, `issues.batchCreate`, `stats.get`, `config.list`, `config.get`, `dependencies.cycles`, `dependencies.list`, `dependencies.blocking`, `dependencies.tree`, `dependencies.add`, `dependencies.remove`, `memories.list`, `memories.get`, `memories.remember`, `memories.forget`, `events.list`; it grows additively, and an operation never appears here unless it is fully implemented. This is how a client checks for an operation — never the version string.
+	//
+	// THIS LIST IS BUILD-LEVEL, NOT WORKSPACE-LEVEL. It says which operations this binary serves, and for every entry but one that is the whole answer. `events.list` is the exception: the durable events journal is a per-workspace setting that is OFF by default, so a server that advertises `events.list` may still refuse every request to it with 409 `events_journal_disabled` — correctly, because the operation exists and the workspace has no journal. A consumer of that operation MUST treat the capability as "this server speaks it" and the 409 as "not on this workspace", and must not read the capability as a promise that records will arrive.
 	Capabilities []string `json:"capabilities"`
 
 	// Database Logical database name (not a host or a DSN).
@@ -395,6 +398,28 @@ type DependencyTreePage struct {
 	Items []TreeNode `json:"items"`
 }
 
+// EventRecord One record of the durable events journal: a single committed issue mutation, as a replaying consumer receives it.
+//
+// THIS IS THE CLI'S RECORD. It is pinned to the same Go struct `bd events tail` and `bd events export` marshal one per line, so the JSONL a consumer reads from stdout and the elements of an `EventsPage.records` array are the same bytes for the same row. A committed golden fixture pins that encoding field by field.
+//
+// `issue` is the full issue state AFTER the mutation and is ALWAYS PRESENT, carrying the literal `null` on a delete — where there is no surviving row to describe. That is the one place this document's general "treat null as absent" rule does not apply to a member's meaning: a consumer must be able to tell a delete from a payload the server failed to record, so the member is emitted rather than omitted. `dep` and `comment` are the opposite: they are ABSENT on the ops that have no such half, because their absence says the op has none, not that one was empty.
+type EventRecord = eventsjournal.Record
+
+// EventsPage One page of the journal plus the position of its end.
+//
+// THERE IS NO `has_more`, and that is deliberate rather than an omission. Every other page on this surface reports truncation with a boolean because its ordering is a query's; here the answer is a number the client already needs for its next request. Compare the last record's `seq` with `head`: equal means caught up, lower means keep reading. A full page proves nothing either way, and a `has_more` computed from the limit would be a second, weaker way to ask the same question.
+type EventsPage struct {
+	// Head The highest `seq` this journal has ever assigned, read in the same transaction as the records above.
+	//
+	// It is the journal's HISTORY, not its contents: pruning deletes rows and never touches the counter, so a fully pruned journal still reports the head it reached. `0` means no mutation has ever been journaled here — which, given that a disabled journal is refused with 409 rather than answered, means an enabled journal on a workspace that has not been written to yet.
+	//
+	// Because it is read after the rows within one transaction, it is always greater than or equal to the last record's `seq`; it may be greater simply because a mutation committed while the page was being read, which is the ordinary signal to poll again.
+	Head int64 `json:"head"`
+
+	// Records Records with `seq` strictly greater than the requested `since`, in ASCENDING `seq` order and contiguous — a gap in the retained window is a 410, never a quietly shortened list. Empty array (never null) when the caller is caught up.
+	Records []EventRecord `json:"records"`
+}
+
 // Health defines model for Health.
 type Health struct {
 	Status HealthStatus `json:"status"`
@@ -506,7 +531,7 @@ type Problem struct {
 	// BlockerIsAncestor With `dependency_cycle`, hierarchy refusal only: true when `blocker_id` is an ANCESTOR of `issue_id` (which cannot close until its descendants finish, so the gate would never clear), false when it is a DESCENDANT (blocked status cascades, so it would inherit the block and never close). Both polarities are reported; this member is never omitted to mean false. See `issue_id`.
 	BlockerIsAncestor *bool `json:"blocker_is_ancestor,omitempty"`
 
-	// Code The stable machine-readable reason, and the ONLY member a client may dispatch on. v0's vocabulary: `invalid_argument` (400, also emitted by the Host-header middleware on any route), `invalid_cursor` (400), `not_found` (404), `already_claimed` (409), `not_claimable` (409), `not_closable` (409), `dependency_cycle` (409), `dependency_exists` (409), `busy` (503), `db_unavailable` (503), `internal` (500). Renaming or removing a status+code pair is a breaking change; ADDING one is not, so clients MUST default-branch on unknown values and fall back to the status class (unknown 4xx → client bug, fail loud; unknown 503 → retry per `Retry-After`; other unknown 5xx → server fault).
+	// Code The stable machine-readable reason, and the ONLY member a client may dispatch on. v0's vocabulary: `invalid_argument` (400, also emitted by the Host-header middleware on any route), `invalid_cursor` (400), `not_found` (404), `already_claimed` (409), `not_claimable` (409), `not_closable` (409), `dependency_cycle` (409), `dependency_exists` (409), `events_journal_disabled` (409), `events_journal_truncated` (410), `busy` (503), `db_unavailable` (503), `internal` (500). Renaming or removing a status+code pair is a breaking change; ADDING one is not, so clients MUST default-branch on unknown values and fall back to the status class (unknown 4xx → client bug, fail loud; unknown 503 → retry per `Retry-After`; other unknown 5xx → server fault).
 	Code string `json:"code"`
 
 	// Detail Optional prose, never load-bearing. For 5xx codes it is a FIXED string per code and carries nothing about the underlying failure: driver and dial errors routinely embed the DSN, database user and host:port, and this API supports binding beyond loopback. 4xx details reflect the caller's own input back and are specific.
@@ -514,6 +539,12 @@ type Problem struct {
 
 	// ExistingType With `dependency_exists`: the type of the edge the pair already carries, read inside the refusing transaction.
 	ExistingType *string `json:"existing_type,omitempty"`
+
+	// Floor With `events_journal_truncated`: the lowest seq still retained, or `head + 1` when the journal retains nothing at all. Resuming from `floor - 1` continues with a known, explicit gap.
+	Floor *int64 `json:"floor,omitempty"`
+
+	// Head With `events_journal_truncated`: the highest seq this journal has ever assigned. It never decreases under a prune, so `floor > head` means the journal was pruned empty and the caller is at the end of its history. Emitted even when zero.
+	Head *int64 `json:"head,omitempty"`
 
 	// IssueId With `dependency_cycle`, and ONLY on the hierarchy refusal: the issue the requested blocking edge would have gated. Its PRESENCE is the discriminator — absent means a plain scheduling cycle, present means the edge pointed at the issue's own ancestor or descendant.
 	//
@@ -539,6 +570,11 @@ type Problem struct {
 
 	// RequestedType With `dependency_exists`: the type the request asked for. Together with `existing_type` it is the whole refusal, so a client never parses either out of `detail`.
 	RequestedType *string `json:"requested_type,omitempty"`
+
+	// Since With `events_journal_truncated`: the checkpoint the reported window begins after.
+	//
+	// It is NOT always the value the request sent. In the ordinary case — the prefix you asked for was pruned — it IS your checkpoint. When the prefix is intact but the retained window has an interior hole, it is instead the last seq the server could serve contiguously from your checkpoint, and `floor` is where the next intact stretch begins. It never reports a value BELOW what you sent, so echoing it back can never re-deliver records you already hold.
+	Since *int64 `json:"since,omitempty"`
 
 	// Status The HTTP status code, repeated in the body.
 	Status int `json:"status"`
@@ -868,6 +904,25 @@ type GetDependencyTreeParams struct {
 
 // GetDependencyTreeParamsDirection defines parameters for GetDependencyTree.
 type GetDependencyTreeParamsDirection string
+
+// ListEventsParams defines parameters for ListEvents.
+type ListEventsParams struct {
+	// Since Return records with `seq` strictly greater than this value. Pass `0` to read from the beginning of the retained journal.
+	//
+	// REQUIRED, and deliberately not defaulted to zero. A consumer that omitted its checkpoint by mistake would be served the whole retained window, which reads as a flood of duplicate records rather than as an error. A negative value is a 400 `invalid_argument` for the same reason `bd events tail --since` refuses one: it is almost always arithmetic on an empty cursor, and `seq > -5` would quietly serve everything as though it were a legitimate resume.
+	//
+	// A value at or above `head` is not an error — it is the caught-up case, a 200 with an empty `records` array.
+	Since int64 `form:"since" json:"since"`
+
+	// Limit Maximum number of records to return, from 1 to 10000. A value outside that range — `0` included — is a 400 `invalid_argument`.
+	//
+	// THERE IS NO UNLIMITED READ HERE, and `0` does NOT mean unlimited as it does on `GET /v0/beads/issues`. A caller resuming from an old checkpoint would otherwise ask one process to buffer the entire retained window — a hundred thousand records under the shipped `events-journal-retain-rows` floor — and encode it into a single response. The ceiling is unconditional and does not depend on the bind mode.
+	//
+	// The default of 1000 is deliberately much larger than the issue listings' 50: a journal consumer is a machine draining a backlog in order rather than a person reading a page, and the number that matters to it is round trips to catch up.
+	//
+	// A FULL PAGE DOES NOT MEAN THERE IS MORE, and a short one does not mean there is not. Compare the last record's `seq` against `head`; that is the only correct test, and it is why this envelope carries no `has_more`.
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+}
 
 // ListIssuesParams defines parameters for ListIssues.
 type ListIssuesParams struct {

--- a/internal/httpapi/claim.go
+++ b/internal/httpapi/claim.go
@@ -14,6 +14,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/steveyegge/beads/internal/httpapi/apigen"
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/uow"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/issueops"
@@ -308,22 +309,23 @@ type timedProvider struct {
 // provider it holds for the role — the same two-step a CLI command performs on
 // a store — instead of reaching past it to a constructor.
 var (
-	_ uow.IssueReaderSource       = timedProvider{}
-	_ uow.IssueClaimerSource      = timedProvider{}
-	_ uow.IssueLifecycleSource    = timedProvider{}
-	_ uow.WorkspaceConfigSource   = timedProvider{}
-	_ uow.StatsReporterSource     = timedProvider{}
-	_ uow.CycleDetectorSource     = timedProvider{}
-	_ uow.EdgeReaderSource        = timedProvider{}
-	_ uow.BlockingAnnotatorSource = timedProvider{}
-	_ uow.TreeWalkerSource        = timedProvider{}
-	_ uow.ReadyCounterSource      = timedProvider{}
-	_ uow.QuerierSource           = timedProvider{}
-	_ uow.SweeperSource           = timedProvider{}
-	_ uow.DeleterSource           = timedProvider{}
-	_ uow.BatchCreatorSource      = timedProvider{}
-	_ uow.DependencyEditorSource  = timedProvider{}
-	_ uow.MemoriesSource          = timedProvider{}
+	_ uow.IssueReaderSource         = timedProvider{}
+	_ uow.IssueClaimerSource        = timedProvider{}
+	_ uow.IssueLifecycleSource      = timedProvider{}
+	_ uow.WorkspaceConfigSource     = timedProvider{}
+	_ uow.StatsReporterSource       = timedProvider{}
+	_ uow.CycleDetectorSource       = timedProvider{}
+	_ uow.EdgeReaderSource          = timedProvider{}
+	_ uow.BlockingAnnotatorSource   = timedProvider{}
+	_ uow.TreeWalkerSource          = timedProvider{}
+	_ uow.ReadyCounterSource        = timedProvider{}
+	_ uow.QuerierSource             = timedProvider{}
+	_ uow.SweeperSource             = timedProvider{}
+	_ uow.DeleterSource             = timedProvider{}
+	_ uow.BatchCreatorSource        = timedProvider{}
+	_ uow.DependencyEditorSource    = timedProvider{}
+	_ uow.MemoriesSource            = timedProvider{}
+	_ uow.EventsJournalCursorSource = timedProvider{}
 )
 
 // IssueReader builds the reader OVER THIS WRAPPER rather than delegating to the
@@ -450,6 +452,10 @@ func (p timedProvider) DependencyEditor() (issueops.DependencyEditor, error) {
 // whose role is not an issueops role; the binding rule is the same.
 func (p timedProvider) Memories() (memoryops.Memories, error) {
 	return uow.NewMemories(p)
+}
+
+func (p timedProvider) EventsJournalCursor() (storage.EventsJournalCursor, error) {
+	return uow.NewEventsJournalCursor(p)
 }
 
 func (p timedProvider) NewUOW(ctx context.Context) (uow.UnitOfWork, error) {

--- a/internal/httpapi/events.go
+++ b/internal/httpapi/events.go
@@ -1,0 +1,191 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/steveyegge/beads/internal/eventsjournal"
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+// The durable events journal, published as a read.
+//
+// This is the operation that lets a hosted consumer stop shelling out to
+// `bd events tail`. The records it serves are the SAME records that command
+// prints — literally, through eventsjournal.NewRecord, which is the one
+// projection from a stored row onto the published envelope and is byte-pinned
+// by the CLI's golden fixture. There is no wire struct in this package for a
+// journal record and there must never be one: a mirror here would satisfy its
+// own tests while serving a `ts` in a different shape or a `dep` that appeared
+// when empty, and the consumer that notices is the one reconciling an HTTP
+// mirror against a CLI export at three in the morning.
+//
+// WHAT IS NOT HERE, in the reads.go tradition. No seq arithmetic, no gap
+// detection, no decision about whether a page is contiguous: that is
+// issueops.ComputeEventsTruncation, which every read plumbing runs, and it
+// reaches this file as a typed error that problem.go maps. A handler that
+// decided for itself whether a batch was continuous would be a second retention
+// contract, and the failure mode of getting it wrong is silent record loss —
+// which is the one thing this feature exists to prevent.
+//
+// NO FOLLOW, NO STREAM, NO LONG POLL in v0. A consumer polls with the highest
+// seq it has durably processed. That is a real constraint on the design and not
+// an omission: a held-open response would have to survive the write-stall
+// deadline, hold a database slot for its whole life out of a pool of sixteen,
+// and still leave the consumer needing the polling path for the reconnect —
+// so v0 ships the path that is always needed and nothing else. `head` is what
+// makes polling cheap to pace: a consumer that sees its last seq equal to
+// `head` knows it is caught up and can back off, instead of inferring it from
+// a short page.
+
+// Journal paging bounds. There is no unlimited read here, unlike the issue
+// listings: a caller resuming from an old checkpoint would otherwise ask one
+// process to buffer the entire retained window — a hundred thousand records
+// under the shipped retain-rows floor — and encode it into one response.
+//
+// The default is deliberately much larger than the issue listings' 50. A
+// journal consumer is a machine draining a backlog in order, not a person
+// reading a page, and its cost per record is a fraction of an issue row's; the
+// interesting number for it is round trips to catch up, which at 50 would be
+// two thousand for a full window.
+const (
+	defaultEventsLimit = 1000
+	maxEventsLimit     = 10000
+)
+
+// handleListEvents answers GET /v0/beads/events.
+func (s *Server) handleListEvents(w http.ResponseWriter, r *http.Request) {
+	q := newQuery(r.URL.Query())
+
+	// Read BOTH parameters before deciding anything, so an unknown third one is
+	// still reported by the shared rule rather than shadowed by the `since`
+	// refusal below.
+	since := q.integer64("since")
+	limit := q.boundedLimit(defaultEventsLimit, maxEventsLimit)
+
+	if !s.acceptQuery(w, r, q) {
+		return
+	}
+	// `since` is required, and its absence is refused HERE rather than defaulted
+	// to 0 — the tree walker's argument for `root_id`, with more at stake. A
+	// missing checkpoint defaulted to zero would serve the whole retained window
+	// to a consumer that meant to resume, which reads as a flood of duplicate
+	// records rather than as an error.
+	//
+	// A NEGATIVE checkpoint is refused for the reason `bd events tail --since`
+	// refuses one: it is almost always arithmetic on an empty cursor, and
+	// `seq > -5` would quietly serve everything as though it were a legitimate
+	// resume. q.integer64 has already refused a value that is not an integer at
+	// all, so reaching here with a non-nil pointer means it parsed.
+	if since == nil || *since < 0 {
+		requestInfo(r.Context()).refuse("since")
+		s.fail(w, r, InvalidArgument("since", ReasonInvalidValue,
+			"since is required and must be zero or a positive sequence number; use 0 to read from the beginning"))
+		return
+	}
+
+	// The activation gate, BEFORE the read. A disabled journal answers zero rows
+	// and a head of zero, which is indistinguishable from an enabled journal
+	// nothing has written to yet — so a consumer would poll a workspace that
+	// will never produce a record and call itself caught up. This is the only
+	// place the difference is knowable, and it costs no database round trip.
+	if !s.cfg.EventsJournalEnabled {
+		s.fail(w, r, EventsJournalDisabled())
+		return
+	}
+
+	cursor, err := s.eventsJournalCursor(r)
+	if err != nil {
+		s.failErr(w, r, err)
+		return
+	}
+	page, err := cursor.ReadEventsJournalPage(r.Context(), *since, limit)
+	if err != nil {
+		// A pruned-past checkpoint arrives as *storage.EventsJournalTruncatedError
+		// and leaves as the 410 with its window attached; ClassifyError owns that
+		// row, so this handler has no special case for it.
+		s.failErr(w, r, err)
+		return
+	}
+
+	writeEventsPage(w, page)
+}
+
+// writeEventsPage streams the answer instead of building it.
+//
+// writeJSON would cost two further whole-page copies on top of the rows the
+// seam already handed back: one []Record slice, whose json.RawMessage members
+// copy every stored payload out of its string, and then encoding/json's own
+// buffer, which assembles the entire body before a byte reaches the socket. At
+// the 10000-record ceiling with issue payloads of a few hundred bytes that is
+// tens of megabytes of transient garbage per request, times the sixteen
+// requests this server admits at once. Here each record is projected and
+// encoded on its way out, so the live cost is one record rather than the page.
+//
+// FULL CURSOR STREAMING — reading rows off the database cursor and emitting
+// them without materializing the page at all — is deliberately NOT what this
+// does, and cannot be until the retention contract changes. The truncation
+// check needs the whole batch in memory: firstEventsSeqGap makes a linear pass
+// looking for an interior hole, and it must reach a verdict BEFORE the first
+// byte of a 200 is written, because a gap discovered halfway through a body is
+// no longer expressible as the 410 the contract promises. Materialized rows
+// are bounded by the limit cap; the two copies removed here were not bounded
+// by anything the caller could not raise.
+//
+// The member names, their order and the `head` type all come from
+// apigen.EventsPage, which is the document's shape — not from this function's
+// opinion of it. TestEventsStreamsExactlyTheGeneratedEnvelope encodes the same
+// data through that generated struct and requires the two to be byte-identical,
+// so this stays one wire shape rather than a second one that agrees today.
+func writeEventsPage(w http.ResponseWriter, page storage.EventsJournalPage) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+
+	// `head` LEADS, because that is the order the generated envelope serializes
+	// its fields in and this body must be the same bytes. It happens to be the
+	// better order for a streaming reader too — the pacing number arrives before
+	// the page it describes — but the reason it is written this way is the pin.
+	//
+	// gosec's taint analysis flags every direct write to a ResponseWriter as a
+	// possible XSS sink, because it cannot see a Content-Type. It is
+	// application/json here, set above, and both writes below are the output of
+	// encoding/json — a decimal integer and one marshaled record — never a
+	// caller string reflected into a document. writeJSON is unflagged only
+	// because the encoder hides the write, which is the same bytes.
+	//nolint:gosec // G705: application/json body, JSON-encoded content, no HTML sink.
+	if _, err := fmt.Fprintf(w, `{"head":%d,"records":[`, page.Head); err != nil {
+		return
+	}
+	for i, row := range page.Rows {
+		// json.Marshal rather than an Encoder: Encode appends a newline per
+		// value, and while that is insignificant JSON whitespace it would put
+		// this body one byte per record away from the generated envelope's, and
+		// the byte-identity test below is what keeps the two one shape.
+		encoded, err := json.Marshal(eventsjournal.NewRecord(row))
+		if err != nil {
+			// Unreachable for a well-formed row, and a truncated 200 is all the
+			// client can be told either way: the status is already on the wire.
+			// The alternative — buffering the whole body to keep the option of
+			// a 500 — is the cost this function exists to avoid, and writeJSON
+			// does not buy it either.
+			return
+		}
+		if i > 0 {
+			if _, err := w.Write([]byte(",")); err != nil {
+				return
+			}
+		}
+		//nolint:gosec // G705: as above — encoding/json output into an application/json body.
+		if _, err := w.Write(encoded); err != nil {
+			return
+		}
+	}
+	// `records` is never null: an empty page closes an empty array here, so a
+	// caught-up consumer decodes a list of length zero rather than having to
+	// treat a missing member as one. The trailing newline is writeJSON's, kept
+	// so this body and a generated one are the same BYTES rather than merely
+	// the same document.
+	_, _ = io.WriteString(w, "]}\n")
+}

--- a/internal/httpapi/events_test.go
+++ b/internal/httpapi/events_test.go
@@ -1,0 +1,593 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/eventsjournal"
+	"github.com/steveyegge/beads/internal/httpapi/apigen"
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+// The events journal read. Three of these cases are about a distinction the
+// data cannot make on its own — caught-up versus disabled versus pruned-past —
+// and those are the ones worth having: an implementation that gets the happy
+// path right and collapses any two of those three is a consumer that stalls
+// forever or loses records without ever seeing an error.
+
+// eventsRows builds a contiguous run of journal rows starting at from.
+func eventsRows(from int64, n int) []storage.EventsJournalRow {
+	rows := make([]storage.EventsJournalRow, 0, n)
+	for i := range n {
+		seq := from + int64(i)
+		rows = append(rows, storage.EventsJournalRow{
+			Seq:       seq,
+			TS:        "2026-01-02T03:04:05Z",
+			Op:        "create",
+			IssueID:   fmt.Sprintf("bd-%d", seq),
+			IssueJSON: fmt.Sprintf(`{"id":"bd-%d"}`, seq),
+		})
+	}
+	return rows
+}
+
+// journalServer stands up a roles-backed server over one journal fake, with the
+// journal ENABLED — the ordinary configuration. The disabled case names itself.
+func journalServer(t *testing.T, journal *roleEventsJournal) *testServer {
+	t.Helper()
+	return newTestServer(t, rolesConfig(Config{EventsJournal: journal, EventsJournalEnabled: true}))
+}
+
+// TestEventsServesTheRecordsAndTheHead is the happy path, and it asserts the
+// RECORD SHAPE rather than only the count: these bodies are the same records
+// `bd events tail` prints, and a wire struct that quietly diverged from the
+// CLI's would pass a length check.
+func TestEventsServesTheRecordsAndTheHead(t *testing.T) {
+	journal := &roleEventsJournal{page: storage.EventsJournalPage{Rows: eventsRows(4, 3), Head: 9}}
+	ts := journalServer(t, journal)
+
+	resp := ts.get(t, "/v0/beads/events?since=3")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	body := decodeBody(t, resp)
+
+	if got := body["head"]; got != float64(9) {
+		t.Errorf("head = %v, want 9", got)
+	}
+	records, _ := body["records"].([]any)
+	if len(records) != 3 {
+		t.Fatalf("records = %d, want 3", len(records))
+	}
+	first, _ := records[0].(map[string]any)
+	if got := first["seq"]; got != float64(4) {
+		t.Errorf("records[0].seq = %v, want 4", got)
+	}
+	if got := first["issue_id"]; got != "bd-4" {
+		t.Errorf("records[0].issue_id = %v, want bd-4", got)
+	}
+	if got := first["op"]; got != "create" {
+		t.Errorf("records[0].op = %v, want create", got)
+	}
+	// Present with the ops that have no such half ABSENT, which is the envelope
+	// contract rather than a formatting detail: absence says the op has no
+	// dependency, where a null would say it had an empty one.
+	if _, ok := first["dep"]; ok {
+		t.Error("a create record carries `dep`; it must be absent")
+	}
+	if _, ok := first["issue"]; !ok {
+		t.Error("`issue` is absent; it must always be present, carrying null on a delete")
+	}
+
+	// The checkpoint reached the seam unchanged. `since` is the whole cursor, so
+	// a handler that dropped or shifted it would re-serve or skip records.
+	if reads := journal.reads(); len(reads) != 1 || reads[0].since != 3 {
+		t.Errorf("journal reads = %+v, want one read at since=3", reads)
+	}
+}
+
+// TestEventsSerializesADeleteRecordAsANullIssue: `issue` is always present and
+// carries the literal null on a delete, which is how a replaying consumer tells
+// "this row is gone" from "this server failed to record the payload".
+func TestEventsSerializesADeleteRecordAsANullIssue(t *testing.T) {
+	journal := &roleEventsJournal{page: storage.EventsJournalPage{
+		Rows: []storage.EventsJournalRow{{Seq: 1, TS: "2026-01-02T03:04:05Z", Op: "delete", IssueID: "bd-1"}},
+		Head: 1,
+	}}
+	ts := journalServer(t, journal)
+
+	resp := ts.get(t, "/v0/beads/events?since=0")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	// Decoded generically, because the point is the JSON and not a Go zero
+	// value: an absent member and an explicit null both decode to nil in a map.
+	raw := readAll(t, resp)
+	var body struct {
+		Records []map[string]json.RawMessage `json:"records"`
+	}
+	if err := json.Unmarshal([]byte(raw), &body); err != nil {
+		t.Fatalf("decode %q: %v", raw, err)
+	}
+	if len(body.Records) != 1 {
+		t.Fatalf("records = %d, want 1", len(body.Records))
+	}
+	issue, ok := body.Records[0]["issue"]
+	if !ok {
+		t.Fatal("`issue` is absent on a delete record; it must be present and null")
+	}
+	if string(issue) != "null" {
+		t.Errorf("issue = %s, want null", issue)
+	}
+}
+
+// TestEventsCaughtUpIsAnEmptyPage: a checkpoint at or past the head is a normal
+// steady state for a poller, not a miss. A 404 here would make the surface's
+// error vocabulary part of a consumer's happy path.
+func TestEventsCaughtUpIsAnEmptyPage(t *testing.T) {
+	journal := &roleEventsJournal{page: storage.EventsJournalPage{Head: 12}}
+	ts := journalServer(t, journal)
+
+	resp := ts.get(t, "/v0/beads/events?since=12")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	// The RAW body, because `records: null` and `records: []` both decode to an
+	// empty slice and only one of them is the contract.
+	raw := readAll(t, resp)
+	var body struct {
+		Records json.RawMessage `json:"records"`
+		Head    int64           `json:"head"`
+	}
+	if err := json.Unmarshal([]byte(raw), &body); err != nil {
+		t.Fatalf("decode %q: %v", raw, err)
+	}
+	if string(body.Records) != "[]" {
+		t.Errorf("records = %s, want []", body.Records)
+	}
+	if body.Head != 12 {
+		t.Errorf("head = %d, want 12", body.Head)
+	}
+}
+
+// TestEventsEmptyJournalIsNotTheDisabledRefusal is the distinction the whole
+// activation gate exists for. An enabled journal nothing has written to is a
+// 200 with an empty page and a head of zero; a DISABLED one is a 409. A server
+// that answered both the same way would tell a consumer polling a workspace
+// that records nothing that it was caught up.
+func TestEventsEmptyJournalIsNotTheDisabledRefusal(t *testing.T) {
+	ts := journalServer(t, &roleEventsJournal{page: storage.EventsJournalPage{Head: 0}})
+
+	resp := ts.get(t, "/v0/beads/events?since=0")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if got := decodeBody(t, resp)["head"]; got != float64(0) {
+		t.Errorf("head = %v, want 0", got)
+	}
+}
+
+// TestEventsRefusesWhenTheJournalIsDisabled is the other half of that pair, and
+// it also pins that the refusal costs no database work: a workspace that
+// records nothing must not spend a slot and a transaction to say so.
+func TestEventsRefusesWhenTheJournalIsDisabled(t *testing.T) {
+	journal := &roleEventsJournal{page: storage.EventsJournalPage{Rows: eventsRows(1, 2), Head: 2}}
+	ts := newTestServer(t, rolesConfig(Config{EventsJournal: journal, EventsJournalEnabled: false}))
+
+	resp := ts.get(t, "/v0/beads/events?since=0")
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status = %d, want 409: %s", resp.StatusCode, readAll(t, resp))
+	}
+	body := decodeBody(t, resp)
+	if got := body["code"]; got != string(CodeEventsJournalDisabled) {
+		t.Errorf("code = %v, want %q", got, CodeEventsJournalDisabled)
+	}
+	if got, _ := body["detail"].(string); got == "" {
+		t.Error("no detail on the disabled refusal; it is the only place an operator learns what to set")
+	}
+	if n := len(journal.reads()); n != 0 {
+		t.Errorf("the journal was read %d times behind a disabled gate, want 0", n)
+	}
+}
+
+// TestEventsMapsTruncationToGone is the mapping this feature cannot ship
+// without. A pruned-past checkpoint has to arrive as a typed 410 carrying the
+// window the server CAN serve — the client's only two recoveries (resume from
+// floor-1, or rebuild) are both computed from these three numbers.
+func TestEventsMapsTruncationToGone(t *testing.T) {
+	truncated := &storage.EventsJournalTruncatedError{Since: 2, Floor: 7, Head: 40}
+	journal := &roleEventsJournal{err: truncated}
+	ts := journalServer(t, journal)
+
+	resp := ts.get(t, "/v0/beads/events?since=2")
+	if resp.StatusCode != http.StatusGone {
+		t.Fatalf("status = %d, want 410: %s", resp.StatusCode, readAll(t, resp))
+	}
+	body := decodeBody(t, resp)
+	if got := body["code"]; got != string(CodeEventsJournalTruncated) {
+		t.Errorf("code = %v, want %q", got, CodeEventsJournalTruncated)
+	}
+	for _, tc := range []struct {
+		member string
+		want   float64
+	}{{"since", 2}, {"floor", 7}, {"head", 40}} {
+		if got := body[tc.member]; got != tc.want {
+			t.Errorf("%s = %v, want %v", tc.member, got, tc.want)
+		}
+	}
+	// The storage error's OWN sentence, so a consumer reading the CLI's failure
+	// and this one sees a single description of a single condition.
+	if got, _ := body["detail"].(string); got != truncated.Error() {
+		t.Errorf("detail = %q, want the storage error's own message %q", got, truncated.Error())
+	}
+	// The code the CLI's --json failure carries, matched against storage's
+	// constant rather than a literal: two spellings of one condition is exactly
+	// what a consumer branching on `code` cannot survive.
+	if string(CodeEventsJournalTruncated) != storage.EventsJournalTruncatedCode {
+		t.Errorf("wire code %q has drifted from storage's %q", CodeEventsJournalTruncated, storage.EventsJournalTruncatedCode)
+	}
+}
+
+// TestEventsMapsAWrappedTruncationToGone: the seam wraps its errors on the way
+// out (a unit of work, a transaction helper), so the mapping has to be
+// errors.As and not a type assertion. A wrapped truncation demoted to a 500 is
+// the silent-loss case wearing a retryable status.
+func TestEventsMapsAWrappedTruncationToGone(t *testing.T) {
+	wrapped := fmt.Errorf("read events journal: %w", &storage.EventsJournalTruncatedError{Since: 0, Floor: 4, Head: 5})
+	ts := journalServer(t, &roleEventsJournal{err: wrapped})
+
+	resp := ts.get(t, "/v0/beads/events?since=0")
+	if resp.StatusCode != http.StatusGone {
+		t.Fatalf("status = %d, want 410: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if got := decodeBody(t, resp)["floor"]; got != float64(4) {
+		t.Errorf("floor = %v, want 4", got)
+	}
+}
+
+// TestEventsAnOrdinaryFailureIsNotGone bounds the row above: only the typed
+// truncation earns a 410. A journal read that failed for any other reason is
+// the generic 500, because 410 tells a client its checkpoint is unusable and
+// retrying is pointless — advice that would be wrong for a transient fault.
+func TestEventsAnOrdinaryFailureIsNotGone(t *testing.T) {
+	ts := journalServer(t, &roleEventsJournal{err: errors.New("connection reset by the database")})
+
+	resp := ts.get(t, "/v0/beads/events?since=0")
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500: %s", resp.StatusCode, readAll(t, resp))
+	}
+	body := decodeBody(t, resp)
+	if got := body["code"]; got != string(CodeInternal) {
+		t.Errorf("code = %v, want %q", got, CodeInternal)
+	}
+	// The 5xx detail is fixed per code and the underlying text goes to the log
+	// only; a journal error can carry a DSN like any other driver error.
+	if got, _ := body["detail"].(string); got != staticDetail[CodeInternal] {
+		t.Errorf("detail = %q, want the fixed 5xx string", got)
+	}
+}
+
+// TestEventsRefusesABadCheckpoint. `since` is required and must be a
+// non-negative integer; each refusal names the parameter, because `param` is
+// what a client dispatches on.
+func TestEventsRefusesABadCheckpoint(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		query string
+	}{
+		{name: "absent", query: ""},
+		{name: "empty", query: "?since="},
+		{name: "negative", query: "?since=-5"},
+		{name: "not a number", query: "?since=abc"},
+		{name: "fractional", query: "?since=1.5"},
+		{name: "repeated", query: "?since=1&since=2"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			journal := &roleEventsJournal{}
+			ts := journalServer(t, journal)
+
+			resp := ts.get(t, "/v0/beads/events"+tc.query)
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
+			}
+			body := decodeBody(t, resp)
+			if got := body["code"]; got != string(CodeInvalidArgument) {
+				t.Errorf("code = %v, want %q", got, CodeInvalidArgument)
+			}
+			if got := body["param"]; got != "since" {
+				t.Errorf("param = %v, want since", got)
+			}
+			if got := body["reason"]; got != string(ReasonInvalidValue) {
+				t.Errorf("reason = %v, want %q", got, ReasonInvalidValue)
+			}
+			if n := len(journal.reads()); n != 0 {
+				t.Errorf("the journal was read %d times for a refused request, want 0", n)
+			}
+		})
+	}
+}
+
+// TestEventsRefusesAnUnknownParameterRatherThanTheCheckpoint: the shared
+// unknown-parameter rule runs BEFORE the required-`since` refusal, so a client
+// one version ahead learns that this server does not know its parameter instead
+// of being told to fix a checkpoint it already sent.
+func TestEventsRefusesAnUnknownParameterRatherThanTheCheckpoint(t *testing.T) {
+	ts := journalServer(t, &roleEventsJournal{})
+
+	resp := ts.get(t, "/v0/beads/events?since=0&follow=true")
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
+	}
+	body := decodeBody(t, resp)
+	if got := body["param"]; got != "follow" {
+		t.Errorf("param = %v, want follow", got)
+	}
+	if got := body["reason"]; got != string(ReasonUnknownParameter) {
+		t.Errorf("reason = %v, want %q", got, ReasonUnknownParameter)
+	}
+}
+
+// TestEventsAppliesTheDocumentedLimitBounds. The default and the ceiling are
+// asserted on the value that reached the SEAM, not on the response size: a
+// handler that ignored `limit` entirely would return whatever the fake held and
+// pass any assertion about the body.
+func TestEventsAppliesTheDocumentedLimitBounds(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		query     string
+		wantLimit int
+		wantRefus bool
+	}{
+		{name: "absent takes the default", query: "?since=0", wantLimit: defaultEventsLimit},
+		{name: "explicit is honored", query: "?since=0&limit=25", wantLimit: 25},
+		{name: "the ceiling itself is legal", query: "?since=0&limit=10000", wantLimit: maxEventsLimit},
+		{name: "one is legal", query: "?since=0&limit=1", wantLimit: 1},
+		{name: "zero is refused, not unlimited", query: "?since=0&limit=0", wantRefus: true},
+		{name: "negative is refused", query: "?since=0&limit=-1", wantRefus: true},
+		{name: "above the ceiling is refused", query: "?since=0&limit=10001", wantRefus: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			journal := &roleEventsJournal{}
+			ts := journalServer(t, journal)
+
+			resp := ts.get(t, "/v0/beads/events"+tc.query)
+			if tc.wantRefus {
+				if resp.StatusCode != http.StatusBadRequest {
+					t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
+				}
+				if got := decodeBody(t, resp)["param"]; got != "limit" {
+					t.Errorf("param = %v, want limit", got)
+				}
+				if n := len(journal.reads()); n != 0 {
+					t.Errorf("the journal was read %d times for a refused limit, want 0", n)
+				}
+				return
+			}
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+			}
+			reads := journal.reads()
+			if len(reads) != 1 {
+				t.Fatalf("journal reads = %d, want 1", len(reads))
+			}
+			if reads[0].limit != tc.wantLimit {
+				t.Errorf("limit reaching the seam = %d, want %d", reads[0].limit, tc.wantLimit)
+			}
+		})
+	}
+}
+
+// TestEventsLimitZeroIsNotUnlimitedHere is the one cross-operation trap on this
+// surface: `limit=0` means UNLIMITED on the issue listings and is refused
+// outright here. Reinterpreting it as the default would hand a caller a page a
+// thousand records long when it asked for the whole journal, silently.
+func TestEventsLimitZeroIsNotUnlimitedHere(t *testing.T) {
+	journal := &roleEventsJournal{}
+	ts := journalServer(t, journal)
+
+	resp := ts.get(t, "/v0/beads/events?since=0&limit=0")
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if got, _ := decodeBody(t, resp)["detail"].(string); got == "" {
+		t.Error("no detail naming the accepted range")
+	}
+	if n := len(journal.reads()); n != 0 {
+		t.Errorf("the journal was read %d times, want 0", n)
+	}
+}
+
+// TestEventsAcceptsALargeCheckpoint: `since` is an int64 on the wire and in
+// storage, so a checkpoint above 2^31 must survive the decode on every build.
+// Parsing it as a platform `int` would make this work on a 64-bit server and
+// fail on a 32-bit one.
+func TestEventsAcceptsALargeCheckpoint(t *testing.T) {
+	const big = int64(1) << 40
+	journal := &roleEventsJournal{page: storage.EventsJournalPage{Head: big}}
+	ts := journalServer(t, journal)
+
+	resp := ts.get(t, fmt.Sprintf("/v0/beads/events?since=%d", big))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	reads := journal.reads()
+	if len(reads) != 1 || reads[0].since != big {
+		t.Fatalf("journal reads = %+v, want one read at since=%d", reads, big)
+	}
+}
+
+// TestListenRequiresTheJournalReaderOnlyWhenTheWorkspaceHasOne is the
+// conditional half of the database-source check, and both polarities are the
+// point.
+//
+// A workspace with the journal OFF must bind without a reader: the journal is
+// off by default, and a storage backend with no journal seam at all is an
+// ordinary backend as long as nobody asked it to record anything. Requiring one
+// unconditionally would refuse to start servers that have no use for it.
+//
+// A workspace with the journal ON and no reader must be refused AT STARTUP,
+// because the alternative is the shape checkDatabaseSource exists to prevent:
+// a server that binds, answers every other route, and fails this one with a nil
+// dereference on the first client that finds it.
+func TestListenRequiresTheJournalReaderOnlyWhenTheWorkspaceHasOne(t *testing.T) {
+	t.Run("off, no reader, binds", func(t *testing.T) {
+		cfg := rolesConfig(Config{})
+		cfg.EventsJournal = nil
+		cfg.EventsJournalEnabled = false
+		ts := newTestServer(t, cfg)
+
+		resp := ts.get(t, "/v0/beads/events?since=0")
+		if resp.StatusCode != http.StatusConflict {
+			t.Fatalf("status = %d, want 409: %s", resp.StatusCode, readAll(t, resp))
+		}
+	})
+
+	t.Run("on, no reader, refused at Listen", func(t *testing.T) {
+		cfg := rolesConfig(Config{})
+		cfg.EventsJournal = nil
+		cfg.EventsJournalEnabled = true
+		cfg.Addr = "127.0.0.1:0"
+
+		srv, err := Listen(cfg)
+		if err == nil {
+			_ = srv.http.Close()
+			t.Fatal("Listen bound a journal-enabled server with no EventsJournal reader")
+		}
+	})
+}
+
+// TestEventsStreamsExactlyTheGeneratedEnvelope is what lets the handler write
+// the body itself without that becoming a second wire shape.
+//
+// writeEventsPage streams `records` a record at a time so the page is never
+// buffered whole, which means the member names, their order and the trailing
+// newline are spelled in that function rather than derived from
+// apigen.EventsPage. This encodes the same data THROUGH the generated struct,
+// exactly as writeJSON would have, and requires the two to be byte-identical —
+// so a member renamed in the document, reordered by the generator, or given a
+// different JSON type fails here instead of shipping.
+func TestEventsStreamsExactlyTheGeneratedEnvelope(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		page storage.EventsJournalPage
+	}{
+		{name: "empty", page: storage.EventsJournalPage{Head: 0}},
+		{name: "one record", page: storage.EventsJournalPage{Rows: eventsRows(1, 1), Head: 1}},
+		{name: "several records", page: storage.EventsJournalPage{Rows: eventsRows(7, 4), Head: 40}},
+		{
+			// The three payload members at once, including the delete's null
+			// issue and the absent dep/comment — the places the two encoders
+			// could most plausibly disagree.
+			name: "every payload shape",
+			page: storage.EventsJournalPage{
+				Rows: []storage.EventsJournalRow{
+					{Seq: 1, TS: "2026-01-02T03:04:05Z", Op: "delete", IssueID: "bd-1"},
+					{Seq: 2, TS: "2026-01-02T03:04:06Z", Op: "dep_add", IssueID: "bd-2",
+						IssueJSON: `{"id":"bd-2","title":"a < b & c > d"}`,
+						DepJSON:   `{"kind":"blocks","target":"bd-1","metadata":""}`},
+					{Seq: 3, TS: "2026-01-02T03:04:07Z", Op: "comment", IssueID: "bd-2",
+						IssueJSON:   `{"id":"bd-2"}`,
+						CommentJSON: `{"id":"cmt-1","author":"worker","text":"note"}`},
+				},
+				Head: 3,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			streamed := httptest.NewRecorder()
+			writeEventsPage(streamed, tc.page)
+
+			generated := httptest.NewRecorder()
+			writeJSON(generated, apigen.EventsPage{
+				Records: eventsjournal.Records(tc.page.Rows),
+				Head:    tc.page.Head,
+			})
+
+			if streamed.Body.String() != generated.Body.String() {
+				t.Errorf("streamed body has drifted from the generated envelope\n streamed: %s\ngenerated: %s",
+					streamed.Body.String(), generated.Body.String())
+			}
+			if got, want := streamed.Header().Get("Content-Type"), generated.Header().Get("Content-Type"); got != want {
+				t.Errorf("Content-Type = %q, want %q", got, want)
+			}
+			if streamed.Code != generated.Code {
+				t.Errorf("status = %d, want %d", streamed.Code, generated.Code)
+			}
+		})
+	}
+}
+
+// TestEventsLimitBoundsMatchTheDocument. The default and the ceiling are stated
+// twice — as Go constants the handler applies, and as `default`/`minimum`/
+// `maximum` in the parameter the document publishes — and nothing else compares
+// them. A client reads the document and sizes its pages from it; a server that
+// had quietly moved either number would refuse requests the document promised
+// to accept, which is version skew a client cannot detect.
+func TestEventsLimitBoundsMatchTheDocument(t *testing.T) {
+	doc := loadSpec(t)
+	events := mapAt(t, mapAt(t, mapAt(t, doc, "paths"), "/v0/beads/events"), "get")
+
+	params, _ := events["parameters"].([]any)
+	var limit map[string]any
+	for _, raw := range params {
+		p, ok := raw.(map[string]any)
+		if ok && p["name"] == "limit" {
+			limit = mapAt(t, p, "schema")
+			break
+		}
+	}
+	if limit == nil {
+		t.Fatal("the document publishes no `limit` parameter for listEvents")
+	}
+
+	for _, tc := range []struct {
+		key  string
+		want int
+	}{
+		{key: "default", want: defaultEventsLimit},
+		{key: "minimum", want: 1},
+		{key: "maximum", want: maxEventsLimit},
+	} {
+		got, ok := limit[tc.key].(int)
+		if !ok {
+			t.Errorf("limit schema has no integer %q (got %v)", tc.key, limit[tc.key])
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("document says limit %s = %d, the handler applies %d", tc.key, got, tc.want)
+		}
+	}
+}
+
+// TestEventsIsReadOnly: the surface publishes GET and nothing else. A method
+// this document does not describe gets the 404 every other unrouted request
+// gets — 405 is not in the v0 vocabulary — and the point is that no prune,
+// acknowledge or truncate verb exists here at all.
+func TestEventsIsReadOnly(t *testing.T) {
+	journal := &roleEventsJournal{}
+	ts := journalServer(t, journal)
+
+	for _, method := range []string{http.MethodPost, http.MethodDelete, http.MethodPatch, http.MethodPut} {
+		t.Run(method, func(t *testing.T) {
+			req, err := http.NewRequest(method, ts.base+"/v0/beads/events?since=0", nil)
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			resp, err := ts.client.Do(req)
+			if err != nil {
+				t.Fatalf("%s: %v", method, err)
+			}
+			t.Cleanup(func() { _ = resp.Body.Close() })
+			if resp.StatusCode != http.StatusNotFound {
+				t.Errorf("status = %d, want 404: %s", resp.StatusCode, readAll(t, resp))
+			}
+		})
+	}
+	if n := len(journal.reads()); n != 0 {
+		t.Errorf("the journal was reached %d times by a non-GET method, want 0", n)
+	}
+}

--- a/internal/httpapi/pinning.go
+++ b/internal/httpapi/pinning.go
@@ -1,6 +1,7 @@
 package httpapi
 
 import (
+	"github.com/steveyegge/beads/internal/eventsjournal"
 	"github.com/steveyegge/beads/internal/httpapi/apigen"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/issueops"
@@ -43,6 +44,14 @@ var (
 	// `bd list` renders its decoration from.
 	_ apigen.IssueBlocking = issueops.IssueBlocking{}
 
+	// The journal record is pinned to neither internal/types nor a role package
+	// but to the journal's own leaf: eventsjournal.Record is what
+	// `bd events tail` prints one of per line, and the committed golden fixture
+	// is a byte-level pin on that encoding. This assignment is what stops a
+	// regenerated mirror from quietly giving GET /v0/beads/events a record shape
+	// the golden never sees.
+	_ apigen.EventRecord = eventsjournal.Record{}
+
 	// The envelopes carry the canonical types too — pinning the schema is not
 	// enough if a page's items resolve to something else.
 	_ []types.IssueWithCounts = apigen.ReadyPage{}.Items
@@ -62,6 +71,8 @@ var (
 	_ []types.Dependency       = apigen.DependencyEdges{}.Items
 	_ []issueops.IssueBlocking = apigen.BlockingAnnotations{}.Items
 	_ []types.Issue            = apigen.BatchCreateResponse{}.Items
+
+	_ []eventsjournal.Record = apigen.EventsPage{}.Records
 )
 
 // SettingsPage.Items and BatchCreateRequest.Items are deliberately absent:

--- a/internal/httpapi/problem.go
+++ b/internal/httpapi/problem.go
@@ -82,6 +82,35 @@ const (
 	// CodeDependencyExists is the pair that already carries an edge of a
 	// DIFFERENT type, with both types in `existing_type`/`requested_type`.
 	CodeDependencyExists Code = "dependency_exists"
+	// CodeEventsJournalDisabled is the events journal being OFF on the served
+	// workspace. It exists because the alternative answer is a lie: a disabled
+	// journal reads as zero rows and a head of zero, which is byte-identical to
+	// an enabled journal nothing has written to yet — so a consumer would poll a
+	// workspace that will never produce a record and call it "caught up"
+	// forever. This is the one refusal on this surface that a client cannot
+	// discover any other way.
+	//
+	// A 409 for the reason CodeNotClosable gives: it is a statement about the
+	// current state of the workspace, which the same request stops earning the
+	// moment an operator sets `events-journal true` and restarts the server.
+	// Not a 404 — the operation and the resource both exist — and not a 501,
+	// which this surface reserves for an operation this BUILD does not
+	// implement, whereas every build implements this one.
+	CodeEventsJournalDisabled Code = "events_journal_disabled"
+	// CodeEventsJournalTruncated is a journal read whose checkpoint has fallen
+	// below the retained window. The value is storage's own constant, so the
+	// code a `bd events tail --json` failure carries and the code this surface
+	// emits cannot drift to two spellings of one condition.
+	//
+	// A 410 Gone, and the only one in the vocabulary: the records the caller
+	// asked for existed, were addressable by exactly this request, and have been
+	// deliberately deleted. That is what 410 means and what 404 does not — a 404
+	// would say the resource never existed and invite a retry, and the whole
+	// point of this refusal is that retrying the same `since` can never succeed.
+	// The `since`, `floor` and `head` members carry the window the server can
+	// still serve, so the recovery (resume from `floor - 1` and accept the gap,
+	// or re-baseline) is a decision the client makes from data rather than prose.
+	CodeEventsJournalTruncated Code = Code(storage.EventsJournalTruncatedCode)
 	// CodeBusy is retryable contention: the transaction retry budget was
 	// exhausted, or the in-flight request limit was saturated.
 	CodeBusy Code = "busy"
@@ -109,9 +138,13 @@ var codeStatus = map[Code]int{
 	CodeNotClosable:      http.StatusConflict,
 	CodeDependencyCycle:  http.StatusConflict,
 	CodeDependencyExists: http.StatusConflict,
-	CodeBusy:             http.StatusServiceUnavailable,
-	CodeDBUnavailable:    http.StatusServiceUnavailable,
-	CodeInternal:         http.StatusInternalServerError,
+
+	CodeEventsJournalDisabled:  http.StatusConflict,
+	CodeEventsJournalTruncated: http.StatusGone,
+
+	CodeBusy:          http.StatusServiceUnavailable,
+	CodeDBUnavailable: http.StatusServiceUnavailable,
+	CodeInternal:      http.StatusInternalServerError,
 }
 
 // Status returns the HTTP status frozen to c, or 0 if c is not in the v0
@@ -251,6 +284,17 @@ const (
 	// It is the operation that makes stored memories DISCOVERABLE rather than
 	// merely readable by a caller who already knows a key.
 	OpListMemories = "listMemories"
+	// OpListEvents pages the durable mutation journal from a caller-held
+	// checkpoint. It is the first operation on this surface whose paging is not
+	// a cursor this server minted: `since` is a sequence number the journal
+	// itself assigned, so a consumer's position survives a restart on either
+	// side and is meaningful to `bd events tail` as well.
+	//
+	// It is a READ of a log, not a subscription: v0 has no streaming, no
+	// long-poll and no follow. The retention contract is what makes that safe to
+	// publish — a consumer that falls too far behind is told so with
+	// `events_journal_truncated` rather than served a silently shortened history.
+	OpListEvents = "listEvents"
 )
 
 // operationCodes is the per-operation problem vocabulary: exactly the codes
@@ -394,6 +438,21 @@ var operationCodes = map[string][]Code{
 	// one of its values. No 404 — a search matching nothing is an empty page,
 	// because a question about a set has an answer even when the set is empty.
 	OpListMemories: {CodeInvalidArgument, CodeBusy, CodeDBUnavailable, CodeInternal},
+	// The two journal codes are this operation's alone and neither has a
+	// precedent elsewhere on this surface, because no other operation reads a
+	// LOG. The 400 is its own too: `since` is required, and a negative or
+	// unparseable checkpoint is refused rather than treated as zero — `seq > -5`
+	// would quietly serve the whole journal as if it were a legitimate resume,
+	// which is the same refusal `bd events tail --since` makes.
+	//
+	// No 404. A checkpoint at or past the head is a caught-up 200 with an empty
+	// list, because "nothing new yet" is an answer about a log rather than a
+	// missing resource, and a poller that got a 404 for being up to date would
+	// have to treat the surface's miss vocabulary as a normal steady state.
+	OpListEvents: {
+		CodeInvalidArgument, CodeEventsJournalDisabled, CodeEventsJournalTruncated,
+		CodeBusy, CodeDBUnavailable, CodeInternal,
+	},
 	// NO 404, for a stronger version of the batch create's reason: an edge that
 	// is not there is `removed: false`, and an endpoint id that names nothing
 	// holds no edge either, so this operation probes no id's existence and has
@@ -485,6 +544,28 @@ func (r Result) WithHierarchyConflict(issueID, blockerID string, blockerIsAncest
 	return r
 }
 
+// WithJournalWindow attaches the three `events_journal_truncated` extension
+// members: the checkpoint the reported window begins after, the lowest seq
+// still retained, and the highest seq ever assigned.
+//
+// They come from *storage.EventsJournalTruncatedError's own fields — computed
+// inside the transaction that saw the gap — for the reason every other typed
+// member on this envelope does, and one more: `since` is NOT always the value
+// the caller sent. On an interior hole it is the last seq the server could
+// serve contiguously from the caller's checkpoint, which is strictly the more
+// useful number and cannot be recovered by a client that assumed it was
+// echoing its own input back.
+//
+// All three are emitted together and none is omitted to mean zero: a head of 0
+// is a real journal state (nothing has ever been written), and a client
+// computing `floor - 1` needs the value rather than an absence to interpret.
+func (r Result) WithJournalWindow(since, floor, head int64) Result {
+	r.Problem.Since = &since
+	r.Problem.Floor = &floor
+	r.Problem.Head = &head
+	return r
+}
+
 // WithRequestID sets the `request_id` member, the correlation id echoed in the
 // request log line. It is what makes a 5xx actionable: the body carries a fixed
 // static detail by design, so the id is the client's only handle on the one log
@@ -550,6 +631,28 @@ func NotFound() Result {
 	return newResult(CodeNotFound, "no issue or wisp with that id")
 }
 
+// EventsJournalDisabled builds the 409 for a workspace whose journal is off.
+//
+// The detail names the setting rather than describing the state, because the
+// recovery is entirely on the SERVER side — a client can do nothing about it —
+// and the human reading this response is the operator who has to go turn it on.
+func EventsJournalDisabled() Result {
+	return newResult(CodeEventsJournalDisabled,
+		"the durable events journal is not enabled on this workspace; set `events-journal true` and restart the server")
+}
+
+// EventsJournalTruncated builds the 410 for a checkpoint below the retained
+// window, carrying the window the server can still serve.
+//
+// The detail is the storage error's OWN sentence, which is the one `bd events
+// tail` prints. A consumer that reads both surfaces sees one description of one
+// condition, and this is a 4xx, so reflecting the server's own state here is
+// within what staticDetail allows.
+func EventsJournalTruncated(err *storage.EventsJournalTruncatedError) Result {
+	return newResult(CodeEventsJournalTruncated, err.Error()).
+		WithJournalWindow(err.Since, err.Floor, err.Head)
+}
+
 // MemoryNotFound builds the 404 for a key this workspace holds no memory under.
 //
 // A separate constructor rather than a detail argument on NotFound, because the
@@ -566,9 +669,20 @@ func MemoryNotFound() Result {
 // is responsible for logging err: everything mapped to a 5xx deliberately
 // drops the error text on the floor (see staticDetail).
 func ClassifyError(err error) Result {
+	// The one row that carries data out of the error rather than only a code.
+	// It lives HERE, in the shared mapping, rather than in the events handler:
+	// the journal read is reached from two database sources through two
+	// different plumbings, and a mapping a handler applied itself would be one
+	// `if` away from a pruned-past checkpoint arriving as a generic 500 on
+	// whichever arm forgot it.
+	var truncated *storage.EventsJournalTruncatedError
+
 	switch {
 	case err == nil:
 		return newResult(CodeInternal, "")
+
+	case errors.As(err, &truncated):
+		return EventsJournalTruncated(truncated)
 
 	// Not-found normalization belongs in the shared read path, which folds the
 	// two miss shapes (a wrapped sql.ErrNoRows, and a nil issue with a nil

--- a/internal/httpapi/query.go
+++ b/internal/httpapi/query.go
@@ -114,6 +114,26 @@ func (q *query) integer(name string) *int {
 	return &v
 }
 
+// integer64 reads an optional 64-bit integer, returning nil when absent.
+//
+// It is separate from integer above because `int` is 32 bits on a 32-bit build,
+// and the one parameter that needs this — a journal sequence number — is
+// declared int64 in the document and int64 in storage. Parsing it through Atoi
+// would make a checkpoint past 2^31 unreadable on some builds and readable on
+// others, which is the kind of divergence a consumer discovers years later.
+func (q *query) integer64(name string) *int64 {
+	raw := q.str(name)
+	if raw == "" {
+		return nil
+	}
+	v, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		q.invalid(name, fmt.Sprintf("%q is not a 64-bit integer", raw))
+		return nil
+	}
+	return &v
+}
+
 // limit reads the page limit: absent stays nil (the shared default), and a
 // negative value is refused. 0 is legal and means unlimited, so it is not
 // bounded here — the loopback-only refusal of an unlimited read is a bind-mode
@@ -125,6 +145,31 @@ func (q *query) limit() *int {
 		return nil
 	}
 	return v
+}
+
+// boundedLimit reads a page limit that has a hard ceiling and no unlimited
+// spelling, substituting fallback when it is absent.
+//
+// It is a SECOND limit decoder rather than a mode of limit() above, because the
+// two operations mean different things by the same parameter name and a shared
+// one would have to hide that behind a flag. On the issue listings `0` means
+// unlimited and the only refusal is a bind-mode one; on a journal read there is
+// no unlimited — a caller with an old checkpoint would ask one process to
+// buffer the entire retained window, which under the shipped floors is a
+// hundred thousand records — so the ceiling is unconditional and `0` is refused
+// by name instead of being reinterpreted as "the default". A parameter that
+// means unlimited on one operation and something else on another is exactly the
+// silent divergence this decoder exists to prevent.
+func (q *query) boundedLimit(fallback, ceiling int) int {
+	v := q.integer("limit")
+	if v == nil {
+		return fallback
+	}
+	if *v < 1 || *v > ceiling {
+		q.invalid("limit", fmt.Sprintf("limit must be between 1 and %d (default %d); this operation has no unlimited read", ceiling, fallback))
+		return fallback
+	}
+	return *v
 }
 
 // timestamp reads an optional RFC 3339 instant.

--- a/internal/httpapi/roles_test.go
+++ b/internal/httpapi/roles_test.go
@@ -366,6 +366,41 @@ func (m *roleMemories) List(_ context.Context, req memoryops.ListRequest) (memor
 	return m.listed, nil
 }
 
+// roleEventsJournal is the journal read of the store-shaped source, the same
+// shape as its siblings so a case can hand Listen a complete source without
+// deciding what its journal answer should be.
+type roleEventsJournal struct {
+	page storage.EventsJournalPage
+	err  error
+
+	mu    sync.Mutex
+	calls []journalRead
+}
+
+// journalRead is one recorded (since, limit) pair. The pair is what the
+// handler's defaults and bounds are asserted on, so it is recorded rather than
+// only the count.
+type journalRead struct {
+	since int64
+	limit int
+}
+
+func (j *roleEventsJournal) ReadEventsJournalPage(_ context.Context, since int64, limit int) (storage.EventsJournalPage, error) {
+	j.mu.Lock()
+	j.calls = append(j.calls, journalRead{since: since, limit: limit})
+	j.mu.Unlock()
+	if j.err != nil {
+		return storage.EventsJournalPage{}, j.err
+	}
+	return j.page, nil
+}
+
+func (j *roleEventsJournal) reads() []journalRead {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return append([]journalRead(nil), j.calls...)
+}
+
 func (m *roleMemories) rememberRequests() []memoryops.RememberRequest {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -627,6 +662,9 @@ func rolesConfig(cfg Config) Config {
 	}
 	if cfg.Memories == nil {
 		cfg.Memories = &roleMemories{}
+	}
+	if cfg.EventsJournal == nil {
+		cfg.EventsJournal = &roleEventsJournal{}
 	}
 	return cfg
 }

--- a/internal/httpapi/routes.go
+++ b/internal/httpapi/routes.go
@@ -421,6 +421,19 @@ var routeTable = []route{
 		handler:     (*Server).handleGetMemory,
 	},
 	{
+		op:     OpListEvents,
+		method: http.MethodGet,
+		// A plain collection read, not a custom method and not a sub-resource of
+		// issues: the journal is its own collection whose members happen to
+		// describe issue mutations. `since` and `limit` are ordinary query
+		// parameters, exactly as they are on /v0/beads/issues, so pattern and
+		// specPath agree and no declaration is needed.
+		pattern:     "/v0/beads/events",
+		capability:  "events.list",
+		implemented: true,
+		handler:     (*Server).handleListEvents,
+	},
+	{
 		op:     OpForgetMemory,
 		method: http.MethodDelete,
 		// The surface's first DELETE. It shares a pattern with the read above

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -206,6 +206,38 @@ type Config struct {
 	// a partial set is refused, so the field and the operations that reach it
 	// land together.
 	Memories memoryops.Memories
+	// EventsJournal is the durable mutation journal's READ side, and the ONE
+	// role here that is required CONDITIONALLY — which is why it is absent from
+	// sourceRoles and checked on its own. Like Memories it is not an issueops
+	// role: the journal is engine state on a dolt_ignored table, not a bead
+	// query, so its seam lives in internal/storage beside the rows it yields.
+	//
+	// Required exactly when EventsJournalEnabled. A workspace that records
+	// nothing needs no reader, and a storage backend that cannot read the
+	// journal at all is a perfectly ordinary backend as long as nobody asked it
+	// to journal — the same deal eventsjournal.Apply takes when it binds
+	// activation to a store. Demanding it unconditionally would make a
+	// capability nothing uses a precondition for running the server.
+	//
+	// It is a storage.EventsJournalCursor and deliberately NOT the wider
+	// storage.EventsJournalAccessor the CLI takes. That interface also prunes,
+	// and a server that is documented to publish the journal and never retain
+	// it should not be holding a delete it merely promises not to call.
+	EventsJournal storage.EventsJournalCursor
+	// EventsJournalEnabled is whether the served workspace actually records
+	// mutations, resolved by the caller through eventsjournal.EnabledFor.
+	//
+	// It is a resolved BOOLEAN rather than something this package works out,
+	// for the reason Config gives at the top: activation reads the target
+	// workspace's own config.yaml and the BD_EVENTS_JOURNAL environment
+	// override, which is workspace state, and this package resolves none.
+	//
+	// It cannot be inferred from the data either, which is the whole reason the
+	// field exists. A disabled journal presents as zero rows and a head of
+	// zero — byte-identical to an enabled journal nothing has written yet — so
+	// a server without this flag would answer "you are caught up" to a consumer
+	// polling a workspace that will never emit a record.
+	EventsJournalEnabled bool
 	// Workspace is the startup snapshot GET /v0/beads/context answers from.
 	// Only the allowlisted fields are ever serialized — see contextResponse,
 	// which names the whole set and the reasons for the exclusions.
@@ -249,6 +281,7 @@ type Server struct {
 	issueBatchCreator issueops.BatchCreator
 	issueDependencies issueops.DependencyEditor
 	workspaceMemories memoryops.Memories
+	eventsJournal     storage.EventsJournalCursor
 
 	listener net.Listener
 	http     *http.Server
@@ -361,6 +394,7 @@ func Listen(cfg Config) (*Server, error) {
 		issueBatchCreator: cfg.BatchCreator,
 		issueDependencies: cfg.DependencyEditor,
 		workspaceMemories: cfg.Memories,
+		eventsJournal:     cfg.EventsJournal,
 
 		sem:        make(chan struct{}, maxInflight),
 		semTimeout: semAcquireTimeout,
@@ -449,6 +483,12 @@ func Listen(cfg Config) (*Server, error) {
 // A role is compared against nil as an INTERFACE, which is what the caller
 // actually sets; a typed nil stored in one of these fields is a value as far as
 // this check is concerned.
+//
+// It carries only the roles every deployment must have. EventsJournal is
+// deliberately NOT here: it is required only when the workspace's journal is
+// enabled, and folding a conditional field into a set whose whole value is
+// "all or nothing" would turn an honest condition into a special case inside
+// three functions. It is checked once, on its own, below.
 func sourceRoles(cfg Config) []any {
 	return []any{cfg.Reader, cfg.Claimer, cfg.Lifecycle, cfg.Settings, cfg.Stats, cfg.CycleDetector, cfg.EdgeReader, cfg.BlockingAnnotator, cfg.TreeWalker, cfg.ReadyCounter, cfg.Querier, cfg.Sweeper, cfg.Deleter, cfg.BatchCreator, cfg.DependencyEditor, cfg.Memories}
 }
@@ -471,10 +511,19 @@ func anyRoleFiresHooks(cfg Config) bool {
 
 func checkDatabaseSource(cfg Config) error {
 	switch {
-	case cfg.Provider != nil && anyRoleSet(cfg):
+	case cfg.Provider != nil && (anyRoleSet(cfg) || cfg.EventsJournal != nil):
 		return errors.New("httpapi: both a unit-of-work provider and issue roles were set; pass exactly one database source")
 	case cfg.Provider == nil && !everyRoleSet(cfg):
 		return errors.New("httpapi: no database source: set Provider, or " + roleSourceNames + " together")
+	// The conditional role, checked where every other configuration mistake is.
+	// A workspace that HAS a journal and a server that cannot read it is the
+	// one combination that would bind, answer every other route, and fail this
+	// one — with a nil dereference, which is the shape checkDatabaseSource
+	// exists to prevent. A workspace with the journal off needs no reader and
+	// this says nothing about it.
+	case cfg.Provider == nil && cfg.EventsJournalEnabled && cfg.EventsJournal == nil:
+		return errors.New("httpapi: this workspace's events journal is enabled but no EventsJournal reader was configured; " +
+			"take one off the store (storage.EventsJournalCursor), or serve a workspace with the journal off")
 	case anyRoleFiresHooks(cfg):
 		return errors.New("httpapi: a configured role fires this workspace's hooks; " +
 			"this server does not run hooks, so take the roles from the store beneath the hook decorator " +
@@ -828,6 +877,34 @@ func (s *Server) memories(r *http.Request) (memoryops.Memories, error) {
 	}
 	var src uow.MemoriesSource = timedProvider{inner: s.provider, rec: requestInfo(r.Context())}
 	return src.Memories()
+}
+
+// eventsJournalCursor returns the journal read surface for one request, on the
+// same terms as every role above and held by INTERFACE so
+// uow.EventsJournalCursorSource is load-bearing rather than decorative.
+//
+// It goes out UNWRAPPED: a page is a value carrying a slice, so there is
+// nothing for a checked wrapper to make safe — the querier's argument.
+//
+// The narrow type is the point of this accessor rather than an accident of it.
+// The provider can also hand out uw.EventsJournalUseCase(), which PRUNES; going
+// through a source that only publishes storage.EventsJournalCursor is what
+// keeps the read-only promise a fact about what the handler is holding.
+func (s *Server) eventsJournalCursor(r *http.Request) (storage.EventsJournalCursor, error) {
+	if s.provider == nil {
+		if s.eventsJournal == nil {
+			// Unreachable through the handler, which refuses a disabled
+			// workspace before asking for a reader, and Listen refuses an
+			// enabled one with no reader. Said out loud rather than returned as
+			// a nil interface for the reason WithUOW says its own: a 500 naming
+			// the condition beats a panic on a live server if either of those
+			// two gates is ever moved.
+			return nil, errors.New("httpapi: this server has no events-journal reader; it was configured for a workspace with the journal off")
+		}
+		return s.eventsJournal, nil
+	}
+	var src uow.EventsJournalCursorSource = timedProvider{inner: s.provider, rec: requestInfo(r.Context())}
+	return src.EventsJournalCursor()
 }
 
 // WithUOW runs fn inside one unit of work and guarantees the rollback.

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -588,7 +588,7 @@ func TestCapabilitiesAdvertiseEveryImplementedOperation(t *testing.T) {
 	want := []string{
 		"config.get", "config.list", "dependencies.add", "dependencies.blocking",
 		"dependencies.cycles", "dependencies.list", "dependencies.remove",
-		"dependencies.tree", "issues.batchCreate",
+		"dependencies.tree", "events.list", "issues.batchCreate",
 		"issues.claim", "issues.close", "issues.delete", "issues.get", "issues.list",
 		"issues.query", "issues.reopen", "issues.sweep", "issues.update",
 		"memories.forget", "memories.get",

--- a/internal/httpapi/spec/openapi.v0.yaml
+++ b/internal/httpapi/spec/openapi.v0.yaml
@@ -119,13 +119,14 @@ info:
 
     `Issue`, `IssueWithCounts`, `IssueDetails`,
     `IssueWithDependencyMetadata`, `TreeNode`, `Dependency`, `Comment`,
-    `BondRef`, `Statistics`, `Cycle`, `CycleMember` and `IssueBlocking` are
+    `BondRef`, `Statistics`, `Cycle`, `CycleMember`, `IssueBlocking` and
+    `EventRecord` are
     pinned to the canonical Go structs (`x-go-type`), so the CLI's `--json`
     output and these response bodies are one compatibility domain and cannot
     drift apart. Changes to them are limited to NEW optional fields, and each
     addition must land with its entry in this document in the same change — a
-    two-way JSON-tag bijection test, covering all twelve, fails CI otherwise. A
-    breaking change to those shapes requires cutting `/v1`, not editing `/v0`.
+    two-way JSON-tag bijection test, covering all thirteen, fails CI otherwise.
+    A breaking change to those shapes requires cutting `/v1`, not editing `/v0`.
 
 
     A member that is absent is not set. When reading a RESPONSE, clients MUST
@@ -2672,6 +2673,243 @@ paths:
         '503':
           $ref: '#/components/responses/Unavailable'
 
+  /v0/beads/events:
+    get:
+      operationId: listEvents
+      summary: Read the durable events journal
+      description: >-
+        The workspace's append-only record of every committed issue mutation,
+        paged from a caller-held checkpoint. It is the HTTP form of
+        `bd events tail --since`, and it exists so a hosted consumer can mirror
+        or replay a workspace without shelling out to the CLI.
+
+
+        THE RECORDS ARE THE CLI'S RECORDS, byte for byte. `records[]` elements
+        are the same `EventRecord` objects `bd events tail` and
+        `bd events export` print one per line, produced by the same projection
+        and covered by the same committed golden fixture. A consumer may
+        reconcile an HTTP mirror against a CLI export without a translation
+        layer.
+
+
+        `since` IS THE CURSOR, and it is not one this server minted. It is a
+        sequence number the journal itself assigned, gapless and strictly
+        increasing in commit order, so a consumer's position is durable across
+        restarts on both sides and means the same thing to the CLI. Read with
+        `since` set to the highest `seq` you have DURABLY PROCESSED — not the
+        highest you have received — and advance it only after your own write
+        lands, because this server keeps no per-consumer state and cannot
+        redeliver.
+
+
+        POLL; THERE IS NO STREAMING, no long poll and no `follow` in v0. `head`
+        is what makes polling cheap to pace: when the last record's `seq`
+        equals `head` you are caught up and can back off until your next
+        interval. A caught-up read is a 200 with an EMPTY `records` array, never
+        a 404 — "nothing new yet" is an ordinary answer about a log.
+
+
+        SCOPE IS PER REPLICA AND PER BRANCH, and this is the part that most
+        often surprises. The journal records what THIS clone mutated on the
+        branch its writer commits to. Rows arrive by direct write, never by
+        merge, so `bd dolt pull` and the changes a merge settles into this
+        workspace are NOT journaled — they arrived as data, and nothing here
+        wrote them through the mutation seam. Each replica also has its OWN seq
+        space, counted from its own first mutation: a checkpoint taken against
+        one server is meaningless against another, where the same number names a
+        different record and a number above that replica's head reads as
+        "caught up" and stalls forever. Track a checkpoint per server URL, and
+        re-baseline (a fresh export or full re-read) after a sync rather than
+        carrying one across.
+
+
+        NOT EVERY MUTATION IS COVERED. Raw DML through `bd sql` bypasses the
+        mutation seam and is not journaled; nor are the schema migrations and
+        version reconciliation that run while a store is being opened, which
+        touch no bead. Dependency records are not symmetric either: `dep_add` is
+        emitted for an idempotent same-type re-add that only refreshes edge
+        metadata, so treat it as an upsert of the edge rather than proof the
+        edge is new, and a `dep_remove` naming an edge that is already gone
+        emits nothing at all.
+
+
+        THIS OPERATION NEVER DELETES. Retention is the workspace's decision,
+        made by `bd events prune` and by the automatic bounding that keeps an
+        enabled journal inside its floors; no prune is reachable over HTTP, and
+        reading a record does not acknowledge or release it.
+
+
+        IT ALSO DEPENDS ON WORKSPACE STATE, alone among the operations here.
+        `events.list` in `ContextResponse.capabilities` says this BUILD serves
+        the operation; it does not say this workspace has a journal, because the
+        journal is a per-workspace setting that is off by default. A server that
+        advertises the capability and answers 409 `events_journal_disabled` to
+        every request is behaving correctly. Handle that 409 as "not on this
+        workspace" rather than as a fault, and do not read the capability as a
+        promise that records will arrive.
+
+
+        A workspace that HAS enabled the journal on a storage backend with no
+        journal seam does not reach this operation at all: `bd serve` refuses to
+        start, matching the refusal that opening such a workspace already
+        produces. Either the server is running and this operation can answer, or
+        the operator saw the failure at startup.
+      parameters:
+        - name: since
+          in: query
+          required: true
+          description: >-
+            Return records with `seq` strictly greater than this value. Pass `0`
+            to read from the beginning of the retained journal.
+
+
+            REQUIRED, and deliberately not defaulted to zero. A consumer that
+            omitted its checkpoint by mistake would be served the whole retained
+            window, which reads as a flood of duplicate records rather than as
+            an error. A negative value is a 400 `invalid_argument` for the same
+            reason `bd events tail --since` refuses one: it is almost always
+            arithmetic on an empty cursor, and `seq > -5` would quietly serve
+            everything as though it were a legitimate resume.
+
+
+            A value at or above `head` is not an error — it is the caught-up
+            case, a 200 with an empty `records` array.
+          schema:
+            type: integer
+            format: int64
+            minimum: 0
+        - name: limit
+          in: query
+          description: >-
+            Maximum number of records to return, from 1 to 10000. A value
+            outside that range — `0` included — is a 400 `invalid_argument`.
+
+
+            THERE IS NO UNLIMITED READ HERE, and `0` does NOT mean unlimited as
+            it does on `GET /v0/beads/issues`. A caller resuming from an old
+            checkpoint would otherwise ask one process to buffer the entire
+            retained window — a hundred thousand records under the shipped
+            `events-journal-retain-rows` floor — and encode it into a single
+            response. The ceiling is unconditional and does not depend on the
+            bind mode.
+
+
+            The default of 1000 is deliberately much larger than the issue
+            listings' 50: a journal consumer is a machine draining a backlog in
+            order rather than a person reading a page, and the number that
+            matters to it is round trips to catch up.
+
+
+            A FULL PAGE DOES NOT MEAN THERE IS MORE, and a short one does not
+            mean there is not. Compare the last record's `seq` against `head`;
+            that is the only correct test, and it is why this envelope carries
+            no `has_more`.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 10000
+            default: 1000
+      responses:
+        '200':
+          description: >-
+            A page of journal records in ascending `seq` order, with the
+            journal head.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EventsPage'
+        '400':
+          description: >-
+            Invalid request: `since` absent, negative or unparseable, a `limit`
+            outside 1..10000, or an unknown query parameter.
+          x-bd-codes: [invalid_argument]
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '409':
+          description: >-
+            The durable events journal is NOT ENABLED on this workspace, so it
+            records nothing and never will until an operator turns it on
+            (`events-journal true`, or `BD_EVENTS_JOURNAL=1` in the server's
+            environment) and restarts the server.
+
+
+            This refusal exists because the honest alternative does not: a
+            disabled journal presents as zero rows and a head of zero, which is
+            byte-identical to an enabled journal nothing has written to yet. A
+            consumer given that answer would poll a workspace that will never
+            produce a record and report itself caught up indefinitely. An EMPTY
+            journal is the 200 — `records: []` with `head: 0` — and the two are
+            distinguishable only here.
+
+
+            A 409 rather than a 404 because the operation and the resource both
+            exist: this is a statement about the workspace's current
+            configuration, which the same request stops earning the moment it
+            changes. It is a server-side fix, never a retry and never a
+            client-side one.
+          x-bd-codes: [events_journal_disabled]
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '410':
+          description: >-
+            The checkpoint in `since` has fallen BELOW the retained window: the
+            records that came next were pruned, and this server cannot serve
+            them. Retrying the same `since` can never succeed.
+
+
+            The read FAILS rather than returning an empty success or silently
+            skipping ahead, and that is the whole point of the code. `WHERE seq
+            > since` cannot itself distinguish "nothing new" from "your prefix
+            is gone", so a consumer resuming past a prune would either stall
+            forever or jump to the current floor and lose every record in
+            between — both silent data loss.
+
+
+            The response carries `since`, `floor` and `head`: `floor` is the
+            lowest seq still retained, `head` the highest ever assigned. The
+            recovery is a decision the CONSUMER makes and this server will not
+            make for it — resume from `floor - 1` and accept a known gap, or
+            rebuild from a full export.
+
+
+            `since` IN THE RESPONSE IS NOT ALWAYS THE VALUE YOU SENT, and the
+            case where it differs has a third recovery. On an interior hole in
+            the retained window — a restored, hand-edited or half-copied journal
+            table; nothing bd does produces one — the response `since` is the
+            last seq that could be served CONTIGUOUSLY from your checkpoint, and
+            everything between your checkpoint and it is intact and servable.
+            This refusal does not hand it over, because a read that returned rows
+            and a gap would be the silent loss the code exists to prevent. Drain
+            it explicitly first: re-request with the SAME `since` you sent and
+            `limit` set to `response.since - request.since`, which stops the page
+            exactly at the hole and succeeds. Then resume from `floor - 1` and
+            take the gap, or re-baseline. A consumer that skips straight to
+            `floor - 1` loses records it could have had.
+
+
+            `since` is never BELOW what you sent in any of these cases, so
+            echoing it back can never re-deliver records you already have.
+
+
+            Sizing the floors — `events-journal-retain-days` and
+            `events-journal-retain-rows` — is how an operator decides the
+            longest consumer outage the workspace can survive. They are time and
+            count based and are NOT a consumer watermark: nothing here knows how
+            far any consumer has got.
+          x-bd-codes: [events_journal_truncated]
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '500':
+          $ref: '#/components/responses/InternalError'
+        '503':
+          $ref: '#/components/responses/Unavailable'
+
 components:
 
   parameters:
@@ -3712,10 +3950,22 @@ components:
             `dependencies.list`, `dependencies.blocking`, `dependencies.tree`,
             `dependencies.add`, `dependencies.remove`,
             `memories.list`, `memories.get`, `memories.remember`,
-            `memories.forget`;
+            `memories.forget`, `events.list`;
             it grows additively, and an operation never
             appears here unless it is fully implemented. This is how a client
             checks for an operation — never the version string.
+
+
+            THIS LIST IS BUILD-LEVEL, NOT WORKSPACE-LEVEL. It says which
+            operations this binary serves, and for every entry but one that is
+            the whole answer. `events.list` is the exception: the durable events
+            journal is a per-workspace setting that is OFF by default, so a
+            server that advertises `events.list` may still refuse every request
+            to it with 409 `events_journal_disabled` — correctly, because the
+            operation exists and the workspace has no journal. A consumer of that
+            operation MUST treat the capability as "this server speaks it" and
+            the 409 as "not on this workspace", and must not read the capability
+            as a promise that records will arrive.
           items:
             type: string
 
@@ -4133,6 +4383,130 @@ components:
           description: >-
             Present if and only if `has_more` is true. Pass it back verbatim as
             `cursor` to fetch the next page. Opaque and server-private.
+
+    EventRecord:
+      type: object
+      description: >-
+        One record of the durable events journal: a single committed issue
+        mutation, as a replaying consumer receives it.
+
+
+        THIS IS THE CLI'S RECORD. It is pinned to the same Go struct
+        `bd events tail` and `bd events export` marshal one per line, so the
+        JSONL a consumer reads from stdout and the elements of an
+        `EventsPage.records` array are the same bytes for the same row. A
+        committed golden fixture pins that encoding field by field.
+
+
+        `issue` is the full issue state AFTER the mutation and is ALWAYS
+        PRESENT, carrying the literal `null` on a delete — where there is no
+        surviving row to describe. That is the one place this document's general
+        "treat null as absent" rule does not apply to a member's meaning: a
+        consumer must be able to tell a delete from a payload the server failed
+        to record, so the member is emitted rather than omitted. `dep` and
+        `comment` are the opposite: they are ABSENT on the ops that have no such
+        half, because their absence says the op has none, not that one was
+        empty.
+      x-go-type: eventsjournal.Record
+      x-go-type-import:
+        name: eventsjournal
+        path: github.com/steveyegge/beads/internal/eventsjournal
+      required: [seq, ts, op, issue_id, issue]
+      properties:
+        seq:
+          type: integer
+          format: int64
+          description: >-
+            Counter-assigned inside the mutation's own transaction: gapless,
+            strictly increasing in commit order, never reused and never reset.
+            This is the value to pass back as `since`. It is scoped to ONE
+            replica — see the operation description.
+        ts:
+          type: string
+          description: >-
+            UTC insert time, stamped inside the committing transaction and
+            normalized to RFC 3339. It is NOT monotone in `seq`: two writers
+            against one SQL server, or a clock stepped back by NTP, can commit
+            an earlier `seq` with a later timestamp. Order by `seq`, never by
+            this.
+        op:
+          type: string
+          description: >-
+            What was done: `create`, `update`, `close`, `delete`, `dep_add`,
+            `dep_remove` or `comment`. The set is closed in v0; a client MUST
+            default-branch on an unknown value rather than fail, so that adding
+            one stays additive.
+        issue_id:
+          type: string
+          description: The mutated issue's canonical id.
+        issue:
+          type: object
+          nullable: true
+          description: >-
+            The full issue state after the mutation — the same object shape
+            `Issue` describes — or `null` on a delete. Always present.
+        dep:
+          type: object
+          description: >-
+            On `dep_add` and `dep_remove` only: `{"kind","target","metadata"}`
+            for the edge. Absent on every other op.
+
+
+            `metadata` differs in PROVENANCE between the two: on `dep_add` it is
+            the value being written as the caller supplied it, on `dep_remove`
+            it is the stored column read back just before the delete. The two
+            can differ byte for byte while meaning the same thing, so compare
+            parsed values rather than strings.
+        comment:
+          type: object
+          description: >-
+            On `comment` only: `{"id","author","text","created_at","source"}`.
+            Absent on every other op.
+
+    EventsPage:
+      type: object
+      required: [records, head]
+      description: >-
+        One page of the journal plus the position of its end.
+
+
+        THERE IS NO `has_more`, and that is deliberate rather than an omission.
+        Every other page on this surface reports truncation with a boolean
+        because its ordering is a query's; here the answer is a number the
+        client already needs for its next request. Compare the last record's
+        `seq` with `head`: equal means caught up, lower means keep reading. A
+        full page proves nothing either way, and a `has_more` computed from the
+        limit would be a second, weaker way to ask the same question.
+      properties:
+        records:
+          type: array
+          description: >-
+            Records with `seq` strictly greater than the requested `since`, in
+            ASCENDING `seq` order and contiguous — a gap in the retained window
+            is a 410, never a quietly shortened list. Empty array (never null)
+            when the caller is caught up.
+          items:
+            $ref: '#/components/schemas/EventRecord'
+        head:
+          type: integer
+          format: int64
+          description: >-
+            The highest `seq` this journal has ever assigned, read in the same
+            transaction as the records above.
+
+
+            It is the journal's HISTORY, not its contents: pruning deletes rows
+            and never touches the counter, so a fully pruned journal still
+            reports the head it reached. `0` means no mutation has ever been
+            journaled here — which, given that a disabled journal is refused
+            with 409 rather than answered, means an enabled journal on a
+            workspace that has not been written to yet.
+
+
+            Because it is read after the rows within one transaction, it is
+            always greater than or equal to the last record's `seq`; it may be
+            greater simply because a mutation committed while the page was being
+            read, which is the ordinary signal to poll again.
 
     QueryPage:
       type: object
@@ -4987,7 +5361,9 @@ components:
             emitted by the Host-header middleware on any route),
             `invalid_cursor` (400), `not_found` (404), `already_claimed` (409),
             `not_claimable` (409), `not_closable` (409),
-            `dependency_cycle` (409), `dependency_exists` (409), `busy` (503),
+            `dependency_cycle` (409), `dependency_exists` (409),
+            `events_journal_disabled` (409), `events_journal_truncated` (410),
+            `busy` (503),
             `db_unavailable` (503),
             `internal` (500). Renaming or removing a status+code pair is a
             breaking change; ADDING one is not, so clients MUST default-branch
@@ -5077,6 +5453,36 @@ components:
             it is a DESCENDANT (blocked status cascades, so it would inherit the
             block and never close). Both polarities are reported; this member is
             never omitted to mean false. See `issue_id`.
+        since:
+          type: integer
+          format: int64
+          description: >-
+            With `events_journal_truncated`: the checkpoint the reported window
+            begins after.
+
+
+            It is NOT always the value the request sent. In the ordinary case —
+            the prefix you asked for was pruned — it IS your checkpoint. When
+            the prefix is intact but the retained window has an interior hole,
+            it is instead the last seq the server could serve contiguously from
+            your checkpoint, and `floor` is where the next intact stretch
+            begins. It never reports a value BELOW what you sent, so echoing it
+            back can never re-deliver records you already hold.
+        floor:
+          type: integer
+          format: int64
+          description: >-
+            With `events_journal_truncated`: the lowest seq still retained, or
+            `head + 1` when the journal retains nothing at all. Resuming from
+            `floor - 1` continues with a known, explicit gap.
+        head:
+          type: integer
+          format: int64
+          description: >-
+            With `events_journal_truncated`: the highest seq this journal has
+            ever assigned. It never decreases under a prune, so `floor > head`
+            means the journal was pruned empty and the caller is at the end of
+            its history. Emitted even when zero.
         request_id:
           type: string
           description: >-

--- a/internal/httpapi/wire_bijection_test.go
+++ b/internal/httpapi/wire_bijection_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/steveyegge/beads/internal/eventsjournal"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/issueops"
 )
@@ -26,9 +27,10 @@ import (
 // structs do not all live in one package: nine are internal/types, and the
 // three that are not — the cycle pair and IssueBlocking — live in the role
 // package issueops, where the results of issueops.CycleDetector and
-// issueops.BlockingAnnotator are declared. Asserting the declared path per
-// schema keeps the pin's TARGET checked, which is what a bare x-go-type name
-// would not do.
+// issueops.BlockingAnnotator are declared, and EventRecord lives in
+// internal/eventsjournal, which owns the journal's published envelope for both
+// front doors. Asserting the declared path per schema keeps the pin's TARGET
+// checked, which is what a bare x-go-type name would not do.
 var pinnedSchemas = []struct {
 	name       string
 	goType     string
@@ -47,11 +49,16 @@ var pinnedSchemas = []struct {
 	{"Cycle", "issueops.Cycle", canonicalRolesImport, issueops.Cycle{}},
 	{"CycleMember", "issueops.CycleMember", canonicalRolesImport, issueops.CycleMember{}},
 	{"IssueBlocking", "issueops.IssueBlocking", canonicalRolesImport, issueops.IssueBlocking{}},
+	{"EventRecord", "eventsjournal.Record", canonicalJournalImport, eventsjournal.Record{}},
 }
 
 const (
 	canonicalTypesImport = "github.com/steveyegge/beads/internal/types"
 	canonicalRolesImport = "github.com/steveyegge/beads/issueops"
+	// The journal record lives in neither: it is the leaf package that owns the
+	// journal's cross-binary concerns, and its Record is what `bd events tail`
+	// marshals.
+	canonicalJournalImport = "github.com/steveyegge/beads/internal/eventsjournal"
 )
 
 // omittedProperties lists JSON field names a pinned schema deliberately does

--- a/internal/storage/dolt/journal_accessor.go
+++ b/internal/storage/dolt/journal_accessor.go
@@ -14,6 +14,7 @@ import (
 // store the same way it does against the embedded store.
 var (
 	_ storage.EventsJournalAccessor    = (*DoltStore)(nil)
+	_ storage.EventsJournalCursor      = (*DoltStore)(nil)
 	_ issueops.EventsMaintenanceRunner = (*DoltStore)(nil)
 )
 
@@ -26,6 +27,18 @@ func (s *DoltStore) ReadEventsJournal(ctx context.Context, since int64, limit in
 		return readErr
 	})
 	return out, err
+}
+
+// ReadEventsJournalPage returns the same rows plus the journal head, in ONE
+// transaction so the pair cannot straddle a commit.
+func (s *DoltStore) ReadEventsJournalPage(ctx context.Context, since int64, limit int) (storage.EventsJournalPage, error) {
+	var page storage.EventsJournalPage
+	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
+		var readErr error
+		page, readErr = issueops.ReadEventsPageInTx(ctx, tx, since, limit)
+		return readErr
+	})
+	return page, err
 }
 
 // PruneEventsJournal deletes journal rows below before, honoring the retain

--- a/internal/storage/domain/db/journal.go
+++ b/internal/storage/domain/db/journal.go
@@ -23,6 +23,10 @@ func (r *eventsJournalSQLRepository) Read(ctx context.Context, since int64, limi
 	return issueops.ReadEventsInTx(ctx, r.runner, since, limit)
 }
 
+func (r *eventsJournalSQLRepository) ReadPage(ctx context.Context, since int64, limit int) (storage.EventsJournalPage, error) {
+	return issueops.ReadEventsPageInTx(ctx, r.runner, since, limit)
+}
+
 func (r *eventsJournalSQLRepository) Prune(ctx context.Context, before int64, retainDays, retainRows int) (int64, error) {
 	return issueops.PruneEventsInTx(ctx, r.runner, before, retainDays, retainRows, time.Now().UTC())
 }

--- a/internal/storage/domain/journal.go
+++ b/internal/storage/domain/journal.go
@@ -10,6 +10,7 @@ import (
 // reading and pruning the durable mutation journal.
 type EventsJournalSQLRepository interface {
 	Read(ctx context.Context, since int64, limit int) ([]storage.EventsJournalRow, error)
+	ReadPage(ctx context.Context, since int64, limit int) (storage.EventsJournalPage, error)
 	Prune(ctx context.Context, before int64, retainDays, retainRows int) (int64, error)
 }
 
@@ -17,6 +18,10 @@ type EventsJournalSQLRepository interface {
 // proxied-server callers without leaking a raw SQL connection.
 type EventsJournalUseCase interface {
 	Read(ctx context.Context, since int64, limit int) ([]storage.EventsJournalRow, error)
+	// ReadPage is Read plus the journal head, for a consumer that must pace
+	// itself rather than merely take what came next. See
+	// issueops.ReadEventsPageInTx for why the head is not folded into Read.
+	ReadPage(ctx context.Context, since int64, limit int) (storage.EventsJournalPage, error)
 	Prune(ctx context.Context, before int64, retainDays, retainRows int) (int64, error)
 }
 
@@ -32,6 +37,10 @@ var _ EventsJournalUseCase = (*eventsJournalUseCase)(nil)
 
 func (u *eventsJournalUseCase) Read(ctx context.Context, since int64, limit int) ([]storage.EventsJournalRow, error) {
 	return u.repo.Read(ctx, since, limit)
+}
+
+func (u *eventsJournalUseCase) ReadPage(ctx context.Context, since int64, limit int) (storage.EventsJournalPage, error) {
+	return u.repo.ReadPage(ctx, since, limit)
 }
 
 func (u *eventsJournalUseCase) Prune(ctx context.Context, before int64, retainDays, retainRows int) (int64, error) {

--- a/internal/storage/embeddeddolt/journal_accessor.go
+++ b/internal/storage/embeddeddolt/journal_accessor.go
@@ -16,6 +16,7 @@ import (
 // embedded mode — where there is no stable *sql.DB to reach via RawDBAccessor.
 var (
 	_ storage.EventsJournalAccessor    = (*EmbeddedDoltStore)(nil)
+	_ storage.EventsJournalCursor      = (*EmbeddedDoltStore)(nil)
 	_ issueops.EventsMaintenanceRunner = (*EmbeddedDoltStore)(nil)
 )
 
@@ -30,6 +31,18 @@ func (s *EmbeddedDoltStore) ReadEventsJournal(ctx context.Context, since int64, 
 		return readErr
 	})
 	return out, err
+}
+
+// ReadEventsJournalPage returns the same rows plus the journal head, on one
+// connection so the pair cannot straddle a commit.
+func (s *EmbeddedDoltStore) ReadEventsJournalPage(ctx context.Context, since int64, limit int) (storage.EventsJournalPage, error) {
+	var page storage.EventsJournalPage
+	err := s.withConn(ctx, false, func(tx *sql.Tx) error {
+		var readErr error
+		page, readErr = issueops.ReadEventsPageInTx(ctx, tx, since, limit)
+		return readErr
+	})
+	return page, err
 }
 
 // PruneEventsJournal deletes journal rows below before, honoring the retain

--- a/internal/storage/embeddeddolt/journal_truncation_test.go
+++ b/internal/storage/embeddeddolt/journal_truncation_test.go
@@ -129,6 +129,76 @@ func TestEventsJournalRestartAndRetentionBoundary(t *testing.T) {
 	}
 }
 
+// TestEventsJournalPageReportsTheHead is the guard for the read that
+// GET /v0/beads/events answers from. The head is the whole reason that read
+// exists beside ReadEventsJournal — it is how a polling consumer tells "this
+// page is the end" from "there is more, keep asking" — so it is checked against
+// the substrate rather than assumed.
+//
+// Three properties, and the last one is the one that would break silently:
+// the head reflects every mutation ever journaled; it survives a prune, because
+// prune deletes rows and never touches the counter; and a truncated read still
+// fails through this path rather than answering with rows and a plausible head.
+func TestEventsJournalPageReportsTheHead(t *testing.T) {
+	env := newTestEnv(t, "pge")
+	ctx := context.Background()
+	store := env.store
+	store.SetEventsJournalEnabled(true)
+
+	must := func(err error, what string) {
+		t.Helper()
+		if err != nil {
+			t.Fatalf("%s: %v", what, err)
+		}
+	}
+	for _, id := range []string{"pge-1", "pge-2", "pge-3", "pge-4", "pge-5"} {
+		must(store.CreateIssue(ctx, &types.Issue{
+			ID: id, Title: "t-" + id, IssueType: types.TypeTask, Status: types.StatusOpen,
+		}, "actor"), "create "+id)
+	}
+
+	// A BOUNDED page: the head must describe the journal, not the page. A head
+	// derived from the last row returned would read as "caught up" here and
+	// stall a consumer three records short.
+	page, err := store.ReadEventsJournalPage(ctx, 0, 2)
+	must(err, "read page")
+	if len(page.Rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(page.Rows))
+	}
+	if page.Head != 5 {
+		t.Fatalf("head = %d, want 5 — the head must be the journal's, not the page's", page.Head)
+	}
+
+	// Caught up: no rows, and the same head.
+	caughtUp, err := store.ReadEventsJournalPage(ctx, 5, 0)
+	must(err, "read caught up")
+	if len(caughtUp.Rows) != 0 || caughtUp.Head != 5 {
+		t.Fatalf("caught-up page = %+v, want no rows and head 5", caughtUp)
+	}
+
+	// Prune the whole journal. The counter is untouched, so the head stands
+	// while the rows are gone — which is what lets a fully pruned journal say
+	// "you are at the end of my history" instead of "I have nothing".
+	if _, err := store.PruneEventsJournal(ctx, 6, 0, 0); err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	afterPrune, err := store.ReadEventsJournalPage(ctx, 5, 0)
+	must(err, "read after prune")
+	if len(afterPrune.Rows) != 0 || afterPrune.Head != 5 {
+		t.Fatalf("post-prune page = %+v, want no rows and head 5", afterPrune)
+	}
+
+	// And a checkpoint below the pruned window still FAILS on this path, with
+	// the same window the CLI's read reports. A page read that answered an
+	// empty success here would be the silent-loss case the truncation contract
+	// exists to prevent, reintroduced by the second read plumbing.
+	_, err = store.ReadEventsJournalPage(ctx, 2, 0)
+	trunc := requireTruncated(t, err)
+	if trunc.Since != 2 || trunc.Floor != 6 || trunc.Head != 5 {
+		t.Fatalf("truncation = %+v, want since 2, floor 6, head 5", trunc)
+	}
+}
+
 func requireTruncated(t *testing.T, err error) *storage.EventsJournalTruncatedError {
 	t.Helper()
 	var trunc *storage.EventsJournalTruncatedError

--- a/internal/storage/issueops/journal_prune.go
+++ b/internal/storage/issueops/journal_prune.go
@@ -105,6 +105,44 @@ func ReadEventsInTx(ctx context.Context, tx DBTX, since int64, limit int) ([]sto
 	return out, nil
 }
 
+// ReadEventsPageInTx is ReadEventsInTx plus the journal HEAD, for a consumer
+// that has to know how far behind it is rather than merely what came next.
+// `bd events tail` does not: it prints what it is given and polls again. A
+// polling HTTP consumer does, because the answer to "keep asking, or wait?"
+// is not in the rows.
+//
+// The head read is UNCONDITIONAL here, where ReadEventsInTx pays for one only
+// in the ambiguous cases. That is the deliberate cost of the extra member:
+// tail --follow runs this decision every second and must stay free, so the two
+// entry points differ in exactly this and share everything else — the row
+// query, the normalization, and ComputeEventsTruncation's verdict.
+//
+// The head is read AFTER the rows and inside the SAME transaction, which is
+// what keeps the pair coherent. Reading it first would let a mutation commit in
+// between and hand back a head BELOW the last row served — a consumer would
+// read that as "you are past the end" and stall. This order can only report a
+// head that is equal to or ahead of the last row, which is the truth a poller
+// acts on correctly either way.
+func ReadEventsPageInTx(ctx context.Context, tx DBTX, since int64, limit int) (storage.EventsJournalPage, error) {
+	rows, err := readEventsRowsInTx(ctx, tx, since, limit)
+	if err != nil {
+		return storage.EventsJournalPage{}, err
+	}
+	head, err := readEventsHeadInTx(ctx, tx)
+	if err != nil {
+		return storage.EventsJournalPage{}, err
+	}
+	// The SAME verdict the CLI read reaches, from the head already in hand: a
+	// truncation this path reported differently would be a second retention
+	// contract.
+	if err := ComputeEventsTruncation(since, rows, func() (int64, error) {
+		return head, nil
+	}); err != nil {
+		return storage.EventsJournalPage{}, err
+	}
+	return storage.EventsJournalPage{Rows: rows, Head: head}, nil
+}
+
 // ComputeEventsTruncation decides whether the rows a read returned are the
 // caller's contiguous continuation from since, or the remains of a window whose
 // prefix a prune already deleted. It returns *storage.EventsJournalTruncatedError

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -762,11 +762,48 @@ func (e *EventsJournalTruncatedError) Error() string {
 		e.Since, e.Floor, e.Head, e.Since+1, e.Floor-1)
 }
 
+// EventsJournalPage is one journal read that also reports how far behind the
+// caller is: the rows it asked for, and the head of the journal's history at
+// the moment they were read.
+//
+// The two travel together because they are only meaningful together. Rows alone
+// cannot answer "poll again now, or wait?" — a full page might be the end of
+// the journal or the first thousand of a hundred thousand — and a head read
+// separately could be taken from a different instant and land BELOW the last
+// row served, which a consumer reads as "past the end" and stalls on.
+//
+// Head is the highest seq the counter has ever assigned. It never decreases
+// under a prune (see EventsJournalTruncatedError), so it is the journal's
+// history rather than its contents: a fully pruned journal reports its rows
+// gone and its head unchanged.
+type EventsJournalPage struct {
+	Rows []EventsJournalRow
+	Head int64
+}
+
+// EventsJournalCursor is the READ-ONLY half of the journal seam, for a consumer
+// that pages through the journal with a checkpoint.
+//
+// It is separate from EventsJournalAccessor rather than a method on it because
+// of who holds it. Retention is an operator decision made by the workspace
+// (`bd events prune` and the automatic bounding); a surface that only PUBLISHES
+// the journal — bd serve's GET /v0/beads/events — must not be handed a delete.
+// Narrowing the interface is what makes "this surface cannot prune" a fact
+// about the type rather than a promise about the handler.
+type EventsJournalCursor interface {
+	// ReadEventsJournalPage returns rows with seq greater than since, ordered
+	// by seq ascending and capped by limit (0 = no cap), together with the
+	// journal head read in the same transaction. It returns
+	// *EventsJournalTruncatedError on the same terms ReadEventsJournal does.
+	ReadEventsJournalPage(ctx context.Context, since int64, limit int) (EventsJournalPage, error)
+}
+
 // EventsJournalAccessor reads and prunes the durable events journal
 // (bd_events_journal) through the store's own transaction machinery. Unlike
 // RawDBAccessor — which only the server-mode store provides — this works on the
 // embedded store too, which owns its connections and exposes no stable *sql.DB.
-// Callers that need the journal should type-assert to this interface.
+// Callers that need the journal should type-assert to this interface; a caller
+// that only reads should ask for EventsJournalCursor instead.
 type EventsJournalAccessor interface {
 	// ReadEventsJournal returns rows with seq greater than since, ordered by
 	// seq ascending, optionally capped by limit (0 = no cap). It returns

--- a/internal/storage/uow/events_journal.go
+++ b/internal/storage/uow/events_journal.go
@@ -1,0 +1,55 @@
+package uow
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+// EventsJournalCursorSource is the capability accessor a unit-of-work provider
+// offers for the READ side of the durable events journal, the sibling of
+// MemoriesSource and WorkspaceConfigSource. It is named here so a consumer
+// holding a provider by interface asks for the journal the way a consumer
+// holding a store asks for it — by accessor, not by reaching for a constructor.
+//
+// There is deliberately no prune accessor beside it. Retention is a decision
+// the workspace makes, and the surfaces that page through the journal
+// (GET /v0/beads/events) must not be one line away from a delete; the prune
+// path stays on uw.EventsJournalUseCase(), where `bd events prune` reaches it
+// inside the ephemeral-commit transaction the dolt_ignored table needs.
+type EventsJournalCursorSource interface {
+	EventsJournalCursor() (storage.EventsJournalCursor, error)
+}
+
+// eventsJournalCursor reads the journal through a unit of work.
+type eventsJournalCursor struct {
+	provider UnitOfWorkProvider
+}
+
+// EventsJournalCursor returns the journal read surface for this provider.
+func (p *doltSQLProvider) EventsJournalCursor() (storage.EventsJournalCursor, error) {
+	return NewEventsJournalCursor(p)
+}
+
+// NewEventsJournalCursor constructs a journal read surface backed by provider.
+func NewEventsJournalCursor(provider UnitOfWorkProvider) (storage.EventsJournalCursor, error) {
+	if isNilUnitOfWorkProvider(provider) {
+		return nil, fmt.Errorf("new events journal cursor: unit-of-work provider must not be nil")
+	}
+	return &eventsJournalCursor{provider: provider}, nil
+}
+
+var _ storage.EventsJournalCursor = (*eventsJournalCursor)(nil)
+
+// ReadEventsJournalPage answers one page inside one unit of work.
+//
+// RunTxRead, not RunTx: this never commits, which is what keeps a read of a
+// dolt_ignored table from minting anything. The rows and the head come from
+// the single transaction the use case runs them in, so the head cannot be
+// taken from a later instant than the rows it describes.
+func (c *eventsJournalCursor) ReadEventsJournalPage(ctx context.Context, since int64, limit int) (storage.EventsJournalPage, error) {
+	return RunTxRead(ctx, c.provider, func(ctx context.Context, uw UnitOfWork) (storage.EventsJournalPage, error) {
+		return uw.EventsJournalUseCase().ReadPage(ctx, since, limit)
+	})
+}

--- a/internal/storage/uow/notifying.go
+++ b/internal/storage/uow/notifying.go
@@ -290,6 +290,15 @@ func (p *notifyingProvider) VersionReconciler() (publicops.VersionReconciler, er
 
 func (p *notifyingProvider) Memories() (memoryops.Memories, error) { return NewMemories(p) }
 
+// EventsJournalCursor builds on THIS provider, like every role above it, so a
+// journal read taken through a notifying provider still runs in a unit of work
+// this layer opened. Nothing here records, and nothing needs to: this accessor
+// reaches only the READ half of EventsJournalUseCase, which the parity guard
+// exempts for reading state and changing none.
+func (p *notifyingProvider) EventsJournalCursor() (storage.EventsJournalCursor, error) {
+	return NewEventsJournalCursor(p)
+}
+
 // ── Provider capabilities that are not roles ────────────────────────
 
 // RunNonTx forwards the maintenance escape hatch. It runs on a pinned
@@ -353,34 +362,35 @@ func (p *notifyingProvider) RunEventsMaintenanceTx(ctx context.Context, fn func(
 }
 
 var (
-	_ UnitOfWorkProvider      = (*notifyingProvider)(nil)
-	_ MaintenanceProvider     = (*notifyingProvider)(nil)
-	_ PoolTuner               = (*notifyingProvider)(nil)
-	_ IssueLifecycleSource    = (*notifyingProvider)(nil)
-	_ IssueReaderSource       = (*notifyingProvider)(nil)
-	_ IssueClaimerSource      = (*notifyingProvider)(nil)
-	_ RelationsSource         = (*notifyingProvider)(nil)
-	_ EdgeReaderSource        = (*notifyingProvider)(nil)
-	_ BlockingAnnotatorSource = (*notifyingProvider)(nil)
-	_ TreeWalkerSource        = (*notifyingProvider)(nil)
-	_ CounterSource           = (*notifyingProvider)(nil)
-	_ ReadyCounterSource      = (*notifyingProvider)(nil)
-	_ ReadyClaimerSource      = (*notifyingProvider)(nil)
-	_ QuerierSource           = (*notifyingProvider)(nil)
-	_ StatsReporterSource     = (*notifyingProvider)(nil)
-	_ CycleDetectorSource     = (*notifyingProvider)(nil)
-	_ CommenterSource         = (*notifyingProvider)(nil)
-	_ BatchCloserSource       = (*notifyingProvider)(nil)
-	_ BatchCreatorSource      = (*notifyingProvider)(nil)
-	_ DependencyEditorSource  = (*notifyingProvider)(nil)
-	_ DeleterSource           = (*notifyingProvider)(nil)
-	_ SweeperSource           = (*notifyingProvider)(nil)
-	_ ImporterSource          = (*notifyingProvider)(nil)
-	_ BootstrapperSource      = (*notifyingProvider)(nil)
-	_ InitVerifierSource      = (*notifyingProvider)(nil)
-	_ WorkspaceConfigSource   = (*notifyingProvider)(nil)
-	_ VersionReconcilerSource = (*notifyingProvider)(nil)
-	_ MemoriesSource          = (*notifyingProvider)(nil)
+	_ UnitOfWorkProvider        = (*notifyingProvider)(nil)
+	_ MaintenanceProvider       = (*notifyingProvider)(nil)
+	_ PoolTuner                 = (*notifyingProvider)(nil)
+	_ IssueLifecycleSource      = (*notifyingProvider)(nil)
+	_ IssueReaderSource         = (*notifyingProvider)(nil)
+	_ IssueClaimerSource        = (*notifyingProvider)(nil)
+	_ RelationsSource           = (*notifyingProvider)(nil)
+	_ EdgeReaderSource          = (*notifyingProvider)(nil)
+	_ BlockingAnnotatorSource   = (*notifyingProvider)(nil)
+	_ TreeWalkerSource          = (*notifyingProvider)(nil)
+	_ CounterSource             = (*notifyingProvider)(nil)
+	_ ReadyCounterSource        = (*notifyingProvider)(nil)
+	_ ReadyClaimerSource        = (*notifyingProvider)(nil)
+	_ QuerierSource             = (*notifyingProvider)(nil)
+	_ StatsReporterSource       = (*notifyingProvider)(nil)
+	_ CycleDetectorSource       = (*notifyingProvider)(nil)
+	_ CommenterSource           = (*notifyingProvider)(nil)
+	_ BatchCloserSource         = (*notifyingProvider)(nil)
+	_ BatchCreatorSource        = (*notifyingProvider)(nil)
+	_ DependencyEditorSource    = (*notifyingProvider)(nil)
+	_ DeleterSource             = (*notifyingProvider)(nil)
+	_ SweeperSource             = (*notifyingProvider)(nil)
+	_ ImporterSource            = (*notifyingProvider)(nil)
+	_ BootstrapperSource        = (*notifyingProvider)(nil)
+	_ InitVerifierSource        = (*notifyingProvider)(nil)
+	_ WorkspaceConfigSource     = (*notifyingProvider)(nil)
+	_ VersionReconcilerSource   = (*notifyingProvider)(nil)
+	_ MemoriesSource            = (*notifyingProvider)(nil)
+	_ EventsJournalCursorSource = (*notifyingProvider)(nil)
 )
 
 // ── The unit of work ────────────────────────────────────────────────

--- a/internal/storage/uow/notifying_parity_test.go
+++ b/internal/storage/uow/notifying_parity_test.go
@@ -111,11 +111,12 @@ func TestNotifyingUOWWrapsEveryMutatingUseCase(t *testing.T) {
 			"DoltRemoteUseCase": "Dolt remotes are repository plumbing; no bead changes and no event to name",
 			"RawSQLUseCase": "the raw escape hatch executes statements this layer cannot read, so it " +
 				"cannot say which bead changed; the DoltStorage chain fires nothing for raw access either",
-			"EventsJournalUseCase": "read-only cursor surface; fires no hooks. Its two operations are a " +
-				"read of bd_events_journal and a prefix delete of records already committed — the " +
-				"delete changes no bead, and the journal itself is written at the issueops seam " +
-				"inside the mutation's own transaction, so everything it records is already covered " +
-				"by the use case that made the change",
+			"EventsJournalUseCase": "read-only cursor surface; fires no hooks. Two of its three " +
+				"operations read bd_events_journal (Read, and ReadPage which adds the counter head " +
+				"GET /v0/beads/events pages with) and the third is a prefix delete of records " +
+				"already committed — the delete changes no bead, and the journal itself is written " +
+				"at the issueops seam inside the mutation's own transaction, so everything it " +
+				"records is already covered by the use case that made the change",
 		})
 }
 


### PR DESCRIPTION
Publishes the events journal (merged in #4916) on the v0 surface: **`GET /v0/beads/events?since=<seq>&limit=<n>`** returning `{"records": [...], "head": N}` in the exact record envelope the CLI golden pins — the marshaling now lives once in `internal/eventsjournal` and both the CLI and this handler render through it, with a byte-identity test against the generated schema type.

## The two things to review first

**What this exposes.** The endpoint serves *history*, not current state: every retained record carries the full snapshot as it was — including titles/descriptions since edited and issues since deleted. That is the journal's documented contract (a binlog; prune and the retention floors are the only redaction), and the v0 surface has **no authentication** (trust = bind address + Host allowlist), so the docs now carry an explicit warning at the bind decision: any process that can reach the address reads the retained history without the `.beads/` filesystem permissions `bd events tail` requires.

**Contract mapping.** A stale checkpoint — or any interior sequence hole — refuses with **410 Gone** in the house RFC 9457 problem+json envelope (`code: events_journal_truncated`, `since`/`floor`/`head` as extension members; same numbers the CLI reports). The 410 description documents all three recoveries, including the drain of an intact prefix ahead of an interior hole. Journal-disabled workspaces answer **409 `events_journal_disabled`** (state, not capability — `/v0/beads/context` still advertises `events.list` because capabilities are build-level; the spec calls out this one exception). Caught-up is 200 + `[]` + `head`. `limit` is 1..10000, default 1000, `limit=0` refused (deliberate divergence from the issues list — unlimited would buffer the whole retained window; a parity test pins spec numbers to code constants).

## Shape notes

- Data path is a new narrow read-only `storage.EventsJournalCursor` role (rows + head, no prune — the "no write surface" promise is a fact about the type), reached per-plumbing (store role arm, uow source arm) with the lint-enforced httpapi/domain boundary intact. `issueops.ReadEventsPageInTx` returns rows **then** head in one transaction, so a served head can never sit below the last served row.
- The role registers conditionally, mirroring activation: required exactly when the journal is enabled; enabled-on-a-backend-without-the-seam refuses `bd serve` at startup (documented, matching the open-time contract).
- Responses stream record-by-record to the wire (one record live at a time; rows bounded by the limit cap); full cursor streaming is deliberately deferred — the interior-gap verdict must precede the first 200 byte, and that requires the page in memory.
- No streaming/push in v0 — consumers poll with `since`; an SSE sibling (`:watch`) is designed and follows as a stacked PR.

## Verification

Handler suite + `-race`; `bd serve` e2e over real HTTP (mutate → read → prune → stale-since → 410 → floor−1 recovery → disabled 409), gated behind the shared-Dolt integration shard like its siblings; `make api-check` clean (13th `x-go-type` pin, generator-alias proof); docs render/freshness/broken-links clean; `make ci-pr-lint` clean; consumer golden untouched byte-for-byte. Review: one three-lens adversarially-verified council — **zero confirmed findings** (one refuted against the docs' own text; six passthrough polish items applied, each mutation-verified where testable).

Tracking: bd-opisf. Stacked next: `GET /v0/beads/events:watch` (SSE).

_claude-code-claude-fable-5[1m]-max on behalf of julianknutsen_
