### PR TITLE
Assert exactly-one history for a comment, and state the bootstrap split per leg

### DIFF
--- a/backend/conformance/bootstrapper_contract.go
+++ b/backend/conformance/bootstrapper_contract.go
@@ -26,8 +26,15 @@ import (
 // pinned without a database in internal/workapi/bootstrap_test.go. What only a
 // real backend can show is the SUBSTRATE half: that the identity is there for the
 // NEXT caller, that a REFUSAL WROTE NOTHING, that a failed read is an error
-// rather than an empty identity, and that a bootstrap costs AT MOST ONE
-// version-control entry.
+// rather than an empty identity, and what a bootstrap costs in version-control
+// entries.
+//
+// THAT LAST COST IS THE ONE THING THE THREE WIRINGS DELIBERATELY DIFFER ON, and
+// it is asserted per-leg rather than as a shared range: the stores record none
+// and the unit-of-work provider records one, each because of the front door it
+// stands behind. RunBootstrapperRecordsNoHistoryEntryOfItsOwn and
+// RunBootstrapperRecordsExactlyOneHistoryEntry state the two halves and cross-
+// reference each other, so neither reads as the other's bug.
 //
 // THE IDENTITY IS GLOBAL TO A WORKSPACE and cannot be namespaced the way the
 // issue contracts namespace their seeded ids. Every case therefore SEEDS the
@@ -56,8 +63,8 @@ type BootstrapperFixture struct {
 	// its own test harness already initialized.
 	SeedIdentity func(ctx context.Context, prefix, projectID string) error
 	// CountHistory reports how many history entries the fixture's branch has.
-	// A nil hook means "this backend cannot observe history", and the case that
-	// needs it SKIPS with that reason rather than passing quietly.
+	// A nil hook means "this backend cannot observe history", and the cases
+	// that need it SKIP with that reason rather than passing quietly.
 	CountHistory func(context.Context) (int, error)
 }
 
@@ -216,14 +223,79 @@ func RunBootstrapperLeavesTheSubstrateUntouchedWhenItCannotComplete(t *testing.T
 	assertWorkspaceIdentity(t, ctx, fixture, "", "")
 }
 
-// RunBootstrapperRecordsAtMostOneHistoryEntry pins bootstrapper.go's "AT MOST
-// ONE VERSION-CONTROL ENTRY".
+// RunBootstrapperRecordsNoHistoryEntryOfItsOwn is the STORE half of
+// bootstrapper.go's "AT MOST ONE VERSION-CONTROL ENTRY ... and a backend that
+// records none is conforming".
 //
-// The promise is an upper bound rather than a number: a backend that commits at
-// all is right to record the bootstrap, and one whose front door commits the
-// whole of `bd init` afterwards is right to record none. What it forbids is the
-// one-entry-per-key shape six ordinary setters would produce.
-func RunBootstrapperRecordsAtMostOneHistoryEntry(t *testing.T, ctx context.Context, fixture BootstrapperFixture) {
+// That clause is a range, and a range cannot fail in the direction that
+// matters: "after-before <= 1" holds whether an entry was written or not, so
+// one shared case would pass on a leg that stopped recording and on a leg that
+// never did, without ever saying which was which. Each wiring therefore pins
+// its own exact number, and this is the number the two stores pin.
+//
+// THEY RECORD NONE BECAUSE THE FRONT DOOR RECORDS IT. dolt's bootstrapper says
+// so in the body it would have to change — "NO VERSION-CONTROL ENTRY IS
+// RECORDED HERE ... the front door's own initial commit is what records them.
+// Adding a DOLT_COMMIT would give a bootstrap an entry that `bd init`'s commit
+// then duplicates" — and embeddeddolt's reaches its transaction through
+// withConn, which mints no Dolt commit either. The commit they defer to is
+// commitInitState's CommitWithConfig(ctx, "bd init") on the direct init route
+// in cmd/bd/init.go. A store that started committing in-role would double-
+// record every `bd init`, and that is what this zero forbids.
+//
+// A ZERO IS ONLY WORTH ASSERTING IF THE HOOK CAN MOVE, which is the question
+// an exact zero has to answer about its own fixture. It can: both store
+// wirings fill CountHistory from the same roleFixtureKit hook that
+// RunCommenterRecordsExactlyOneHistoryEntry drives from n to n+1 on those same
+// two backends. So this zero reads "nothing was recorded", not "nothing is
+// observable here" — the shape a nil hook would have, which skips loudly
+// instead.
+//
+// The unit-of-work wiring pins ONE instead, from
+// RunBootstrapperRecordsExactlyOneHistoryEntry, which owns the other half of
+// the argument. Neither number is the other's bug.
+func RunBootstrapperRecordsNoHistoryEntryOfItsOwn(t *testing.T, ctx context.Context, fixture BootstrapperFixture) {
+	t.Helper()
+	assertBootstrapHistoryDelta(t, ctx, fixture, 0,
+		"this backend leaves the identity entry to `bd init`'s own commit at the front door, and an in-role commit would duplicate it")
+}
+
+// RunBootstrapperRecordsExactlyOneHistoryEntry is the UNIT-OF-WORK half, and
+// the reason the split is ratified rather than queued for convergence.
+//
+// THE PROXIED INIT ROUTE HAS NO OTHER COMMIT POINT: cmd/bd/init_proxied_server.go
+// calls the role and stops, with no commitInitState equivalent behind it, so
+// the entry this body labels ("ONE VERSION-CONTROL ENTRY ... one entry rather
+// than one per key", uow/bootstrapper.go) is the only thing that versions the
+// identity there. Making this leg record none to match the stores would leave a
+// proxied workspace's identity unversioned; making the stores record one to
+// match this leg would duplicate a commit `bd init` already makes. Each leg is
+// right for the front door it stands behind, and the front-door OUTCOME
+// converges: every init route ends with exactly one entry carrying the
+// identity, labeled "bd init" on the store routes and "bd: bootstrap <prefix>"
+// on this one.
+//
+// WHY THIS IS NOT skipKnownDivergence. That mechanism parks a case as
+// UNDECIDED, pending an owner's behavior-unification ruling, and it leaves the
+// parked leg's behavior unpinned while it waits — which is the same blind spot
+// the shared range had, moved to a different file. Here there is nothing to
+// decide, so both numbers get an assertion that RUNS: a stated per-leg promise,
+// where a skip would be a silence.
+//
+// What both halves keep from the single case they replace is its original
+// point: no leg records ONE ENTRY PER KEY. Six ordinary setters would show up
+// as six, and 0 != 6 and 1 != 6 both catch it.
+func RunBootstrapperRecordsExactlyOneHistoryEntry(t *testing.T, ctx context.Context, fixture BootstrapperFixture) {
+	t.Helper()
+	assertBootstrapHistoryDelta(t, ctx, fixture, 1,
+		"the proxied init route has no other commit point, so the role's own entry is the only thing that versions the identity there")
+}
+
+// assertBootstrapHistoryDelta bootstraps a fresh substrate once and pins the
+// history delta at want. why is the leg's rationale, carried into the failure
+// so a reader who trips it lands on the topology that chose the number rather
+// than on a bare count they might "fix" by copying the other leg.
+func assertBootstrapHistoryDelta(t *testing.T, ctx context.Context, fixture BootstrapperFixture, want int, why string) {
 	t.Helper()
 	if fixture.CountHistory == nil {
 		t.Skip("fixture cannot observe history on this backend")
@@ -242,8 +314,8 @@ func RunBootstrapperRecordsAtMostOneHistoryEntry(t *testing.T, ctx context.Conte
 	if err != nil {
 		t.Fatalf("CountHistory() after: %v", err)
 	}
-	if after-before > 1 {
-		t.Fatalf("history entries %d -> %d, want a bootstrap to record at most one", before, after)
+	if after-before != want {
+		t.Fatalf("history entries %d -> %d across one bootstrap, want exactly %d more: %s", before, after, want, why)
 	}
 }
 

--- a/backend/conformance/commenter_contract.go
+++ b/backend/conformance/commenter_contract.go
@@ -30,6 +30,13 @@ import (
 //     pinned once, at dolt, in dolt/commenter_persistence_test.go;
 //   - the dolt_status pending-row sweep, which needs a planted dirty working
 //     set and has no caller-visible meaning on the unit-of-work route.
+//
+// THE HISTORY COST OF A COMMENT IS THE SAME NUMBER ON ALL THREE WIRINGS, and
+// it is asserted here as a number rather than as a bound: exactly one entry
+// for a durable comment, exactly zero for an ephemeral one. Both were measured
+// on all three legs, so neither is a divergence being papered over — see
+// RunCommenterRecordsExactlyOneHistoryEntry for why a bound would have been
+// worse than no assertion at all.
 
 // CommenterFixture supplies adapter-specific storage access for the
 // add-comment assertions. Every field is named and typed exactly like the
@@ -147,9 +154,9 @@ func RunCommenterResultMirrorsTheStoredRow(t *testing.T, ctx context.Context, fi
 // still passed, because a comments row keyed by an id the issues plane does
 // not have is invisible to every thread read of the wisp.
 //
-// The history assertion is an EQUALITY, not the at-most-one bound the durable
-// path carries: commenter.go:72-79 promises an ephemeral comment records no
-// durable history entry at all. The bound would let a regression that records
+// The history assertion is an EQUALITY at ZERO, where the durable path's is an
+// equality at one: AddComment's ephemeral clause promises "NO durable history
+// entry — none, not 'at most one'". A bound would let a regression that records
 // exactly one entry pass on every backend, and that regression is the one that
 // breaks federation — the wisp tables are dolt-ignored so ephemeral work never
 // ships, and an entry naming a wisp thread ships.
@@ -275,12 +282,38 @@ func RunCommenterDoesNotResolvePrefixes(t *testing.T, ctx context.Context, fixtu
 	assertCommenterRowCount(t, ctx, fixture, "comments", partial, 0)
 }
 
-// RunCommenterRecordsAtMostOneHistoryEntry pins commenter.go:66-67: one
-// comment is ONE atomic mutation with at most one history entry. The upper
-// bound is what the doc promises, so that is what is asserted; the "one
-// mutation" half is the exact-one row count, which catches a body that
-// appended the comment twice while the history bound still held.
-func RunCommenterRecordsAtMostOneHistoryEntry(t *testing.T, ctx context.Context, fixture CommenterFixture) {
+// RunCommenterRecordsExactlyOneHistoryEntry pins Commenter.AddComment's "ONE
+// atomic mutation, with at most one history entry" at the number every wiring
+// actually records: a durable comment costs EXACTLY one entry.
+//
+// The case is deliberately stricter than the leaf's bound, because the bound
+// cannot fail in the direction that matters. "after <= before+1" holds whether
+// the entry was written or not, so a body that quietly stopped committing
+// keeps it green — and that is not hypothetical. The deleter role stopped
+// versioning embedded deletes, the identically-shaped range in its contract
+// absorbed it, and what noticed months later was a sibling-write test outside
+// the contract suite (e9acfac6e).
+//
+// EXACTLY ONE IS MEASURED, NOT DEMANDED: all three wirings already record one
+// entry for a durable comment — the server-backed store inside its write
+// transaction, the embedded store on a second connection after the SQL commit,
+// the unit-of-work provider from the message it hands RunTxResult — so this
+// tightens the assertion and asks no backend to change. Ratifying the leaf's
+// own wording to match is the owner's call; until then this case is the
+// stricter of the two statements, and the honest one.
+//
+// What the strictness buys a caller: a comment row no entry carries is a row
+// `bd dolt push` does not ship. The thread then reads back locally and exists
+// nowhere else, and the author who published under their name cannot tell the
+// difference.
+//
+// The ephemeral half of the promise is a different number and is pinned
+// separately, at exactly zero, by
+// RunCommenterCommentOnAWispLandsOnTheWispThread.
+//
+// The "one mutation" half is the exact-one row count, which catches a body that
+// appended the comment twice while the entry count still held.
+func RunCommenterRecordsExactlyOneHistoryEntry(t *testing.T, ctx context.Context, fixture CommenterFixture) {
 	t.Helper()
 	anchor := fixture.IssuePrefix + "-history"
 	seedCommenterIssue(t, ctx, fixture, anchor)
@@ -295,8 +328,9 @@ func RunCommenterRecordsAtMostOneHistoryEntry(t *testing.T, ctx context.Context,
 	}
 
 	after := commenterHistoryCount(t, ctx, fixture)
-	if after < before || after > before+1 {
-		t.Errorf("history entries went %d -> %d across one AddComment, want at most one more", before, after)
+	if after != before+1 {
+		t.Errorf("history entries went %d -> %d across one durable AddComment, want exactly one more: a comment no entry carries never leaves this workspace, and a comment carrying two is not one mutation",
+			before, after)
 	}
 	assertCommenterRowCount(t, ctx, fixture, "comments", anchor, 1)
 }
@@ -551,7 +585,7 @@ func assertCommenterRowCount(t *testing.T, ctx context.Context, fixture Commente
 func commenterHistoryCount(t *testing.T, ctx context.Context, fixture CommenterFixture) int {
 	t.Helper()
 	if fixture.CountHistory == nil {
-		t.Skip("fixture cannot observe history: CountHistory is nil, so the at-most-one-entry clause is unpinned on this backend")
+		t.Skip("fixture cannot observe history: CountHistory is nil, so the entry-count clause is unpinned on this backend")
 	}
 	entries, err := fixture.CountHistory(ctx)
 	if err != nil {

--- a/internal/storage/dolt/bootstrapper_contract_test.go
+++ b/internal/storage/dolt/bootstrapper_contract_test.go
@@ -42,8 +42,14 @@ func TestBootstrapperContract(t *testing.T) {
 	t.Run("LeavesTheSubstrateUntouchedWhenItCannotComplete", func(t *testing.T) {
 		conformance.RunBootstrapperLeavesTheSubstrateUntouchedWhenItCannotComplete(t, ctx, fixture)
 	})
-	t.Run("RecordsAtMostOneHistoryEntry", func(t *testing.T) {
-		conformance.RunBootstrapperRecordsAtMostOneHistoryEntry(t, ctx, fixture)
+	// ZERO, not one, and not a range. This store leaves the identity entry to
+	// `bd init`'s own CommitWithConfig at the front door and says so in
+	// bootstrapper.go's body; the unit-of-work wiring pins ONE because its
+	// proxied front door has no commit of its own. The two are a ratified
+	// split, so do not "fix" either by matching it to the other — read
+	// RunBootstrapperRecordsExactlyOneHistoryEntry first.
+	t.Run("RecordsNoHistoryEntryOfItsOwn", func(t *testing.T) {
+		conformance.RunBootstrapperRecordsNoHistoryEntryOfItsOwn(t, ctx, fixture)
 	})
 	t.Run("VerifierAnswersEmptyForAnUnidentifiedSubstrate", func(t *testing.T) {
 		conformance.RunInitVerifierAnswersEmptyForAnUnidentifiedSubstrate(t, ctx, fixture)

--- a/internal/storage/dolt/commenter_contract_test.go
+++ b/internal/storage/dolt/commenter_contract_test.go
@@ -37,8 +37,8 @@ func TestCommenterContract(t *testing.T) {
 	t.Run("DoesNotResolvePrefixes", func(t *testing.T) {
 		conformance.RunCommenterDoesNotResolvePrefixes(t, ctx, fixture)
 	})
-	t.Run("RecordsAtMostOneHistoryEntry", func(t *testing.T) {
-		conformance.RunCommenterRecordsAtMostOneHistoryEntry(t, ctx, fixture)
+	t.Run("RecordsExactlyOneHistoryEntry", func(t *testing.T) {
+		conformance.RunCommenterRecordsExactlyOneHistoryEntry(t, ctx, fixture)
 	})
 	t.Run("LeavesTheAnchorIssueUntouched", func(t *testing.T) {
 		conformance.RunCommenterLeavesTheAnchorIssueUntouched(t, ctx, fixture)

--- a/internal/storage/embeddeddolt/bootstrapper_contract_test.go
+++ b/internal/storage/embeddeddolt/bootstrapper_contract_test.go
@@ -47,8 +47,14 @@ func TestBootstrapperContract(t *testing.T) {
 	t.Run("LeavesTheSubstrateUntouchedWhenItCannotComplete", func(t *testing.T) {
 		conformance.RunBootstrapperLeavesTheSubstrateUntouchedWhenItCannotComplete(t, ctx, fixture)
 	})
-	t.Run("RecordsAtMostOneHistoryEntry", func(t *testing.T) {
-		conformance.RunBootstrapperRecordsAtMostOneHistoryEntry(t, ctx, fixture)
+	// ZERO, not one, and not a range. This store reaches its transaction
+	// through withConn, which mints no Dolt commit, because `bd init`'s own
+	// commit at the front door is what records the identity; the unit-of-work
+	// wiring pins ONE because its proxied front door has no commit of its own.
+	// The two are a ratified split, so do not "fix" either by matching it to
+	// the other — read RunBootstrapperRecordsExactlyOneHistoryEntry first.
+	t.Run("RecordsNoHistoryEntryOfItsOwn", func(t *testing.T) {
+		conformance.RunBootstrapperRecordsNoHistoryEntryOfItsOwn(t, ctx, fixture)
 	})
 	t.Run("VerifierAnswersEmptyForAnUnidentifiedSubstrate", func(t *testing.T) {
 		conformance.RunInitVerifierAnswersEmptyForAnUnidentifiedSubstrate(t, ctx, fixture)

--- a/internal/storage/embeddeddolt/commenter_contract_test.go
+++ b/internal/storage/embeddeddolt/commenter_contract_test.go
@@ -40,8 +40,8 @@ func TestCommenterContract(t *testing.T) {
 	t.Run("DoesNotResolvePrefixes", func(t *testing.T) {
 		conformance.RunCommenterDoesNotResolvePrefixes(t, ctx, fixture)
 	})
-	t.Run("RecordsAtMostOneHistoryEntry", func(t *testing.T) {
-		conformance.RunCommenterRecordsAtMostOneHistoryEntry(t, ctx, fixture)
+	t.Run("RecordsExactlyOneHistoryEntry", func(t *testing.T) {
+		conformance.RunCommenterRecordsExactlyOneHistoryEntry(t, ctx, fixture)
 	})
 	t.Run("LeavesTheAnchorIssueUntouched", func(t *testing.T) {
 		conformance.RunCommenterLeavesTheAnchorIssueUntouched(t, ctx, fixture)

--- a/internal/storage/uow/bootstrapper_contract_test.go
+++ b/internal/storage/uow/bootstrapper_contract_test.go
@@ -48,8 +48,14 @@ func TestBootstrapperContract(t *testing.T) {
 	t.Run("LeavesTheSubstrateUntouchedWhenItCannotComplete", func(t *testing.T) {
 		conformance.RunBootstrapperLeavesTheSubstrateUntouchedWhenItCannotComplete(t, ctx, fixture)
 	})
-	t.Run("RecordsAtMostOneHistoryEntry", func(t *testing.T) {
-		conformance.RunBootstrapperRecordsAtMostOneHistoryEntry(t, ctx, fixture)
+	// ONE, not zero, and not a range. The proxied init route
+	// (cmd/bd/init_proxied_server.go) calls this role and stops, so the entry
+	// this body labels is the only thing that versions the identity there; both
+	// store wirings pin ZERO because `bd init` commits for them. The two are a
+	// ratified split, so do not "fix" either by matching it to the other — read
+	// RunBootstrapperRecordsNoHistoryEntryOfItsOwn first.
+	t.Run("RecordsExactlyOneHistoryEntry", func(t *testing.T) {
+		conformance.RunBootstrapperRecordsExactlyOneHistoryEntry(t, ctx, fixture)
 	})
 	t.Run("VerifierAnswersEmptyForAnUnidentifiedSubstrate", func(t *testing.T) {
 		conformance.RunInitVerifierAnswersEmptyForAnUnidentifiedSubstrate(t, ctx, fixture)

--- a/internal/storage/uow/commenter_contract_test.go
+++ b/internal/storage/uow/commenter_contract_test.go
@@ -38,8 +38,8 @@ func TestCommenterContract(t *testing.T) {
 	t.Run("DoesNotResolvePrefixes", func(t *testing.T) {
 		conformance.RunCommenterDoesNotResolvePrefixes(t, ctx, fixture)
 	})
-	t.Run("RecordsAtMostOneHistoryEntry", func(t *testing.T) {
-		conformance.RunCommenterRecordsAtMostOneHistoryEntry(t, ctx, fixture)
+	t.Run("RecordsExactlyOneHistoryEntry", func(t *testing.T) {
+		conformance.RunCommenterRecordsExactlyOneHistoryEntry(t, ctx, fixture)
 	})
 	t.Run("LeavesTheAnchorIssueUntouched", func(t *testing.T) {
 		conformance.RunCommenterLeavesTheAnchorIssueUntouched(t, ctx, fixture)


### PR DESCRIPTION
Implements `bd-qxqfj`. A measured investigation of history presence (`dolt_log` deltas, all three legs) found an audit claim that four contracts absorbed a split with "at most one" ranges was **right only for delete/sweep** — those are `bd-gq84y`, in flight separately. For these two the audit was wrong in two different ways.

| op | dolt | embedded | uow |
| --- | --- | --- | --- |
| AddComment | 1 | 1 | 1 |
| Bootstrap | 0 | 0 | **1** |

## Commenter — the audit was simply wrong; the range was slack

All three legs agree. There was no divergence to absorb.

`RunCommenterRecordsAtMostOneHistoryEntry` → `RunCommenterRecordsExactlyOneHistoryEntry`: `after < before || after > before+1` becomes `after != before+1`. No production change. The wisp zero stays exactly where it was.

**A range is unfalsifiable in the direction that matters** — it passes whether or not the entry is written — so the point of the change is that the new assertion fails when the commit doesn't happen. Verified, per body:

- `issueops/commenter.go`: `ExecuteAddComment` stops reporting `comments` as changed, so neither store stages anything → **dolt FAIL / embeddeddolt FAIL**, and confirmed in a scratch worktree that both reds are the *history* line (`75 → 75`), not the row count.
- uow: the first attempt returned `""` as the commit message, which was the **wrong mutation** — `RunTxResult` reads an empty message as "nothing to commit", so the row was lost and both cases reddened for the wrong reason. Re-targeted to `uow/doltserver_tx.go`, demoting `DOLT_COMMIT('-Am',?)` to a plain `COMMIT` so writes persist while `dolt_log` stands still → **exactly-one FAIL / wisp-zero PASS, UNIQUE**. The durable case catches a lost entry; the ephemeral zero cannot.

## Bootstrapper — inverted, and legitimately divergent

The audit said the two stores split from each other. They don't: **both stores are zero and uow is the outlier**, and it's deliberate on both sides. The stores defer to `bd init`'s own `CommitWithConfig`; uow commits in-role because the proxied init route has no other commit point.

Expressed as **two exported cases** — `RunBootstrapperRecordsNoHistoryEntryOfItsOwn` (both store wirings) and `RunBootstrapperRecordsExactlyOneHistoryEntry` (uow) — sharing one helper that carries the leg's rationale into the failure text. Each case doc cross-references the other, and each wiring carries a two-line *"do not fix this by matching the other leg"* note.

**Why not `skipKnownDivergence`**, which exists for this and has zero call sites: a skip parks a case as *undecided* and leaves the parked leg unpinned — the same blind spot as the range, relocated. Nothing here is undecided, so both numbers get an assertion that runs.

Falsifiability verified per leg: dolt committing in-role reddens the zero (77→78); embedded routed through `runIssueOperationTx` reddens the zero (75→76); uow with commits demoted reddens the one (73→73). The zero is meaningful because the store wirings fill `CountHistory` from the same kit hook the commenter case drives n→n+1.

## The table was re-measured, not inherited

AddComment 1/1/1 now passes as an equality on all three legs; Bootstrap 0/0/1 passes as two exact pins. Nothing diverged beyond what the table says.

## One thing left for the owner

`issueops/commenter.go` still says "at most one history entry". The contract is now deliberately **stricter than the published promise**. Ratifying that wording is a one-comment change but widens a published contract, so it's recorded as `bd-6bgnp` rather than done here.

Gates: `go build ./...`, `go vet`, full-repo `golangci-lint run` (0 issues); both contracts green on all three legs, every case confirmed by name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)