### PR TITLE
test(scripts): stabilize Git Bash shim paths

### DIFF
--- a/scripts/conformance_script_test.go
+++ b/scripts/conformance_script_test.go
@@ -117,16 +117,16 @@ fi
 `)
 
 	root := sourceRepoRoot(t)
-	binPath := shellPath(t, bin)
-	statePath := shellPath(t, stateDir)
-	path := binPath + ":" + os.Getenv("PATH") + ":/usr/bin:/bin"
+	pathEnv := shellPathEnv()
+	binPath := shellPathUnderEnv(t, bash, bin, pathEnv)
+	statePath := shellPathUnderEnv(t, bash, stateDir, pathEnv)
+	commandPath := binPath + ":" + os.Getenv("PATH") + ":/usr/bin:/bin"
 	if runtime.GOOS == "windows" {
-		path = binPath + ":/usr/bin:/bin"
+		commandPath = binPath + ":/usr/bin:/bin"
 	}
-	cmd := exec.Command(bash, "scripts/conformance.sh")
-	cmd.Dir = root
-	cmd.Env = []string{
-		"PATH=" + path,
+	env := []string{
+		"PATH=" + os.Getenv("PATH"),
+		"BEADS_TEST_COMMAND_PATH=" + commandPath,
 		"HOME=" + statePath,
 		"LC_ALL=C",
 		"LANG=C",
@@ -137,6 +137,11 @@ fi
 		"GO_FAIL_CALL=" + strconv.Itoa(failCall),
 		"GO_FAIL_EXIT=" + strconv.Itoa(failExit),
 	}
+	requireShellCommandPath(t, bash, root, env, "go", binPath+"/go")
+
+	cmd := bashScriptCommand(bash, "scripts/conformance.sh")
+	cmd.Dir = root
+	cmd.Env = env
 	output, runErr := cmd.CombinedOutput()
 	log, readErr := os.ReadFile(callLog)
 	if readErr != nil {

--- a/scripts/pull_dolt_image_test.go
+++ b/scripts/pull_dolt_image_test.go
@@ -145,16 +145,17 @@ set -eu
 printf '%s\n' "$*" >>"$DOLT_PULL_SLEEP_LOG"
 `)
 
-	binPath := shellPath(t, bin)
-	statePath := shellPath(t, stateDir)
-	path := binPath + ":" + os.Getenv("PATH") + ":/usr/bin:/bin"
+	pathEnv := shellPathEnv()
+	binPath := shellPathUnderEnv(t, bash, bin, pathEnv)
+	statePath := shellPathUnderEnv(t, bash, stateDir, pathEnv)
+	commandPath := binPath + ":" + os.Getenv("PATH") + ":/usr/bin:/bin"
 	if runtime.GOOS == "windows" {
-		path = binPath + ":/usr/bin:/bin"
+		commandPath = binPath + ":/usr/bin:/bin"
 	}
