### PR TITLE
test(conformance): fail on a role method with no contract case

### DIFF
--- a/backend/conformance/conformance.go
+++ b/backend/conformance/conformance.go
@@ -48,6 +48,13 @@
 // required, while CountHistory, CountHistoryMatching, Exec and the seed hooks
 // are optional and degrade LOUDLY when nil (see history_matching.go).
 //
+// That tier is EXHAUSTIVE over the facade, and role_coverage_gate_test.go is
+// what makes it a fact rather than a wish: it censuses every method of every
+// interface issueops and memoryops declare, resolves which of them the contract
+// cases here actually call, and fails on any method nothing calls. A role
+// method with no contract is admissible only as a waiver naming its reason, and
+// that waiver list can only shrink.
+//
 // # Usage from a backend test file
 //
 //	func TestConformance(t *testing.T) {

--- a/backend/conformance/role_coverage_gate_test.go
+++ b/backend/conformance/role_coverage_gate_test.go
@@ -1,0 +1,208 @@
+package conformance
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// uncoveredRoleMethods waives the role methods this package knowingly has no
+// contract case for. It is SHRINK-ONLY: the gate fails on an entry that names
+// no real method and on an entry the package has since covered, so the PR that
+// writes the first case for a waived method deletes its entry in the same
+// change. Nothing may be added here to land a role method without a contract.
+var uncoveredRoleMethods = map[string]string{
+	"issueops.Importer.ImportBatch": "Importer is the one role no storage accessor hands out: " +
+		"internal/storage/uow reaches it through its own provider and the other two " +
+		"backends do not implement it at all. The role tier reaches a backend through " +
+		"storage accessors, so there is no fixture to run this contract from until " +
+		"Importer joins that surface.",
+}
+
+// TestEveryRoleMethodHasAContractCase is the exhaustiveness gate on the role
+// tier: every method of every interface the public facade declares must be
+// called by a contract case here, or be waived above with a reason.
+//
+// It exists because coverage was aspirational. Nothing failed when a role
+// method landed with no contract behind it — issueops.Importer.ImportBatch has
+// had none since it was written and nothing noticed. Both halves of the
+// comparison are derived, so a twenty-fifth role interface, a thirty-seventh
+// method, or a contract case that stops calling what it claims to all reach
+// this test on their own.
+func TestEveryRoleMethodHasAContractCase(t *testing.T) {
+	facade, err := roleFacade()
+	if err != nil {
+		t.Fatalf("reading the role facade: %v", err)
+	}
+	if len(facade) == 0 {
+		t.Fatal("the role facade census is empty; the gate would pass vacuously")
+	}
+	root, err := repoRoot()
+	if err != nil {
+		t.Fatalf("locating the repository root: %v", err)
+	}
+	covered, err := scanRoleCalls(filepath.Join(root, "backend", "conformance"))
+	if err != nil {
+		t.Fatalf("scanning contract cases: %v", err)
+	}
+	for _, problem := range auditRoleCoverage(facade, covered, uncoveredRoleMethods) {
+		t.Error(problem)
+	}
+}
+
+// TestRoleFacadeCensusAgreesWithReflection checks the source census against the
+// compiler for every role a storage accessor hands out. The census is parsed
+// from source because reflection cannot enumerate a package's types; this is
+// what keeps that parse honest, so a method set the parser reads wrong fails
+// here rather than quietly excusing a contract.
+func TestRoleFacadeCensusAgreesWithReflection(t *testing.T) {
+	facade, err := roleFacade()
+	if err != nil {
+		t.Fatalf("reading the role facade: %v", err)
+	}
+	accessors := reflectRoleAccessors()
+	if len(accessors) == 0 {
+		t.Fatal("no storage accessor returns a facade role; the cross-check would pass vacuously")
+	}
+	for role, reflected := range accessors {
+		parsed, ok := facade[role]
+		if !ok {
+			t.Errorf("%s is handed out by a storage accessor but the source census never saw it", role)
+			continue
+		}
+		if strings.Join(parsed, ",") != strings.Join(reflected, ",") {
+			t.Errorf("%s method set: source census has %v, reflection has %v", role, parsed, reflected)
+		}
+	}
+}
+
+// auditRoleCoverage reports every way the role facade, the contract cases that
+// call it, and the waiver list disagree. It is separated from the scanning so
+// it can be exercised against fabricated inputs, which is the only way to prove
+// the gate fails when it should.
+func auditRoleCoverage(facade map[string][]string, covered map[roleMethod][]string, waived map[string]string) []string {
+	var problems []string
+	known := map[string]bool{}
+	for _, role := range sortedKeys(facade) {
+		for _, method := range facade[role] {
+			target := roleMethod{Role: role, Method: method}
+			known[target.String()] = true
+			_, isWaived := waived[target.String()]
+			switch {
+			case len(covered[target]) > 0 && isWaived:
+				problems = append(problems, fmt.Sprintf(
+					"%s is waived as uncovered but %s calls it: delete its entry from uncoveredRoleMethods",
+					target, strings.Join(covered[target], ", ")))
+			case len(covered[target]) == 0 && !isWaived:
+				problems = append(problems, fmt.Sprintf(
+					"%s has no contract case: no conformance entrypoint calls it. Write one, or waive it in uncoveredRoleMethods with a reason",
+					target))
+			}
+		}
+	}
+	for _, entry := range sortedKeys(waived) {
+		if !known[entry] {
+			problems = append(problems, fmt.Sprintf(
+				"uncoveredRoleMethods waives %q, which names no method of any facade role", entry))
+			continue
+		}
+		if strings.TrimSpace(waived[entry]) == "" {
+			problems = append(problems, fmt.Sprintf("uncoveredRoleMethods waives %s with no reason", entry))
+		}
+	}
+	return problems
+}
+
+// sortedKeys returns a map's keys in a deterministic order, so the gate reports
+// the same problems in the same order every run.
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// These are the gate's own tests. A gate nobody has watched fail is a gate
+// nobody knows works, so each case fabricates the drift it is meant to catch
+// and asserts the report names it.
+
+func TestAuditRoleCoverageReportsNothingWhenEveryMethodHasACase(t *testing.T) {
+	facade := map[string][]string{"issueops.Reader": {"Get", "Ready"}}
+	covered := map[roleMethod][]string{
+		{Role: "issueops.Reader", Method: "Get"}:   {"RunReaderGetHydratesLabels"},
+		{Role: "issueops.Reader", Method: "Ready"}: {"RunReaderReadyExcludesBlocked"},
+	}
+	if problems := auditRoleCoverage(facade, covered, nil); len(problems) != 0 {
+		t.Errorf("fully covered facade reported %v, want no problems", problems)
+	}
+}
+
+func TestAuditRoleCoverageCatchesAMethodNoCaseCalls(t *testing.T) {
+	facade := map[string][]string{"issueops.Reader": {"Get", "Ready"}}
+	covered := map[roleMethod][]string{
+		{Role: "issueops.Reader", Method: "Get"}: {"RunReaderGetHydratesLabels"},
+	}
+	problems := auditRoleCoverage(facade, covered, nil)
+	if len(problems) != 1 || !strings.Contains(problems[0], "issueops.Reader.Ready has no contract case") {
+		t.Errorf("uncovered method reported %v, want one problem naming issueops.Reader.Ready", problems)
+	}
+}
+
+func TestAuditRoleCoverageCatchesAWholeUncoveredRole(t *testing.T) {
+	facade := map[string][]string{
+		"issueops.Reader":   {"Get"},
+		"issueops.Importer": {"ImportBatch"},
+	}
+	covered := map[roleMethod][]string{
+		{Role: "issueops.Reader", Method: "Get"}: {"RunReaderGetHydratesLabels"},
+	}
+	problems := auditRoleCoverage(facade, covered, nil)
+	if len(problems) != 1 || !strings.Contains(problems[0], "issueops.Importer.ImportBatch") {
+		t.Errorf("uncovered role reported %v, want one problem naming issueops.Importer.ImportBatch", problems)
+	}
+}
+
+func TestAuditRoleCoverageAcceptsAWaivedMethod(t *testing.T) {
+	facade := map[string][]string{"issueops.Importer": {"ImportBatch"}}
+	waived := map[string]string{"issueops.Importer.ImportBatch": "no accessor hands this role out"}
+	if problems := auditRoleCoverage(facade, nil, waived); len(problems) != 0 {
+		t.Errorf("waived method reported %v, want no problems", problems)
+	}
+}
+
+func TestAuditRoleCoverageCatchesAWaiverThatIsNoLongerNeeded(t *testing.T) {
+	facade := map[string][]string{"issueops.Importer": {"ImportBatch"}}
+	covered := map[roleMethod][]string{
+		{Role: "issueops.Importer", Method: "ImportBatch"}: {"RunImporterLandsOneBatch"},
+	}
+	waived := map[string]string{"issueops.Importer.ImportBatch": "no accessor hands this role out"}
+	problems := auditRoleCoverage(facade, covered, waived)
+	if len(problems) != 1 || !strings.Contains(problems[0], "delete its entry from uncoveredRoleMethods") {
+		t.Errorf("stale waiver reported %v, want one problem telling the author to delete it", problems)
+	}
+}
+
+func TestAuditRoleCoverageCatchesAWaiverNamingNoSuchMethod(t *testing.T) {
+	facade := map[string][]string{"issueops.Reader": {"Get"}}
+	covered := map[roleMethod][]string{
+		{Role: "issueops.Reader", Method: "Get"}: {"RunReaderGetHydratesLabels"},
+	}
+	waived := map[string]string{"issueops.Reader.Renamed": "stale after a rename"}
+	problems := auditRoleCoverage(facade, covered, waived)
+	if len(problems) != 1 || !strings.Contains(problems[0], "names no method of any facade role") {
+		t.Errorf("waiver for a missing method reported %v, want one problem naming it", problems)
+	}
+}
+
+func TestAuditRoleCoverageCatchesAWaiverWithNoReason(t *testing.T) {
+	facade := map[string][]string{"issueops.Importer": {"ImportBatch"}}
+	waived := map[string]string{"issueops.Importer.ImportBatch": "  "}
+	problems := auditRoleCoverage(facade, nil, waived)
+	if len(problems) != 1 || !strings.Contains(problems[0], "with no reason") {
+		t.Errorf("reasonless waiver reported %v, want one problem naming it", problems)
+	}
+}

