### PR TITLE
Version embedded role deletes and sweeps, and replace the range that hid it

### DIFF
--- a/backend/conformance/deleter_contract.go
+++ b/backend/conformance/deleter_contract.go
@@ -57,6 +57,24 @@ type DeleterFixture struct {
 	// A nil hook means "this backend cannot observe history", and the case that
 	// needs it SKIPS with that reason rather than passing quietly.
 	CountHistory func(context.Context) (int, error)
+	// CommitPending puts everything written so far into the version history,
+	// so a later CountHistory delta measures the call under test and nothing
+	// that led up to it.
+	//
+	// IT IS A PRECONDITION OF THE HISTORY CASE, NOT A CONVENIENCE. Deleting a
+	// row that never reached the history is not a change AGAINST the history:
+	// the working set returns to the state HEAD is already at, every backend's
+	// commit finds an empty diff, and none of them records an entry. Two of
+	// the three kits happen to version each seed as a side effect of writing
+	// it and one does not, so without this hook the same case measures a
+	// versioned deletion on two legs and an unversioned one on the third — and
+	// on that third leg it also depends on which OTHER subtests ran first,
+	// because their uncommitted seeds are what keep the working set dirty.
+	//
+	// A nil hook means the backend cannot settle its history on demand, and
+	// the case that needs it SKIPS with that reason rather than passing
+	// quietly.
+	CommitPending func(context.Context) error
 }
 
 // RunDeleterRefusesAMalformedRequest pins the request rules that need no
@@ -620,21 +638,44 @@ func RunDeleterDryRunChangesNothing(t *testing.T, ctx context.Context, fixture D
 	deleterAssertIssueRows(t, ctx, fixture, 0, first, second)
 }
 
-// RunDeleterRecordsAtMostOneHistoryEntry pins the versioning clause
-// (issueops/deleter.go, Deleter.Delete: "one call records AT MOST ONE entry").
+// RunDeleterRecordsExactlyOneHistoryEntry pins the versioning clause
+// (issueops/deleter.go, Deleter.Delete: "one call records EXACTLY ONE entry").
 //