-	cmd := exec.Command(bash, "scripts/ci/pull-dolt-image.sh")
-	cmd.Dir = sourceRepoRoot(t)
-	cmd.Env = []string{
-		"PATH=" + path,
+	root := sourceRepoRoot(t)
+	env := []string{
+		"PATH=" + os.Getenv("PATH"),
+		"BEADS_TEST_COMMAND_PATH=" + commandPath,
 		"LC_ALL=C",
 		"LANG=C",
 		"BASH_ENV=",
@@ -164,6 +165,12 @@ printf '%s\n' "$*" >>"$DOLT_PULL_SLEEP_LOG"
 		"DOLT_PULL_SLEEP_LOG=" + statePath + "/sleep-calls",
 		"DOLT_PULL_FAILURES=" + strconv.Itoa(failures),
 	}
+	requireShellCommandPath(t, bash, root, env, "docker", binPath+"/docker")
+	requireShellCommandPath(t, bash, root, env, "sleep", binPath+"/sleep")
+
+	cmd := bashScriptCommand(bash, "scripts/ci/pull-dolt-image.sh")
+	cmd.Dir = root
+	cmd.Env = env
 	output, runErr := cmd.CombinedOutput()
 
 	dockerCalls := readCallLines(t, dockerLog)

--- a/scripts/release_script_test.go
+++ b/scripts/release_script_test.go
@@ -283,6 +283,70 @@ func shellPath(t *testing.T, path string) string {
 	return msysPath(path)
 }
 
+func shellPathUnderEnv(t *testing.T, bash, path string, env []string) string {
+	t.Helper()
+	clean := filepath.Clean(path)
+	dir := clean
+	base := ""
+	if info, err := os.Stat(clean); err == nil && !info.IsDir() {
+		dir = filepath.Dir(clean)
+		base = filepath.Base(clean)
+	}
+	cmd := exec.Command(bash, "--noprofile", "--norc", "-c", "pwd")
+	cmd.Dir = dir
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("resolve shell path for %s under script environment: %v\n%s", path, err, out)
+	}
+	converted := strings.TrimSpace(string(out))
+	if converted == "" {
+		t.Fatalf("resolve shell path for %s under script environment: empty output", path)
+	}
+	if base != "" {
+		return converted + "/" + filepath.ToSlash(base)
+	}
+	return converted
+}
+
+// shellPathEnv keeps minimal-environment path conversion independent of
+// inherited temporary-path mounts. Git for Windows can map /tmp differently
+// when TEMP/TMP are omitted, so helpers that replace the child environment
+// must resolve paths under that same authority.
+func shellPathEnv() []string {
+	path := os.Getenv("PATH")
+	if runtime.GOOS == "windows" {
+		path = "/usr/bin:/bin"
+	}
+	return []string{
+		"PATH=" + path,
+		"LC_ALL=C",
+		"LANG=C",
+		"BASH_ENV=",
+		"ENV=",
+	}
+}
+
+func requireShellCommandPath(t *testing.T, bash, dir string, env []string, name, want string) {
+	t.Helper()
+	cmd := exec.Command(bash, "--noprofile", "--norc", "-c", `PATH="$BEADS_TEST_COMMAND_PATH"; export PATH; printf '%s\n' "$PATH"; command -v -- "$1"`, "shim-path-check", name)
+	cmd.Dir = dir
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("resolve injected %s under script environment: %v\n%s", name, err, out)
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	got := lines[len(lines)-1]
+	if got != want {
+		t.Fatalf("injected %s resolved to %q, want %q; PATH=%q", name, got, want, lines[0])
+	}
+}
+
+func bashScriptCommand(bash, script string) *exec.Cmd {
+	return exec.Command(bash, "--noprofile", "--norc", "-c", `PATH="$BEADS_TEST_COMMAND_PATH"; export PATH; exec "$BASH" --noprofile --norc "$1"`, "script-test", script)
+}
+
 // bashPathList converts a host-style PATH value (entries separated by
 // os.PathListSeparator) into a Bash-visible, colon-separated PATH so the
 // caller's PATH is preserved (not just /usr/bin:/bin) when it is prepended


### PR DESCRIPTION
## Summary

- derive Bash-visible shim and state paths under the same minimal environment used by the test subprocesses
- reset the effective command path inside profile-free Git Bash and fail early unless `docker`, `sleep`, and `go` resolve to the generated shims
- preserve the existing release-test helper behavior; production scripts, Make targets, and workflows are unchanged

## Motivation

On native Windows, the harnesses previously canonicalized paths with ambient `TEMP`/`TMP`, then launched Git Bash with a minimal environment that omitted them. A path emitted as `/tmp/...` could therefore map to a different Windows directory in the child process, making generated shims and state files invisible. Git for Windows can also prepend `/usr/bin` during Bash startup, allowing real commands such as `sleep` to outrank test shims.

This keeps path conversion and execution under one explicit environment and makes shim identity an asserted test invariant.

Fixes #5314.

## Validation

- `go test -count=1 ./scripts`
- focused pull-Dolt, conformance, and release-script tests
- focused pull-Dolt and conformance tests with `-race`
- `go vet ./scripts`
- whole-tree golangci-lint with zero findings in both native and Windows/CGO-disabled lanes
- independent review of the exact base/head pair: READY, no findings

The canonical native-Windows `mingw32-make test` lane reached the repository-wide 25-minute Go timeout amid existing failures in unrelated packages; the changed `scripts` package passed in that same run.

_codex-gpt-5-unknown-reasoning on behalf of Ewen Cuthiell_