--- a/backend/conformance/role_coverage_gate_test.go
+++ b/backend/conformance/role_coverage_gate_test.go
@@ -9,10 +9,16 @@ import (
 )
 
 // uncoveredRoleMethods waives the role methods this package knowingly has no
-// contract case for. It is SHRINK-ONLY: the gate fails on an entry that names
-// no real method and on an entry the package has since covered, so the PR that
-// writes the first case for a waived method deletes its entry in the same
-// change. Nothing may be added here to land a role method without a contract.
+// contract case for. It is SHRINK-ONLY in the sense that matters: the gate
+// fails on an entry that names no real method and on an entry the package has
+// since covered, so the PR that writes the first case for a waived method
+// deletes its entry in the same change.
+//
+// Adding an entry stays possible, and deliberately so — a role that genuinely
+// cannot be reached from the contract tier has to be recordable somewhere. What
+// the gate takes away is doing it quietly: an addition must name a real method,
+// carry a reason, and land in a diff a reviewer reads. It converts silence into
+// an argument someone has to make.
 var uncoveredRoleMethods = map[string]string{
 	"issueops.Importer.ImportBatch": "Importer is the one role no storage accessor hands out: " +
 		"internal/storage/uow reaches it through its own provider and the other two " +
@@ -62,7 +68,10 @@ func TestRoleFacadeCensusAgreesWithReflection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reading the role facade: %v", err)
 	}
-	accessors := reflectRoleAccessors()
+	accessors, err := reflectRoleAccessors()
+	if err != nil {
+		t.Fatalf("censusing the storage accessors: %v", err)
+	}
 	if len(accessors) == 0 {
 		t.Fatal("no storage accessor returns a facade role; the cross-check would pass vacuously")
 	}

