### PR TITLE
feat(httpapi): issues:batchClose operation (per-item outcomes, claim_next)

### DIFF
--- a/cmd/bd/serve.go
+++ b/cmd/bd/serve.go
@@ -196,6 +196,7 @@ func runServe() error {
 			Sweeper:           roles.sweeper,
 			Deleter:           roles.deleter,
 			BatchCreator:      roles.batchCreator,
+			BatchCloser:       roles.batchCloser,
 			DependencyEditor:  roles.dependencyEditor,
 			MetadataCAS:       roles.metadataCAS,
 			BatchApplier:      roles.batchApplier,
@@ -512,6 +513,7 @@ func serveIssueRoles(src storage.DoltStorage, journalEnabled bool) (serveRoles, 
 		{"sweeper", func() (err error) { roles.sweeper, err = src.Sweeper(); return }},
 		{"deleter", func() (err error) { roles.deleter, err = src.Deleter(); return }},
 		{"batch creator", func() (err error) { roles.batchCreator, err = src.BatchCreator(); return }},
+		{"batch closer", func() (err error) { roles.batchCloser, err = src.BatchCloser(); return }},
 		{"dependency editor", func() (err error) { roles.dependencyEditor, err = src.DependencyEditor(); return }},
 		{"metadata cas", func() (err error) { roles.metadataCAS, err = src.MetadataCAS(); return }},
 		{"batch applier", func() (err error) { roles.batchApplier, err = src.BatchApplier(); return }},
@@ -567,6 +569,7 @@ type serveRoles struct {
 	sweeper      issueops.Sweeper
 	deleter      issueops.Deleter
 	batchCreator issueops.BatchCreator
+	batchCloser  issueops.BatchCloser
 	// dependencyEditor is the second role here whose accessor recurses through
 	// the hook decorator, so taking it off the peeled store is not optional:
 	// HookFiringStore.DependencyEditor fires the workspace's update hook per

--- a/internal/httpapi/apigen/types.gen.go
+++ b/internal/httpapi/apigen/types.gen.go
@@ -60,6 +60,24 @@ func (e ApplyItemResultKind) Valid() bool {
 	}
 }
 
+// Defines values for BatchCloseItemErrorCode.
+const (
+	BatchCloseItemErrorCodeNotClosable BatchCloseItemErrorCode = "not_closable"
+	BatchCloseItemErrorCodeNotFound    BatchCloseItemErrorCode = "not_found"
+)
+
+// Valid indicates whether the value is a known member of the BatchCloseItemErrorCode enum.
+func (e BatchCloseItemErrorCode) Valid() bool {
+	switch e {
+	case BatchCloseItemErrorCodeNotClosable:
+		return true
+	case BatchCloseItemErrorCodeNotFound:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for HealthStatus.
 const (
 	Ok HealthStatus = "ok"
@@ -579,6 +597,77 @@ type ApplyUpdateItem struct {
 	Target Ref `json:"target"`
 }
 
+// BatchCloseItem defines model for BatchCloseItem.
+type BatchCloseItem struct {
+	// Id The issue to close. An EXACT canonical id, resolved across both planes exactly as `POST /v0/beads/issues/{id}:close` resolves one. An id that names nothing is not a request error: it is reported as a `not_found` outcome in this item's response entry, and the rest of the batch still commits.
+	Id string `json:"id"`
+
+	// Reason Why this issue is closed, recorded against this item ALONE — reasons are per item, not per request, because `bd close a b c -r x -r y -r z` maps them positionally. Stored on the issue and read back as `close_reason`, under `CloseIssueRequest.reason`'s first-close-wins rule and the same bounds: refused for control characters, and bounded by what the column holds rather than by the number above.
+	Reason *string `json:"reason,omitempty"`
+}
+
+// BatchCloseItemError Why one item in a batch close was refused. It is NOT the `Problem` envelope: it rides inside a `200` as one outcome of a batch that ran, so it carries only the members a per-item refusal needs.
+type BatchCloseItemError struct {
+	// Code The machine-readable reason, from the same frozen vocabulary the `Problem` envelope draws on. `not_found`: the id names no issue or wisp. `not_closable`: close policy refused an unforced close — open children or a live blocker, both bypassable with request-wide `force`. The set grows additively exactly as `Problem.code` does, so a client MUST default-branch on an unknown value.
+	Code BatchCloseItemErrorCode `json:"code"`
+
+	// Detail Optional prose, never load-bearing. It reflects the caller's own id back and names no server internals.
+	Detail *string `json:"detail,omitempty"`
+
+	// OpenChildren With `not_closable`: how many open children the transaction that refused the close observed, read inside that transaction rather than parsed out of `detail`. PRESENT ONLY for the open-children refusal; the live-blocker refusal carries none, so member presence — not prose — is how a client tells the two apart. This is `Problem.open_children`'s rule, per item.
+	OpenChildren *int `json:"open_children,omitempty"`
+}
+
+// BatchCloseItemErrorCode The machine-readable reason, from the same frozen vocabulary the `Problem` envelope draws on. `not_found`: the id names no issue or wisp. `not_closable`: close policy refused an unforced close — open children or a live blocker, both bypassable with request-wide `force`. The set grows additively exactly as `Problem.code` does, so a client MUST default-branch on an unknown value.
+type BatchCloseItemErrorCode string
+
+// BatchCloseOutcome What happened to ONE requested item. It carries EXACTLY ONE of `issue` or `error`: `issue` with `already_closed` and `open_children` when the close landed or was an idempotent re-close, `error` when the id was refused. Member presence is the discriminator — a client reads `error` first and falls through to `issue`.
+type BatchCloseOutcome struct {
+	// AlreadyClosed Present with `issue`: true when the issue was already closed and this call changed nothing — the idempotent re-close, mirroring `CloseIssueResponse.already_closed`. `reason`/`session` were not rewritten.
+	AlreadyClosed *bool `json:"already_closed,omitempty"`
+
+	// Error Why this item was refused, present when this item was NOT closed. Mutually exclusive with `issue`.
+	Error *BatchCloseItemError `json:"error,omitempty"`
+
+	// Id The id the caller asked for, echoed so an outcome can be read without indexing back into the request.
+	Id string `json:"id"`
+
+	// Issue The post-close snapshot, present when this item was NOT refused. Mutually exclusive with `error`.
+	Issue *Issue `json:"issue,omitempty"`
+
+	// OpenChildren Present with `issue`: how many open children the close observed, `CloseIssueResponse.open_children`'s rule per item. A FORCED close reports it; an unforced close that got this far had none, so it reports 0.
+	OpenChildren *int `json:"open_children,omitempty"`
+}
+
+// BatchCloseRequest defines model for BatchCloseRequest.
+type BatchCloseRequest struct {
+	// Actor Who is closing the issues, under `ClaimRequest.actor`'s rules and for the same reasons: the server trims it, refuses an empty result, anything longer than 256 BYTES, and any control character including newline. It is attributed to every item and interpolated into the storage commit message.
+	Actor string `json:"actor"`
+
+	// ClaimNext When present, claim the next ready issue after the closes land, in the same transaction, and ONLY when at least one item actually closed — a batch whose items were all already closed mutated nothing and earns no claim. The claimed row is returned in `claimed_next`. Absent skips it entirely.
+	ClaimNext *ClaimNextRequest `json:"claim_next,omitempty"`
+
+	// Force Bypass close policy — the open-children refusal and the live-blocker refusal — for every item, and nothing else. The refusals are the ROLE's, so this endpoint cannot skip a guard by forgetting one exists. Request-wide because the flag that spells it is. A forced item still reports `open_children`.
+	Force *bool `json:"force,omitempty"`
+
+	// Items The issues to close, in order. An empty array is a `400` rather than a successful no-op, `BatchCreateRequest.items`' rule: a write request that writes nothing is a client bug. Each entry appears in the response's `items` at the same index.
+	//
+	// The 100-item cap is a bound on how long one request may hold a write transaction, not a statement about batch semantics. Split a larger list; each request is atomic on its own.
+	Items []BatchCloseItem `json:"items"`
+
+	// Session The working session that closed the issues, recorded against every item, stored and read back as `closed_by_session`. Request-wide, unlike `reason`. Under `CloseIssueRequest`'s first-close-wins rule and the same bounds: refused for control characters, and bounded by what the column holds rather than by the number above.
+	Session *string `json:"session,omitempty"`
+}
+
+// BatchCloseResponse defines model for BatchCloseResponse.
+type BatchCloseResponse struct {
+	// ClaimedNext The row a requested `claim_next` won, hydrated with its counts in the same transaction. Present only when `claim_next` was sent, at least one item closed, and a ready issue was eligible; absent otherwise.
+	ClaimedNext *IssueWithCounts `json:"claimed_next,omitempty"`
+
+	// Items One outcome per requested item, in REQUEST ORDER — including the items that refused, so a caller reporting per-id status walks it against its own argument list. Never null and never shorter than the request. There is no `has_more` and no `next_cursor`: this is not a page, and a partial-length answer does not exist on this operation.
+	Items []BatchCloseOutcome `json:"items"`
+}
+
 // BatchCreateDependency defines model for BatchCreateDependency.
 type BatchCreateDependency struct {
 	// TargetId The far end of the edge: an issue this workspace holds, an `external:` reference, or an id whose prefix belongs to another repository. Anything else is a `400` and nothing is created.
@@ -638,6 +727,54 @@ type BlockingAnnotations struct {
 
 // BondRef A constituent of a compound molecule.
 type BondRef = types.BondRef
+
+// ClaimNextRequest The filter that chooses `BatchCloseRequest.claim_next`'s issue. Its members are `GET /v0/beads/ready`'s filter vocabulary BY REFERENCE — every member here has the meaning the `listReadyWork` parameter of the same name documents, and a value this server cannot decode is refused the same way that operation refuses it. It excludes only what a claim has no use for: `limit`, the page bound, and `sort`, an ordering a single claim does not need. An unknown member is a `400`.
+type ClaimNextRequest struct {
+	// Assignee As `listReadyWork`'s `assignee` parameter.
+	Assignee *string `json:"assignee,omitempty"`
+
+	// ExcludeLabel As `listReadyWork`'s `exclude_label` parameter.
+	ExcludeLabel *[]string `json:"exclude_label,omitempty"`
+
+	// ExcludeType As `listReadyWork`'s `exclude_type` parameter.
+	ExcludeType *[]string `json:"exclude_type,omitempty"`
+
+	// HasMetadataKey As `listReadyWork`'s `has_metadata_key` parameter.
+	HasMetadataKey *string `json:"has_metadata_key,omitempty"`
+
+	// IncludeDeferred As `listReadyWork`'s `include_deferred` parameter.
+	IncludeDeferred *bool `json:"include_deferred,omitempty"`
+
+	// IncludeEphemeral As `listReadyWork`'s `include_ephemeral` parameter.
+	IncludeEphemeral *bool `json:"include_ephemeral,omitempty"`
+
+	// Label As `listReadyWork`'s `label` parameter.
+	Label *[]string `json:"label,omitempty"`
+
+	// LabelAny As `listReadyWork`'s `label_any` parameter.
+	LabelAny *[]string `json:"label_any,omitempty"`
+
+	// LabelPattern As `listReadyWork`'s `label_pattern` parameter.
+	LabelPattern *string `json:"label_pattern,omitempty"`
+
+	// LabelRegex As `listReadyWork`'s `label_regex` parameter.
+	LabelRegex *string `json:"label_regex,omitempty"`
+
+	// MetadataField As `listReadyWork`'s `metadata_field` parameter: `key=value` equality, split on the first `=`. An invalid key is a `400`.
+	MetadataField *[]string `json:"metadata_field,omitempty"`
+
+	// Parent As `listReadyWork`'s `parent` parameter.
+	Parent *string `json:"parent,omitempty"`
+
+	// Priority As `listReadyWork`'s `priority` parameter.
+	Priority *int `json:"priority,omitempty"`
+
+	// Type As `listReadyWork`'s `type` parameter.
+	Type *string `json:"type,omitempty"`
+
+	// Unassigned As `listReadyWork`'s `unassigned` parameter.
+	Unassigned *bool `json:"unassigned,omitempty"`
+}
 
 // ClaimRequest defines model for ClaimRequest.
 type ClaimRequest struct {
@@ -734,7 +871,7 @@ type ContextResponse struct {
 	// BeadsDir Absolute path of the served workspace's `.beads` directory. A host path, kept because it is the single-workspace server's only workspace-identity handshake; disclosing it to network peers is part of what an operator accepts when binding beyond loopback.
 	BeadsDir string `json:"beads_dir"`
 
-	// Capabilities The operations this server actually implements, derived from its route table. v0's vocabulary is `ready.list`, `ready.count`, `issues.list`, `issues.query`, `issues.get`, `issues.create`, `issues.claim`, `issues.close`, `issues.reopen`, `issues.update`, `issues.sweep`, `issues.delete`, `issues.batchCreate`, `issues.batchApply`, `stats.get`, `config.list`, `config.get`, `dependencies.cycles`, `dependencies.list`, `dependencies.blocking`, `dependencies.tree`, `dependencies.add`, `dependencies.remove`, `memories.list`, `memories.get`, `memories.remember`, `memories.forget`, `events.list`, `events.watch`, `issues.casMetadata`; it grows additively, and an operation never appears here unless it is fully implemented. This is how a client checks for an operation — never the version string.
+	// Capabilities The operations this server actually implements, derived from its route table. v0's vocabulary is `ready.list`, `ready.count`, `issues.list`, `issues.query`, `issues.get`, `issues.create`, `issues.claim`, `issues.close`, `issues.reopen`, `issues.update`, `issues.sweep`, `issues.delete`, `issues.batchCreate`, `issues.batchApply`, `issues.batchClose`, `stats.get`, `config.list`, `config.get`, `dependencies.cycles`, `dependencies.list`, `dependencies.blocking`, `dependencies.tree`, `dependencies.add`, `dependencies.remove`, `memories.list`, `memories.get`, `memories.remember`, `memories.forget`, `events.list`, `events.watch`, `issues.casMetadata`; it grows additively, and an operation never appears here unless it is fully implemented. This is how a client checks for an operation — never the version string.
 	//
 	// THIS LIST IS BUILD-LEVEL, NOT WORKSPACE-LEVEL. It says which operations this binary serves, and for every entry but two that is the whole answer. `events.list` and `events.watch` are the exceptions: the durable events journal is a per-workspace setting that is OFF by default, so a server that advertises them may still refuse every request to both with 409 `events_journal_disabled` — correctly, because the operations exist and the workspace has no journal. A consumer of either MUST treat the capability as "this server speaks it" and the 409 as "not on this workspace", and must not read the capability as a promise that records will arrive.
 	Capabilities []string `json:"capabilities"`
@@ -1916,6 +2053,9 @@ type ReopenIssueJSONRequestBody = ReopenIssueRequest
 
 // ApplyBatchJSONRequestBody defines body for ApplyBatch for application/json ContentType.
 type ApplyBatchJSONRequestBody = ApplyBatchRequest
+
+// BatchCloseIssuesJSONRequestBody defines body for BatchCloseIssues for application/json ContentType.
+type BatchCloseIssuesJSONRequestBody = BatchCloseRequest
 
 // BatchCreateIssuesJSONRequestBody defines body for BatchCreateIssues for application/json ContentType.
 type BatchCreateIssuesJSONRequestBody = BatchCreateRequest

--- a/internal/httpapi/batch_close.go
+++ b/internal/httpapi/batch_close.go
@@ -1,0 +1,510 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"slices"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/steveyegge/beads/internal/httpapi/apigen"
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/issueops"
+)
+
+const (
+	// maxBatchCloseItems is the document's cap on `items`. It bounds how long one
+	// request may hold a write transaction, not batch semantics — the same bound
+	// batchCreate carries and for the same reason.
+	maxBatchCloseItems = 100
+	// maxBatchCloseBodyBytes bounds the request body at 1 MiB. A hundred items
+	// each carrying an id and a short reason, plus a claim_next filter, is the
+	// shape this admits; anything larger is refused before it is parsed.
+	maxBatchCloseBodyBytes = 1 << 20
+)
+
+// The member vocabulary at each level. The schemas are additionalProperties:
+// false, so anything else is refused BY NAME, which is why the body is decoded as
+// raw members first — batchCreate's posture exactly.
+var (
+	batchCloseRequestMembers = []string{"actor", "items", "session", "force", "claim_next"}
+	batchCloseItemMembers    = []string{"id", "reason"}
+)
+
+// handleBatchClose closes every item in the request it can, and commits the ones
+// that landed together. It is the write side of `bd close a b c`.
+//
+// It shares the claim's posture exactly: the actor is caller-ASSERTED provenance
+// and not authenticated identity, hooks do not fire, and the per-command
+// auto-commit machinery never runs. The only durable effect is the single
+// storage commit the role makes inside its own transaction.
+//
+// Everything above the role is argument validation. The close policy, the
+// per-item outcomes, the atomic claim_next and the transaction retry all belong
+// to issueops.BatchCloser, reached through the provider's own accessor. Unlike
+// batchCreate this operation is NOT all-or-nothing: a refused id is a per-item
+// outcome inside a 200, not a 4xx, so a caller keeps the answers for the ids that
+// did close.
+func (s *Server) handleBatchClose(w http.ResponseWriter, r *http.Request) {
+	if !s.requireNoQuery(w, r) {
+		return
+	}
+	if !s.requireJSONContent(w, r) {
+		return
+	}
+	request, ok := s.batchCloseRequest(w, r)
+	if !ok {
+		return
+	}
+
+	closer, err := s.batchCloser(r)
+	if err != nil {
+		s.failBatchClose(w, r, err)
+		return
+	}
+	result, err := closer.CloseBatch(r.Context(), request)
+	if err != nil {
+		s.failBatchClose(w, r, err)
+		return
+	}
+	writeJSON(w, batchCloseResponse(result))
+}
+
+// batchCloseRequest decodes and validates the body, and reports whether the
+// request may proceed. Every refusal here happens BEFORE any database work, which
+// is what lets the 400s reflect the caller's own input back — and what lets a
+// per-item outcome be reserved for the id refusals only the transaction can see.
+func (s *Server) batchCloseRequest(w http.ResponseWriter, r *http.Request) (issueops.CloseBatchRequest, bool) {
+	members, res := decodeJSONObject(w, r, maxBatchCloseBodyBytes)
+	if res != nil {
+		s.fail(w, r, *res)
+		return issueops.CloseBatchRequest{}, false
+	}
+	if offender, unknown := unknownMember(members, batchCloseRequestMembers); unknown {
+		s.failUnknownMember(w, r, offender, batchCloseRequestMembers)
+		return issueops.CloseBatchRequest{}, false
+	}
+
+	// actor is required and reaches the same columns and commit message the claim
+	// validates, so it is bodyActor's rules unchanged. session and reason land in
+	// stored columns renderers print, so both take storedTextMember's control-
+	// character and length bounds. force defaults false, the guarded answer.
+	actor, ok := s.bodyActor(w, r, members)
+	if !ok {
+		return issueops.CloseBatchRequest{}, false
+	}
+	items, ok := s.batchCloseItems(w, r, members)
+	if !ok {
+		return issueops.CloseBatchRequest{}, false
+	}
+	session, ok := s.storedTextMember(w, r, members, "session")
+	if !ok {
+		return issueops.CloseBatchRequest{}, false
+	}
+	force, ok := s.booleanMember(w, r, members, "force")
+	if !ok {
+		return issueops.CloseBatchRequest{}, false
+	}
+	claimNext, ok := s.batchCloseClaimNext(w, r, members)
+	if !ok {
+		return issueops.CloseBatchRequest{}, false
+	}
+
+	return issueops.CloseBatchRequest{
+		Actor:     actor,
+		Items:     items,
+		Session:   session,
+		Force:     force,
+		ClaimNext: claimNext,
+	}, true
+}
+
+// batchCloseItems validates `items` and projects it onto the role's items. It is
+// batchCreateItems' shape: the array bounds, the per-item unknown-member refusal,
+// and the malformed-vs-missing distinction each item earns.
+func (s *Server) batchCloseItems(w http.ResponseWriter, r *http.Request, members map[string]json.RawMessage) ([]issueops.BatchCloseItem, bool) {
+	raw, ok := members["items"]
+	if !ok {
+		s.fail(w, r, InvalidArgument("items", ReasonInvalidValue, "`items` is required"))
+		return nil, false
+	}
+	var rawItems []map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &rawItems); err != nil || rawItems == nil {
+		s.fail(w, r, InvalidArgument("items", ReasonInvalidValue, "`items` must be an array of objects"))
+		return nil, false
+	}
+	switch {
+	case len(rawItems) == 0:
+		s.fail(w, r, InvalidArgument("items", ReasonInvalidValue,
+			"`items` must name at least one issue; a close that closes nothing is refused rather than answered"))
+		return nil, false
+	case len(rawItems) > maxBatchCloseItems:
+		s.fail(w, r, InvalidArgument("items", ReasonInvalidValue,
+			fmt.Sprintf("`items` carries %d issues; the limit is %d per request", len(rawItems), maxBatchCloseItems)))
+		return nil, false
+	}
+
+	items := make([]issueops.BatchCloseItem, 0, len(rawItems))
+	for i, rawItem := range rawItems {
+		if rawItem == nil {
+			s.fail(w, r, InvalidArgument(batchCloseItemParam(i, ""), ReasonInvalidValue, "an item must be a JSON object"))
+			return nil, false
+		}
+		if offender, unknown := unknownMember(rawItem, batchCloseItemMembers); unknown {
+			s.failUnknownMember(w, r, batchCloseItemParam(i, offender), batchCloseItemMembers)
+			return nil, false
+		}
+		item, res := batchCloseItem(i, rawItem)
+		if res != nil {
+			s.fail(w, r, *res)
+			return nil, false
+		}
+		items = append(items, item)
+	}
+	return items, true
+}
+
+// batchCloseItem projects one decoded item onto the role's item, or reports the
+// refusal it earned. It decodes into the GENERATED struct, which is what makes a
+// member's type the document's type: `id: 7` is refused here rather than reaching
+// a role that would have to guess.
+//
+// An id that names nothing is NOT refused here: it is a per-item not_found
+// outcome the transaction reports, so a mistyped id in a list of five keeps the
+// other four. Only a shape the request itself got wrong — a blank id, an
+// over-long id or reason, a control character — is a 400.
+func batchCloseItem(index int, raw map[string]json.RawMessage) (issueops.BatchCloseItem, *Result) {
+	refuse := func(member, detail string) *Result {
+		res := InvalidArgument(batchCloseItemParam(index, member), ReasonInvalidValue, detail)
+		return &res
+	}
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		return issueops.BatchCloseItem{}, refuse("", "an item must be a JSON object")
+	}
+	var wire apigen.BatchCloseItem
+	if err := json.Unmarshal(encoded, &wire); err != nil {
+		return issueops.BatchCloseItem{}, refuse("", "an item member carries the wrong JSON type")
+	}
+	if strings.TrimSpace(wire.Id) == "" {
+		return issueops.BatchCloseItem{}, refuse("id", "`id` is required and must not be blank")
+	}
+	// The column is VARCHAR(255) and the id is exact, so a longer one names no row
+	// that can exist. Refused here rather than let through to a 500 from the
+	// column, the single close's edge bound applied per item.
+	if types.CheckFieldLen("id", wire.Id) != nil {
+		return issueops.BatchCloseItem{}, refuse("id",
+			fmt.Sprintf("`id` is longer than the %d characters storage holds", types.MaxFieldLen))
+	}
+	item := issueops.BatchCloseItem{IssueID: wire.Id}
+	if wire.Reason != nil {
+		switch {
+		case types.CheckFieldLen("reason", *wire.Reason) != nil:
+			return issueops.BatchCloseItem{}, refuse("reason",
+				fmt.Sprintf("`reason` is %d characters; storage holds at most %d",
+					utf8.RuneCountInString(*wire.Reason), types.MaxFieldLen))
+		case strings.ContainsFunc(*wire.Reason, isControlChar):
+			return issueops.BatchCloseItem{}, refuse("reason", "`reason` must not contain control characters")
+		}
+		item.Reason = *wire.Reason
+	}
+	return item, nil
+}
+
+// batchCloseItemParam spells the `param` member for a refusal inside `items`, so
+// a client dispatching on it learns WHICH item and WHICH member. It is
+// batchCreateItemParam's shape; each batch operation keeps its own because the
+// two vocabularies are not the same.
+func batchCloseItemParam(index int, member string) string {
+	param := fmt.Sprintf("items[%d]", index)
+	if member == "" {
+		return param
+	}
+	return param + "." + member
+}
+
+// batchCloseClaimNext decodes the optional claim_next onto the ready-request type
+// through the SAME readyFilters the query decode runs. Absent stays nil — no
+// claim was asked for. The filter's Limit and Offset stay unset here, which is
+// what ClaimNext's contract requires and readyFilters never sets, so the role's
+// own limit/offset refusal is unreachable from this front door.
+func (s *Server) batchCloseClaimNext(w http.ResponseWriter, r *http.Request, members map[string]json.RawMessage) (*issueops.ReadyRequest, bool) {
+	raw, ok := members["claim_next"]
+	if !ok {
+		return nil, true
+	}
+	var claimMembers map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &claimMembers); err != nil || claimMembers == nil {
+		s.fail(w, r, InvalidArgument(claimNextParam, ReasonInvalidValue, "`"+claimNextParam+"` must be an object"))
+		return nil, false
+	}
+	src := newReadyFilterObject(claimMembers)
+	req := readyFilters(src)
+	if res := src.result(); res != nil {
+		s.fail(w, r, *res)
+		return nil, false
+	}
+	return &req, true
+}
+
+// claimNextParam prefixes a refusal inside claim_next, so `claim_next.priority`
+// tells a client which member of which object it must fix.
+const claimNextParam = "claim_next"
+
+// readyFilterObject decodes the ready filter vocabulary from a JSON object, the
+// claim_next front door onto readyFilters. It is *query's twin: the same five
+// accessors, each validating its own value against the same rules and recording a
+// first refusal, plus the unknown-member refusal *query reports for a parameter
+// it never read. The metadata split is splitMetadataFields, shared with the
+// query so the two cannot disagree about what a malformed `key=value` is.
+type readyFilterObject struct {
+	members map[string]json.RawMessage
+	// read marks every member readyFilters asked for, so the allowlist is the
+	// vocabulary itself rather than a second copy of it — a member no accessor
+	// reads is, by construction, unknown.
+	read map[string]bool
+	// res holds the FIRST refusal, so the answer does not depend on the order the
+	// filters happen to be read in; `param` is what a client dispatches on.
+	res *Result
+}
+
+func newReadyFilterObject(members map[string]json.RawMessage) *readyFilterObject {
+	return &readyFilterObject{members: members, read: map[string]bool{}}
+}
+
+func (o *readyFilterObject) param(name string) string { return claimNextParam + "." + name }
+
+func (o *readyFilterObject) invalid(name, detail string) {
+	if o.res == nil {
+		res := InvalidArgument(o.param(name), ReasonInvalidValue, detail)
+		o.res = &res
+	}
+}
+
+// raw marks name read — so it is not reported as an unknown member — and returns
+// its value if the object carried one.
+func (o *readyFilterObject) raw(name string) (json.RawMessage, bool) {
+	o.read[name] = true
+	v, ok := o.members[name]
+	return v, ok
+}
+
+// str decodes through a POINTER so an explicit `null` reaches the type-mismatch
+// branch rather than sliding through as the empty string, the close body's rule.
+func (o *readyFilterObject) str(name string) string {
+	raw, ok := o.raw(name)
+	if !ok {
+		return ""
+	}
+	var v *string
+	if err := json.Unmarshal(raw, &v); err != nil || v == nil {
+		o.invalid(name, "`"+name+"` must be a string")
+		return ""
+	}
+	return *v
+}
+
+func (o *readyFilterObject) boolean(name string) bool {
+	raw, ok := o.raw(name)
+	if !ok {
+		return false
+	}
+	var v *bool
+	if err := json.Unmarshal(raw, &v); err != nil || v == nil {
+		o.invalid(name, "`"+name+"` must be a boolean")
+		return false
+	}
+	return *v
+}
+
+func (o *readyFilterObject) list(name string) []string {
+	raw, ok := o.raw(name)
+	if !ok {
+		return nil
+	}
+	var v []string
+	if err := json.Unmarshal(raw, &v); err != nil {
+		o.invalid(name, "`"+name+"` must be an array of strings")
+		return nil
+	}
+	return v
+}
+
+func (o *readyFilterObject) integer(name string) *int {
+	raw, ok := o.raw(name)
+	if !ok {
+		return nil
+	}
+	var v *int
+	if err := json.Unmarshal(raw, &v); err != nil || v == nil {
+		o.invalid(name, "`"+name+"` must be an integer")
+		return nil
+	}
+	return v
+}
+
+func (o *readyFilterObject) metadataFields(name string) map[string]string {
+	raw, ok := o.raw(name)
+	if !ok {
+		return nil
+	}
+	var entries []string
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		o.invalid(name, "`"+name+"` must be an array of `key=value` strings")
+		return nil
+	}
+	return splitMetadataFields(entries, func(bad string) {
+		o.invalid(name, fmt.Sprintf("%q is not key=value", bad))
+	})
+}
+
+// result reports the refusal claim_next earned, if any. A malformed value on a
+// member this server DOES know is reported ahead of an unknown one — the query's
+// ordering — because the two carry opposite client recoveries.
+func (o *readyFilterObject) result() *Result {
+	if o.res != nil {
+		return o.res
+	}
+	var unknown []string
+	for name := range o.members {
+		if !o.read[name] {
+			unknown = append(unknown, name)
+		}
+	}
+	if len(unknown) == 0 {
+		return nil
+	}
+	// One offender, chosen deterministically so a client dispatching on `param`
+	// never sees it depend on map order.
+	offender := slices.Min(unknown)
+	res := InvalidArgument(o.param(offender), ReasonUnknownParameter,
+		"`"+claimNextParam+"` carries the listReadyWork filter vocabulary and nothing else")
+	return &res
+}
+
+// batchCloseResponse projects the role's result onto the wire body: one outcome
+// per item in request order, and the claimed row when one was won.
+//
+// ClaimedNext is the role's *IssueWithCounts, which IS the generated pointer
+// type (the schema is x-go-type-pinned), so it passes through unrewritten and
+// nil — no claim asked for, nothing closed, or nothing eligible — omits the
+// member.
+func batchCloseResponse(result issueops.CloseBatchResult) apigen.BatchCloseResponse {
+	items := make([]apigen.BatchCloseOutcome, len(result.Outcomes))
+	for i := range result.Outcomes {
+		items[i] = batchCloseOutcome(result.Outcomes[i])
+	}
+	return apigen.BatchCloseResponse{
+		Items:       items,
+		ClaimedNext: result.ClaimedNext,
+	}
+}
+
+// batchCloseOutcome maps one role outcome onto the wire, carrying EXACTLY ONE of
+// issue or error.
+//
+// The error branch wins when Err is set, which is also the branch a role that
+// broke the exactly-one invariant lands in — checkedBatchCloser has already
+// folded a neither-issue-nor-error outcome into Err, so the else branch
+// dereferences a snapshot that is present by construction, the checkedClaimer
+// guarantee once per item.
+func batchCloseOutcome(o issueops.CloseOutcome) apigen.BatchCloseOutcome {
+	out := apigen.BatchCloseOutcome{Id: o.IssueID}
+	if o.Err != nil {
+		itemErr := batchCloseItemError(o.Err)
+		out.Error = &itemErr
+		return out
+	}
+	// already_closed and open_children accompany the snapshot, mirroring
+	// CloseIssueResponse: `already_closed` is the idempotent re-close (Changed
+	// false), and a forced close reports the children it observed.
+	issue := *o.Issue
+	alreadyClosed := !o.Changed
+	openChildren := o.OpenChildren
+	out.Issue = &issue
+	out.AlreadyClosed = &alreadyClosed
+	out.OpenChildren = &openChildren
+	return out
+}
+
+// batchCloseItemErrorCodes is the EXACT set of codes batchCloseItemError emits,
+// declared once so TestBatchCloseItemErrorGovernance can pin it against the spec
+// enum and the frozen problem registry in one place. Adding a case that emits a
+// new code means adding it here, adding it to the schema enum, and adding it to
+// the registry — all three, which is the whole point of the three-way pin.
+var batchCloseItemErrorCodes = []apigen.BatchCloseItemErrorCode{
+	apigen.BatchCloseItemErrorCodeNotFound,
+	apigen.BatchCloseItemErrorCodeNotClosable,
+}
+
+// batchCloseItemError maps one item's typed refusal onto the wire, reusing the
+// frozen close vocabulary the single close already maps: ErrNotFound is
+// not_found, and both close-policy refusals are not_closable with the open-
+// children count present only for the children refusal — the member-presence
+// discriminator failClose uses, per item.
+//
+// The count and the detail come from the typed error's own field, never from
+// parsing the sentinel's message, exactly as WithOpenChildren requires. The
+// default branch folds anything else — a role that returned an unclassified
+// error, or the neither-issue-nor-error fault checkedBatchCloser synthesizes —
+// into not_closable, so the codes this function emits are exactly
+// batchCloseItemErrorCodes. New per-item codes are ADDED here, which is what the
+// schema's "default-branch on an unknown value" note tells clients to expect.
+func batchCloseItemError(err error) apigen.BatchCloseItemError {
+	detail := func(s string) *string { return &s }
+
+	var openChildren *issueops.CloseOpenChildrenError
+	switch {
+	case errors.As(err, &openChildren):
+		n := openChildren.OpenChildren
+		return apigen.BatchCloseItemError{
+			Code:         apigen.BatchCloseItemErrorCodeNotClosable,
+			Detail:       detail("issue has open children; close them first or close with force"),
+			OpenChildren: &n,
+		}
+	case errors.Is(err, issueops.ErrCloseOpenChildren):
+		// The sentinel without the typed carrier. There is no count to publish, so
+		// none is — the live-blocker shape, which is the honest report when the
+		// number the children refusal needs did not arrive.
+		return apigen.BatchCloseItemError{
+			Code:   apigen.BatchCloseItemErrorCodeNotClosable,
+			Detail: detail("issue has open children; close them first or close with force"),
+		}
+	case errors.Is(err, issueops.ErrCloseBlocked):
+		return apigen.BatchCloseItemError{
+			Code:   apigen.BatchCloseItemErrorCodeNotClosable,
+			Detail: detail("issue is blocked; clear the blocker or close with force"),
+		}
+	case errors.Is(err, issueops.ErrNotFound):
+		return apigen.BatchCloseItemError{
+			Code:   apigen.BatchCloseItemErrorCodeNotFound,
+			Detail: detail("no issue or wisp with that id"),
+		}
+	default:
+		return apigen.BatchCloseItemError{
+			Code:   apigen.BatchCloseItemErrorCodeNotClosable,
+			Detail: detail("the item could not be closed"),
+		}
+	}
+}
+
+// failBatchClose answers a failed batch.
+//
+// The method's own error is reserved for request validation, cancellation and
+// infrastructure — the failures that mean the batch NEVER RAN — so a per-item
+// refusal never reaches here; it is a 200 outcome. The role's ErrValidation is
+// answered as the 400 it is in the SERVER's own words rather than quoting the
+// storage sentence, and without a `param`: it is about the request as a whole,
+// which the handler already validated member by member, so this branch is
+// defensive. Everything else keeps the shared classifier's codes.
+func (s *Server) failBatchClose(w http.ResponseWriter, r *http.Request, err error) {
+	if errors.Is(err, issueops.ErrValidation) {
+		s.event("request_refused", "request_id", requestInfo(r.Context()).id, "error", err.Error())
+		s.fail(w, r, InvalidArgument("", ReasonInvalidValue,
+			"the batch was refused by validation; nothing was closed"))
+		return
+	}
+	s.failErr(w, r, err)
+}

--- a/internal/httpapi/batch_close_test.go
+++ b/internal/httpapi/batch_close_test.go
@@ -1,0 +1,617 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/httpapi/apigen"
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/issueops"
+)
+
+// These cover the transport half of POST /v0/beads/issues:batchClose — the body
+// shape, the refusals this operation owns, how the role's per-item outcomes are
+// mapped onto the wire, and the claim_next decode's parity with the ready query.
+// Everything below the wire is the role's, pinned by the BatchCloser conformance
+// contract at all three backends.
+
+const batchClosePath = "/v0/beads/issues:batchClose"
+
+func newBatchCloseServer(t *testing.T, closer *roleBatchCloser) *testServer {
+	t.Helper()
+	return newTestServer(t, rolesConfig(Config{BatchCloser: closer}))
+}
+
+// TestBatchClosePathReachesItsHandler drives the DOCUMENTED path and asserts it
+// reaches the batch-close handler rather than the claim's wide POST wildcard: the
+// literal `:batchClose` is registered after `/v0/beads/issues/{idop}` and
+// ServeMux prefers it by specificity, the sweep/delete precedent.
+func TestBatchClosePathReachesItsHandler(t *testing.T) {
+	closer := &roleBatchCloser{}
+	ts := newBatchCloseServer(t, closer)
+
+	resp := ts.claim(t, batchClosePath, `{"actor":"alice","items":[{"id":"bd-1"}]}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if calls := closer.closeRequests(); len(calls) != 1 {
+		t.Fatalf("role calls = %d, want 1 — the request did not reach the batch-close handler", len(calls))
+	}
+}
+
+// TestBatchClosePassesTheRequestToTheRoleAndAnswersWithOutcomes pins the
+// projection both ways: the wire members become the role's request, and the
+// role's outcomes come back in request order carrying the snapshot, the
+// idempotent flag and the open-child count.
+func TestBatchClosePassesTheRequestToTheRoleAndAnswersWithOutcomes(t *testing.T) {
+	closer := &roleBatchCloser{}
+	ts := newBatchCloseServer(t, closer)
+
+	resp := ts.claim(t, batchClosePath, `{"actor":"alice","session":"s-1","force":true,"items":[
+		{"id":"bd-1","reason":"done"},
+		{"id":"bd-2"}
+	]}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	body := decodeBody(t, resp)
+	items, _ := body["items"].([]any)
+	if len(items) != 2 {
+		t.Fatalf("items = %v, want two outcomes", body["items"])
+	}
+	for i, want := range []string{"bd-1", "bd-2"} {
+		outcome, _ := items[i].(map[string]any)
+		issue, ok := outcome["issue"].(map[string]any)
+		if !ok {
+			t.Fatalf("items[%d] carries no issue: %v", i, outcome)
+		}
+		if issue["id"] != want {
+			t.Errorf("items[%d].issue.id = %v, want %q in request order", i, issue["id"], want)
+		}
+		if _, present := outcome["error"]; present {
+			t.Errorf("items[%d] carries both issue and error; exactly one is the contract", i)
+		}
+		if outcome["already_closed"] != false {
+			t.Errorf("items[%d].already_closed = %v, want false for a landed close", i, outcome["already_closed"])
+		}
+	}
+	if _, present := body["claimed_next"]; present {
+		t.Error("claimed_next is present without a claim_next request")
+	}
+
+	reqs := closer.closeRequests()
+	if len(reqs) != 1 {
+		t.Fatalf("role calls = %d, want 1", len(reqs))
+	}
+	got := reqs[0]
+	if got.Actor != "alice" || got.Session != "s-1" || !got.Force {
+		t.Errorf("request = %+v, want the wire's actor, session and force", got)
+	}
+	if len(got.Items) != 2 || got.Items[0].IssueID != "bd-1" || got.Items[0].Reason != "done" {
+		t.Errorf("items = %+v, want the wire's ids and per-item reason", got.Items)
+	}
+	if got.Items[1].Reason != "" {
+		t.Errorf("items[1].reason = %q, want empty: an omitted reason is not a lie", got.Items[1].Reason)
+	}
+	if got.ClaimNext != nil {
+		t.Errorf("claim_next = %+v, want nil: none was sent", got.ClaimNext)
+	}
+}
+
+// TestBatchCloseMapsPerItemOutcomes is the heart of the operation: a mixed batch
+// of successes and refusals, each mapped to EXACTLY ONE of issue or error, with
+// the open-children member present only where the discriminator says it should
+// be.
+func TestBatchCloseMapsPerItemOutcomes(t *testing.T) {
+	closer := &roleBatchCloser{outcomes: []issueops.CloseOutcome{
+		// A forced close reporting the children it observed.
+		{IssueID: "bd-1", Issue: &types.Issue{ID: "bd-1", Status: types.StatusClosed}, Changed: true, OpenChildren: 2},
+		// An id that names nothing: not_found, no children member.
+		{IssueID: "bd-2", Err: issueops.ErrNotFound},
+		// Open children refused an unforced close: not_closable WITH the count.
+		{IssueID: "bd-3", Err: &issueops.CloseOpenChildrenError{IssueID: "bd-3", OpenChildren: 3}},
+		// A live blocker: not_closable with NO count.
+		{IssueID: "bd-4", Err: issueops.ErrCloseBlocked},
+		// Idempotent re-close: a success that changed nothing.
+		{IssueID: "bd-5", Issue: &types.Issue{ID: "bd-5", Status: types.StatusClosed}, Changed: false},
+	}}
+	ts := newBatchCloseServer(t, closer)
+
+	resp := ts.claim(t, batchClosePath, `{"actor":"alice","items":[
+		{"id":"bd-1"},{"id":"bd-2"},{"id":"bd-3"},{"id":"bd-4"},{"id":"bd-5"}]}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (a batch that refused items still RAN): %s", resp.StatusCode, readAll(t, resp))
+	}
+	items, _ := decodeBody(t, resp)["items"].([]any)
+	if len(items) != 5 {
+		t.Fatalf("items = %d, want 5 in request order", len(items))
+	}
+
+	for i, outcome := range items {
+		m, _ := outcome.(map[string]any)
+		_, hasIssue := m["issue"]
+		_, hasError := m["error"]
+		if hasIssue == hasError {
+			t.Errorf("items[%d] has issue=%v error=%v; exactly one is the contract", i, hasIssue, hasError)
+		}
+	}
+
+	// items[0]: forced-close success carries open_children on the ISSUE side.
+	if got := items[0].(map[string]any); got["already_closed"] != false || got["open_children"] != float64(2) {
+		t.Errorf("items[0] = %v, want already_closed false and open_children 2", got)
+	}
+	// items[1]: not_found, no open_children.
+	if e := items[1].(map[string]any)["error"].(map[string]any); e["code"] != "not_found" {
+		t.Errorf("items[1].error.code = %v, want not_found", e["code"])
+	} else if _, present := e["open_children"]; present {
+		t.Error("items[1].error carries open_children; not_found never does")
+	}
+	// items[2]: not_closable WITH the count.
+	if e := items[2].(map[string]any)["error"].(map[string]any); e["code"] != "not_closable" || e["open_children"] != float64(3) {
+		t.Errorf("items[2].error = %v, want not_closable with open_children 3", e)
+	}
+	// items[3]: not_closable, the live-blocker shape — member ABSENT is the discriminator.
+	if e := items[3].(map[string]any)["error"].(map[string]any); e["code"] != "not_closable" {
+		t.Errorf("items[3].error.code = %v, want not_closable", e["code"])
+	} else if _, present := e["open_children"]; present {
+		t.Error("items[3].error carries open_children; the live-blocker refusal must not, that is the discriminator")
+	}
+	// items[4]: idempotent re-close.
+	if got := items[4].(map[string]any); got["already_closed"] != true {
+		t.Errorf("items[4].already_closed = %v, want true for an unchanged re-close", got["already_closed"])
+	}
+}
+
+// TestBatchClosePostCommitFaultIsFoldedPerItem pins checkedBatchCloser: an
+// outcome the role reports with NEITHER a snapshot nor a refusal is folded into
+// that item's own error rather than tanking the whole batch — the survivors
+// already committed, so the response keeps them.
+func TestBatchClosePostCommitFaultIsFoldedPerItem(t *testing.T) {
+	closer := &roleBatchCloser{outcomes: []issueops.CloseOutcome{
+		{IssueID: "bd-1", Issue: &types.Issue{ID: "bd-1", Status: types.StatusClosed}, Changed: true},
+		{IssueID: "bd-2"}, // neither issue nor error: a post-commit fault
+	}}
+	ts := newBatchCloseServer(t, closer)
+
+	resp := ts.claim(t, batchClosePath, `{"actor":"alice","items":[{"id":"bd-1"},{"id":"bd-2"}]}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 — the survivors committed: %s", resp.StatusCode, readAll(t, resp))
+	}
+	items, _ := decodeBody(t, resp)["items"].([]any)
+	if got := items[0].(map[string]any); got["issue"] == nil {
+		t.Errorf("items[0] lost its committed snapshot: %v", got)
+	}
+	folded, _ := items[1].(map[string]any)
+	if folded["issue"] != nil {
+		t.Errorf("items[1] carries an issue for an outcome that had none: %v", folded)
+	}
+	e, ok := folded["error"].(map[string]any)
+	if !ok || e["code"] != "not_closable" {
+		t.Errorf("items[1].error = %v, want the folded fault as not_closable (the default branch)", folded["error"])
+	}
+	assertNoPanic(t, ts)
+}
+
+// TestBatchCloseReturnsClaimedNext pins that a claim the role won comes back in
+// claimed_next, hydrated with the counts the ready element carries.
+func TestBatchCloseReturnsClaimedNext(t *testing.T) {
+	closer := &roleBatchCloser{claimedNext: &types.IssueWithCounts{Issue: &types.Issue{ID: "bd-next"}, DependencyCount: 1}}
+	ts := newBatchCloseServer(t, closer)
+
+	resp := ts.claim(t, batchClosePath, `{"actor":"alice","items":[{"id":"bd-1"}],"claim_next":{"assignee":"alice"}}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	body := decodeBody(t, resp)
+	claimed, ok := body["claimed_next"].(map[string]any)
+	if !ok {
+		t.Fatalf("claimed_next is absent: %v", body)
+	}
+	if claimed["id"] != "bd-next" {
+		t.Errorf("claimed_next.id = %v, want bd-next", claimed["id"])
+	}
+
+	reqs := closer.closeRequests()
+	if len(reqs) != 1 || reqs[0].ClaimNext == nil {
+		t.Fatalf("role received claim_next = %v, want the decoded filter", reqs)
+	}
+	if reqs[0].ClaimNext.Assignee != "alice" {
+		t.Errorf("claim_next.assignee reached the role as %q, want alice", reqs[0].ClaimNext.Assignee)
+	}
+	// The limit/offset ClaimNext refuses stay unset, so the role's own refusal is
+	// unreachable from this front door.
+	if reqs[0].ClaimNext.Limit != nil || reqs[0].ClaimNext.Offset != 0 {
+		t.Errorf("claim_next reached the role with a limit/offset set: %+v", reqs[0].ClaimNext)
+	}
+}
+
+// TestBatchCloseRefusesTheShapesTheDocumentRefuses walks the 400s this operation
+// owns. Every one is answered BEFORE the role is reached, which is also the proof
+// that nothing was closed — a per-item refusal, by contrast, is a 200 outcome.
+func TestBatchCloseRefusesTheShapesTheDocumentRefuses(t *testing.T) {
+	long := strings.Repeat("x", types.MaxFieldLen+1)
+	for _, test := range []struct {
+		name      string
+		body      string
+		wantParam string
+	}{
+		{"no actor", `{"items":[{"id":"bd-1"}]}`, "actor"},
+		{"blank actor", `{"actor":"  ","items":[{"id":"bd-1"}]}`, "actor"},
+		{"actor with a newline", "{\"actor\":\"alice\\nbd: close\",\"items\":[{\"id\":\"bd-1\"}]}", "actor"},
+		{"null actor", `{"actor":null,"items":[{"id":"bd-1"}]}`, "actor"},
+		{"no items", `{"actor":"alice"}`, "items"},
+		{"empty items", `{"actor":"alice","items":[]}`, "items"},
+		{"items is not an array", `{"actor":"alice","items":{"id":"bd-1"}}`, "items"},
+		{"unknown top-level member", `{"actor":"alice","items":[{"id":"bd-1"}],"dry_run":true}`, "dry_run"},
+		{"unknown item member", `{"actor":"alice","items":[{"id":"bd-1","force":true}]}`, "items[0].force"},
+		{"no id", `{"actor":"alice","items":[{"reason":"r"}]}`, "items[0].id"},
+		{"blank id", `{"actor":"alice","items":[{"id":"  "}]}`, "items[0].id"},
+		{"id is not a string", `{"actor":"alice","items":[{"id":7}]}`, "items[0]"},
+		{"over-long id", `{"actor":"alice","items":[{"id":"` + long + `"}]}`, "items[0].id"},
+		{"over-long reason", `{"actor":"alice","items":[{"id":"bd-1","reason":"` + long + `"}]}`, "items[0].reason"},
+		{"reason with a control character", "{\"actor\":\"alice\",\"items\":[{\"id\":\"bd-1\",\"reason\":\"a\\u0007b\"}]}", "items[0].reason"},
+		{"the second item is the bad one", `{"actor":"alice","items":[{"id":"bd-1"},{"id":""}]}`, "items[1].id"},
+		{"session with a control character", "{\"actor\":\"alice\",\"session\":\"a\\u0007b\",\"items\":[{\"id\":\"bd-1\"}]}", "session"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			closer := &roleBatchCloser{}
+			ts := newBatchCloseServer(t, closer)
+
+			resp := ts.claim(t, batchClosePath, test.body)
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
+			}
+			body := decodeBody(t, resp)
+			if body["code"] != string(CodeInvalidArgument) {
+				t.Errorf("code = %v, want %q", body["code"], CodeInvalidArgument)
+			}
+			if body["param"] != test.wantParam {
+				t.Errorf("param = %v, want %q — a client dispatches on this", body["param"], test.wantParam)
+			}
+			if calls := closer.closeRequests(); len(calls) != 0 {
+				t.Errorf("the role was called %d times for a refused request; nothing may be closed", len(calls))
+			}
+		})
+	}
+}
+
+// TestBatchCloseRefusesAMalformedClaimNext pins that the claim_next object is
+// decoded with the ready query's own validators: a malformed value is refused
+// under `claim_next.member`, and an unknown member is version skew.
+func TestBatchCloseRefusesAMalformedClaimNext(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		claimNext  string
+		wantParam  string
+		wantReason Reason
+	}{
+		{"claim_next is not an object", `"soon"`, "claim_next", ReasonInvalidValue},
+		{"unassigned is not a boolean", `{"unassigned":"yes"}`, "claim_next.unassigned", ReasonInvalidValue},
+		{"priority is not an integer", `{"priority":"high"}`, "claim_next.priority", ReasonInvalidValue},
+		{"label is not an array", `{"label":"api"}`, "claim_next.label", ReasonInvalidValue},
+		{"metadata_field is not key=value", `{"metadata_field":["noeq"]}`, "claim_next.metadata_field", ReasonInvalidValue},
+		{"unknown member", `{"bogus":true}`, "claim_next.bogus", ReasonUnknownParameter},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			closer := &roleBatchCloser{}
+			ts := newBatchCloseServer(t, closer)
+
+			resp := ts.claim(t, batchClosePath, `{"actor":"alice","items":[{"id":"bd-1"}],"claim_next":`+test.claimNext+`}`)
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
+			}
+			body := decodeBody(t, resp)
+			if body["param"] != test.wantParam {
+				t.Errorf("param = %v, want %q", body["param"], test.wantParam)
+			}
+			if body["reason"] != string(test.wantReason) {
+				t.Errorf("reason = %v, want %q", body["reason"], test.wantReason)
+			}
+			if calls := closer.closeRequests(); len(calls) != 0 {
+				t.Error("the role was called for a request with a bad claim_next")
+			}
+		})
+	}
+}
+
+// TestBatchCloseClaimNextDecodesLikeTheReadyQuery is the parity pin the design
+// asks for directly: the JSON claim_next object and the ready URL query, given
+// the same filter values, build the SAME ReadyRequest through the SAME
+// readyFilters. Copying the decoder is what would let the two come apart.
+func TestBatchCloseClaimNextDecodesLikeTheReadyQuery(t *testing.T) {
+	query := newQuery(url.Values{
+		"assignee":          {"alice"},
+		"unassigned":        {"true"},
+		"type":              {"bug"},
+		"exclude_type":      {"gate", "rig"},
+		"label":             {"a", "b"},
+		"priority":          {"2"},
+		"parent":            {"bd-9"},
+		"metadata_field":    {"env=prod"},
+		"has_metadata_key":  {"team"},
+		"include_ephemeral": {"true"},
+	})
+	fromQuery := readyFilters(query)
+	if res := query.result(); res != nil {
+		t.Fatalf("the ready query refused a valid filter: %+v", res)
+	}
+
+	object := newReadyFilterObject(map[string]json.RawMessage{
+		"assignee":          json.RawMessage(`"alice"`),
+		"unassigned":        json.RawMessage(`true`),
+		"type":              json.RawMessage(`"bug"`),
+		"exclude_type":      json.RawMessage(`["gate","rig"]`),
+		"label":             json.RawMessage(`["a","b"]`),
+		"priority":          json.RawMessage(`2`),
+		"parent":            json.RawMessage(`"bd-9"`),
+		"metadata_field":    json.RawMessage(`["env=prod"]`),
+		"has_metadata_key":  json.RawMessage(`"team"`),
+		"include_ephemeral": json.RawMessage(`true`),
+	})
+	fromObject := readyFilters(object)
+	if res := object.result(); res != nil {
+		t.Fatalf("the claim_next object refused a valid filter: %+v", res)
+	}
+
+	if !reflect.DeepEqual(fromQuery, fromObject) {
+		t.Errorf("claim_next decoded a different ReadyRequest than the ready query:\n query  = %+v\n object = %+v", fromQuery, fromObject)
+	}
+}
+
+// TestBatchCloseCapBoundary pins the one size bound this operation owns from both
+// sides: 100 items serves, 101 refuses before the role is reached.
+func TestBatchCloseCapBoundary(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		count      int
+		wantStatus int
+		wantCalls  int
+	}{
+		{"at the cap", maxBatchCloseItems, http.StatusOK, 1},
+		{"over the cap", maxBatchCloseItems + 1, http.StatusBadRequest, 0},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			closer := &roleBatchCloser{}
+			ts := newBatchCloseServer(t, closer)
+
+			ids := make([]string, test.count)
+			for i := range ids {
+				ids[i] = fmt.Sprintf(`{"id":"bd-%d"}`, i)
+			}
+			resp := ts.claim(t, batchClosePath, `{"actor":"alice","items":[`+strings.Join(ids, ",")+`]}`)
+			if resp.StatusCode != test.wantStatus {
+				t.Fatalf("status = %d, want %d: %s", resp.StatusCode, test.wantStatus, readAll(t, resp))
+			}
+			if test.wantStatus == http.StatusBadRequest {
+				if body := decodeBody(t, resp); body["param"] != "items" {
+					t.Errorf("param = %v, want items", body["param"])
+				}
+			}
+			if calls := closer.closeRequests(); len(calls) != test.wantCalls {
+				t.Errorf("role calls = %d, want %d", len(calls), test.wantCalls)
+			}
+		})
+	}
+}
+
+// TestBatchCloseNamesARoleValidationRefusal is failBatchClose's reason to exist:
+// the role's request-level ErrValidation is answered as the 400 it is, in the
+// server's own words. A non-validation failure keeps the shared classifier's 500.
+func TestBatchCloseNamesARoleValidationRefusal(t *testing.T) {
+	t.Run("ErrValidation is a 400", func(t *testing.T) {
+		ts := newBatchCloseServer(t, &roleBatchCloser{err: fmt.Errorf("%w: close batch requires an actor", issueops.ErrValidation)})
+		resp := ts.claim(t, batchClosePath, `{"actor":"alice","items":[{"id":"bd-1"}]}`)
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
+		}
+		if body := decodeBody(t, resp); body["code"] != string(CodeInvalidArgument) {
+			t.Errorf("code = %v, want %q", body["code"], CodeInvalidArgument)
+		}
+	})
+	t.Run("a generic failure is a 500", func(t *testing.T) {
+		ts := newBatchCloseServer(t, &roleBatchCloser{err: errors.New("connection reset by the void")})
+		resp := ts.claim(t, batchClosePath, `{"actor":"alice","items":[{"id":"bd-1"}]}`)
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want 500: %s", resp.StatusCode, readAll(t, resp))
+		}
+		if body := decodeBody(t, resp); body["code"] != string(CodeInternal) {
+			t.Errorf("code = %v, want %q", body["code"], CodeInternal)
+		}
+	})
+}
+
+// TestBatchCloseRefusesAMiscountedResult pins the whole-batch half of
+// checkedBatchCloser: a result that cannot be walked against the request is the
+// generic 500 rather than a truncated or misaligned answer.
+func TestBatchCloseRefusesAMiscountedResult(t *testing.T) {
+	closer := &roleBatchCloser{outcomes: []issueops.CloseOutcome{
+		{IssueID: "bd-1", Issue: &types.Issue{ID: "bd-1"}, Changed: true},
+	}}
+	ts := newBatchCloseServer(t, closer)
+
+	resp := ts.claim(t, batchClosePath, `{"actor":"alice","items":[{"id":"bd-1"},{"id":"bd-2"}]}`)
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 for a result with the wrong outcome count: %s", resp.StatusCode, readAll(t, resp))
+	}
+	assertNoPanic(t, ts)
+}
+
+// TestBatchCloseRefusesANonJSONContentType pins the CSRF control this operation
+// inherits from the claim: a JSON content type is not CORS-simple, so a
+// cross-origin write always triggers a preflight this server never approves.
+func TestBatchCloseRefusesANonJSONContentType(t *testing.T) {
+	closer := &roleBatchCloser{}
+	ts := newBatchCloseServer(t, closer)
+
+	resp := ts.postBody(t, batchClosePath, "text/plain", `{"actor":"alice","items":[{"id":"bd-1"}]}`)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if body := decodeBody(t, resp); body["param"] != "Content-Type" {
+		t.Errorf("param = %v, want Content-Type", body["param"])
+	}
+	if calls := closer.closeRequests(); len(calls) != 0 {
+		t.Error("the role was called for a request that skipped the preflight")
+	}
+}
+
+// TestBatchCloseRefusesAQueryParameter pins that the document-level unknown-
+// parameter rule reaches this operation too: it declares no parameters.
+func TestBatchCloseRefusesAQueryParameter(t *testing.T) {
+	ts := newBatchCloseServer(t, &roleBatchCloser{})
+
+	resp := ts.claim(t, batchClosePath+"?force=true", `{"actor":"alice","items":[{"id":"bd-1"}]}`)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
+	}
+	body := decodeBody(t, resp)
+	if body["param"] != "force" || body["reason"] != string(ReasonUnknownParameter) {
+		t.Errorf("param/reason = %v/%v, want force/unknown_parameter", body["param"], body["reason"])
+	}
+}
+
+// TestBatchCloseIsNotReachableByOtherMethods pins that the collection custom
+// method is a POST and nothing else.
+func TestBatchCloseIsNotReachableByOtherMethods(t *testing.T) {
+	ts := newBatchCloseServer(t, &roleBatchCloser{})
+
+	if resp := ts.get(t, batchClosePath); resp.StatusCode == http.StatusOK {
+		t.Fatalf("GET %s = 200; the custom method is a POST", batchClosePath)
+	}
+}
+
+// TestBatchCloseItemErrorGovernance is the NAMED three-way pin: the spec's
+// BatchCloseItemError.code enum, the set the handler actually emits, and the
+// frozen problem registry are one vocabulary. A per-item code added to any one
+// without the others fails here.
+func TestBatchCloseItemErrorGovernance(t *testing.T) {
+	// The handler's emission set, driven over the whole close vocabulary plus an
+	// unclassified error that exercises the default branch.
+	emitted := map[string]bool{}
+	for _, err := range []error{
+		issueops.ErrNotFound,
+		issueops.ErrCloseBlocked,
+		issueops.ErrCloseOpenChildren,
+		&issueops.CloseOpenChildrenError{IssueID: "bd-1", OpenChildren: 2},
+		errors.New("a fault no close sentinel names"),
+	} {
+		emitted[string(batchCloseItemError(err).Code)] = true
+	}
+
+	// The declared set is the bridge the other two legs pin to.
+	declared := map[string]bool{}
+	for _, c := range batchCloseItemErrorCodes {
+		declared[string(c)] = true
+	}
+	if !reflect.DeepEqual(emitted, declared) {
+		t.Errorf("batchCloseItemError emits %v, batchCloseItemErrorCodes declares %v", emitted, declared)
+	}
+
+	// The documented registry: exactly {not_found, not_closable}, and every one a
+	// FROZEN problem code with a status behind it.
+	registry := map[string]bool{string(CodeNotFound): true, string(CodeNotClosable): true}
+	for c := range declared {
+		if Code(c).Status() == 0 {
+			t.Errorf("per-item code %q is not in the frozen problem vocabulary", c)
+		}
+	}
+	if !reflect.DeepEqual(declared, registry) {
+		t.Errorf("per-item codes %v, the documented registry is %v", declared, registry)
+	}
+
+	// The spec enum.
+	doc := loadSpec(t)
+	schema := mapAt(t, mapAt(t, mapAt(t, doc, "components"), "schemas"), "BatchCloseItemError")
+	code := mapAt(t, mapAt(t, schema, "properties"), "code")
+	specEnum := map[string]bool{}
+	for _, c := range toStrings(t, code["enum"]) {
+		specEnum[c] = true
+	}
+	if !reflect.DeepEqual(specEnum, declared) {
+		t.Errorf("spec BatchCloseItemError.code enum %v, the handler emits %v", specEnum, declared)
+	}
+}
+
+// TestBatchCloseRequestMembersMatchTheHandler is the claim's and the close's
+// gate for the batch-close bodies, at BOTH object levels: the handler decodes raw
+// members so it can name the offending one, which makes additionalProperties:
+// false enforceable — at the cost of a hand-rolled member list with nothing tying
+// it to the document. A spec revision adding an optional member would otherwise
+// leave every spec test green while the server refused it as unknown_parameter.
+func TestBatchCloseRequestMembersMatchTheHandler(t *testing.T) {
+	doc := loadSpec(t)
+	schemas := mapAt(t, mapAt(t, doc, "components"), "schemas")
+
+	for _, tc := range []struct {
+		schema   string
+		accepted []string
+		goType   reflect.Type
+	}{
+		{"BatchCloseRequest", batchCloseRequestMembers, reflect.TypeOf(apigen.BatchCloseRequest{})},
+		{"BatchCloseItem", batchCloseItemMembers, reflect.TypeOf(apigen.BatchCloseItem{})},
+	} {
+		t.Run(tc.schema, func(t *testing.T) {
+			accepted := map[string]bool{}
+			for _, name := range tc.accepted {
+				accepted[name] = true
+			}
+
+			goFields := jsonTagNames(t, tc.goType)
+			if extra := diff(goFields, accepted); len(extra) > 0 {
+				t.Errorf("generated %s declares members the handler refuses as unknown: %v", tc.schema, extra)
+			}
+			if missing := diff(accepted, goFields); len(missing) > 0 {
+				t.Errorf("the handler accepts members %s does not declare: %v", tc.schema, missing)
+			}
+
+			specProps := schemaProperties(t, doc, mapAt(t, schemas, tc.schema))
+			if extra := diff(specProps, accepted); len(extra) > 0 {
+				t.Errorf("the %s schema documents members the handler refuses: %v", tc.schema, extra)
+			}
+			if missing := diff(accepted, specProps); len(missing) > 0 {
+				t.Errorf("the handler accepts members the %s schema does not document: %v", tc.schema, missing)
+			}
+		})
+	}
+}
+
+// TestClaimNextMembersMatchTheReadyFilterDecode is the same gate for the
+// claim_next object, and it derives the handler's accepted set from the decode
+// itself: every member readyFilters reads is marked on the source, so the
+// allowlist is the vocabulary rather than a second copy of it. The ready query
+// reads that same set through the same function, so this also pins that the two
+// front doors admit the same members.
+func TestClaimNextMembersMatchTheReadyFilterDecode(t *testing.T) {
+	src := newReadyFilterObject(map[string]json.RawMessage{})
+	_ = readyFilters(src)
+	accepted := src.read
+	if len(accepted) == 0 {
+		t.Fatal("readyFilters read no members; the decode is the source of truth for the vocabulary")
+	}
+
+	goFields := jsonTagNames(t, reflect.TypeOf(apigen.ClaimNextRequest{}))
+	if extra := diff(goFields, accepted); len(extra) > 0 {
+		t.Errorf("generated ClaimNextRequest declares members claim_next refuses as unknown: %v", extra)
+	}
+	if missing := diff(accepted, goFields); len(missing) > 0 {
+		t.Errorf("claim_next accepts members ClaimNextRequest does not declare: %v", missing)
+	}
+
+	doc := loadSpec(t)
+	schema := mapAt(t, mapAt(t, mapAt(t, doc, "components"), "schemas"), "ClaimNextRequest")
+	specProps := schemaProperties(t, doc, schema)
+	if extra := diff(specProps, accepted); len(extra) > 0 {
+		t.Errorf("the ClaimNextRequest schema documents members claim_next refuses: %v", extra)
+	}
+	if missing := diff(accepted, specProps); len(missing) > 0 {
+		t.Errorf("claim_next accepts members the ClaimNextRequest schema does not document: %v", missing)
+	}
+}
+
+var _ issueops.BatchCloser = (*roleBatchCloser)(nil)

--- a/internal/httpapi/claim.go
+++ b/internal/httpapi/claim.go
@@ -323,6 +323,7 @@ var (
 	_ uow.SweeperSource             = timedProvider{}
 	_ uow.DeleterSource             = timedProvider{}
 	_ uow.BatchCreatorSource        = timedProvider{}
+	_ uow.BatchCloserSource         = timedProvider{}
 	_ uow.DependencyEditorSource    = timedProvider{}
 	_ uow.MetadataCASSource         = timedProvider{}
 	_ uow.BatchApplierSource        = timedProvider{}
@@ -440,6 +441,13 @@ func (p timedProvider) Deleter() (issueops.Deleter, error) {
 // per call.
 func (p timedProvider) BatchCreator() (issueops.BatchCreator, error) {
 	return uow.NewBatchCreator(p)
+}
+
+// BatchCloser builds the batch closer OVER THIS WRAPPER, for the same reason as
+// the roles above. Like BatchCreator it opens a WRITE unit of work per call — the
+// close-many transaction, plus the optional claim_next that lands inside it.
+func (p timedProvider) BatchCloser() (issueops.BatchCloser, error) {
+	return uow.NewBatchCloser(p)
 }
 
 // DependencyEditor builds the graph's write role OVER THIS WRAPPER, for the

--- a/internal/httpapi/pinning.go
+++ b/internal/httpapi/pinning.go
@@ -73,6 +73,15 @@ var (
 	_ []types.Issue            = apigen.BatchCreateResponse{}.Items
 
 	_ []eventsjournal.Record = apigen.EventsPage{}.Records
+
+	// The batch close resolves its per-item snapshot and its claimed row to the
+	// canonical structs through the pointer members the outcome carries: wrapping
+	// each in an allOf to make it optional must not have detached it from the pin
+	// (Issue and IssueWithCounts keep their x-go-type; the property is a
+	// single-branch allOf, not a composed component). BatchCloseOutcome.Issue and
+	// BatchCloseResponse.ClaimedNext are the two dereferences the handler makes.
+	_ *types.Issue           = apigen.BatchCloseOutcome{}.Issue
+	_ *types.IssueWithCounts = apigen.BatchCloseResponse{}.ClaimedNext
 )
 
 // SettingsPage.Items and BatchCreateRequest.Items are deliberately absent:

--- a/internal/httpapi/problem.go
+++ b/internal/httpapi/problem.go
@@ -355,6 +355,12 @@ const (
 	// close-policy conflict, the claim's assignee fence and both of the graph's
 	// conflicts, because it performs all three families of write.
 	OpApplyBatch = "applyBatch"
+	// OpBatchCloseIssues closes many issues the request NAMES as one act, and is
+	// the write side of `bd close a b c`. Unlike the create it is NOT
+	// all-or-nothing: a refused id is a per-item outcome inside a 200, so the top
+	// level carries batchCreate's status set exactly and the not_found /
+	// not_closable vocabulary lives on BatchCloseItemError instead.
+	OpBatchCloseIssues = "batchCloseIssues"
 	// OpRememberMemory stores one memory, behind memoryops.Memories. It is the
 	// first operation on this surface that reaches a role outside issueops: the
 	// memory plane is user data riding in the config table, not settings, and
@@ -590,6 +596,13 @@ var operationCodes = map[string][]Code{
 		CodeDependencyCycle, CodeDependencyExists,
 		CodeBusy, CodeDBUnavailable, CodeInternal,
 	},
+	// batchCreate's status set EXACTLY, and the reason is the operation's shape:
+	// this batch is not all-or-nothing, so a per-item refusal (not_found,
+	// not_closable) is an outcome carried inside the 200 on BatchCloseItemError,
+	// never a top-level status. No 404 and no 409 here — the only thing above the
+	// per-item outcomes is request validation (400) plus the shared 500/503. The
+	// role's ErrValidation reaches the wire as the 400 through failBatchClose.
+	OpBatchCloseIssues: {CodeInvalidArgument, CodeBusy, CodeDBUnavailable, CodeInternal},
 	// No 404 and no conflict code: this is an UPSERT with a server-derivable
 	// key, so there is no resource it can fail to address and no row it can
 	// collide with. Its 400 is the body vocabulary plus the ROLE's two

--- a/internal/httpapi/query.go
+++ b/internal/httpapi/query.go
@@ -188,16 +188,31 @@ func (q *query) timestamp(name string) *time.Time {
 
 // metadataFields reads the repeatable `key=value` equality filter, split on the
 // FIRST `=` so a value may contain one.
+//
+// The split itself is splitMetadataFields, shared with the batch-close
+// claim_next decode so the query string and the JSON object refuse a malformed
+// entry the same way — the filter vocabulary readyFilters reads is one decode
+// with two front doors, and this is one of the validators both call.
 func (q *query) metadataFields(name string) map[string]string {
-	raw := q.list(name)
-	if len(raw) == 0 {
+	return splitMetadataFields(q.list(name), func(bad string) {
+		q.invalid(name, fmt.Sprintf("%q is not key=value", bad))
+	})
+}
+
+// splitMetadataFields parses the `key=value` metadata equality entries, split on
+// the FIRST `=` so a value may contain one. An entry with no `=` or an empty key
+// is reported through onBad and collapses the whole filter to nil, so a
+// malformed entry never reaches storage as a half-parsed map. An empty input is
+// nil, not an empty map — the caller asked for no metadata filter.
+func splitMetadataFields(entries []string, onBad func(bad string)) map[string]string {
+	if len(entries) == 0 {
 		return nil
 	}
-	out := make(map[string]string, len(raw))
-	for _, entry := range raw {
+	out := make(map[string]string, len(entries))
+	for _, entry := range entries {
 		k, v, ok := strings.Cut(entry, "=")
 		if !ok || k == "" {
-			q.invalid(name, fmt.Sprintf("%q is not key=value", entry))
+			onBad(entry)
 			return nil
 		}
 		out[k] = v

--- a/internal/httpapi/reads.go
+++ b/internal/httpapi/reads.go
@@ -89,35 +89,53 @@ func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// readyFilters decodes the ready-work filter vocabulary the two ready
-// operations share — everything except the PAGE, which only the listing has,
-// and the ORDER, which only the listing needs.
+// readyFilterInput is the named-accessor surface readyFilters reads the ready
+// vocabulary through, so the SAME decode serves two front doors: the URL query
+// (*query) that listReadyWork and countReadyWork parse, and the JSON object
+// (readyFilterObject) that batchCloseIssues decodes claim_next from. Each
+// accessor validates its own value and records a first refusal; readyFilters
+// itself only names members. Factoring the reader rather than copying it is what
+// keeps the query and the body admitting the same filters and refusing the same
+// malformed ones.
+type readyFilterInput interface {
+	str(name string) string
+	boolean(name string) bool
+	list(name string) []string
+	integer(name string) *int
+	metadataFields(name string) map[string]string
+}
+
+// readyFilters decodes the ready-work filter vocabulary the ready operations
+// share — everything except the PAGE, which only the listing has, the ORDER,
+// which only the listing needs, and MolType, which no front door on this surface
+// exposes.
 //
-// It is one function because the two operations must admit exactly the same
-// filters: countReadyWork answers with the size of the set listReadyWork
-// returns, and a parameter one of them decoded and the other did not would
-// make that identity false for any client that sent it.
-func readyFilters(q *query) issueops.ReadyRequest {
+// It is one function because the operations that use it must admit exactly the
+// same filters: countReadyWork answers with the size of the set listReadyWork
+// returns, and claim_next chooses from the same ready set, so a member one of
+// them decoded and another did not would make those identities false for any
+// client that sent it.
+func readyFilters(in readyFilterInput) issueops.ReadyRequest {
 	return issueops.ReadyRequest{
-		Assignee:     q.str("assignee"),
-		Unassigned:   q.boolean("unassigned"),
-		IssueType:    q.str("type"),
-		ExcludeTypes: q.list("exclude_type"),
+		Assignee:     in.str("assignee"),
+		Unassigned:   in.boolean("unassigned"),
+		IssueType:    in.str("type"),
+		ExcludeTypes: in.list("exclude_type"),
 
-		Labels:        q.list("label"),
-		LabelsAny:     q.list("label_any"),
-		ExcludeLabels: q.list("exclude_label"),
-		LabelPattern:  q.str("label_pattern"),
-		LabelRegex:    q.str("label_regex"),
+		Labels:        in.list("label"),
+		LabelsAny:     in.list("label_any"),
+		ExcludeLabels: in.list("exclude_label"),
+		LabelPattern:  in.str("label_pattern"),
+		LabelRegex:    in.str("label_regex"),
 
-		Priority: q.integer("priority"),
-		ParentID: q.str("parent"),
+		Priority: in.integer("priority"),
+		ParentID: in.str("parent"),
 
-		MetadataFields: q.metadataFields("metadata_field"),
-		HasMetadataKey: q.str("has_metadata_key"),
+		MetadataFields: in.metadataFields("metadata_field"),
+		HasMetadataKey: in.str("has_metadata_key"),
 
-		IncludeEphemeral: q.boolean("include_ephemeral"),
-		IncludeDeferred:  q.boolean("include_deferred"),
+		IncludeEphemeral: in.boolean("include_ephemeral"),
+		IncludeDeferred:  in.boolean("include_deferred"),
 	}
 }
 

--- a/internal/httpapi/roles.go
+++ b/internal/httpapi/roles.go
@@ -91,6 +91,46 @@ func (c checkedBatchCreator) CreateBatch(ctx context.Context, req issueops.Creat
 	return result, nil
 }
 
+// checkedBatchCloser is the closer the batch-close handler is handed.
+//
+// The role's contract is exactly-one-of {Issue, Err} per outcome, and the
+// response body dereferences the issue snapshot for every landed item — the
+// checkedClaimer hazard, once per item. Two broken shapes are folded here so
+// neither reaches the wire:
+//
+//   - A result whose outcome count does not match the request cannot be walked
+//     against the caller's items at all, so it is the generic 500 with the fault
+//     in the log. This is checkedBatchCreator's whole-batch refusal exactly,
+//     because a miscounted result says nothing trustworthy about any item.
+//
+//   - An outcome reporting NEITHER a snapshot NOR a refusal is a post-commit
+//     fault: the batch is not all-or-nothing and its survivors already
+//     committed, so failing the whole request would hide a durable close. It is
+//     folded into THAT item's Err instead — a per-item error the handler maps
+//     through its default branch — and the rest of the outcomes are untouched.
+type checkedBatchCloser struct{ inner issueops.BatchCloser }
+
+// CloseBatch refuses a miscounted result and folds a neither-issue-nor-error
+// outcome into its own item's Err.
+func (c checkedBatchCloser) CloseBatch(ctx context.Context, req issueops.CloseBatchRequest) (issueops.CloseBatchResult, error) {
+	result, err := c.inner.CloseBatch(ctx, req)
+	if err != nil {
+		return result, err
+	}
+	if len(result.Outcomes) != len(req.Items) {
+		return issueops.CloseBatchResult{}, fmt.Errorf(
+			"close batch: the closer reported %d outcomes for %d items", len(result.Outcomes), len(req.Items))
+	}
+	for i := range result.Outcomes {
+		outcome := &result.Outcomes[i]
+		if outcome.Err == nil && outcome.Issue == nil {
+			outcome.Err = fmt.Errorf(
+				"close batch: the closer reported outcome %d (%q) with neither an issue nor an error", i, outcome.IssueID)
+		}
+	}
+	return result, nil
+}
+
 // checkedLifecycle is the lifecycle role every mutation handler is handed.
 //
 // All four methods are why it exists: every handler over this role writes

--- a/internal/httpapi/roles_test.go
+++ b/internal/httpapi/roles_test.go
@@ -253,6 +253,47 @@ func (c *roleBatchCreator) createRequests() []issueops.CreateBatchRequest {
 	return append([]issueops.CreateBatchRequest(nil), c.requests...)
 }
 
+// roleBatchCloser is the store-shaped source's batch-close role. By default it
+// answers with one LANDED outcome per requested item — the exactly-one-of
+// {Issue, Err} shape the role promises and the checked wrapper insists on — and
+// a case overrides outcomes, the claimed row, or the whole-batch error to drive
+// the handler's mapping.
+type roleBatchCloser struct {
+	outcomes    []issueops.CloseOutcome
+	claimedNext *types.IssueWithCounts
+	err         error
+
+	mu       sync.Mutex
+	requests []issueops.CloseBatchRequest
+}
+
+func (c *roleBatchCloser) CloseBatch(_ context.Context, req issueops.CloseBatchRequest) (issueops.CloseBatchResult, error) {
+	c.mu.Lock()
+	c.requests = append(c.requests, req)
+	c.mu.Unlock()
+	if c.err != nil {
+		return issueops.CloseBatchResult{}, c.err
+	}
+	if c.outcomes != nil {
+		return issueops.CloseBatchResult{Outcomes: c.outcomes, ClaimedNext: c.claimedNext}, nil
+	}
+	outcomes := make([]issueops.CloseOutcome, len(req.Items))
+	for i, item := range req.Items {
+		outcomes[i] = issueops.CloseOutcome{
+			IssueID: item.IssueID,
+			Issue:   &types.Issue{ID: item.IssueID, Status: types.StatusClosed},
+			Changed: true,
+		}
+	}
+	return issueops.CloseBatchResult{Outcomes: outcomes, ClaimedNext: c.claimedNext}, nil
+}
+
+func (c *roleBatchCloser) closeRequests() []issueops.CloseBatchRequest {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]issueops.CloseBatchRequest(nil), c.requests...)
+}
+
 // roleDependencyEditor is the store-shaped source's graph-write role.
 //
 // It records the request each method was handed, because what is worth
@@ -674,6 +715,9 @@ func rolesConfig(cfg Config) Config {
 	if cfg.BatchCreator == nil {
 		cfg.BatchCreator = &roleBatchCreator{}
 	}
+	if cfg.BatchCloser == nil {
+		cfg.BatchCloser = &roleBatchCloser{}
+	}
 	if cfg.DependencyEditor == nil {
 		cfg.DependencyEditor = &roleDependencyEditor{}
 	}
@@ -1016,6 +1060,21 @@ func TestListenRequiresExactlyOneDatabaseSource(t *testing.T) {
 		{
 			name:    "a provider and a batch applier",
 			cfg:     Config{Provider: &fakeProvider{}, BatchApplier: &roleBatchApplier{}},
+			wantErr: "exactly one database source",
+		},
+		{
+			name:    "no batch closer",
+			cfg:     rolesConfigWithout(func(c *Config) { c.BatchCloser = nil }),
+			wantErr: "no database source",
+		},
+		{
+			name:    "a batch closer alone",
+			cfg:     Config{BatchCloser: &roleBatchCloser{}},
+			wantErr: "no database source",
+		},
+		{
+			name:    "a provider and a batch closer",
+			cfg:     Config{Provider: &fakeProvider{}, BatchCloser: &roleBatchCloser{}},
 			wantErr: "exactly one database source",
 		},
 		{

--- a/internal/httpapi/routes.go
+++ b/internal/httpapi/routes.go
@@ -334,6 +334,21 @@ var routeTable = []route{
 		handler:     (*Server).handleApplyBatch,
 	},
 	{
+		op:     OpBatchCloseIssues,
+		method: http.MethodPost,
+		// A literal collection-level custom method, spelled the way :batchCreate,
+		// :sweep and :delete are. It is registered AFTER the claim's wildcard
+		// `/v0/beads/issues/{idop}` and ServeMux prefers the literal by
+		// specificity, so `:batchClose` is never parsed as a claim of an issue
+		// called ":batchClose"; the separating slash the wildcard requires is
+		// absent here, so the two never match the same request either.
+		// TestBatchClosePathReachesItsHandler drives the documented path.
+		pattern:     "/v0/beads/issues:batchClose",
+		capability:  "issues.batchClose",
+		implemented: true,
+		handler:     (*Server).handleBatchClose,
+	},
+	{
 		op:      OpClaimIssue,
 		method:  http.MethodPost,
 		pattern: customMethodPattern,

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -195,6 +195,11 @@ type Config struct {
 	// Deleter is the OTHER destructive one, required for the same reason.
 	Deleter      issueops.Deleter
 	BatchCreator issueops.BatchCreator
+	// BatchCloser is the close-many write side, behind batchCloseIssues. Required
+	// on the same terms as BatchCreator: whether this build serves the batch
+	// close is a decision for the operator who ran bd serve, not a consequence of
+	// whether a caller remembered a field.
+	BatchCloser issueops.BatchCloser
 	// DependencyEditor is the graph's write side. Required on the same terms as
 	// the two destructive roles above: whether this build can rewire the
 	// dependency graph is a decision for the operator who chose to run bd serve,
@@ -296,6 +301,7 @@ type Server struct {
 	issueSweeper      issueops.Sweeper
 	issueDeleter      issueops.Deleter
 	issueBatchCreator issueops.BatchCreator
+	issueBatchCloser  issueops.BatchCloser
 	issueDependencies issueops.DependencyEditor
 	issueMetadataCAS  issueops.MetadataCAS
 	issueBatchApplier issueops.BatchApplier
@@ -428,6 +434,7 @@ func Listen(cfg Config) (*Server, error) {
 		issueSweeper:      cfg.Sweeper,
 		issueDeleter:      cfg.Deleter,
 		issueBatchCreator: cfg.BatchCreator,
+		issueBatchCloser:  cfg.BatchCloser,
 		issueDependencies: cfg.DependencyEditor,
 		issueMetadataCAS:  cfg.MetadataCAS,
 		issueBatchApplier: cfg.BatchApplier,
@@ -536,12 +543,12 @@ func Listen(cfg Config) (*Server, error) {
 // "all or nothing" would turn an honest condition into a special case inside
 // three functions. It is checked once, on its own, below.
 func sourceRoles(cfg Config) []any {
-	return []any{cfg.Reader, cfg.Claimer, cfg.Lifecycle, cfg.Settings, cfg.Stats, cfg.CycleDetector, cfg.EdgeReader, cfg.BlockingAnnotator, cfg.TreeWalker, cfg.ReadyCounter, cfg.Querier, cfg.Sweeper, cfg.Deleter, cfg.BatchCreator, cfg.DependencyEditor, cfg.BatchApplier, cfg.Memories, cfg.MetadataCAS}
+	return []any{cfg.Reader, cfg.Claimer, cfg.Lifecycle, cfg.Settings, cfg.Stats, cfg.CycleDetector, cfg.EdgeReader, cfg.BlockingAnnotator, cfg.TreeWalker, cfg.ReadyCounter, cfg.Querier, cfg.Sweeper, cfg.Deleter, cfg.BatchCreator, cfg.BatchCloser, cfg.DependencyEditor, cfg.BatchApplier, cfg.Memories, cfg.MetadataCAS}
 }
 
 // roleSourceNames spells sourceRoles for the refusal message, in the same
 // order, so a caller reading the error learns the whole set it must pass.
-const roleSourceNames = "Reader, Claimer, Lifecycle, Settings, Stats, CycleDetector, EdgeReader, BlockingAnnotator, TreeWalker, ReadyCounter, Querier, Sweeper, Deleter, BatchCreator, DependencyEditor, BatchApplier, Memories and MetadataCAS"
+const roleSourceNames = "Reader, Claimer, Lifecycle, Settings, Stats, CycleDetector, EdgeReader, BlockingAnnotator, TreeWalker, ReadyCounter, Querier, Sweeper, Deleter, BatchCreator, BatchCloser, DependencyEditor, BatchApplier, Memories and MetadataCAS"
 
 func anyRoleSet(cfg Config) bool {
 	return slices.ContainsFunc(sourceRoles(cfg), func(r any) bool { return r != nil })
@@ -889,6 +896,27 @@ func (s *Server) batchCreator(r *http.Request) (issueops.BatchCreator, error) {
 		return nil, err
 	}
 	return checkedBatchCreator{inner: creator}, nil
+}
+
+// batchCloser returns the close-many surface for one request, on the same terms
+// as batchCreator and held by INTERFACE so uow.BatchCloserSource is load-bearing
+// rather than decorative.
+//
+// It goes out CHECKED, like the batch creator. The role's contract is exactly-
+// one-of {issue, error} per outcome, and the response body dereferences the
+// issue snapshot for every landed item; a role that answered an outcome with
+// neither is folded per item rather than allowed to reach the wire as a broken
+// entry or a nil dereference. See checkedBatchCloser.
+func (s *Server) batchCloser(r *http.Request) (issueops.BatchCloser, error) {
+	if s.provider == nil {
+		return checkedBatchCloser{inner: s.issueBatchCloser}, nil
+	}
+	var src uow.BatchCloserSource = timedProvider{inner: s.provider, rec: requestInfo(r.Context())}
+	closer, err := src.BatchCloser()
+	if err != nil {
+		return nil, err
+	}
+	return checkedBatchCloser{inner: closer}, nil
 }
 
 // dependencyEditor returns the guarded dependency-graph write surface for one

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -597,7 +597,7 @@ func TestCapabilitiesAdvertiseEveryImplementedOperation(t *testing.T) {
 		"config.get", "config.list", "dependencies.add", "dependencies.blocking",
 		"dependencies.cycles", "dependencies.list", "dependencies.remove",
 		"dependencies.tree", "events.list", "events.watch", "issues.batchApply",
-		"issues.batchCreate", "issues.casMetadata",
+		"issues.batchClose", "issues.batchCreate", "issues.casMetadata",
 		"issues.claim", "issues.close", "issues.create", "issues.delete", "issues.get", "issues.list",
 		"issues.query", "issues.reopen", "issues.sweep", "issues.update",
 		"memories.forget", "memories.get",

--- a/internal/httpapi/spec/openapi.v0.yaml
+++ b/internal/httpapi/spec/openapi.v0.yaml
@@ -2390,6 +2390,14 @@ paths:
         create has no outcome that could be reported.
 
 
+        CONTRAST `POST /v0/beads/issues:batchClose`, the OTHER batch write on
+        this surface. That operation only closes, and it is skip-and-continue: a
+        refused id is a per-item outcome inside a `200` and the survivors still
+        commit, with an in-transaction `claim_next`. Reach for it to close a set
+        where one bad id should be skipped rather than roll the batch back; reach
+        for THIS one when the work is an ordered plan that must land whole.
+
+
         THAT IS WHY A PRECONDITION MISS IS A `409` HERE and not an answer.
         `POST /v0/beads/issues/{id}:casMetadata` reports a lost compare-and-set
         as a 200, because a retry loop is its designed caller and a miss is the
@@ -2599,6 +2607,126 @@ paths:
           x-bd-codes:
             [already_claimed, already_exists, dependency_cycle,
              dependency_exists, not_closable, precondition_failed]
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '500':
+          $ref: '#/components/responses/InternalError'
+        '503':
+          $ref: '#/components/responses/Unavailable'
+
+  /v0/beads/issues:batchClose:
+    post:
+      operationId: batchCloseIssues
+      summary: Close many issues as one act
+      description: >-
+        Closes every item in the request that it can, and commits the ones that
+        landed together. It is the write side of `bd close a b c`, and it
+        completes the batch write surface `issues:batchCreate` and
+        `issues:delete` opened: the collection-level operation for closing a set
+        the request NAMES.
+
+
+        IT IS NOT ALL-OR-NOTHING, and that is the OPPOSITE of
+        `issues:batchCreate` on purpose. A create that half-succeeded could not
+        be re-sent without duplicating the half that landed; a close that
+        half-succeeded can, because closing is idempotent. So an id this request
+        refuses is SKIPPED and reported in its own `items` entry, and the
+        survivors still commit — the same skip-and-continue `bd close a b c` has
+        always done when one argument is a typo. The whole request is still ONE
+        transaction with at most one history entry, and none at all when nothing
+        landed.
+
+
+        THAT IS THE OTHER AXIS FROM `POST /v0/beads/issues:batchApply`, which is
+        the atomic sibling: it applies an ORDERED plan of creates, updates,
+        closes and edges as one transaction or none of it, and a refused item is
+        a top-level `409` that rolls the whole plan back. Use THIS operation to
+        close a set and skip the ids that will not close; use that one when the
+        work is a plan that must land whole.
+
+
+        ## Per-item outcomes
+
+
+        The response is a `200` whether every item closed, some did, or none
+        did: the batch RAN. Each `items` entry carries EXACTLY ONE of `issue`
+        (the post-close snapshot) or `error` (why that id was refused), in
+        request order, so a caller walks the outcomes against its own argument
+        list without matching ids back up. A successful entry also carries
+        `already_closed` — the idempotent re-close, mirroring
+        `CloseIssueResponse.already_closed` — and `open_children`, the count a
+        forced close observed. A refused entry's `error.code` is `not_found`
+        (the id names no issue or wisp) or `not_closable` (close policy refused
+        an unforced close), and the open-children refusal carries
+        `error.open_children` while the live-blocker refusal carries none — the
+        SAME member-presence discriminator `POST /v0/beads/issues/{id}:close`
+        uses on its 409. `force` bypasses close policy for every item, and
+        nothing else; the refusals are the ROLE's, so this endpoint cannot skip
+        a guard by forgetting one exists.
+
+
+        ## Reason and session
+
+
+        Each item carries its own `reason`, recorded against that issue alone,
+        because `bd close a b c -r x -r y -r z` has always mapped reasons
+        positionally. `session` is request-wide. Both follow
+        `CloseIssueRequest`'s first-close-wins rule: an idempotent re-close
+        writes neither.
+
+
+        ## claim_next
+
+
+        `claim_next`, when present, claims the next ready issue AFTER the closes
+        land, in the same transaction, and only when at least one item actually
+        closed — a claim handed out by a request that closed nothing would be a
+        claim the caller never earned. It carries the same filter vocabulary as
+        `GET /v0/beads/ready` (see `ClaimNextRequest`); the claimed row comes
+        back in `claimed_next`, hydrated with its counts. This is what lets an
+        agent close its finished work and pick up its next task in one atomic
+        round trip.
+
+
+        ## Planes, hooks and auto-commit
+
+
+        An id resolves across BOTH planes, exactly as
+        `POST /v0/beads/issues/{id}:close` does; a wisp close lands on the
+        unversioned plane and records no durable history entry. Hooks do not
+        fire and the per-command auto-commit machinery does not run, exactly as
+        for `POST /v0/beads/issues/{id}:claim`. The only durable effect is the
+        single storage commit the role makes in its own transaction.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BatchCloseRequest'
+      responses:
+        '200':
+          description: >-
+            The batch ran. `items` carries one per-item outcome in request
+            order, each either `issue` or `error`. This status is returned even
+            when every item was refused — the batch committed nothing, but it
+            ran.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BatchCloseResponse'
+        '400':
+          description: >-
+            Invalid request: an unknown query parameter, an unparseable or
+            oversized body, an unknown body member at any level, an `actor` that
+            is empty after trimming, longer than 256 bytes or carrying control
+            characters, an empty or over-long `items` array, a blank or
+            over-long item `id`, a `reason` or `session` longer than the column
+            holds or carrying control characters, or a `claim_next` filter this
+            server cannot decode. Nothing is closed in any of these cases. A
+            per-item refusal is NOT one of these — it is an outcome inside a 200.
+          x-bd-codes: [invalid_argument]
           content:
             application/problem+json:
               schema:
@@ -4900,6 +5028,7 @@ components:
             `issues.close`, `issues.reopen`, `issues.update`,
             `issues.sweep`, `issues.delete`, `issues.batchCreate`,
             `issues.batchApply`,
+            `issues.batchClose`,
             `stats.get`, `config.list`, `config.get`, `dependencies.cycles`,
             `dependencies.list`, `dependencies.blocking`, `dependencies.tree`,
             `dependencies.add`, `dependencies.remove`,
@@ -5894,6 +6023,262 @@ components:
             look for a second page that can never exist.
           items:
             $ref: '#/components/schemas/Issue'
+
+    BatchCloseRequest:
+      type: object
+      additionalProperties: false
+      required: [actor, items]
+      properties:
+        actor:
+          type: string
+          minLength: 1
+          maxLength: 256
+          pattern: '^[^\u0000-\u001F\u007F-\u009F\u2028\u2029]+$'
+          description: >-
+            Who is closing the issues, under `ClaimRequest.actor`'s rules and
+            for the same reasons: the server trims it, refuses an empty result,
+            anything longer than 256 BYTES, and any control character including
+            newline. It is attributed to every item and interpolated into the
+            storage commit message.
+        items:
+          type: array
+          minItems: 1
+          maxItems: 100
+          description: >-
+            The issues to close, in order. An empty array is a `400` rather
+            than a successful no-op, `BatchCreateRequest.items`' rule: a write
+            request that writes nothing is a client bug. Each entry appears in
+            the response's `items` at the same index.
+
+
+            The 100-item cap is a bound on how long one request may hold a write
+            transaction, not a statement about batch semantics. Split a larger
+            list; each request is atomic on its own.
+          items:
+            $ref: '#/components/schemas/BatchCloseItem'
+        session:
+          type: string
+          maxLength: 255
+          description: >-
+            The working session that closed the issues, recorded against every
+            item, stored and read back as `closed_by_session`. Request-wide,
+            unlike `reason`. Under `CloseIssueRequest`'s first-close-wins rule
+            and the same bounds: refused for control characters, and bounded by
+            what the column holds rather than by the number above.
+        force:
+          type: boolean
+          default: false
+          description: >-
+            Bypass close policy — the open-children refusal and the
+            live-blocker refusal — for every item, and nothing else. The
+            refusals are the ROLE's, so this endpoint cannot skip a guard by
+            forgetting one exists. Request-wide because the flag that spells it
+            is. A forced item still reports `open_children`.
+        claim_next:
+          allOf:
+            - $ref: '#/components/schemas/ClaimNextRequest'
+          description: >-
+            When present, claim the next ready issue after the closes land, in
+            the same transaction, and ONLY when at least one item actually
+            closed — a batch whose items were all already closed mutated
+            nothing and earns no claim. The claimed row is returned in
+            `claimed_next`. Absent skips it entirely.
+
+    BatchCloseItem:
+      type: object
+      additionalProperties: false
+      required: [id]
+      properties:
+        id:
+          type: string
+          minLength: 1
+          maxLength: 255
+          description: >-
+            The issue to close. An EXACT canonical id, resolved across both
+            planes exactly as `POST /v0/beads/issues/{id}:close` resolves one.
+            An id that names nothing is not a request error: it is reported as a
+            `not_found` outcome in this item's response entry, and the rest of
+            the batch still commits.
+        reason:
+          type: string
+          maxLength: 255
+          description: >-
+            Why this issue is closed, recorded against this item ALONE — reasons
+            are per item, not per request, because `bd close a b c -r x -r y
+            -r z` maps them positionally. Stored on the issue and read back as
+            `close_reason`, under `CloseIssueRequest.reason`'s first-close-wins
+            rule and the same bounds: refused for control characters, and
+            bounded by what the column holds rather than by the number above.
+
+    ClaimNextRequest:
+      type: object
+      additionalProperties: false
+      description: >-
+        The filter that chooses `BatchCloseRequest.claim_next`'s issue. Its
+        members are `GET /v0/beads/ready`'s filter vocabulary BY REFERENCE —
+        every member here has the meaning the `listReadyWork` parameter of the
+        same name documents, and a value this server cannot decode is refused
+        the same way that operation refuses it. It excludes only what a claim
+        has no use for: `limit`, the page bound, and `sort`, an ordering a
+        single claim does not need. An unknown member is a `400`.
+      properties:
+        assignee:
+          type: string
+          description: As `listReadyWork`'s `assignee` parameter.
+        unassigned:
+          type: boolean
+          description: As `listReadyWork`'s `unassigned` parameter.
+        type:
+          type: string
+          description: As `listReadyWork`'s `type` parameter.
+        exclude_type:
+          type: array
+          items:
+            type: string
+          description: As `listReadyWork`'s `exclude_type` parameter.
+        label:
+          type: array
+          items:
+            type: string
+          description: As `listReadyWork`'s `label` parameter.
+        label_any:
+          type: array
+          items:
+            type: string
+          description: As `listReadyWork`'s `label_any` parameter.
+        exclude_label:
+          type: array
+          items:
+            type: string
+          description: As `listReadyWork`'s `exclude_label` parameter.
+        label_pattern:
+          type: string
+          description: As `listReadyWork`'s `label_pattern` parameter.
+        label_regex:
+          type: string
+          description: As `listReadyWork`'s `label_regex` parameter.
+        priority:
+          type: integer
+          description: As `listReadyWork`'s `priority` parameter.
+        parent:
+          type: string
+          description: As `listReadyWork`'s `parent` parameter.
+        metadata_field:
+          type: array
+          items:
+            type: string
+          description: >-
+            As `listReadyWork`'s `metadata_field` parameter: `key=value`
+            equality, split on the first `=`. An invalid key is a `400`.
+        has_metadata_key:
+          type: string
+          description: As `listReadyWork`'s `has_metadata_key` parameter.
+        include_ephemeral:
+          type: boolean
+          default: false
+          description: As `listReadyWork`'s `include_ephemeral` parameter.
+        include_deferred:
+          type: boolean
+          default: false
+          description: As `listReadyWork`'s `include_deferred` parameter.
+
+    BatchCloseItemError:
+      type: object
+      required: [code]
+      description: >-
+        Why one item in a batch close was refused. It is NOT the `Problem`
+        envelope: it rides inside a `200` as one outcome of a batch that ran, so
+        it carries only the members a per-item refusal needs.
+      properties:
+        code:
+          type: string
+          enum: [not_found, not_closable]
+          description: >-
+            The machine-readable reason, from the same frozen vocabulary the
+            `Problem` envelope draws on. `not_found`: the id names no issue or
+            wisp. `not_closable`: close policy refused an unforced close —
+            open children or a live blocker, both bypassable with request-wide
+            `force`. The set grows additively exactly as `Problem.code` does, so
+            a client MUST default-branch on an unknown value.
+        detail:
+          type: string
+          description: >-
+            Optional prose, never load-bearing. It reflects the caller's own id
+            back and names no server internals.
+        open_children:
+          type: integer
+          description: >-
+            With `not_closable`: how many open children the transaction that
+            refused the close observed, read inside that transaction rather than
+            parsed out of `detail`. PRESENT ONLY for the open-children refusal;
+            the live-blocker refusal carries none, so member presence — not
+            prose — is how a client tells the two apart. This is
+            `Problem.open_children`'s rule, per item.
+
+    BatchCloseOutcome:
+      type: object
+      required: [id]
+      description: >-
+        What happened to ONE requested item. It carries EXACTLY ONE of `issue`
+        or `error`: `issue` with `already_closed` and `open_children` when the
+        close landed or was an idempotent re-close, `error` when the id was
+        refused. Member presence is the discriminator — a client reads `error`
+        first and falls through to `issue`.
+      properties:
+        id:
+          type: string
+          description: >-
+            The id the caller asked for, echoed so an outcome can be read
+            without indexing back into the request.
+        issue:
+          allOf:
+            - $ref: '#/components/schemas/Issue'
+          description: >-
+            The post-close snapshot, present when this item was NOT refused.
+            Mutually exclusive with `error`.
+        already_closed:
+          type: boolean
+          description: >-
+            Present with `issue`: true when the issue was already closed and
+            this call changed nothing — the idempotent re-close, mirroring
+            `CloseIssueResponse.already_closed`. `reason`/`session` were not
+            rewritten.
+        open_children:
+          type: integer
+          description: >-
+            Present with `issue`: how many open children the close observed,
+            `CloseIssueResponse.open_children`'s rule per item. A FORCED close
+            reports it; an unforced close that got this far had none, so it
+            reports 0.
+        error:
+          allOf:
+            - $ref: '#/components/schemas/BatchCloseItemError'
+          description: >-
+            Why this item was refused, present when this item was NOT closed.
+            Mutually exclusive with `issue`.
+
+    BatchCloseResponse:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          description: >-
+            One outcome per requested item, in REQUEST ORDER — including the
+            items that refused, so a caller reporting per-id status walks it
+            against its own argument list. Never null and never shorter than the
+            request. There is no `has_more` and no `next_cursor`: this is not a
+            page, and a partial-length answer does not exist on this operation.
+          items:
+            $ref: '#/components/schemas/BatchCloseOutcome'
+        claimed_next:
+          allOf:
+            - $ref: '#/components/schemas/IssueWithCounts'
+          description: >-
+            The row a requested `claim_next` won, hydrated with its counts in
+            the same transaction. Present only when `claim_next` was sent, at
+            least one item closed, and a ready issue was eligible; absent
+            otherwise.
 
     ApplyBatchRequest:
       type: object


### PR DESCRIPTION
## What

Adds `POST /v0/beads/issues:batchClose` (`operationId: batchCloseIssues`) to the
`bd serve` HTTP surface: close a set of issues the request names, as one act.

This completes the batch write surface. `issues:batchCreate` and
`issues:delete` already let an API consumer create and erase a set in one
transaction; the write side of `bd close a b c` was the missing collection-level
close. It sits behind the existing `issueops.BatchCloser` role — the same one
`bd close` drives — so nothing new lands in storage.

## Shape

- **Not all-or-nothing** (the deliberate opposite of `batchCreate`). A refused id
  is a per-item outcome inside a `200`, never a top-level `4xx`, so a caller
  keeps the answers for the ids that did close. The whole request is still one
  transaction with at most one history entry.
- **Per-item outcomes.** Each `items` entry carries exactly one of `issue` (the
  post-close snapshot, with `already_closed` and `open_children`) or `error`.
- **Frozen problem codes.** `BatchCloseItemError.code` is drawn from the same
  registry the `Problem` envelope uses — `not_found`, `not_closable` — with
  `open_children` present only for the open-children refusal, the same
  member-presence discriminator `POST /v0/beads/issues/{id}:close` uses on its
  `409`. `force` bypasses close policy for every item and nothing else.
- **Top-level statuses are `batchCreate`'s exactly** (`400`/`500`/`503`; `400` =
  `invalid_argument`). No `207`, and an all-items-refused batch is still a `200`:
  the batch ran, it just committed nothing. The role's request-level
  `ErrValidation` reaches the wire as that `400`.
- **`claim_next`** closes and claims the next ready issue in the same
  transaction, and only when at least one item actually closed. Its filter is the
  `listReadyWork` vocabulary, decoded through the same shared `readyFilters` both
  the URL query and this JSON object call — so the two front doors admit the same
  members and refuse the same malformed values, by construction rather than by a
  copied validator.

## Verification (CI is disabled on this repo — verified locally)

- `make api-check` — clean (types regenerated from the spec, no drift; spec
  tests green).
- `go test -tags gms_pure_go ./internal/httpapi/...` — green, including the
  existing route-parity, status-code, capability-vocabulary and
  POST-surface-narrowing governance tests, which pick the new operation up
  automatically.
- `go vet -tags gms_pure_go ./internal/httpapi/...` and
  `go build -tags gms_pure_go ./cmd/bd` — clean.

New `internal/httpapi` tests cover routing, request/outcome mapping, the
issue-vs-error and open-children discriminators, `claim_next` decode parity with
the ready query, the item-cap boundary (100 serves / 101 refuses), the
post-commit-fault per-item fold, and a named three-way governance pin tying the
spec `BatchCloseItemError.code` enum to the handler's emission set and the frozen
problem registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
