### PR TITLE
fix(conformance): repair the role bundle's rename skew, and dispatch the two cases it lost

### DIFF
--- a/backend/conformance/role_bundle_cases.go
+++ b/backend/conformance/role_bundle_cases.go
@@ -85,7 +85,15 @@ var roleContractCases = []roleContract{
 		RunBootstrapperRefusesASubstrateCarryingOnlyAProjectID,
 		RunBootstrapperRefusesAnInvalidRequestWithoutWriting,
 		RunBootstrapperLeavesTheSubstrateUntouchedWhenItCannotComplete,
-		RunBootstrapperRecordsAtMostOneHistoryEntry,
+		// The bootstrap history pair is a ratified per-leg split (#5455): the
+		// store legs record no entry of their own because `bd init` commits the
+		// identity itself, and the proxied route records exactly one because it
+		// has no other commit point. Both halves are listed because every case
+		// in this package must be dispatched exactly once; a supplier that can
+		// observe history answers one of them and leaves CountHistory nil if it
+		// cannot state which side it is on, which skips both loudly.
+		RunBootstrapperRecordsNoHistoryEntryOfItsOwn,
+		RunBootstrapperRecordsExactlyOneHistoryEntry,
 		RunInitVerifierAnswersEmptyForAnUnidentifiedSubstrate,
 		RunInitVerifierReportsAPartialIdentityAsItStands,
 		RunInitVerifierReportsAFailedReadAsAnError,
@@ -111,11 +119,12 @@ var roleContractCases = []roleContract{
 		func(b RoleContractBundle) func(t *testing.T) *CommenterFixture { return b.Commenter },
 		RunCommenterStoresTextVerbatim,
 		RunCommenterResultMirrorsTheStoredRow,
+		RunCommenterAdvancesALiveStampPastTheThreadsNewestComment,
 		RunCommenterCommentOnAWispLandsOnTheWispThread,
 		RunCommenterRefusesAnIDOnNeitherPlane,
 		RunCommenterRefusesAnEmptyIssueID,
 		RunCommenterDoesNotResolvePrefixes,
-		RunCommenterRecordsAtMostOneHistoryEntry,
+		RunCommenterRecordsExactlyOneHistoryEntry,
 		RunCommenterLeavesTheAnchorIssueUntouched,
 		RunCommenterRefusesBlankText,
 		RunCommenterRefusesAnEmptyAuthor,
@@ -169,7 +178,7 @@ var roleContractCases = []roleContract{
 		RunDeleterCollapsesDuplicateIDs,
 		RunDeleterRewritesReferencesInNeighbors,
 		RunDeleterDryRunChangesNothing,
-		RunDeleterRecordsAtMostOneHistoryEntry,
+		RunDeleterRecordsExactlyOneHistoryEntry,
 		RunDeleterDoesNotMutateTheCallerRequest,
 		RunDeleterSettlesTheSurvivorsOfADeletedBlocker,
 		RunDeleterSettlesTheChildrenOfADeletedParent,
@@ -457,7 +466,7 @@ var roleContractCases = []roleContract{
 		RunSweeperProtectsRowsCitedFromAWispComment,
 		RunSweeperProtectsCitedRows,
 		RunSweeperEmptyMatchIsZeroAndNil,
-		RunSweeperRecordsAtMostOneHistoryEntry,
+		RunSweeperRecordsExactlyOneHistoryEntry,
 		RunSweeperDoesNotMutateTheCallerRequest,
 	),
 


### PR DESCRIPTION
## main does not compile

`origin/main` at `1d6d8477f` fails to build. Anything that imports
`backend/conformance` — which is every storage leg's test binary — is red for
everyone:

```
$ go build ./backend/conformance/
backend/conformance/role_bundle_cases.go:88:3:  undefined: RunBootstrapperRecordsAtMostOneHistoryEntry
backend/conformance/role_bundle_cases.go:118:3: undefined: RunCommenterRecordsAtMostOneHistoryEntry
backend/conformance/role_bundle_cases.go:172:3: undefined: RunDeleterRecordsAtMostOneHistoryEntry
backend/conformance/role_bundle_cases.go:460:3: undefined: RunSweeperRecordsAtMostOneHistoryEntry
```

Live evidence on an unrelated PR: [#5460, "Storage backend conformance (embedded
Dolt oracle)"](https://github.com/gastownhall/beads/actions/runs/31300149160/job/93211512993)
— `FAIL github.com/steveyegge/beads/internal/storage/embeddeddolt [build failed]`
with those four lines.

**How it happened — two merges, one cause.** `roleContractCases` arrived in
#5456 against a base that predated #5455's commenter rename and bootstrap
split; #5458 then renamed the deleter and sweeper cases and did not follow them
into the table. Neither merge saw the other.

## The repair

Three are plain renames to `RecordsExactlyOneHistoryEntry` (`Commenter` by
#5455, `Deleter` and `Sweeper` by #5458).

**The bootstrapper one is not a rename**, and it is the only judgement in this
PR. #5455 split that case into a ratified per-leg *pair*:
`RecordsNoHistoryEntryOfItsOwn` (the store legs — `bd init` commits the identity
itself, so an in-role commit would double it) and `RecordsExactlyOneHistoryEntry`
(the proxied route — no other commit point, so a zero would leave the identity
unversioned). #5455 states it plainly: *"Neither number is the other's bug."*

I list **both halves**, because the table admits no other shape. The bundle is
leg-agnostic — it is how an out-of-tree backend runs the role tier — and its two
guards leave exactly one option:

- `TestRoleContractCasesCoverEveryContractCase` derives the expected set from
  the package source: every top-level `Run*` taking a fixture must be dispatched
  **exactly once**. Dropping either half fails it.
- The same test compares **declaration order**. The two halves sit adjacent at
  `bootstrapper_contract.go:257,288`, between the last bootstrap case and the
  first init-verifier one — all in the same row — so splitting them into two
  adjacent rows would put the second half *after* the init-verifier cases in
  flattened order and fail the order check.

So: one row, both halves, in declaration order. That executes #5455's design
rather than reopening it.

### The residual gap, stated plainly

Both halves assert over the same operation, so a supplier that sets
`CountHistory` necessarily fails one of them. Today's escape hatch is
all-or-nothing: leave `CountHistory` nil and both skip loudly. **Letting a
supplier declare which side it is on is a mechanism the bundle does not have**,
and inventing one is #5456's design call, not a rename repair — so this PR
carries a comment at the table row saying so, and nothing more. Worth a
follow-up before an external backend leans on `RunRoleContracts`.

## A second loss, found by fixing the first

With the package compiling again, `TestRoleContractCasesCoverEveryContractCase`
ran for the first time since #5456 and immediately caught this:

```
role_bundle_test.go:52: RunCommenterAdvancesALiveStampPastTheThreadsNewestComment is a role
contract case but no roleContractCases row dispatches it; an external backend running
RunRoleContracts would never see it
```

#5462 added that case and no row dispatches it — precisely the "suite that
quietly stops covering what it claims to" defect the guard exists to prevent.
Added, in declaration order.

## Verification

```
$ go build ./...                      # ok
$ go vet ./backend/...                # clean
$ go test ./backend/... -count=1
ok  	github.com/steveyegge/beads/backend	0.056s
ok  	github.com/steveyegge/beads/backend/conformance	0.191s
$ golangci-lint run --new-from-rev=HEAD
0 issues.
```

## Scope

Rename-skew repair plus the one missing dispatch. 13 insertions, 4 deletions,
one file. No contract body, fixture, or guard is touched.