--- a/backend/conformance/role_coverage_scan_test.go
+++ b/backend/conformance/role_coverage_scan_test.go
@@ -31,6 +31,10 @@ type roleMethod struct {
 // String renders the fully qualified name the gate reports and waives by.
 func (rm roleMethod) String() string { return rm.Role + "." + rm.Method }
 
+// modulePath is this module's import path, used to turn an in-module import
+// into the directory that declares it.
+const modulePath = "github.com/steveyegge/beads"
+
 // facadePackages maps each facade package's import path to the qualifier this
 // gate names its interfaces by. The paths come from real types rather than
 // string literals, so moving a package breaks the build here instead of
@@ -63,20 +67,25 @@ func repoRoot() (string, error) {
 // module mentions — issueops.Importer is one today — is invisible to any
 // reflection-only census and visible here.
 //
-// An embedded interface is refused rather than skipped: silently counting zero
-// methods for it would be the same aspirational coverage the gate is here to
-// end. Resolving embeds is a change to make when the facade grows one.
-func parseFacadeInterfaces(dir, qualifier string) (map[string][]string, error) {
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseDir(fset, dir, func(fi fs.FileInfo) bool {
-		return !strings.HasSuffix(fi.Name(), "_test.go")
-	}, 0)
+// Anything it cannot classify is REFUSED rather than skipped, because a skip is
+// a silently smaller census, which is the failure mode the gate is built to
+// end. That covers an embedded interface, whose method set this parse cannot
+// resolve, and an exported alias that turns out to name an interface: a
+// `type Reader = roles.Reader` compat shim would otherwise delete the role from
+// the census while reading as an ordinary alias. Aliases to non-interfaces are
+// ordinary and pass; the fourteen in issueops today all name structs and
+// strings.
+func parseFacadeInterfaces(root, dir, qualifier string) (map[string][]string, error) {
+	pkgs, err := parsePackageSources(dir, func(name string) bool {
+		return !strings.HasSuffix(name, "_test.go")
+	})
 	if err != nil {
-		return nil, fmt.Errorf("parsing %s: %w", dir, err)
+		return nil, err
 	}
 	roles := map[string][]string{}
 	for _, pkg := range pkgs {
 		for _, file := range pkg.Files {
+			imports := importPaths(file)
 			for _, decl := range file.Decls {
 				gd, ok := decl.(*ast.GenDecl)
 				if !ok || gd.Tok != token.TYPE {
@@ -84,14 +93,20 @@ func parseFacadeInterfaces(dir, qualifier string) (map[string][]string, error) {
 				}
 				for _, spec := range gd.Specs {
 					ts, ok := spec.(*ast.TypeSpec)
-					if !ok || ts.Assign.IsValid() || !ast.IsExported(ts.Name.Name) {
+					if !ok || !ast.IsExported(ts.Name.Name) {
+						continue
+					}
+					name := qualifier + "." + ts.Name.Name
+					if ts.Assign.IsValid() {
+						if err := refuseInterfaceAlias(root, name, ts.Type, imports, pkg); err != nil {
+							return nil, err
+						}
 						continue
 					}
 					it, ok := ts.Type.(*ast.InterfaceType)
 					if !ok {
 						continue
 					}
-					name := qualifier + "." + ts.Name.Name
 					methods := []string{}
 					for _, field := range it.Methods.List {
 						if len(field.Names) == 0 {
@@ -110,6 +125,90 @@ func parseFacadeInterfaces(dir, qualifier string) (map[string][]string, error) {
 	return roles, nil
 }
 
+// refuseInterfaceAlias fails when an exported alias names an interface, or when
+// this parse cannot tell what it names.
+func refuseInterfaceAlias(root, name string, target ast.Expr, imports map[string]string, local *ast.Package) error {
+	kind, err := classifyAliasTarget(root, target, imports, local)
+	if err != nil {
+		return fmt.Errorf("%s is an alias the census cannot classify: %w", name, err)
+	}
+	if kind == aliasNamesInterface {
+		return fmt.Errorf("%s aliases an interface; the census would lose the role while the alias reads as ordinary", name)
+	}
+	return nil
+}
+
+type aliasKind int
+
+const (
+	aliasNamesInterface aliasKind = iota
+	aliasNamesSomethingElse
+)
+
+// classifyAliasTarget reports whether an alias target is an interface, parsing
+// the declaring package when the target lives in another one.
+func classifyAliasTarget(root string, target ast.Expr, imports map[string]string, local *ast.Package) (aliasKind, error) {
+	switch e := target.(type) {
+	case *ast.IndexExpr:
+		return classifyAliasTarget(root, e.X, imports, local)
+	case *ast.IndexListExpr:
+		return classifyAliasTarget(root, e.X, imports, local)
+	case *ast.InterfaceType:
+		return aliasNamesInterface, nil
+	case *ast.Ident:
+		return classifyDeclaredType(local, e.Name)
+	case *ast.SelectorExpr:
+		pkg, ok := e.X.(*ast.Ident)
+		if !ok {
+			return 0, fmt.Errorf("its target is not a package-qualified name")
+		}
+		path := imports[pkg.Name]
+		if path != modulePath && !strings.HasPrefix(path, modulePath+"/") {
+			return 0, fmt.Errorf("its target %s.%s is outside this module", pkg.Name, e.Sel.Name)
+		}
+		dir := filepath.Join(root, filepath.FromSlash(strings.TrimPrefix(strings.TrimPrefix(path, modulePath), "/")))
+		pkgs, err := parsePackageSources(dir, func(name string) bool {
+			return !strings.HasSuffix(name, "_test.go")
+		})
+		if err != nil {
+			return 0, err
+		}
+		for _, declaring := range pkgs {
+			if kind, err := classifyDeclaredType(declaring, e.Sel.Name); err == nil {
+				return kind, nil
+			}
+		}
+		return 0, fmt.Errorf("its target %s.%s is declared nowhere in %s", pkg.Name, e.Sel.Name, dir)
+	default:
+		// A structural target — a map, slice, channel or func type — is not a
+		// named type and cannot be an interface.
+		return aliasNamesSomethingElse, nil
+	}
+}
+
+// classifyDeclaredType reports whether a package declares name as an interface.
+func classifyDeclaredType(pkg *ast.Package, name string) (aliasKind, error) {
+	for _, file := range pkg.Files {
+		for _, decl := range file.Decls {
+			gd, ok := decl.(*ast.GenDecl)
+			if !ok || gd.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range gd.Specs {
+				ts, ok := spec.(*ast.TypeSpec)
+				if !ok || ts.Name.Name != name {
+					continue
+				}
+				if _, ok := ts.Type.(*ast.InterfaceType); ok {
+					return aliasNamesInterface, nil
+				}
+				return aliasNamesSomethingElse, nil
+			}
+		}
+	}
+	return 0, fmt.Errorf("package %s declares no type named %s", pkg.Name, name)
+}
+
 // roleFacade is the whole public role surface: every exported interface the
 // facade packages declare, with its method set.
 func roleFacade() (map[string][]string, error) {
@@ -120,7 +219,7 @@ func roleFacade() (map[string][]string, error) {
 	facade := map[string][]string{}
 	for path, qualifier := range facadePackages {
 		dir := filepath.Join(root, filepath.Base(path))
-		roles, err := parseFacadeInterfaces(dir, qualifier)
+		roles, err := parseFacadeInterfaces(root, dir, qualifier)
 		if err != nil {
 			return nil, err
 		}
@@ -136,11 +235,16 @@ func roleFacade() (map[string][]string, error) {
 // method sets taken from the compiler rather than from source. It is the
 // independent second opinion the source census is checked against; it cannot
 // stand alone, because a role with no accessor never appears in it.
-func reflectRoleAccessors() map[string][]string {
+//
+// An accessor whose interface belongs to no known facade package is an ERROR,
+// not a skip. That is the shape a third facade package would arrive in, and a
+// skip would drop every role in it while every other check stayed green.
+func reflectRoleAccessors() (map[string][]string, error) {
 	surface := reflect.TypeOf((*storage.DoltStorage)(nil)).Elem()
 	roles := map[string][]string{}
 	for i := range surface.NumMethod() {
-		signature := surface.Method(i).Type
+		accessor := surface.Method(i)
+		signature := accessor.Type
 		if signature.NumIn() != 0 || signature.NumOut() != 2 || signature.Out(1) != errorType {
 			continue
 		}
@@ -150,7 +254,9 @@ func reflectRoleAccessors() map[string][]string {
 		}
 		qualifier, ok := facadePackages[role.PkgPath()]
 		if !ok {
-			continue
+			return nil, fmt.Errorf("accessor %s hands out %s.%s, which belongs to no known facade package: "+
+				"add that package to facadePackages, or this census silently omits every role in it",
+				accessor.Name, role.PkgPath(), role.Name())
 		}
 		methods := make([]string, 0, role.NumMethod())
 		for j := range role.NumMethod() {
@@ -159,35 +265,47 @@ func reflectRoleAccessors() map[string][]string {
 		sort.Strings(methods)
 		roles[qualifier+"."+role.Name()] = methods
 	}
-	return roles
+	return roles, nil
+}
+
+// funcFacts is what one function declaration contributes to the scan.
+type funcFacts struct {
+	// calls are the role methods the function invokes.
+	calls map[roleMethod]bool
+	// callees are the package functions and methods it calls, by func key.
+	callees []string
+	// root reports whether it is an exported Run entrypoint.
+	root bool
 }
 
 // scanRoleCalls reports which role methods the conformance sources at dir
 // actually call, mapped to the functions that call them.
 //
-// It resolves a call's receiver rather than matching method names, so a
-// role method named Close is told apart from every other Close in the package.
-// A receiver resolves when it is a role-typed parameter, local variable or
+// It resolves a call's receiver rather than matching method names, so a role
+// method named Close is told apart from every other Close in the package. A
+// receiver resolves when it is a role-typed parameter, local variable or
 // assignment, or a field of a struct declared in the package whose own type is
 // a role interface — which is the shape every contract fixture uses.
 //
-// Only functions reachable from an exported Run entrypoint count, so a contract
-// case cannot be credited to a helper nothing runs. Methods with receivers are
-// treated as reachable: resolving which values reach them needs type flow this
-// scan does not do, and crediting a live helper is the safer error.
+// ONLY exported Run entrypoints are reachability roots. Everything else, a
+// method as much as a function, earns its reachability from the call that names
+// it: a method resolves through its receiver's type exactly as a role call
+// does. Rooting methods outright — which an earlier draft did, by an operator
+// precedence slip — let an uncalled probe method vouch for a role method
+// nothing ran.
 func scanRoleCalls(dir string) (map[roleMethod][]string, error) {
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseDir(fset, dir, func(fi fs.FileInfo) bool {
-		return !strings.HasSuffix(fi.Name(), "_test.go")
-	}, 0)
+	pkgs, err := parsePackageSources(dir, func(name string) bool {
+		return !strings.HasSuffix(name, "_test.go")
+	})
 	if err != nil {
-		return nil, fmt.Errorf("parsing %s: %w", dir, err)
+		return nil, err
 	}
 
 	covered := map[roleMethod]map[string]bool{}
 	for _, pkg := range pkgs {
 		fields := roleTypedFields(pkg)
-		reachable := reachableFuncs(pkg)
+		results := funcResultTypes(pkg)
+		facts := map[string]*funcFacts{}
 		for _, file := range pkg.Files {
 			imports := importPaths(file)
 			for _, decl := range file.Decls {
@@ -195,16 +313,15 @@ func scanRoleCalls(dir string) (map[roleMethod][]string, error) {
 				if !ok || fn.Body == nil {
 					continue
 				}
-				name := funcKey(fn)
-				if !reachable[name] {
-					continue
+				facts[funcKey(fn)] = analyzeFunc(fn, imports, fields, results)
+			}
+		}
+		for name := range reachableFuncs(facts) {
+			for target := range facts[name].calls {
+				if covered[target] == nil {
+					covered[target] = map[string]bool{}
 				}
-				for target := range roleCallsIn(fn, imports, fields) {
-					if covered[target] == nil {
-						covered[target] = map[string]bool{}
-					}
-					covered[target][name] = true
-				}
+				covered[target][name] = true
 			}
 		}
 	}
@@ -219,6 +336,28 @@ func scanRoleCalls(dir string) (map[roleMethod][]string, error) {
 		out[target] = names
 	}
 	return out, nil
+}
+
+// reachableFuncs reports the declarations reachable from an exported Run
+// entrypoint.
+func reachableFuncs(facts map[string]*funcFacts) map[string]bool {
+	var queue []string
+	for name, fact := range facts {
+		if fact.root {
+			queue = append(queue, name)
+		}
+	}
+	reachable := map[string]bool{}
+	for len(queue) > 0 {
+		name := queue[len(queue)-1]
+		queue = queue[:len(queue)-1]
+		if reachable[name] || facts[name] == nil {
+			continue
+		}
+		reachable[name] = true
+		queue = append(queue, facts[name].callees...)
+	}
+	return reachable
 }
 
 // roleTypedFields maps each struct type in the package to its role-typed
@@ -260,52 +399,33 @@ func roleTypedFields(pkg *ast.Package) map[string]map[string]string {
 	return fields
 }
 
-// reachableFuncs reports the package functions reachable from an exported Run
-// entrypoint, walking calls to package-level function names.
-func reachableFuncs(pkg *ast.Package) map[string]bool {
-	declared := map[string]bool{}
-	calls := map[string][]string{}
-	var queue []string
+// funcResultTypes maps each package function returning a single package-local
+// named type to that type, so `probe := newProbe(...)` gives probe a type and
+// the methods called on it resolve to their declarations.
+func funcResultTypes(pkg *ast.Package) map[string]string {
+	results := map[string]string{}
 	for _, file := range pkg.Files {
 		for _, decl := range file.Decls {
 			fn, ok := decl.(*ast.FuncDecl)
-			if !ok || fn.Body == nil {
+			if !ok || fn.Recv != nil || fn.Type.Results == nil || len(fn.Type.Results.List) != 1 {
 				continue
 			}
-			name := funcKey(fn)
-			declared[name] = true
-			if fn.Recv != nil || strings.HasPrefix(fn.Name.Name, "Run") && ast.IsExported(fn.Name.Name) {
-				queue = append(queue, name)
+			if len(fn.Type.Results.List[0].Names) > 1 {
+				continue
 			}
-			ast.Inspect(fn.Body, func(n ast.Node) bool {
-				call, ok := n.(*ast.CallExpr)
-				if !ok {
-					return true
-				}
-				if callee, ok := call.Fun.(*ast.Ident); ok {
-					calls[name] = append(calls[name], callee.Name)
-				}
-				return true
-			})
+			if named := localTypeName(fn.Type.Results.List[0].Type); named != "" {
+				results[fn.Name.Name] = named
+			}
 		}
 	}
-	reachable := map[string]bool{}
-	for len(queue) > 0 {
-		name := queue[len(queue)-1]
-		queue = queue[:len(queue)-1]
-		if reachable[name] || !declared[name] {
-			continue
-		}
-		reachable[name] = true
-		queue = append(queue, calls[name]...)
-	}
-	return reachable
+	return results
 }
 
-// roleCallsIn reports the role methods one function calls.
-func roleCallsIn(fn *ast.FuncDecl, imports map[string]string, fields map[string]map[string]string) map[roleMethod]bool {
+// analyzeFunc reports the role methods one declaration calls and the package
+// functions and methods it calls.
+func analyzeFunc(fn *ast.FuncDecl, imports map[string]string, fields map[string]map[string]string, results map[string]string) *funcFacts {
 	roleVars := map[string]string{}
-	structVars := map[string]string{}
+	localVars := map[string]string{}
 	bind := func(names []*ast.Ident, typ ast.Expr) {
 		if role := roleTypeName(typ, imports); role != "" {
 			for _, name := range names {
@@ -315,7 +435,7 @@ func roleCallsIn(fn *ast.FuncDecl, imports map[string]string, fields map[string]
 		}
 		if named := localTypeName(typ); named != "" {
 			for _, name := range names {
-				structVars[name.Name] = named
+				localVars[name.Name] = named
 			}
 		}
 	}
@@ -330,13 +450,13 @@ func roleCallsIn(fn *ast.FuncDecl, imports map[string]string, fields map[string]
 	bindParams(fn.Recv)
 	bindParams(fn.Type.Params)
 
-	resolve := func(expr ast.Expr) string {
+	roleOf := func(expr ast.Expr) string {
 		switch e := expr.(type) {
 		case *ast.Ident:
 			return roleVars[e.Name]
 		case *ast.SelectorExpr:
 			if base, ok := e.X.(*ast.Ident); ok {
-				return fields[structVars[base.Name]][e.Sel.Name]
+				return fields[localVars[base.Name]][e.Sel.Name]
 			}
 		}
 		return ""
@@ -358,29 +478,59 @@ func roleCallsIn(fn *ast.FuncDecl, imports map[string]string, fields map[string]
 			if !ok {
 				return true
 			}
-			if role := resolve(node.Rhs[0]); role != "" {
+			if role := roleOf(node.Rhs[0]); role != "" {
 				roleVars[target.Name] = role
+				return true
+			}
+			if named := constructedTypeName(node.Rhs[0], results); named != "" {
+				localVars[target.Name] = named
 			}
 		}
 		return true
 	})
 
-	found := map[roleMethod]bool{}
+	facts := &funcFacts{
+		calls: map[roleMethod]bool{},
+		root:  fn.Recv == nil && strings.HasPrefix(fn.Name.Name, "Run"),
+	}
 	ast.Inspect(fn.Body, func(n ast.Node) bool {
 		call, ok := n.(*ast.CallExpr)
 		if !ok {
 			return true
 		}
-		selector, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok {
-			return true
-		}
-		if role := resolve(selector.X); role != "" {
-			found[roleMethod{Role: role, Method: selector.Sel.Name}] = true
+		switch callee := call.Fun.(type) {
+		case *ast.Ident:
+			facts.callees = append(facts.callees, callee.Name)
+		case *ast.SelectorExpr:
+			if role := roleOf(callee.X); role != "" {
+				facts.calls[roleMethod{Role: role, Method: callee.Sel.Name}] = true
+				return true
+			}
+			if base, ok := callee.X.(*ast.Ident); ok && localVars[base.Name] != "" {
+				facts.callees = append(facts.callees, localVars[base.Name]+"."+callee.Sel.Name)
+			}
 		}
 		return true
 	})
-	return found
+	return facts
+}
+
+// constructedTypeName reports the package-local type an expression yields, for
+// a composite literal or a call to a package function that returns one.
+func constructedTypeName(expr ast.Expr, results map[string]string) string {
+	switch e := expr.(type) {
+	case *ast.UnaryExpr:
+		if e.Op == token.AND {
+			return constructedTypeName(e.X, results)
+		}
+	case *ast.CompositeLit:
+		return localTypeName(e.Type)
+	case *ast.CallExpr:
+		if callee, ok := e.Fun.(*ast.Ident); ok {
+			return results[callee.Name]
+		}
+	}
+	return ""
 }
 
 // funcKey names a declaration for the call graph: bare for a function, and
@@ -390,6 +540,19 @@ func funcKey(fn *ast.FuncDecl) string {
 		return fn.Name.Name
 	}
 	return localTypeName(fn.Recv.List[0].Type) + "." + fn.Name.Name
+}
+
+// parsePackageSources parses one directory's packages, keeping the files accept
+// admits.
+func parsePackageSources(dir string, accept func(name string) bool) (map[string]*ast.Package, error) {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, dir, func(fi fs.FileInfo) bool {
+		return accept(fi.Name())
+	}, 0)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", dir, err)
+	}
+	return pkgs, nil
 }
 
 // importPaths maps each file-local package name to the path it imports.
@@ -531,6 +694,57 @@ func orphanedHelper(ctx context.Context, fixture ReaderFixture) {
 	}
 }
 
+// TestScanRoleCallsIgnoresAMethodNoEntrypointRuns is the same rule for methods,
+// and it is the one an earlier draft got wrong: it rooted every method
+// declaration, so an uncalled probe method silently vouched for a role method
+// nothing ran. A method earns its reachability from the call that names it, or
+// it earns nothing.
+func TestScanRoleCallsIgnoresAMethodNoEntrypointRuns(t *testing.T) {
+	dir := writeFakeContractPackage(t, `package fake
+
+import (
+	"context"
+
+	publicops "github.com/steveyegge/beads/issueops"
+)
+
+type ReaderFixture struct {
+	Reader publicops.Reader
+}
+
+type probe struct {
+	Reader publicops.Reader
+}
+
+func newProbe(fixture ReaderFixture) *probe {
+	return &probe{Reader: fixture.Reader}
+}
+
+func (p *probe) readList(ctx context.Context) {
+	p.Reader.List(ctx)
+}
+
+func (p *probe) readReady(ctx context.Context) {
+	p.Reader.Ready(ctx)
+}
+
+func RunReaderListsThroughAProbe(ctx context.Context, fixture ReaderFixture) {
+	p := newProbe(fixture)
+	p.readList(ctx)
+}
+`)
+	covered, err := scanRoleCalls(dir)
+	if err != nil {
+		t.Fatalf("scanning the fabricated package: %v", err)
+	}
+	if callers := covered[roleMethod{Role: "issueops.Reader", Method: "List"}]; len(callers) != 1 || callers[0] != "probe.readList" {
+		t.Errorf("List was credited to %v, want the probe method the entrypoint calls", callers)
+	}
+	if callers := covered[roleMethod{Role: "issueops.Reader", Method: "Ready"}]; len(callers) != 0 {
+		t.Errorf("Ready was credited to %v, but only a method no entrypoint calls reads it", callers)
+	}
+}
+
 func TestScanRoleCallsTellsRoleMethodsApartFromLookalikes(t *testing.T) {
 	dir := writeFakeContractPackage(t, `package fake
 
@@ -566,6 +780,9 @@ func RunLifecycleCreates(ctx context.Context, fixture LifecycleFixture) {
 	}
 }
 
+// The census parser's own cases: everything it cannot classify has to be an
+// error, because the alternative is a smaller census that still reads green.
+
 func TestParseFacadeInterfacesRefusesAnEmbeddedInterface(t *testing.T) {
 	dir := writeFakeContractPackage(t, `package fake
 
@@ -578,8 +795,62 @@ type Wider interface {
 	List()
 }
 `)
-	if _, err := parseFacadeInterfaces(dir, "fake"); err == nil {
+	if _, err := parseFacadeInterfaces(dir, dir, "fake"); err == nil {
 		t.Error("parsing an embedded interface succeeded; the census would silently count zero methods for it")
+	}
+}
+
+func TestParseFacadeInterfacesRefusesAnAliasedRole(t *testing.T) {
+	dir := writeFakeContractPackage(t, `package fake
+
+type shim interface {
+	Get()
+}
+
+type Reader = shim
+`)
+	_, err := parseFacadeInterfaces(dir, dir, "fake")
+	if err == nil {
+		t.Fatal("parsing an interface alias succeeded; the role would vanish from the census")
+	}
+	if !strings.Contains(err.Error(), "aliases an interface") {
+		t.Errorf("error = %v, want it to name the alias as the problem", err)
+	}
+}
+
+func TestParseFacadeInterfacesRefusesAnAliasItCannotClassify(t *testing.T) {
+	dir := writeFakeContractPackage(t, `package fake
+
+import "example.com/elsewhere/roles"
+
+type Reader = roles.Reader
+`)
+	_, err := parseFacadeInterfaces(dir, dir, "fake")
+	if err == nil {
+		t.Fatal("parsing an out-of-module alias succeeded; the census cannot tell whether it hid a role")
+	}
+	if !strings.Contains(err.Error(), "cannot classify") {
+		t.Errorf("error = %v, want it to say the alias could not be classified", err)
+	}
+}
+
+func TestParseFacadeInterfacesAcceptsAnAliasToSomethingElse(t *testing.T) {
+	dir := writeFakeContractPackage(t, `package fake
+
+type row struct{}
+
+type Row = row
+
+type Reader interface {
+	Get()
+}
+`)
+	roles, err := parseFacadeInterfaces(dir, dir, "fake")
+	if err != nil {
+		t.Fatalf("an alias to a struct was refused: %v", err)
+	}
+	if _, ok := roles["fake.Reader"]; !ok {
+		t.Errorf("census %v lost the role beside the alias", roles)
 	}
 }
 

--- a/backend/conformance/role_coverage_scan_test.go
+++ b/backend/conformance/role_coverage_scan_test.go
@@ -1,0 +1,595 @@
+package conformance
+
+import (
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/issueops"
+	"github.com/steveyegge/beads/memoryops"
+)
+
+// roleMethod names one method of one role interface on the public facade.
+type roleMethod struct {
+	// Role is the qualified interface name, e.g. "issueops.Reader".
+	Role string
+	// Method is the method name, e.g. "Ready".
+	Method string
+}
+
+// String renders the fully qualified name the gate reports and waives by.
+func (rm roleMethod) String() string { return rm.Role + "." + rm.Method }
+
+// facadePackages maps each facade package's import path to the qualifier this
+// gate names its interfaces by. The paths come from real types rather than
+// string literals, so moving a package breaks the build here instead of
+// quietly emptying the census.
+var facadePackages = map[string]string{
+	reflect.TypeOf((*issueops.Reader)(nil)).Elem().PkgPath():    "issueops",
+	reflect.TypeOf((*memoryops.Memories)(nil)).Elem().PkgPath(): "memoryops",
+}
+
+var errorType = reflect.TypeOf((*error)(nil)).Elem()
+
+// repoRoot locates the module root from this file's own path, so the gate
+// finds the facade packages without depending on the working directory.
+func repoRoot() (string, error) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", errors.New("runtime.Caller failed")
+	}
+	return filepath.Join(filepath.Dir(thisFile), "..", ".."), nil
+}
+
+// parseFacadeInterfaces reads one facade package's non-test sources and reports
+// every exported interface it declares, keyed "qualifier.Interface", with its
+// method names.
+//
+// Source is the census's authority rather than reflection because reflection
+// cannot enumerate a package's types: it can only answer questions about types
+// something already names, and naming them is the hand-written list this gate
+// exists to abolish. An interface the package declares but nothing else in the
+// module mentions — issueops.Importer is one today — is invisible to any
+// reflection-only census and visible here.
+//
+// An embedded interface is refused rather than skipped: silently counting zero
+// methods for it would be the same aspirational coverage the gate is here to
+// end. Resolving embeds is a change to make when the facade grows one.
+func parseFacadeInterfaces(dir, qualifier string) (map[string][]string, error) {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, dir, func(fi fs.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", dir, err)
+	}
+	roles := map[string][]string{}
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Files {
+			for _, decl := range file.Decls {
+				gd, ok := decl.(*ast.GenDecl)
+				if !ok || gd.Tok != token.TYPE {
+					continue
+				}
+				for _, spec := range gd.Specs {
+					ts, ok := spec.(*ast.TypeSpec)
+					if !ok || ts.Assign.IsValid() || !ast.IsExported(ts.Name.Name) {
+						continue
+					}
+					it, ok := ts.Type.(*ast.InterfaceType)
+					if !ok {
+						continue
+					}
+					name := qualifier + "." + ts.Name.Name
+					methods := []string{}
+					for _, field := range it.Methods.List {
+						if len(field.Names) == 0 {
+							return nil, fmt.Errorf("%s embeds an interface; this census cannot resolve embedded method sets", name)
+						}
+						for _, m := range field.Names {
+							methods = append(methods, m.Name)
+						}
+					}
+					sort.Strings(methods)
+					roles[name] = methods
+				}
+			}
+		}
+	}
+	return roles, nil
+}
+
+// roleFacade is the whole public role surface: every exported interface the
+// facade packages declare, with its method set.
+func roleFacade() (map[string][]string, error) {
+	root, err := repoRoot()
+	if err != nil {
+		return nil, err
+	}
+	facade := map[string][]string{}
+	for path, qualifier := range facadePackages {
+		dir := filepath.Join(root, filepath.Base(path))
+		roles, err := parseFacadeInterfaces(dir, qualifier)
+		if err != nil {
+			return nil, err
+		}
+		for name, methods := range roles {
+			facade[name] = methods
+		}
+	}
+	return facade, nil
+}
+
+// reflectRoleAccessors reports the facade roles a backend hands out through a
+// storage accessor — a method taking nothing and returning (role, error) — with
+// method sets taken from the compiler rather than from source. It is the
+// independent second opinion the source census is checked against; it cannot
+// stand alone, because a role with no accessor never appears in it.
+func reflectRoleAccessors() map[string][]string {
+	surface := reflect.TypeOf((*storage.DoltStorage)(nil)).Elem()
+	roles := map[string][]string{}
+	for i := range surface.NumMethod() {
+		signature := surface.Method(i).Type
+		if signature.NumIn() != 0 || signature.NumOut() != 2 || signature.Out(1) != errorType {
+			continue
+		}
+		role := signature.Out(0)
+		if role.Kind() != reflect.Interface {
+			continue
+		}
+		qualifier, ok := facadePackages[role.PkgPath()]
+		if !ok {
+			continue
+		}
+		methods := make([]string, 0, role.NumMethod())
+		for j := range role.NumMethod() {
+			methods = append(methods, role.Method(j).Name)
+		}
+		sort.Strings(methods)
+		roles[qualifier+"."+role.Name()] = methods
+	}
+	return roles
+}
+
+// scanRoleCalls reports which role methods the conformance sources at dir
+// actually call, mapped to the functions that call them.
+//
+// It resolves a call's receiver rather than matching method names, so a
+// role method named Close is told apart from every other Close in the package.
+// A receiver resolves when it is a role-typed parameter, local variable or
+// assignment, or a field of a struct declared in the package whose own type is
+// a role interface — which is the shape every contract fixture uses.
+//
+// Only functions reachable from an exported Run entrypoint count, so a contract
+// case cannot be credited to a helper nothing runs. Methods with receivers are
+// treated as reachable: resolving which values reach them needs type flow this
+// scan does not do, and crediting a live helper is the safer error.
+func scanRoleCalls(dir string) (map[roleMethod][]string, error) {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, dir, func(fi fs.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", dir, err)
+	}
+
+	covered := map[roleMethod]map[string]bool{}
+	for _, pkg := range pkgs {
+		fields := roleTypedFields(pkg)
+		reachable := reachableFuncs(pkg)
+		for _, file := range pkg.Files {
+			imports := importPaths(file)
+			for _, decl := range file.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || fn.Body == nil {
+					continue
+				}
+				name := funcKey(fn)
+				if !reachable[name] {
+					continue
+				}
+				for target := range roleCallsIn(fn, imports, fields) {
+					if covered[target] == nil {
+						covered[target] = map[string]bool{}
+					}
+					covered[target][name] = true
+				}
+			}
+		}
+	}
+
+	out := map[roleMethod][]string{}
+	for target, callers := range covered {
+		names := make([]string, 0, len(callers))
+		for name := range callers {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		out[target] = names
+	}
+	return out, nil
+}
+
+// roleTypedFields maps each struct type in the package to its role-typed
+// fields, so `fixture.Closer.CloseBatch(...)` resolves to the role the fixture
+// declares rather than to whatever another fixture calls its Closer.
+func roleTypedFields(pkg *ast.Package) map[string]map[string]string {
+	fields := map[string]map[string]string{}
+	for _, file := range pkg.Files {
+		imports := importPaths(file)
+		for _, decl := range file.Decls {
+			gd, ok := decl.(*ast.GenDecl)
+			if !ok || gd.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range gd.Specs {
+				ts, ok := spec.(*ast.TypeSpec)
+				if !ok {
+					continue
+				}
+				st, ok := ts.Type.(*ast.StructType)
+				if !ok {
+					continue
+				}
+				for _, field := range st.Fields.List {
+					role := roleTypeName(field.Type, imports)
+					if role == "" {
+						continue
+					}
+					if fields[ts.Name.Name] == nil {
+						fields[ts.Name.Name] = map[string]string{}
+					}
+					for _, name := range field.Names {
+						fields[ts.Name.Name][name.Name] = role
+					}
+				}
+			}
+		}
+	}
+	return fields
+}
+
+// reachableFuncs reports the package functions reachable from an exported Run
+// entrypoint, walking calls to package-level function names.
+func reachableFuncs(pkg *ast.Package) map[string]bool {
+	declared := map[string]bool{}
+	calls := map[string][]string{}
+	var queue []string
+	for _, file := range pkg.Files {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			name := funcKey(fn)
+			declared[name] = true
+			if fn.Recv != nil || strings.HasPrefix(fn.Name.Name, "Run") && ast.IsExported(fn.Name.Name) {
+				queue = append(queue, name)
+			}
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				if callee, ok := call.Fun.(*ast.Ident); ok {
+					calls[name] = append(calls[name], callee.Name)
+				}
+				return true
+			})
+		}
+	}
+	reachable := map[string]bool{}
+	for len(queue) > 0 {
+		name := queue[len(queue)-1]
+		queue = queue[:len(queue)-1]
+		if reachable[name] || !declared[name] {
+			continue
+		}
+		reachable[name] = true
+		queue = append(queue, calls[name]...)
+	}
+	return reachable
+}
+
+// roleCallsIn reports the role methods one function calls.
+func roleCallsIn(fn *ast.FuncDecl, imports map[string]string, fields map[string]map[string]string) map[roleMethod]bool {
+	roleVars := map[string]string{}
+	structVars := map[string]string{}
+	bind := func(names []*ast.Ident, typ ast.Expr) {
+		if role := roleTypeName(typ, imports); role != "" {
+			for _, name := range names {
+				roleVars[name.Name] = role
+			}
+			return
+		}
+		if named := localTypeName(typ); named != "" {
+			for _, name := range names {
+				structVars[name.Name] = named
+			}
+		}
+	}
+	bindParams := func(list *ast.FieldList) {
+		if list == nil {
+			return
+		}
+		for _, param := range list.List {
+			bind(param.Names, param.Type)
+		}
+	}
+	bindParams(fn.Recv)
+	bindParams(fn.Type.Params)
+
+	resolve := func(expr ast.Expr) string {
+		switch e := expr.(type) {
+		case *ast.Ident:
+			return roleVars[e.Name]
+		case *ast.SelectorExpr:
+			if base, ok := e.X.(*ast.Ident); ok {
+				return fields[structVars[base.Name]][e.Sel.Name]
+			}
+		}
+		return ""
+	}
+
+	// Bindings first, so a call site reached before its variable's declaration
+	// in traversal order still resolves.
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.FuncLit:
+			bindParams(node.Type.Params)
+		case *ast.ValueSpec:
+			bind(node.Names, node.Type)
+		case *ast.AssignStmt:
+			if len(node.Lhs) != 1 || len(node.Rhs) != 1 {
+				return true
+			}
+			target, ok := node.Lhs[0].(*ast.Ident)
+			if !ok {
+				return true
+			}
+			if role := resolve(node.Rhs[0]); role != "" {
+				roleVars[target.Name] = role
+			}
+		}
+		return true
+	})
+
+	found := map[roleMethod]bool{}
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if role := resolve(selector.X); role != "" {
+			found[roleMethod{Role: role, Method: selector.Sel.Name}] = true
+		}
+		return true
+	})
+	return found
+}
+
+// funcKey names a declaration for the call graph: bare for a function, and
+// receiver-qualified for a method.
+func funcKey(fn *ast.FuncDecl) string {
+	if fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return fn.Name.Name
+	}
+	return localTypeName(fn.Recv.List[0].Type) + "." + fn.Name.Name
+}
+
+// importPaths maps each file-local package name to the path it imports.
+func importPaths(file *ast.File) map[string]string {
+	paths := map[string]string{}
+	for _, spec := range file.Imports {
+		path := strings.Trim(spec.Path.Value, `"`)
+		name := path[strings.LastIndexByte(path, '/')+1:]
+		if spec.Name != nil {
+			name = spec.Name.Name
+		}
+		paths[name] = path
+	}
+	return paths
+}
+
+// roleTypeName reports the qualified role name a type expression denotes, or
+// "" when it names something outside the facade packages.
+func roleTypeName(typ ast.Expr, imports map[string]string) string {
+	selector, ok := typ.(*ast.SelectorExpr)
+	if !ok {
+		return ""
+	}
+	pkg, ok := selector.X.(*ast.Ident)
+	if !ok {
+		return ""
+	}
+	qualifier, ok := facadePackages[imports[pkg.Name]]
+	if !ok {
+		return ""
+	}
+	return qualifier + "." + selector.Sel.Name
+}
+
+// localTypeName reports the package-local type name a type expression denotes,
+// dropping one level of pointer.
+func localTypeName(typ ast.Expr) string {
+	if star, ok := typ.(*ast.StarExpr); ok {
+		typ = star.X
+	}
+	if ident, ok := typ.(*ast.Ident); ok {
+		return ident.Name
+	}
+	return ""
+}
+
+// The scanner's own cases. Each writes a miniature conformance package to a
+// temporary directory and asserts what the scan makes of it.
+
+func TestScanRoleCallsResolvesFixtureFieldsHelpersAndAliases(t *testing.T) {
+	dir := writeFakeContractPackage(t, `package fake
+
+import (
+	"context"
+
+	publicops "github.com/steveyegge/beads/issueops"
+)
+
+type ReaderFixture struct {
+	Reader publicops.Reader
+}
+
+type ClaimerFixture struct {
+	// Two fixtures naming one field differently typed: resolving by field
+	// name alone would credit the wrong role.
+	Claimer publicops.ReadyClaimer
+}
+
+func RunReaderGetsAnIssue(ctx context.Context, fixture ReaderFixture) {
+	fixture.Reader.Get(ctx, "id")
+	readerList(ctx, fixture)
+}
+
+func RunReaderReadyThroughAnAlias(ctx context.Context, fixture ReaderFixture) {
+	reader := fixture.Reader
+	reader.Ready(ctx)
+}
+
+func RunClaimerClaimsTheFront(ctx context.Context, fixture ClaimerFixture) {
+	fixture.Claimer.ClaimNext(ctx)
+}
+
+func readerList(ctx context.Context, fixture ReaderFixture) {
+	fixture.Reader.List(ctx)
+}
+`)
+	covered, err := scanRoleCalls(dir)
+	if err != nil {
+		t.Fatalf("scanning the fabricated package: %v", err)
+	}
+	for _, want := range []roleMethod{
+		{Role: "issueops.Reader", Method: "Get"},
+		{Role: "issueops.Reader", Method: "Ready"},
+		{Role: "issueops.Reader", Method: "List"},
+		{Role: "issueops.ReadyClaimer", Method: "ClaimNext"},
+	} {
+		if len(covered[want]) == 0 {
+			t.Errorf("%s was not seen as covered; scan found %v", want, covered)
+		}
+	}
+	if callers := covered[roleMethod{Role: "issueops.Claimer", Method: "ClaimNext"}]; len(callers) != 0 {
+		t.Errorf("ClaimNext was credited to issueops.Claimer (%v); the field is typed ReadyClaimer", callers)
+	}
+	if callers := covered[roleMethod{Role: "issueops.Reader", Method: "List"}]; len(callers) != 1 || callers[0] != "readerList" {
+		t.Errorf("List was credited to %v, want the helper that calls it", callers)
+	}
+}
+
+func TestScanRoleCallsIgnoresAHelperNoEntrypointRuns(t *testing.T) {
+	dir := writeFakeContractPackage(t, `package fake
+
+import (
+	"context"
+
+	publicops "github.com/steveyegge/beads/issueops"
+)
+
+type ReaderFixture struct {
+	Reader publicops.Reader
+}
+
+func RunReaderGetsAnIssue(ctx context.Context, fixture ReaderFixture) {
+	fixture.Reader.Get(ctx, "id")
+}
+
+func orphanedHelper(ctx context.Context, fixture ReaderFixture) {
+	fixture.Reader.Ready(ctx)
+}
+`)
+	covered, err := scanRoleCalls(dir)
+	if err != nil {
+		t.Fatalf("scanning the fabricated package: %v", err)
+	}
+	if callers := covered[roleMethod{Role: "issueops.Reader", Method: "Ready"}]; len(callers) != 0 {
+		t.Errorf("Ready was credited to %v, but only an unreachable helper calls it", callers)
+	}
+	if len(covered[roleMethod{Role: "issueops.Reader", Method: "Get"}]) == 0 {
+		t.Error("Get was not credited to the entrypoint that calls it")
+	}
+}
+
+func TestScanRoleCallsTellsRoleMethodsApartFromLookalikes(t *testing.T) {
+	dir := writeFakeContractPackage(t, `package fake
+
+import (
+	"context"
+
+	publicops "github.com/steveyegge/beads/issueops"
+)
+
+type LifecycleFixture struct {
+	Lifecycle publicops.Lifecycle
+	Rows      *rows
+}
+
+type rows struct{}
+
+func (r *rows) Close() {}
+
+func RunLifecycleCreates(ctx context.Context, fixture LifecycleFixture) {
+	fixture.Lifecycle.Create(ctx, publicops.CreateRequest{})
+	fixture.Rows.Close()
+}
+`)
+	covered, err := scanRoleCalls(dir)
+	if err != nil {
+		t.Fatalf("scanning the fabricated package: %v", err)
+	}
+	if len(covered[roleMethod{Role: "issueops.Lifecycle", Method: "Create"}]) == 0 {
+		t.Error("Create was not credited to the entrypoint that calls it")
+	}
+	if callers := covered[roleMethod{Role: "issueops.Lifecycle", Method: "Close"}]; len(callers) != 0 {
+		t.Errorf("Lifecycle.Close was credited to %v, but only *rows.Close is called", callers)
+	}
+}
+
+func TestParseFacadeInterfacesRefusesAnEmbeddedInterface(t *testing.T) {
+	dir := writeFakeContractPackage(t, `package fake
+
+type Reader interface {
+	Get()
+}
+
+type Wider interface {
+	Reader
+	List()
+}
+`)
+	if _, err := parseFacadeInterfaces(dir, "fake"); err == nil {
+		t.Error("parsing an embedded interface succeeded; the census would silently count zero methods for it")
+	}
+}
+
+// writeFakeContractPackage writes source to a temporary directory as a contract
+// file and returns the directory.
+func writeFakeContractPackage(t *testing.T, source string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "fake_contract.go"), []byte(source), 0o600); err != nil {
+		t.Fatalf("writing the fabricated package: %v", err)
+	}
+	return dir
+}


### PR DESCRIPTION
## What

A gate in `backend/conformance` that fails when a method of the public role
facade has no contract case behind it.

Test-only. No production behavior changes; the one non-test edit is a paragraph
in the package doc.

## Why

Role-tier coverage was aspirational. Nothing failed when a role method landed
with no contract behind it — and one already had. `issueops.Importer.ImportBatch`
has never had a case and nothing noticed, because "every role has a contract"
lived in a doc comment rather than in a test.

## The design, and what I rejected

The facade is 25 exported interfaces / 40 methods (24 in `issueops`, one in
`memoryops`). Both halves of the comparison are **derived**. Nothing here is a
list a contributor has to remember to update.

**Census: parsed from source, cross-checked by reflection.** Reflection cannot
enumerate a package's types. It only answers questions about types something
already *names* — and naming them is exactly the hand-written list a gate like
this exists to abolish. It also has a concrete blind spot here:
`issueops.Importer` is the one role no storage accessor hands out, so a
reflection-only census never sees the single uncovered method in the repo.
So `parseFacadeInterfaces` reads the exported interface declarations of
`issueops` and `memoryops`, and `TestRoleFacadeCensusAgreesWithReflection` keeps
that parse honest by comparing it to `reflect` over `storage.DoltStorage`'s
accessors for all 24 roles that have one.

Anything the census cannot classify is **refused**, because a skip is a silently
smaller census — the exact failure mode the gate exists to end:

- an embedded interface, whose method set this parse cannot resolve;
- an exported alias that names an interface. A `type Reader = roles.Reader`
  compat shim would otherwise delete the role from the source census while
  reflection drifted with it. Aliases are classified rather than banned — the
  fourteen in `issueops` name structs and strings and pass; an alias to an
  interface is refused; one whose target is outside the module cannot be
  classified and is refused too;
- an accessor handing out a role from a package outside `facadePackages`. That
  is precisely the shape a third facade package would arrive in, and the old
  `continue` would have dropped every role in it while every check stayed green.

**Coverage: derived call sites, not a declared table.** I started on the
explicit `method -> case` table and dropped it. A 385-entry table is the same
aspirational bookkeeping this bead exists to kill: it records a promise that a
case covers a method, and rots the first time a case is rewritten. Name-parsing
the `Run*` identifiers is worse — the names don't contain the method they
exercise.

What the scan does instead is resolve each call's **receiver**: role-typed
fixture fields (`fixture.Closer.CloseBatch(...)`, the shape every contract file
uses), parameters, and local aliases (`reader := fixture.Reader`). Fields are
keyed by their declaring struct, so `ClaimerFixture.Claimer` (typed
`ReadyClaimer`) is not confused with a namesake in another file — an early draft
keyed by field name alone and misattributed `ClaimNext`. Because it resolves
receivers rather than matching method names, `Lifecycle.Close` is told apart
from every other `Close()` in the package.

**Reachability: only exported `Run*` entrypoints are roots.** Everything else —
a method as much as a function — earns reachability from the call that names it;
a method resolves through its receiver's type exactly as a role call does, and a
local variable picks up its type from a composite literal or from a package
function that returns one. This is a review fix: the first draft's root
predicate read `fn.Recv != nil || HasPrefix(...) && IsExported(...)`, and `&&`
binds tighter than `||`, so **every method declaration was an unconditional
root**. An uncalled method on a fixture struct therefore vouched for whatever
role method it named — a false green. Tightening it lost no real coverage (same
39 covered, `ImportBatch` still the only waiver), because nothing in the package
hides a role call behind a method today. The point is that nothing can start to.

The cost of deriving is that a future contract case written in a shape the
resolver doesn't handle reads as uncovered. That failure is loud, conservative
and localized, and the waiver list gives it an escape hatch that can't be
forgotten.

**Waiver: shrink-only, enforced by evidence.** `uncoveredRoleMethods` holds
exactly one entry, `issueops.Importer.ImportBatch`, with its reason. The gate
fails on an entry naming no real method, on an entry with no reason, and — the
part that makes it shrink-only — on an entry the package has since covered. The
change that writes the first Importer case deletes the waiver in the same diff
or goes red. Adding an entry stays possible and deliberately so: a role the
contract tier genuinely cannot reach has to be recordable. What the gate removes
is doing it quietly.

## Evidence

```
$ go test ./backend/conformance/ -count=1 -v
--- PASS: TestEveryRoleMethodHasAContractCase (0.11s)
--- PASS: TestRoleFacadeCensusAgreesWithReflection (0.05s)
--- PASS: TestAuditRoleCoverageReportsNothingWhenEveryMethodHasACase
--- PASS: TestAuditRoleCoverageCatchesAMethodNoCaseCalls
--- PASS: TestAuditRoleCoverageCatchesAWholeUncoveredRole
--- PASS: TestAuditRoleCoverageAcceptsAWaivedMethod
--- PASS: TestAuditRoleCoverageCatchesAWaiverThatIsNoLongerNeeded
--- PASS: TestAuditRoleCoverageCatchesAWaiverNamingNoSuchMethod
--- PASS: TestAuditRoleCoverageCatchesAWaiverWithNoReason
--- PASS: TestScanRoleCallsResolvesFixtureFieldsHelpersAndAliases
--- PASS: TestScanRoleCallsIgnoresAHelperNoEntrypointRuns
--- PASS: TestScanRoleCallsIgnoresAMethodNoEntrypointRuns
--- PASS: TestScanRoleCallsTellsRoleMethodsApartFromLookalikes
--- PASS: TestParseFacadeInterfacesRefusesAnEmbeddedInterface
--- PASS: TestParseFacadeInterfacesRefusesAnAliasedRole
--- PASS: TestParseFacadeInterfacesRefusesAnAliasItCannotClassify
--- PASS: TestParseFacadeInterfacesAcceptsAnAliasToSomethingElse
ok  	github.com/steveyegge/beads/backend/conformance	0.211s
```

Watched to fail, then reverted (none of these are committed):

| Mutation | Result |
| --- | --- |
| An **uncalled fixture method** as `Counter.Count`'s only caller — the reviewer's traced false green | `issueops.Counter.Count has no contract case` |
| A fabricated exported alias `type ReaderCompat = Reader` in `issueops` | `issueops.ReaderCompat aliases an interface; the census would lose the role while the alias reads as ordinary` |
| `memoryops` dropped from `facadePackages` | `accessor Memories hands out .../memoryops.Memories, which belongs to no known facade package` |
| Waiver list emptied | `issueops.Importer.ImportBatch has no contract case` |
| `counterTotal`'s `fixture.Counter.Count(...)` rerouted to a local stub | `issueops.Counter.Count has no contract case` |
| A fabricated 25th interface `Rehearser` added to `issueops` | `issueops.Rehearser.Rehearse has no contract case` |

The self-tests are the same discipline applied to the gate's own core:
`auditRoleCoverage` is a pure function over fabricated inputs, and the scanner
cases each write a miniature conformance package to a temp dir — an
unresolvable lookalike `Close`, an unreachable helper **and an unreachable
method**, two fixtures with same-named fields of different role types, and the
four alias-classification outcomes.

Also clean: `go vet ./...`, `golangci-lint run --new-from-rev=HEAD` (0 issues),
`gofmt`.

## Files

- `backend/conformance/role_coverage_gate_test.go` — the gate, the waiver list, the pure `auditRoleCoverage` core, and its cases
- `backend/conformance/role_coverage_scan_test.go` — the facade census, the alias classifier, the reflection cross-check, the call-site scan, and their cases
- `backend/conformance/conformance.go` — package doc: the role tier now says it is exhaustive and names what makes that a fact

## Note on numbers

The role tier is **385** exported `Run*` entrypoints across 25 `*_contract.go`
files, not the 356 an earlier audit recorded — recent PRs added cases. (The
companion PR #5460 shows the role-shaped set is 387 once the two staging
entrypoints outside those files are counted.) This gate asserts no count; it
asserts the relation.