-// AT MOST, not exactly one: only the server-backed store records an entry at
-// all, so asserting exactly one would be asserting a property of one wiring.
-// The DRY RUN half is the sharp one — a preview that left a commit behind
-// would be a mutation wearing a preview's name.
-func RunDeleterRecordsAtMostOneHistoryEntry(t *testing.T, ctx context.Context, fixture DeleterFixture) {
+// EXACTLY ONE, not at most one. The range this case used to assert passed
+// whether or not the entry was written, which is precisely the direction that
+// regressed once already: the port of `bd delete` onto this role reached its
+// transaction through a helper that mints no Dolt commit, embedded deletes
+// stopped being versioned, and no contract case went red — the hole was found
+// by a CLI test and patched at the CLI. A lower bound that cannot fail is not
+// a promise.
+//
+// THE ENTRY IS NOT PROMISED TO BE CRASH-ATOMIC WITH THE DELETION. The
+// server-backed store writes it inside the write transaction; the embedded one
+// writes it after its SQL commit, on a second connection, so a crash in that
+// window leaves the rows gone and the entry unwritten until the next flush.
+// What all three wirings promise, and what this case reads, is the steady
+// state one returned call leaves behind.
+//
+// The DRY RUN half is the other sharp one — a preview that left a commit
+// behind would be a mutation wearing a preview's name.
+//
+// THE SEEDS ARE SETTLED INTO THE HISTORY BEFORE ANYTHING IS MEASURED; see
+// DeleterFixture.CommitPending for why deleting an unversioned row records
+// nothing anywhere.
+func RunDeleterRecordsExactlyOneHistoryEntry(t *testing.T, ctx context.Context, fixture DeleterFixture) {
 	t.Helper()
 	if fixture.CountHistory == nil {
 		t.Skip("this backend cannot observe history, so the entry-per-call clause is unobservable here")
 	}
+	if fixture.CommitPending == nil {
+		t.Skip("this backend cannot settle its history on demand, so a delete of these seeds is not a change against the history and the clause is unobservable here")
+	}
 	first := deleterSeedIssue(t, ctx, fixture, "hist", "1")
 	second := deleterSeedIssue(t, ctx, fixture, "hist", "2")
 	request := publicops.DeleteRequest{IDs: []string{first, second}, Force: true}
+	if err := fixture.CommitPending(ctx); err != nil {
+		t.Fatalf("CommitPending() after seeding: %v", err)
+	}
 
 	before := deleterHistory(t, ctx, fixture)
 	deleterDelete(t, ctx, fixture, deleterWithDryRun(request, true))
@@ -644,8 +685,9 @@ func RunDeleterRecordsAtMostOneHistoryEntry(t *testing.T, ctx context.Context, f
 
 	before = deleterHistory(t, ctx, fixture)
 	deleterDelete(t, ctx, fixture, request)
-	if after := deleterHistory(t, ctx, fixture); after < before || after > before+1 {
-		t.Errorf("history went %d -> %d across one delete of 2 rows, want at most one more entry", before, after)
+	if after := deleterHistory(t, ctx, fixture); after != before+1 {
+		t.Errorf("history went %d -> %d across one delete of 2 rows, want exactly one more entry: a deletion is one act, not none and not one per row",
+			before, after)
 	}
 }
 

--- a/backend/conformance/sweeper_contract.go
+++ b/backend/conformance/sweeper_contract.go
@@ -58,6 +58,24 @@ type SweeperFixture struct {
 	// A nil hook means "this backend cannot observe history", and the case
 	// that needs it SKIPS with that reason rather than passing quietly.
 	CountHistory func(context.Context) (int, error)
+	// CommitPending puts everything written so far into the version history,
+	// so a later CountHistory delta measures the call under test and nothing
+	// that led up to it.
+	//
+	// IT IS A PRECONDITION OF THE HISTORY CASE, NOT A CONVENIENCE. Sweeping
+	// rows that never reached the history is not a change AGAINST the history:
+	// the working set returns to the state HEAD is already at, every backend's
+	// commit finds an empty diff, and none of them records an entry. Two of
+	// the three kits happen to version each seed as a side effect of writing
+	// it and one does not, so without this hook the same case measures a
+	// versioned sweep on two legs and an unversioned one on the third — and on
+	// that third leg it also depends on which OTHER subtests ran first,
+	// because their uncommitted seeds are what keep the working set dirty.
+	//
+	// A nil hook means the backend cannot settle its history on demand, and
+	// the case that needs it SKIPS with that reason rather than passing
+	// quietly.
+	CommitPending func(context.Context) error
 	// AddComment attaches a comment to an issue OR a wisp. It is filled from
 	// the backend's Commenter role, which resolves the plane itself, so a case
 	// can cite a candidate from a wisp's comment without knowing how that
@@ -409,19 +427,38 @@ func RunSweeperEmptyMatchIsZeroAndNil(t *testing.T, ctx context.Context, fixture
 	}
 }
 
-// RunSweeperRecordsAtMostOneHistoryEntry pins the versioning clause
+// RunSweeperRecordsExactlyOneHistoryEntry pins the versioning clause
 // (issueops.Sweeper.Sweep, "A DRY RUN CHANGES NOTHING, including history"): a
-// dry run and a no-op record NONE, and a sweep that deleted rows records at
-// most ONE — the deletion is one act, not one per row.
+// dry run and a no-op record NONE, and a sweep that deleted durable rows
+// records EXACTLY ONE — the deletion is one act, not none and not one per row.
 //
-// "AT MOST" rather than "exactly" is the honest promise across these backends:
-// the server-backed store records a Dolt commit, the embedded one commits
-// outside the SQL transaction and records none here, and an ephemeral sweep
-// touches only tables the version-control plane ignores.
-func RunSweeperRecordsAtMostOneHistoryEntry(t *testing.T, ctx context.Context, fixture SweeperFixture) {
+// The two zeros and the one are all exact. The range this case used to assert
+// on the last half absorbed a real split — the embedded store minted no Dolt
+// commit for a sweep at all — and passed either way; a lower bound that cannot
+// fail pins nothing. The zeros were always exact and stay that way: they are
+// what makes a preview a preview.
+//
+// AN EPHEMERAL SWEEP IS DELIBERATELY NOT THIS CASE'S SUBJECT. It touches only
+// tables the version-control plane ignores, so every wiring records none for
+// it — a uniform property of dolt_ignore rather than of the role.
+//
+// THE ENTRY IS NOT PROMISED TO BE CRASH-ATOMIC WITH THE SWEEP. The
+// server-backed store writes it inside the write transaction; the embedded one
+// writes it after its SQL commit, on a second connection, so a crash in that
+// window leaves the rows swept and the entry unwritten until the next flush.
+// What all three wirings promise, and what this case reads, is the steady
+// state one returned call leaves behind.
+//
+// THE SEEDS ARE SETTLED INTO THE HISTORY BEFORE ANYTHING IS MEASURED; see
+// SweeperFixture.CommitPending for why sweeping unversioned rows records
+// nothing anywhere.
+func RunSweeperRecordsExactlyOneHistoryEntry(t *testing.T, ctx context.Context, fixture SweeperFixture) {
 	t.Helper()
 	if fixture.CountHistory == nil {
 		t.Skip("this backend cannot observe history, so the entry-per-call clause is unobservable here")
+	}
+	if fixture.CommitPending == nil {
+		t.Skip("this backend cannot settle its history on demand, so a sweep of these seeds is not a change against the history and the clause is unobservable here")
 	}
 	ids := []string{
 		sweeperSeed(t, ctx, fixture, sweeperIssue(fixture, "hist", "1", false), nil),
@@ -430,6 +467,9 @@ func RunSweeperRecordsAtMostOneHistoryEntry(t *testing.T, ctx context.Context, f
 	request := publicops.SweepRequest{
 		Tier:      publicops.SweepDurable,
 		IDPattern: sweeperPattern(fixture, "hist"),
+	}
+	if err := fixture.CommitPending(ctx); err != nil {
+		t.Fatalf("CommitPending() after seeding: %v", err)
 	}
 
 	before := sweeperHistory(t, ctx, fixture)
@@ -450,8 +490,8 @@ func RunSweeperRecordsAtMostOneHistoryEntry(t *testing.T, ctx context.Context, f
 	before = sweeperHistory(t, ctx, fixture)
 	sweeperSweep(t, ctx, fixture, request)
 	after := sweeperHistory(t, ctx, fixture)
-	if after < before || after > before+1 {
-		t.Errorf("history went %d -> %d across one sweep of %d rows, want at most one more entry",
+	if after != before+1 {
+		t.Errorf("history went %d -> %d across one sweep of %d rows, want exactly one more entry",
 			before, after, len(ids))
 	}
 }

--- a/cmd/bd/autocommit_embedded_test.go
+++ b/cmd/bd/autocommit_embedded_test.go
@@ -173,6 +173,22 @@ Created while Dolt auto-commit is in batch mode.
 
 		assertEmbeddedHeadUnchanged(t, beadsDir, "dd", before, "delete")
 	})
+
+	// Prune rides the Sweeper role, which mints its own version commit — so
+	// batch mode has to reach it on the context, exactly as delete's does.
+	// Before the role versioned an embedded sweep, this route was deferred by
+	// accident: nothing under it committed at all, and the post-run flush
+	// already honored the mode.
+	t.Run("prune", func(t *testing.T) {
+		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "dp")
+		issue := bdCreate(t, bd, dir, "Batch prune target")
+		bdClose(t, bd, dir, issue.ID, "--reason", "done")
+		before := embeddedCurrentCommit(t, beadsDir, "dp")
+
+		bdCommand(t, bd, dir, "--dolt-auto-commit", "batch", "prune", "--pattern", "dp-*", "--force")
+
+		assertEmbeddedHeadUnchanged(t, beadsDir, "dp", before, "prune")
+	})
 }
 
 func TestEmbeddedRoutedSiblingWritesCommitTargetHead(t *testing.T) {

--- a/cmd/bd/delete.go
+++ b/cmd/bd/delete.go
@@ -157,24 +157,16 @@ Force: Delete and orphan dependents
 
 		commandDidWrite.Store(true)
 
-		// THE DELETE IS VERSIONED HERE. issueops.Deleter reaches its transaction
-		// through withConn, which does a SQL commit and no Dolt version commit, so
-		// nothing below the role advances HEAD. Before the role this route ran
-		// transactHonoringAutoCommit with a "bd: delete <id>" message, and that is
-		// what versioned the change; dropping it made embedded deletes unversioned
-		// and left a routed sibling's HEAD standing still.
-		//
-		// It commits the store the rows were actually deleted from, which for a
-		// prefix-routed id is the TARGET repository rather than this workspace.
-		// Batch and off modes are honored inside: maybeAutoCommitStore returns
-		// early unless auto-commit is on.
-		if err := commitPendingIfEmbedded(ctx, activeStore, actor, doltAutoCommitParams{
-			Command:         "delete",
-			IssueIDs:        []string{issueID},
-			MessageOverride: fmt.Sprintf("bd: delete %s", issueID),
-		}); err != nil {
-			WarnError("failed to commit: %v", err)
-		}
+		// NO COMMIT COMPENSATION HERE. The role versions its own deletion on
+		// every backend now, including the embedded one, which publishes the
+		// entry after its SQL commit — and it does so on the store the rows
+		// were actually deleted from, which for a prefix-routed id is the
+		// TARGET repository rather than this workspace. This route once had to
+		// mint that commit itself, because the port onto the role dropped the
+		// version commit embedded deletes used to get; a compensation here
+		// would now find a clean working set and add nothing but a second
+		// spelling of the same event. Batch and off modes are still honored:
+		// issueOpsContext above defers the role's commit in either.
 
 		if jsonOutput {
 			// The single-issue keys, unchanged: `deleted` is the id rather than a
@@ -372,23 +364,9 @@ func deleteBatch(_ *cobra.Command, issueIDs []string, force bool, dryRun bool, c
 
 	commandDidWrite.Store(true)
 
-	// THE DELETE IS VERSIONED HERE. issueops.Deleter reaches its transaction
-	// through withConn, which does a SQL commit and no Dolt version commit, so
-	// nothing below the role advances HEAD. Before the role this route ran
-	// transactHonoringAutoCommit with a "bd: delete <id>" message, and that is
-	// what versioned the change; dropping it made embedded deletes unversioned
-	// and left a routed sibling's HEAD standing still.
-	//
-	// It commits the store the rows were actually deleted from, which for a
-	// prefix-routed id is the TARGET repository rather than this workspace.
-	// Batch and off modes are honored inside: maybeAutoCommitStore returns
-	// early unless auto-commit is on.
-	if err := commitPendingIfEmbedded(ctx, batchStore, actor, doltAutoCommitParams{
-		Command:  "delete",
-		IssueIDs: resolvedIDs,
-	}); err != nil {
-		WarnError("failed to commit: %v", err)
-	}
+	// NO COMMIT COMPENSATION HERE, for the reason the single-id path gives:
+	// the role versions the deletion itself, on the store the rows were
+	// deleted from, and defers it in batch and off modes.
 
 	if jsonOutput {
 		if err := outputJSON(map[string]interface{}{

--- a/cmd/bd/purge.go
+++ b/cmd/bd/purge.go
@@ -148,7 +148,15 @@ func runPurgeOrPrune(cmd *cobra.Command, scope purgeScope) error {
 	if err != nil {
 		return HandleErrorRespectJSON("%v", err)
 	}
-	result, err := sweeper.Sweep(rootCtx, request)
+	// The role mints the sweep's version commit itself, so batch and off modes
+	// have to be said on the CONTEXT — the same way `bd delete` says them. Left
+	// off, an embedded `bd prune --dolt-auto-commit batch` advances HEAD, which
+	// is the one thing batch mode promises it will not do.
+	opsCtx, err := issueOpsContext(rootCtx)
+	if err != nil {
+		return HandleErrorRespectJSON("%v", err)
+	}
+	result, err := sweeper.Sweep(opsCtx, request)
 	if err != nil {
 		return HandleErrorRespectJSON("%s failed: %v", scope.cmdName, err)
 	}

--- a/internal/storage/dolt/deleter.go
+++ b/internal/storage/dolt/deleter.go
@@ -44,10 +44,12 @@ var _ issueops.Deleter = (*deleter)(nil)
 // like a mutation to everything watching the store.
 //
 // THE VERSION-CONTROL ENTRY IS ONE PER DELETION, recorded here rather than in
-// the shared body because only this backend records one at all. A deletion
-// confined to the wisp tables touches only tables this plane ignores, so
-// DOLT_COMMIT finds nothing to commit and records no entry — the "at most one"
-// the role promises, not "exactly one".
+// the shared body because the two backends mint it differently: this one
+// INSIDE the write transaction, where the embedded store can only publish
+// after its SQL commit, on a second connection. That is why the role promises
+// exactly one entry in the STEADY STATE and only this leg makes it atomic with
+// the deletion. A deletion confined to the wisp tables touches only tables
+// this plane ignores, so DOLT_COMMIT finds nothing to commit and records none.
 func (s *deleter) Delete(ctx context.Context, req issueops.DeleteRequest) (issueops.DeleteResult, error) {
 	if err := workapi.ValidateDeleteRequest(req); err != nil {
 		return issueops.DeleteResult{}, err

--- a/internal/storage/dolt/deleter_contract_test.go
+++ b/internal/storage/dolt/deleter_contract_test.go
@@ -9,14 +9,14 @@ import (
 
 // TestDeleterContract runs the Deleter contract against the server-backed
 // store, which reaches internal/storage/issueops.DeleteInTx through its own
-// write transaction and is the ONE wiring that records a version-control entry
-// for a deletion.
+// write transaction and is the one wiring whose version-control entry is
+// recorded INSIDE that transaction; the other two publish theirs after it.
 //
 // The cases are subtests of one parent so the whole role suite shares one store
 // and one copy-on-write branch, which is why every case namespaces its seeds
 // under fixture.IssuePrefix plus its own tag. setupTestStore already marks the
 // PARENT parallel; no subtest here calls t.Parallel, because
-// RecordsAtMostOneHistoryEntry takes a before/after delta.
+// RecordsExactlyOneHistoryEntry takes a before/after delta.
 func TestDeleterContract(t *testing.T) {
 	fixture, ctx, cleanup := newDoltDeleterFixture(t, "del")
 	defer cleanup()
@@ -63,8 +63,8 @@ func TestDeleterContract(t *testing.T) {
 	t.Run("DryRunChangesNothing", func(t *testing.T) {
 		conformance.RunDeleterDryRunChangesNothing(t, ctx, fixture)
 	})
-	t.Run("RecordsAtMostOneHistoryEntry", func(t *testing.T) {
-		conformance.RunDeleterRecordsAtMostOneHistoryEntry(t, ctx, fixture)
+	t.Run("RecordsExactlyOneHistoryEntry", func(t *testing.T) {
+		conformance.RunDeleterRecordsExactlyOneHistoryEntry(t, ctx, fixture)
 	})
 	t.Run("DoesNotMutateTheCallerRequest", func(t *testing.T) {
 		conformance.RunDeleterDoesNotMutateTheCallerRequest(t, ctx, fixture)
@@ -104,5 +104,17 @@ func newDoltDeleterFixture(t *testing.T, prefix string) (conformance.DeleterFixt
 		AddDependency: kit.AddDependency,
 		QueryScalar:   kit.QueryScalar,
 		CountHistory:  kit.CountHistory,
+		CommitPending: doltCommitPending(store),
 	}, ctx, stop
+}
+
+// doltCommitPending settles the working set into the version history. On this
+// backend the seed verbs already version each row on the way in, so it is
+// normally a no-op — Commit tolerates an empty working set — but the history
+// case states settling as a precondition rather than relying on a per-backend
+// side effect.
+func doltCommitPending(store *DoltStore) func(context.Context) error {
+	return func(ctx context.Context) error {
+		return store.Commit(ctx, "conformance: settle seeds before a history delta")
+	}
 }

--- a/internal/storage/dolt/sweeper.go
+++ b/internal/storage/dolt/sweeper.go
@@ -42,9 +42,12 @@ var _ issueops.Sweeper = (*sweeper)(nil)
 // look like a mutation to everything watching the store.
 //
 // THE VERSION-CONTROL ENTRY IS ONE PER SWEEP, recorded here rather than in the
-// shared body because only this backend records one at all. An ephemeral sweep
-// touches only the wisp tables, which this plane ignores, so DOLT_COMMIT finds
-// nothing to commit — the "at most one" the role promises, not "exactly one".
+// shared body because the two backends mint it differently: this one INSIDE
+// the write transaction, where the embedded store can only publish after its
+// SQL commit, on a second connection. That is why the role promises exactly
+// one entry in the STEADY STATE and only this leg makes it atomic with the
+// sweep. An ephemeral sweep touches only the wisp tables, which this plane
+// ignores, so DOLT_COMMIT finds nothing to commit and records none.
 func (s *sweeper) Sweep(ctx context.Context, req issueops.SweepRequest) (issueops.SweepResult, error) {
 	if err := workapi.ValidateSweepRequest(req); err != nil {
 		return issueops.SweepResult{}, err

--- a/internal/storage/dolt/sweeper_contract_test.go
+++ b/internal/storage/dolt/sweeper_contract_test.go
@@ -10,12 +10,12 @@ import (
 
 // TestSweeperContract runs the Sweeper contract against the server-backed
 // store, which reaches internal/storage/issueops.SweepInTx through its own
-// write transaction and is the ONE wiring that records a version-control entry
-// for a sweep.
+// write transaction and is the one wiring whose version-control entry is
+// recorded INSIDE that transaction; the other two publish theirs after it.
 //
 // The cases are subtests of one parent so the whole role suite shares one
 // store and one copy-on-write branch. setupTestStore already marks the PARENT
-// parallel; no subtest here calls t.Parallel, and RecordsAtMostOneHistoryEntry
+// parallel; no subtest here calls t.Parallel, and RecordsExactlyOneHistoryEntry
 // takes a before/after delta that is only meaningful while they run
 // sequentially.
 func TestSweeperContract(t *testing.T) {
@@ -49,8 +49,8 @@ func TestSweeperContract(t *testing.T) {
 	t.Run("EmptyMatchIsZeroAndNil", func(t *testing.T) {
 		conformance.RunSweeperEmptyMatchIsZeroAndNil(t, ctx, fixture)
 	})
-	t.Run("RecordsAtMostOneHistoryEntry", func(t *testing.T) {
-		conformance.RunSweeperRecordsAtMostOneHistoryEntry(t, ctx, fixture)
+	t.Run("RecordsExactlyOneHistoryEntry", func(t *testing.T) {
+		conformance.RunSweeperRecordsExactlyOneHistoryEntry(t, ctx, fixture)
 	})
 	t.Run("DoesNotMutateTheCallerRequest", func(t *testing.T) {
 		conformance.RunSweeperDoesNotMutateTheCallerRequest(t, ctx, fixture)
@@ -74,12 +74,13 @@ func newDoltSweeperFixture(t *testing.T, prefix string) (conformance.SweeperFixt
 	}
 	kit := newDoltRoleFixtureKit(store, prefix)
 	return conformance.SweeperFixture{
-		IssuePrefix:  kit.IssuePrefix,
-		Sweeper:      sweeper,
-		CreateIssue:  kit.CreateIssue,
-		CreateWisp:   kit.CreateWisp,
-		QueryScalar:  kit.QueryScalar,
-		CountHistory: kit.CountHistory,
+		IssuePrefix:   kit.IssuePrefix,
+		Sweeper:       sweeper,
+		CreateIssue:   kit.CreateIssue,
+		CreateWisp:    kit.CreateWisp,
+		QueryScalar:   kit.QueryScalar,
+		CountHistory:  kit.CountHistory,
+		CommitPending: doltCommitPending(store),
 		AddComment: func(ctx context.Context, issueID, author, text string) error {
 			// Through the Commenter ROLE, which resolves the plane itself, so
 			// the case can cite from a wisp's comment without knowing how this

--- a/internal/storage/embeddeddolt/deleter.go
+++ b/internal/storage/embeddeddolt/deleter.go
@@ -5,6 +5,7 @@ package embeddeddolt
 import (
 	"context"
 	"database/sql"
+	"fmt"
 
 	"github.com/steveyegge/beads/internal/storage"
 	storeops "github.com/steveyegge/beads/internal/storage/issueops"
@@ -26,14 +27,34 @@ func (s *EmbeddedDoltStore) Deleter() (issueops.Deleter, error) {
 // package for the reason that one gives: the work needs a TRANSACTION, which
 // storage.DoltStorage does not publish, so the sharing happens below both of
 // them at issueops.DeleteInTx. The two stores differ here only in how they
-// reach a transaction and in whether they record a version-control entry —
-// this one's commit runs outside the SQL transaction, so it records none.
+// reach a transaction and in WHEN the version-control entry lands: the server
+// writes it inside the write transaction, this one after the SQL commit on a
+// second connection.
 type deleter struct{ store *EmbeddedDoltStore }
 
 var _ issueops.Deleter = (*deleter)(nil)
 
 // Delete erases the request's ids. Validation and normalization happen before
 // the connection is opened, so a malformed request costs no database work.
+//
+// A DRY RUN TAKES THE NON-COMMITTING PATH: withConn(commit=false) rolls the
+// transaction back and no version-control entry is attempted — the same
+// distinction Sweep draws here.
+//
+// THE VERSION-CONTROL ENTRY IS ONE PER DELETION, published through
+// runIssueOperationTx like this store's other guarded writes. It was not
+// always: the port of `bd delete` onto this role reached its transaction
+// through withConn, which mints no Dolt commit, so embedded deletes stopped
+// being versioned and were compensated for at the CLI instead. A deletion
+// confined to dolt-ignored tables — a wisp with no sync-plane edges — leaves
+// nothing pending, so StageAndCommit records none.
+//
+// THE ENTRY LANDS AFTER THE SQL TRANSACTION COMMITS, on a second connection —
+// this store has no way to mint a Dolt commit inside its own transaction. A
+// crash in that window leaves the rows deleted and the change sitting
+// uncommitted in the working set, for the next flush to carry. "One entry per
+// deletion" is therefore a steady-state promise here, where the server-backed
+// store's is crash-atomic.
 func (s *deleter) Delete(ctx context.Context, req issueops.DeleteRequest) (issueops.DeleteResult, error) {
 	if err := workapi.ValidateDeleteRequest(req); err != nil {
 		return issueops.DeleteResult{}, err
@@ -41,12 +62,28 @@ func (s *deleter) Delete(ctx context.Context, req issueops.DeleteRequest) (issue
 	req.IDs = workapi.NormalizeDeleteIDs(req.IDs)
 
 	var result issueops.DeleteResult
-	// commit = !DryRun: a preview writes nothing, so it must not take the
-	// committing path — the same distinction Sweep draws here.
-	if err := s.store.withConn(ctx, !req.DryRun, func(tx *sql.Tx) error {
+	run := func(tx *sql.Tx) error {
 		var err error
 		result, err = storeops.DeleteInTx(ctx, tx, req)
 		return err
+	}
+	if req.DryRun {
+		if err := s.store.withConn(ctx, false, run); err != nil {
+			return issueops.DeleteResult{}, err
+		}
+		return result, nil
+	}
+
+	if err := s.store.runIssueOperationTxWithMessage(ctx, func(tx *sql.Tx) (storeops.ChangedTables, string, error) {
+		if err := run(tx); err != nil {
+			return nil, "", err
+		}
+		if result.Deleted == 0 {
+			return nil, "", nil
+		}
+		// The same tables a sweep stages; the neighbor rewrite lands in
+		// `issues` and `events`, which are already on the list.
+		return sweptTables(), fmt.Sprintf("bd: delete %d issue(s)", result.Deleted), nil
 	}); err != nil {
 		return issueops.DeleteResult{}, err
 	}

--- a/internal/storage/embeddeddolt/deleter_contract_test.go
+++ b/internal/storage/embeddeddolt/deleter_contract_test.go
@@ -3,6 +3,7 @@
 package embeddeddolt_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/steveyegge/beads/backend/conformance"
@@ -11,8 +12,9 @@ import (
 // TestDeleterContract runs the Deleter contract against the embedded store,
 // which hands back the SAME body the server-backed store does
 // (internal/storage/issueops.DeleteInTx) and differs only in how it reaches a
-// transaction and in that its commit runs outside one. That is what this wiring
-// catches; it is not an independent vote on the body.
+// transaction and in that its version commit is published after that
+// transaction rather than inside it. That is what this wiring catches; it is
+// not an independent vote on the body.
 //
 // One environment for the whole suite: booting an embedded engine per case
 // would dominate the runtime, every case namespaces its seeds, and the history
@@ -65,8 +67,8 @@ func TestDeleterContract(t *testing.T) {
 	t.Run("DryRunChangesNothing", func(t *testing.T) {
 		conformance.RunDeleterDryRunChangesNothing(t, ctx, fixture)
 	})
-	t.Run("RecordsAtMostOneHistoryEntry", func(t *testing.T) {
-		conformance.RunDeleterRecordsAtMostOneHistoryEntry(t, ctx, fixture)
+	t.Run("RecordsExactlyOneHistoryEntry", func(t *testing.T) {
+		conformance.RunDeleterRecordsExactlyOneHistoryEntry(t, ctx, fixture)
 	})
 	t.Run("DoesNotMutateTheCallerRequest", func(t *testing.T) {
 		conformance.RunDeleterDoesNotMutateTheCallerRequest(t, ctx, fixture)
@@ -97,5 +99,21 @@ func newEmbeddedDeleterFixture(t *testing.T, te *testEnv, prefix string) conform
 		AddDependency: kit.AddDependency,
 		QueryScalar:   kit.QueryScalar,
 		CountHistory:  kit.CountHistory,
+		CommitPending: embeddedCommitPending(te),
+	}
+}
+
+// embeddedCommitPending settles the working set into the version history. It is
+// the hook the history case needs and the frozen role kit does not carry: this
+// backend's seed verbs write rows WITHOUT minting a Dolt commit, where the
+// other two backends' version each seed on the way in, so a delete or a sweep
+// of nothing but seeds would find the working set already equal to HEAD and
+// have nothing to record.
+//
+// Commit is the store's own working-set flush and tolerates an empty one, so
+// calling it when there is nothing pending is a no-op rather than an error.
+func embeddedCommitPending(te *testEnv) func(context.Context) error {
+	return func(ctx context.Context) error {
+		return te.store.Commit(ctx, "conformance: settle seeds before a history delta")
 	}
 }

--- a/internal/storage/embeddeddolt/sweeper.go
+++ b/internal/storage/embeddeddolt/sweeper.go
@@ -5,6 +5,7 @@ package embeddeddolt
 import (
 	"context"
 	"database/sql"
+	"fmt"
 
 	"github.com/steveyegge/beads/internal/storage"
 	storeops "github.com/steveyegge/beads/internal/storage/issueops"
@@ -23,28 +24,76 @@ func (s *EmbeddedDoltStore) Sweeper() (issueops.Sweeper, error) {
 // sweeper clears closed rows from one tier inside one connection's transaction.
 // The work needs a TRANSACTION, which storage.DoltStorage does not publish, so
 // the sharing with the server-backed store happens at issueops.SweepInTx. The
-// two differ only in how they reach a transaction and in whether they record a
-// version-control entry — this one's commit runs outside the SQL transaction,
-// so it records none.
+// two differ only in how they reach a transaction and in WHEN the
+// version-control entry lands: the server writes it inside the write
+// transaction, this one after the SQL commit on a second connection.
 type sweeper struct{ store *EmbeddedDoltStore }
 
 var _ issueops.Sweeper = (*sweeper)(nil)
 
 // Sweep clears the request's tier. Validation happens before the connection is
 // opened, so a refused request costs no database work.
+//
+// A DRY RUN TAKES THE NON-COMMITTING PATH: withConn(commit=false) rolls the
+// transaction back and no version-control entry is attempted, so a preview
+// cannot look like a mutation to anything watching the store.
+//
+// THE VERSION-CONTROL ENTRY IS ONE PER SWEEP THAT SWEPT, published through
+// runIssueOperationTx like this store's other guarded writes. A sweep that
+// deleted nothing composes no message and commits nothing, and an ephemeral
+// sweep that touched only dolt-ignored tables stages nothing, so
+// StageAndCommit finds nothing pending and records none.
+//
+// THE ENTRY LANDS AFTER THE SQL TRANSACTION COMMITS, on a second connection —
+// this store has no way to mint a Dolt commit inside its own transaction. A
+// crash in that window leaves the rows swept and the change sitting
+// uncommitted in the working set, for the next flush to carry. "One entry per
+// sweep" is therefore a steady-state promise here, where the server-backed
+// store's is crash-atomic.
 func (s *sweeper) Sweep(ctx context.Context, req issueops.SweepRequest) (issueops.SweepResult, error) {
 	if err := workapi.ValidateSweepRequest(req); err != nil {
 		return issueops.SweepResult{}, err
 	}
 	var result issueops.SweepResult
-	// commit = !DryRun: a preview writes nothing, so it must not take the
-	// committing path — the same distinction DeleteIssues draws here.
-	if err := s.store.withConn(ctx, !req.DryRun, func(tx *sql.Tx) error {
+	run := func(tx *sql.Tx) error {
 		var err error
 		result, err = storeops.SweepInTx(ctx, tx, req)
 		return err
+	}
+	if req.DryRun {
+		if err := s.store.withConn(ctx, false, run); err != nil {
+			return issueops.SweepResult{}, err
+		}
+		return result, nil
+	}
+
+	if err := s.store.runIssueOperationTxWithMessage(ctx, func(tx *sql.Tx) (storeops.ChangedTables, string, error) {
+		if err := run(tx); err != nil {
+			return nil, "", err
+		}
+		if result.Swept == 0 {
+			return nil, "", nil
+		}
+		return sweptTables(), fmt.Sprintf("bd: sweep %d %s bead(s)", result.Swept, req.Tier), nil
 	}); err != nil {
 		return issueops.SweepResult{}, err
 	}
 	return result, nil
+}
+
+// sweptTables are the versioned tables a sweep stages before its commit. It is
+// the server-backed store's list of the same name, derived from the shared
+// cascade description rather than hand-listed, so a migration that adds a
+// cascade cannot leave rows deleted in the working set and absent from the
+// version commit.
+//
+// It is the set a DELETE stages too, because a sweep IS a delete of a selected
+// set. BOTH PLANES ARE ASKED FOR: one call can name rows in either, and
+// ChangedTables.Add drops the ephemeral members — leaving the durable set plus
+// the sync-plane `dependencies` rows a wisp delete removes explicitly.
+func sweptTables() storeops.ChangedTables {
+	tables := storeops.ChangedTables{}
+	tables.Add(storeops.DeleteCascadeTables(false)...)
+	tables.Add(storeops.DeleteCascadeTables(true)...)
+	return tables
 }

--- a/internal/storage/embeddeddolt/sweeper_contract_test.go
+++ b/internal/storage/embeddeddolt/sweeper_contract_test.go
@@ -13,8 +13,9 @@ import (
 // TestSweeperContract runs the Sweeper contract against the embedded store,
 // which hands back the SAME body the server-backed store does
 // (internal/storage/issueops.SweepInTx) and differs only in how it reaches a
-// transaction and in that its commit runs outside one. That is what this
-// wiring catches; it is not an independent vote on the body.
+// transaction and in that its version commit is published after that
+// transaction rather than inside it. That is what this wiring catches; it is
+// not an independent vote on the body.
 //
 // One environment for the whole suite: booting an embedded engine per case
 // would dominate the runtime, every case scopes itself to prefix-namespaced
@@ -52,8 +53,8 @@ func TestSweeperContract(t *testing.T) {
 	t.Run("EmptyMatchIsZeroAndNil", func(t *testing.T) {
 		conformance.RunSweeperEmptyMatchIsZeroAndNil(t, ctx, fixture)
 	})
-	t.Run("RecordsAtMostOneHistoryEntry", func(t *testing.T) {
-		conformance.RunSweeperRecordsAtMostOneHistoryEntry(t, ctx, fixture)
+	t.Run("RecordsExactlyOneHistoryEntry", func(t *testing.T) {
+		conformance.RunSweeperRecordsExactlyOneHistoryEntry(t, ctx, fixture)
 	})
 	t.Run("DoesNotMutateTheCallerRequest", func(t *testing.T) {
 		conformance.RunSweeperDoesNotMutateTheCallerRequest(t, ctx, fixture)
@@ -68,12 +69,13 @@ func newEmbeddedSweeperFixture(t *testing.T, te *testEnv, prefix string) conform
 	}
 	kit := newEmbeddedRoleFixtureKit(te, prefix)
 	return conformance.SweeperFixture{
-		IssuePrefix:  kit.IssuePrefix,
-		Sweeper:      sweeper,
-		CreateIssue:  kit.CreateIssue,
-		CreateWisp:   kit.CreateWisp,
-		QueryScalar:  kit.QueryScalar,
-		CountHistory: kit.CountHistory,
+		IssuePrefix:   kit.IssuePrefix,
+		Sweeper:       sweeper,
+		CreateIssue:   kit.CreateIssue,
+		CreateWisp:    kit.CreateWisp,
+		QueryScalar:   kit.QueryScalar,
+		CountHistory:  kit.CountHistory,
+		CommitPending: embeddedCommitPending(te),
 		AddComment: func(ctx context.Context, issueID, author, text string) error {
 			// Through the Commenter ROLE, which resolves the plane itself, so
 			// the case can cite from a wisp's comment without knowing how this

--- a/internal/storage/uow/deleter_contract_test.go
+++ b/internal/storage/uow/deleter_contract_test.go
@@ -66,8 +66,8 @@ func TestDeleterContract(t *testing.T) {
 	t.Run("DryRunChangesNothing", func(t *testing.T) {
 		conformance.RunDeleterDryRunChangesNothing(t, ctx, fixture)
 	})
-	t.Run("RecordsAtMostOneHistoryEntry", func(t *testing.T) {
-		conformance.RunDeleterRecordsAtMostOneHistoryEntry(t, ctx, fixture)
+	t.Run("RecordsExactlyOneHistoryEntry", func(t *testing.T) {
+		conformance.RunDeleterRecordsExactlyOneHistoryEntry(t, ctx, fixture)
 	})
 	t.Run("DoesNotMutateTheCallerRequest", func(t *testing.T) {
 		conformance.RunDeleterDoesNotMutateTheCallerRequest(t, ctx, fixture)
@@ -105,5 +105,20 @@ func newUOWDeleterFixture(t *testing.T, ctx context.Context, prefix string) conf
 		AddDependency: kit.AddDependency,
 		QueryScalar:   kit.QueryScalar,
 		CountHistory:  kit.CountHistory,
+		CommitPending: uowCommitPending(provider),
+	}
+}
+
+// uowCommitPending settles the working set into the version history. Every seed
+// on this backend is its own unit of work and versions itself on the way in, so
+// an empty unit of work here has nothing left to publish — doltServerTx.Commit
+// demotes a commit with no pending changes to a plain SQL COMMIT. The history
+// case still asks for it, because settling is a stated precondition rather than
+// a side effect the case is entitled to assume.
+func uowCommitPending(provider UnitOfWorkProvider) func(context.Context) error {
+	return func(ctx context.Context) error {
+		return RunTx(ctx, provider, func(context.Context, UnitOfWork) (string, error) {
+			return "conformance: settle seeds before a history delta", nil
+		})
 	}
 }

--- a/internal/storage/uow/sweeper_contract_test.go
+++ b/internal/storage/uow/sweeper_contract_test.go
@@ -50,8 +50,8 @@ func TestSweeperContract(t *testing.T) {
 	t.Run("EmptyMatchIsZeroAndNil", func(t *testing.T) {
 		conformance.RunSweeperEmptyMatchIsZeroAndNil(t, ctx, fixture)
 	})
-	t.Run("RecordsAtMostOneHistoryEntry", func(t *testing.T) {
-		conformance.RunSweeperRecordsAtMostOneHistoryEntry(t, ctx, fixture)
+	t.Run("RecordsExactlyOneHistoryEntry", func(t *testing.T) {
+		conformance.RunSweeperRecordsExactlyOneHistoryEntry(t, ctx, fixture)
 	})
 	t.Run("DoesNotMutateTheCallerRequest", func(t *testing.T) {
 		conformance.RunSweeperDoesNotMutateTheCallerRequest(t, ctx, fixture)
@@ -73,12 +73,13 @@ func newUOWSweeperFixture(t *testing.T, ctx context.Context, prefix string) conf
 	}
 	kit := newUOWRoleFixtureKit(provider, prefix)
 	return conformance.SweeperFixture{
-		IssuePrefix:  kit.IssuePrefix,
-		Sweeper:      sweeper,
-		CreateIssue:  kit.CreateIssue,
-		CreateWisp:   kit.CreateWisp,
-		QueryScalar:  kit.QueryScalar,
-		CountHistory: kit.CountHistory,
+		IssuePrefix:   kit.IssuePrefix,
+		Sweeper:       sweeper,
+		CreateIssue:   kit.CreateIssue,
+		CreateWisp:    kit.CreateWisp,
+		QueryScalar:   kit.QueryScalar,
+		CountHistory:  kit.CountHistory,
+		CommitPending: uowCommitPending(provider),
 		AddComment: func(ctx context.Context, issueID, author, text string) error {
 			// Through the Commenter ROLE, which resolves the plane itself, so
 			// the case can cite from a wisp's comment without knowing how this

--- a/issueops/deleter.go
+++ b/issueops/deleter.go
@@ -278,7 +278,15 @@ type Deleter interface {
 	//
 	// A DRY RUN CHANGES NOTHING, including history: an implementation that
 	// records a version-control entry for a deletion records none for a dry
-	// run. Where an implementation versions at all, one call records AT MOST
-	// ONE entry — a deletion is one act, not one per row.
+	// run. Where an implementation versions at all, a call that deleted
+	// durable rows records EXACTLY ONE entry — a deletion is one act, not one
+	// per row, and not none. A deletion confined to tables the version-control
+	// plane ignores records none, because there is nothing to version.
+	//
+	// EXACTLY ONE IS A STEADY-STATE PROMISE, NOT A CRASH-ATOMIC ONE. An
+	// implementation may write the entry after the transaction that deleted
+	// the rows — the embedded store has no way to mint one inside its own —
+	// so a crash between the two leaves the rows gone and the entry unwritten
+	// until the next flush.
 	Delete(ctx context.Context, req DeleteRequest) (DeleteResult, error)
 }

--- a/issueops/sweeper.go
+++ b/issueops/sweeper.go
@@ -275,7 +275,15 @@ type Sweeper interface {
 	// A DRY RUN CHANGES NOTHING, including history: an implementation that
 	// records a version-control entry for a sweep records none for a dry run
 	// and none for a sweep that deleted nothing. Where an implementation
-	// versions at all, one sweep records AT MOST ONE entry — the deletion is
-	// one act, not one per row.
+	// versions at all, a sweep that cleared durable rows records EXACTLY ONE
+	// entry — the deletion is one act, not one per row, and not none. An
+	// ephemeral sweep touches only tables the version-control plane ignores,
+	// so it records none.
+	//
+	// EXACTLY ONE IS A STEADY-STATE PROMISE, NOT A CRASH-ATOMIC ONE. An
+	// implementation may write the entry after the transaction that swept the
+	// rows — the embedded store has no way to mint one inside its own — so a
+	// crash between the two leaves the rows swept and the entry unwritten
+	// until the next flush.
 	Sweep(ctx context.Context, req SweepRequest) (SweepResult, error)
 }


### PR DESCRIPTION
Implements `bd-gq84y` — the last outstanding divergence with a **caller-visible** consequence.

| op | dolt | embedded | uow |
| --- | --- | --- | --- |
| Delete | 1 | **0 → 1** | 1 |
| Sweep | 1 | **0 → 1** | 1 |

## It was an accident, and the contract couldn't see it

The role port dropped the pre-existing embedded version commit. The commit that noticed says so outright — *"DELETES STOPPED BEING VERSIONED ON EMBEDDED"* — and it was patched **at the CLI** (`commitPendingIfEmbedded`), not at the role. So the role-level hole stayed open, and `bd dolt log` differed by mode while embedded `Push` doesn't auto-commit pending, meaning an unflushed role delete **did not replicate**.

The contracts absorbed it with an "at most one" range, which is unfalsifiable in the direction that matters. `HISTORY.md` recorded the proof: mutating `dolt/deleter.go` to drop its commit left the dolt-leg case **green**.

**That exact mutation is now caught.** Five runs, each attributed to the body it broke, all UNIQUE:

| mutated | reddens | stays green |
| --- | --- | --- |
| `dolt/deleter.go` — *the previously-INCONCLUSIVE run* | dolt | embedded |
| `embeddeddolt/deleter.go` | embedded | dolt |
| `embeddeddolt/sweeper.go` | embedded | dolt |
| `dolt/sweeper.go` | dolt | embedded |
| `uow/deleter.go` | uow | dolt |

## What changed

Embedded delete and sweep now split dry-run from mutating: a dry run keeps `withConn(commit=false)`; a mutating call goes through `runIssueOperationTxWithMessage` — the same post-SQL-commit `StageAndCommit` publication the commenter and lifecycle verbs already use — with the other legs' messages. Batch-mode deferral comes free, since that path already checks `VersionCommitDeferred`.

The staged set is schema-derived from `issueops.DeleteCascadeTables`, so `TestDeleteCascadeTablesCoversSchema` guards it rather than a hand-maintained list.

## A path that did need the compensation

Both `commitPendingIfEmbedded` calls are retired — but **`bd prune` never called `issueOpsContext`**, so once the role committed, `bd prune --dolt-auto-commit batch` advanced HEAD on embedded. Verified live, fixed in `cmd/bd/purge.go`, with a new `prune` subtest beside the existing `delete` one; reverting the one line reddens it.

(`dolt/sweeper.go` still ignores the deferral flag where `dolt/deleter.go` honours it — pre-existing, untouched, noted.)

## A fixture defect the range was also hiding

Exactly-one was **not true on embedded even after the fix**. The embedded kit's seed verb writes rows without versioning them, where the dolt and uow kits version each seed on the way in. Deleting a row that never reached the history is not a change *against* the history: the working set returns to what HEAD holds, every backend's commit finds an empty diff, and none records an entry.

So the case was measuring a versioned deletion on two legs and an unversioned one on the third — **and on that third it depended on which other subtests ran first**, since their uncommitted seeds were what kept the working set dirty. A new `CommitPending` fixture hook makes settling a stated precondition, filled at each of the six wirings from that backend's own flush verb. The frozen `roleFixtureKit` is untouched.

That is a category this programme hadn't hit before: not a case that cannot fail, but one that passes for reasons depending on test order.

## The crash window, stated where it lives

Embedded's entry lands *after* the SQL commit, on a second connection. The promise is therefore steady-state exactly-one, not crash-atomic, and that is said in the leaf docs (where the promise lives), in both contracts' prose, and beside the code in both stores' bodies — adapted to each site rather than copy-pasted.

Gates: `go build ./...`, `go vet`, full-tree `golangci-lint` clean; deleter and sweeper contracts green on all three legs; `cmd/bd` delete, prune, purge, routed-sibling and batch/on/off auto-commit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)