### PR TITLE
feat(httpapi): stream the events journal over SSE (bd-opisf)

### DIFF
--- a/cmd/bd/events_watch_http_e2e_test.go
+++ b/cmd/bd/events_watch_http_e2e_test.go
@@ -1,0 +1,254 @@
+//go:build cgo && unix
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The journal STREAM, end to end through a real `bd serve`.
+//
+// The handler tests in internal/httpapi drive a fake journal a case can write
+// to, which is the right shape for the framing and the refusal vocabulary and
+// cannot answer the question this file exists for: does a mutation arriving on
+// one connection reach a stream that was already open on another, without
+// anybody polling? Every layer between those two facts is real here — the
+// server-mode provider, the journal write inside the mutation's own
+// transaction, the read loop, and the socket.
+
+// watchConn is one open text/event-stream response plus the pieces a case needs
+// to read frames off it and hang up like a client.
+type watchConn struct {
+	resp   *http.Response
+	frames *bufio.Reader
+	cancel context.CancelFunc
+}
+
+// openWatchStream connects to GET /v0/beads/events:watch and consumes the
+// leading `retry:` frame, so the caller's next read is a record.
+func openWatchStream(t *testing.T, sp *serveProcess, path string, lastEventID string) *watchConn {
+	t.Helper()
+
+	// Its own client with no whole-response timeout: this response never
+	// completes, and the request context is what ends it.
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, sp.url(path), nil)
+	if err != nil {
+		cancel()
+		t.Fatalf("new request: %v", err)
+	}
+	if lastEventID != "" {
+		req.Header.Set("Last-Event-ID", lastEventID)
+	}
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		cancel()
+		t.Fatalf("GET %s: %v\nstderr:\n%s", path, err, sp.stderr.String())
+	}
+	t.Cleanup(func() {
+		cancel()
+		_ = resp.Body.Close()
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s = %d, want 200\nstderr:\n%s", path, resp.StatusCode, sp.stderr.String())
+	}
+	if got := resp.Header.Get("Content-Type"); got != "text/event-stream; charset=utf-8" {
+		t.Errorf("Content-Type = %q, want text/event-stream; charset=utf-8", got)
+	}
+
+	wc := &watchConn{resp: resp, frames: bufio.NewReader(resp.Body), cancel: cancel}
+	if got := wc.next(t); !strings.HasPrefix(got, "retry: ") {
+		t.Fatalf("first frame = %q, want the reconnection delay", got)
+	}
+	return wc
+}
+
+// next reads one frame, skipping the heartbeat comments that keep an idle
+// connection alive — a case waiting for a record must not care how long it
+// waited.
+func (wc *watchConn) next(t *testing.T) string {
+	t.Helper()
+	for {
+		var frame []string
+		for {
+			line, err := wc.frames.ReadString('\n')
+			if err != nil {
+				t.Fatalf("reading the stream: %v", err)
+			}
+			if line == "\n" {
+				break
+			}
+			frame = append(frame, strings.TrimSuffix(line, "\n"))
+		}
+		joined := strings.Join(frame, "\n")
+		if strings.HasPrefix(joined, ":") {
+			continue
+		}
+		return joined
+	}
+}
+
+// record reads the next frame and returns its id and decoded record, failing
+// the case if the frame is not one.
+func (wc *watchConn) record(t *testing.T) (int64, map[string]any) {
+	t.Helper()
+	frame := wc.next(t)
+	var id int64
+	var data string
+	for _, line := range strings.Split(frame, "\n") {
+		switch {
+		case strings.HasPrefix(line, "id: "):
+			if _, err := fmt.Sscanf(line, "id: %d", &id); err != nil {
+				t.Fatalf("id line %q: %v", line, err)
+			}
+		case strings.HasPrefix(line, "data: "):
+			data = strings.TrimPrefix(line, "data: ")
+		default:
+			t.Fatalf("unexpected line %q in a record frame:\n%s", line, frame)
+		}
+	}
+	if data == "" {
+		t.Fatalf("frame carries no data:\n%s", frame)
+	}
+	var rec map[string]any
+	if err := json.Unmarshal([]byte(data), &rec); err != nil {
+		t.Fatalf("frame data %q is not JSON: %v", data, err)
+	}
+	return id, rec
+}
+
+// TestServeStreamsTheJournalItIsWriting: hold a stream open on one connection,
+// mutate on another, and require the records to arrive without anybody asking
+// for them — then drop the stream and resume it with Last-Event-ID, which is
+// the whole reconnection contract.
+func TestServeStreamsTheJournalItIsWriting(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+	p := newServerModeProject(t, bd, "hjw")
+	p.env = append(p.env, "BD_EVENTS_JOURNAL=1")
+
+	sp := startServe(t, bd, p.dir, p.env)
+
+	create := func(title string) {
+		t.Helper()
+		status, body := sp.postJSON(t, "/v0/beads/issues:batchCreate",
+			fmt.Sprintf(`{"actor":"tester","items":[{"title":%q,"issue_type":"task"}]}`, title))
+		if status != http.StatusOK {
+			t.Fatalf("POST batchCreate %q = %d: %v\nstderr:\n%s", title, status, body, sp.stderr.String())
+		}
+	}
+
+	// OPEN FIRST, MUTATE SECOND. The records this asserts on did not exist when
+	// the stream connected, which is the difference between this operation and
+	// the paged read.
+	stream := openWatchStream(t, sp, "/v0/beads/events:watch?since=0", "")
+	mutated := time.Now()
+	create("streamed mutation 1")
+	create("streamed mutation 2")
+
+	for i := range 2 {
+		id, rec := stream.record(t)
+		if id != int64(i+1) {
+			t.Fatalf("record %d arrived with id %d, want %d", i, id, i+1)
+		}
+		// THE ID IS THE SEQ. A client resumes from the id, and it can only do
+		// that if the two are the same number.
+		if seq, _ := rec["seq"].(float64); int64(seq) != id {
+			t.Errorf("record %d: id %d but seq %v", i, id, rec["seq"])
+		}
+		if op, _ := rec["op"].(string); op != "create" {
+			t.Errorf("record %d op = %v, want create", i, rec["op"])
+		}
+		if _, ok := rec["issue"]; !ok {
+			t.Errorf("record %d has no `issue` member", i)
+		}
+	}
+
+	// A LOOSE ARRIVAL BOUND, because "it arrived" is not the claim this
+	// operation makes — "it arrived without anybody asking" is. The read above
+	// blocks for as long as the request context allows, so without a bound a
+	// stream that delivered after a minute would pass. Ten seconds is far above
+	// the one-second poll and far below any interval a consumer would have
+	// chosen for itself.
+	if elapsed := time.Since(mutated); elapsed > 10*time.Second {
+		t.Errorf("the mutations took %s to reach an open stream; that is not push delivery", elapsed)
+	}
+
+	// The paged read answers the same records from the same checkpoint while the
+	// stream is open, which is the fallback the 503 for a saturated cap points
+	// at — and proof the stream is not holding the server's read capacity.
+	status, body, _ := sp.get(t, "/v0/beads/events?since=0")
+	if status != http.StatusOK {
+		t.Fatalf("paged read alongside an open stream = %d: %v", status, body)
+	}
+	if records, _ := body["records"].([]any); len(records) != 2 {
+		t.Errorf("paged read returned %d records while streaming, want 2", len(records))
+	}
+
+	// RECONNECT. The client hangs up and comes back with the id it reached,
+	// against the SAME url — carrying the same stale `since=0` a browser's
+	// EventSource would re-send. The header has to win, or every reconnect
+	// replays the whole journal.
+	stream.cancel()
+	resumed := openWatchStream(t, sp, "/v0/beads/events:watch?since=0", "1")
+
+	id, _ := resumed.record(t)
+	if id != 2 {
+		t.Fatalf("first record after a Last-Event-ID: 1 reconnect = %d, want 2 — `since=0` won and the journal replayed", id)
+	}
+
+	// And the resumed stream is live, not a replay that then stops.
+	create("streamed mutation 3")
+	if id, _ := resumed.record(t); id != 3 {
+		t.Fatalf("record after the reconnect = %d, want 3", id)
+	}
+
+	// SHUTDOWN WITH THE STREAM STILL OPEN. http.Server.Shutdown waits for
+	// active requests, so a stream that did not wind itself up would hold the
+	// drain for its full timeout and then be killed — a graceful stop that takes
+	// twenty seconds and reports itself forced.
+	start := time.Now()
+	sp.shutdown(t)
+	if elapsed := time.Since(start); elapsed > 15*time.Second {
+		t.Errorf("shutdown with an open stream took %s; the stream is holding the drain", elapsed)
+	}
+	if log := sp.stderr.String(); strings.Contains(log, "event=shutdown_forced") {
+		t.Errorf("the shutdown was forced with a stream open:\n%s", log)
+	}
+}
+
+// TestServeRefusesAStreamOnADisabledJournal: the connect-time refusals are
+// ordinary problem+json responses on this operation too, and the stream is
+// never opened. A consumer that got a 200 here would hold a connection open
+// against a workspace that will never emit a record.
+func TestServeRefusesAStreamOnADisabledJournal(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+	p := newServerModeProject(t, bd, "hjx")
+	// Deliberately NOT enabling the journal. The default is off.
+
+	sp := startServe(t, bd, p.dir, p.env)
+
+	status, body, header := sp.get(t, "/v0/beads/events:watch?since=0")
+	if status != http.StatusConflict {
+		t.Fatalf("GET /v0/beads/events:watch on a disabled workspace = %d, want 409: %v\nstderr:\n%s",
+			status, body, sp.stderr.String())
+	}
+	if got := header.Get("Content-Type"); !strings.HasPrefix(got, "application/problem+json") {
+		t.Errorf("Content-Type = %q, want problem+json", got)
+	}
+	if code, _ := body["code"].(string); code != "events_journal_disabled" {
+		t.Errorf("code = %v, want events_journal_disabled", body["code"])
+	}
+
+	sp.shutdown(t)
+}

--- a/cmd/bd/serve_proxied_integration_test.go
+++ b/cmd/bd/serve_proxied_integration_test.go
@@ -146,7 +146,7 @@ var servedCapabilities = []any{
 	"config.get", "config.list",
 	"dependencies.add", "dependencies.blocking", "dependencies.cycles",
 	"dependencies.list", "dependencies.remove", "dependencies.tree",
-	"events.list",
+	"events.list", "events.watch",
 	"issues.batchCreate", "issues.claim", "issues.close", "issues.delete",
 	"issues.get", "issues.list", "issues.query", "issues.reopen", "issues.sweep",
 	"issues.update",

--- a/docs/reference/events-journal.md
+++ b/docs/reference/events-journal.md
@@ -107,8 +107,6 @@ same [record contract](#the-record-contract) — so an HTTP mirror and a
 - `head` is the highest sequence number ever assigned, so a consumer knows
   whether to keep reading or back off. When the last record's `seq` equals
   `head` you are caught up — a full page proves nothing on its own.
-- **Poll; there is no streaming or `--follow` equivalent.** Read with your
-  checkpoint on your own interval.
 - The journal is read-only over HTTP. Pruning stays a workspace decision made
   with `bd events prune` and the retention floors.
 
@@ -142,6 +140,88 @@ gives.)
 The journal is per replica, which matters more over HTTP than on the command
 line: a checkpoint is meaningful only against the server URL that issued it.
 Track one per server, and re-baseline rather than carry one across.
+
+### Streaming instead of polling
+
+`GET /v0/beads/events:watch` is the same journal, pushed. It answers
+`text/event-stream` and holds the connection open, emitting each mutation as it
+commits — the HTTP form of `bd events tail --follow`:
+
+```bash
+curl -N 'http://127.0.0.1:8080/v0/beads/events:watch?since=4211'
+```
+
+```
+retry: 3000
+
+id: 4212
+data: {"seq":4212,"ts":"2026-01-02T03:04:05Z","op":"create","issue_id":"bd-100","issue":{"id":"bd-100","title":"wire the seam","status":"open","priority":1,"issue_type":"task","created_at":"2026-01-02T03:00:00Z","updated_at":"2026-01-02T03:04:05Z"}}
+
+: heartbeat
+```
+
+Each event's `data` is one line carrying exactly the record the paged read
+returns, and `id` is that record's `seq` — the same number `since` takes. The
+comment lines are heartbeats, sent every 20 seconds of silence so idle
+connections survive intermediaries that drop them; clients ignore comments
+automatically.
+
+**Watch or poll?** Poll unless the delay is the point. A poller holds nothing
+between requests and can never be refused for capacity; a stream costs a
+connection for as long as it is open, and this server holds at most **48** of
+them before answering `503` with `events_watch_saturated` and pointing you back
+at `GET /v0/beads/events`. That cap sits deliberately below the server's
+64-connection limit, so a workspace saturated with streams still has room to
+answer polls, mutations and health checks — and room to deliver the `503`
+itself. Stream when something is waiting on the mutation — a live mirror, an
+agent watching a gate — and poll for anything that can afford an interval.
+Neither is faster at draining a backlog.
+
+**Delivery is at-least-once against your own checkpoint.** Within a single
+stream each record is sent once, in `seq` order, with no gaps. Duplicates are
+possible only across a reconnect — if you resume from an id whose records you
+had already applied — so make your consumer idempotent on `seq` and advance
+your checkpoint only after your own write lands, exactly as when polling.
+
+**Reconnecting is the normal case, and it is free.** When a stream drops,
+reconnect with the standard `Last-Event-ID` header carrying the last `seq` you
+processed; it **overrides** `since`. That is what makes a browser's
+`EventSource` correct with no extra code — it re-sends the original URL, whose
+`since` is as old as your process:
+
+```js
+const es = new EventSource('/v0/beads/events:watch?since=0');
+es.onmessage = (e) => apply(JSON.parse(e.data));   // e.lastEventId is the seq
+es.addEventListener('truncated', (e) => { es.close(); rebaseline(JSON.parse(e.data)); });
+```
+
+`since` is still required on every connect — the header is absent on the first
+one — and a `Last-Event-ID` that is not a sequence number is a `400` rather than
+a silent fall back to `since`, which would start the stream somewhere you did
+not ask for.
+
+**Every refusal happens before the stream opens.** The `409` and the `410` above
+are the same responses on this route as on the paged read, decided before the
+first byte, so a client that got its `200` knows its checkpoint was servable.
+
+<Warning>
+There is exactly one failure that can arrive *after* that: a **`truncated`
+event**, sent when a prune removes the records the open stream was about to
+send. Its `data` is the same `410` body — `events_journal_truncated` with
+`since` / `floor` / `head` — and the stream closes immediately after it.
+
+**Treat it as stop-and-re-baseline**, with [the same ways
+forward](#resuming-and-the-truncation-error) as the `410`. A consumer that
+ignores it does not lose records silently, but it does stall loudly: a bare
+`EventSource` will reconnect with the same dead id and earn a connect-time
+`410` on every attempt from then on. The stream raises the reconnection delay to
+60 seconds first so that loop is slow rather than hot.
+</Warning>
+
+The exposure warning above applies identically — a stream is the same history
+over the same unauthenticated address, held open — and so does the capability
+rule: `events.watch` appears in `/v0/beads/context`'s capabilities on every
+build, and says nothing about whether this workspace has a journal.
 
 ## The record contract
 

--- a/engdocs/SERVE_RUNBOOK.md
+++ b/engdocs/SERVE_RUNBOOK.md
@@ -1,7 +1,8 @@
 # `bd serve` operator runbook
 
-Last reviewed: 2026-08-01 (freshness sources: the operating-envelope constants
-in `internal/httpapi/server.go`, and the fields its `event` emitters write)
+Last reviewed: 2026-08-09 (freshness sources: the operating-envelope constants
+in `internal/httpapi/server.go` and `internal/httpapi/events_watch.go`, and the
+fields their `event` emitters write)
 
 Running the v0 HTTP surface. For the contract it serves — the operations, the
 error vocabulary, the cursor, the loopback posture — see
@@ -169,6 +170,51 @@ bound connections: Go spawns a goroutine per connection, and one parked on a
 full semaphore still holds its goroutine, file descriptor and buffers. Excess
 connections wait in the kernel accept backlog instead of in Go memory.
 
+`maxWatchStreams = 48` caps `GET /v0/beads/events:watch`, the one operation
+whose requests last hours, and it sits **16 connections below `maxConns`
+deliberately**. `LimitListener` hands a connection slot back only when the
+connection closes — after the handler returns, and therefore after the stream
+counter has already come down — so a stream cap equal to the connection cap
+would be unreachable: the connect that should earn the `503` would never be
+accepted, and neither would the poll it is told to fall back to. The headroom is
+what makes the refusal deliverable and keeps polls, mutations and a
+fresh-connection `/healthz` answerable while every stream slot is taken.
+
+Watch the gauge, not the cliff: `event=events_watch_admitted` carries
+`streams=N max_streams=48` on every connect, so accumulation is visible before
+the first refusal. `event=events_watch_saturated` is the refusal itself.
+
+**Connection saturation at `maxConns` is the worse cliff and is still
+reachable** — by 64 ordinary clients, or by 48 streams plus 16 other
+connections. It is silent by construction: `LimitListener` simply stops calling
+`Accept`, so further connections wait in the kernel backlog with nothing on
+stderr and `/healthz` unable to get a fresh connection either. `conn_cap_saturated`
+is the only warning, and it is edge-triggered; see [Detecting a wedge](#detecting-a-wedge).
+
+A stream has no read deadline (SSE clients legitimately send nothing for hours,
+so one would kill healthy streams), which raises the question of what reaps a
+consumer that vanishes without a FIN or RST — a yanked cable, a killed VM.
+**TCP keepalive already does**, and is on by default: Go's listener enables
+`SO_KEEPALIVE` on every accepted connection and overrides the system idle and
+interval with its own 15s, leaving the probe count at the system's. Measured on
+this fleet (2026-08-09): `SO_KEEPALIVE=1`, `TCP_KEEPIDLE=15`, `TCP_KEEPINTVL=15`,
+`TCP_KEEPCNT=9` — a **~150 second** reap for a connection that is idle, against
+the ~2h11m the bare system defaults (7200/75/9) would have given. A stream that
+is actively writing when the peer vanishes is reaped by retransmission instead,
+on `tcp_retries2` (15 here, roughly **15 minutes**), because keepalive does not
+run while data is unacknowledged. So the worst case for a stream slot held by a
+vanished peer is minutes, not hours — and the stream cap is sized on the
+assumption that it is minutes.
+
+**Streams cost nothing from the database budget between reads**: the handler
+takes a semaphore slot around each one-second poll and gives it straight back,
+so 48 open streams do not occupy 16 handler slots. They are exempt from the 60s
+whole-request deadline for the same reason, and each read is bounded by its own
+15s deadline instead — short because it also bounds how long a stream can go
+without a heartbeat and how long it can ignore a shutdown, not because a page of
+1000 journal rows should ever take that long. Tell accumulating consumers to
+poll `GET /v0/beads/events`, which is never refused for capacity.
+
 ## Shutdown, and the ambiguous claim
 
 On SIGINT, SIGTERM or SIGHUP the server stops accepting and drains for up to
@@ -176,6 +222,20 @@ On SIGINT, SIGTERM or SIGHUP the server stops accepting and drains for up to
 contexts: the budget covers a claim inside its serialization-retry budget plus
 its commit, because killing such a connection early would leave the client
 unable to tell whether its write landed.
+
+Journal streams are the exception, and they have to be: a held-open response
+would otherwise sit through the whole budget and then be killed anyway. They get
+an explicit close signal when the drain starts and end on their own within a
+poll interval — or, if they are mid-read or mid-backlog, within one 15s read —
+so an open stream does not turn a clean stop into a twenty-second one. Their
+clients reconnect and resume from the id they reached.
+
+One case still forces it, and it is accepted rather than fixed: a stream whose
+client has **stopped reading** blocks in a write, and the write-stall deadline
+that frees it is 30 seconds against a 20-second drain. Such a stream will be
+force-closed, and the `shutdown_forced` line is correct — that connection was
+already ambiguous. Nothing is lost: a stream carries no write, and its client
+resumes from its own last id.
 
 If the drain budget is exceeded, remaining connections are closed and
 `event=shutdown_forced` is logged with the count. That is the ambiguous case,
@@ -243,6 +303,10 @@ Other events on the same stream:
 | `panic` | A panicking handler: the value, the stack, and the same `request_id`. |
 | `semaphore_saturated`, `semaphore_timeout`, `conn_cap_saturated` | See [Detecting a wedge](#detecting-a-wedge). |
 | `shutdown_start`, `shutdown_complete`, `shutdown_forced` | The drain. |
+| `events_watch_admitted` | A journal stream opened, carrying `streams=N max_streams=48`. One line per stream, not per record: this is the gauge that shows accumulation before the cap is hit. |
+| `events_watch_saturated` | A journal stream was refused because this process is already holding its cap. Carries the live count and the cap. Streams end when their consumers leave, so a run of these means consumers are accumulating, not that the server is slow. |
+| `events_watch_failed` | An open journal stream ended on a failure it could not report to the client, because the `200` was already sent: a read that failed (carrying the checkpoint it reached), or a stored payload that would not encode (carrying its `seq`). The client reconnects on its own; a repeated read failure names a database problem, and a repeated `seq` names one unencodable row that will end every stream that reaches it. |
+| `events_watch_unflushable` | A journal stream was refused because the response writer cannot flush. Not reachable through `bd serve`'s own server; it means something is wrapping this handler. |
 
 A 5xx body carries a fixed static detail by design, so `request_id` is the
 client's only handle on the one line that has the real error. When a user

--- a/internal/httpapi/apigen/types.gen.go
+++ b/internal/httpapi/apigen/types.gen.go
@@ -265,9 +265,9 @@ type ContextResponse struct {
 	// BeadsDir Absolute path of the served workspace's `.beads` directory. A host path, kept because it is the single-workspace server's only workspace-identity handshake; disclosing it to network peers is part of what an operator accepts when binding beyond loopback.
 	BeadsDir string `json:"beads_dir"`
 
-	// Capabilities The operations this server actually implements, derived from its route table. v0's vocabulary is `ready.list`, `ready.count`, `issues.list`, `issues.query`, `issues.get`, `issues.claim`, `issues.close`, `issues.reopen`, `issues.update`, `issues.sweep`, `issues.delete`, `issues.batchCreate`, `stats.get`, `config.list`, `config.get`, `dependencies.cycles`, `dependencies.list`, `dependencies.blocking`, `dependencies.tree`, `dependencies.add`, `dependencies.remove`, `memories.list`, `memories.get`, `memories.remember`, `memories.forget`, `events.list`; it grows additively, and an operation never appears here unless it is fully implemented. This is how a client checks for an operation — never the version string.
+	// Capabilities The operations this server actually implements, derived from its route table. v0's vocabulary is `ready.list`, `ready.count`, `issues.list`, `issues.query`, `issues.get`, `issues.claim`, `issues.close`, `issues.reopen`, `issues.update`, `issues.sweep`, `issues.delete`, `issues.batchCreate`, `stats.get`, `config.list`, `config.get`, `dependencies.cycles`, `dependencies.list`, `dependencies.blocking`, `dependencies.tree`, `dependencies.add`, `dependencies.remove`, `memories.list`, `memories.get`, `memories.remember`, `memories.forget`, `events.list`, `events.watch`; it grows additively, and an operation never appears here unless it is fully implemented. This is how a client checks for an operation — never the version string.
 	//
-	// THIS LIST IS BUILD-LEVEL, NOT WORKSPACE-LEVEL. It says which operations this binary serves, and for every entry but one that is the whole answer. `events.list` is the exception: the durable events journal is a per-workspace setting that is OFF by default, so a server that advertises `events.list` may still refuse every request to it with 409 `events_journal_disabled` — correctly, because the operation exists and the workspace has no journal. A consumer of that operation MUST treat the capability as "this server speaks it" and the 409 as "not on this workspace", and must not read the capability as a promise that records will arrive.
+	// THIS LIST IS BUILD-LEVEL, NOT WORKSPACE-LEVEL. It says which operations this binary serves, and for every entry but two that is the whole answer. `events.list` and `events.watch` are the exceptions: the durable events journal is a per-workspace setting that is OFF by default, so a server that advertises them may still refuse every request to both with 409 `events_journal_disabled` — correctly, because the operations exist and the workspace has no journal. A consumer of either MUST treat the capability as "this server speaks it" and the 409 as "not on this workspace", and must not read the capability as a promise that records will arrive.
 	Capabilities []string `json:"capabilities"`
 
 	// Database Logical database name (not a host or a DSN).
@@ -531,7 +531,7 @@ type Problem struct {
 	// BlockerIsAncestor With `dependency_cycle`, hierarchy refusal only: true when `blocker_id` is an ANCESTOR of `issue_id` (which cannot close until its descendants finish, so the gate would never clear), false when it is a DESCENDANT (blocked status cascades, so it would inherit the block and never close). Both polarities are reported; this member is never omitted to mean false. See `issue_id`.
 	BlockerIsAncestor *bool `json:"blocker_is_ancestor,omitempty"`
 
-	// Code The stable machine-readable reason, and the ONLY member a client may dispatch on. v0's vocabulary: `invalid_argument` (400, also emitted by the Host-header middleware on any route), `invalid_cursor` (400), `not_found` (404), `already_claimed` (409), `not_claimable` (409), `not_closable` (409), `dependency_cycle` (409), `dependency_exists` (409), `events_journal_disabled` (409), `events_journal_truncated` (410), `busy` (503), `db_unavailable` (503), `internal` (500). Renaming or removing a status+code pair is a breaking change; ADDING one is not, so clients MUST default-branch on unknown values and fall back to the status class (unknown 4xx → client bug, fail loud; unknown 503 → retry per `Retry-After`; other unknown 5xx → server fault).
+	// Code The stable machine-readable reason, and the ONLY member a client may dispatch on. v0's vocabulary: `invalid_argument` (400, also emitted by the Host-header middleware on any route), `invalid_cursor` (400), `not_found` (404), `already_claimed` (409), `not_claimable` (409), `not_closable` (409), `dependency_cycle` (409), `dependency_exists` (409), `events_journal_disabled` (409), `events_journal_truncated` (410), `busy` (503), `db_unavailable` (503), `events_watch_saturated` (503), `internal` (500). Renaming or removing a status+code pair is a breaking change; ADDING one is not, so clients MUST default-branch on unknown values and fall back to the status class (unknown 4xx → client bug, fail loud; unknown 503 → retry per `Retry-After`; other unknown 5xx → server fault).
 	Code string `json:"code"`
 
 	// Detail Optional prose, never load-bearing. For 5xx codes it is a FIXED string per code and carries nothing about the underlying failure: driver and dial errors routinely embed the DSN, database user and host:port, and this API supports binding beyond loopback. 4xx details reflect the caller's own input back and are specific.
@@ -922,6 +922,23 @@ type ListEventsParams struct {
 	//
 	// A FULL PAGE DOES NOT MEAN THERE IS MORE, and a short one does not mean there is not. Compare the last record's `seq` against `head`; that is the only correct test, and it is why this envelope carries no `has_more`.
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+}
+
+// WatchEventsParams defines parameters for WatchEvents.
+type WatchEventsParams struct {
+	// Since Emit records with `seq` strictly greater than this value. Pass `0` to stream from the beginning of the retained journal.
+	//
+	// REQUIRED on every connect, including a reconnect that also carries `Last-Event-ID`, and refused when negative — both for the reasons `listEvents` gives. When the header is present this value is ignored, but it is still validated: one rule, one spelling, whether or not the client is a browser.
+	Since int64 `form:"since" json:"since"`
+
+	// LastEventID The last `seq` this client processed, as emitted in the `id:` field of a previous event. Present, it REPLACES `since` as the resume point.
+	//
+	// This is the standard SSE reconnection header and browsers attach it automatically, which is the whole reason it outranks the query parameter: an `EventSource` reconnects to the URL it was built with, so honoring `since` there would re-deliver every record since the consumer started on every reconnect.
+	//
+	// A NONEMPTY value that is not a non-negative 64-bit integer is a 400 `invalid_argument` naming this header, rather than a silent fallback to `since`: a client that invented its own id has a broken checkpoint, and a stream that quietly started somewhere else would look correct and lose records.
+	//
+	// An EMPTY value is treated exactly as an absent one — `since` decides — because it says the same thing: no id yet. A client or intermediary that always sets the header sends it empty on the first connect, and refusing that would break the one request this header exists to make work.
+	LastEventID *int64 `json:"Last-Event-ID,omitempty"`
 }
 
 // ListIssuesParams defines parameters for ListIssues.

--- a/internal/httpapi/events.go
+++ b/internal/httpapi/events.go
@@ -30,15 +30,18 @@ import (
 // contract, and the failure mode of getting it wrong is silent record loss —
 // which is the one thing this feature exists to prevent.
 //
-// NO FOLLOW, NO STREAM, NO LONG POLL in v0. A consumer polls with the highest
-// seq it has durably processed. That is a real constraint on the design and not
-// an omission: a held-open response would have to survive the write-stall
-// deadline, hold a database slot for its whole life out of a pool of sixteen,
-// and still leave the consumer needing the polling path for the reconnect —
-// so v0 ships the path that is always needed and nothing else. `head` is what
-// makes polling cheap to pace: a consumer that sees its last seq equal to
-// `head` knows it is caught up and can back off, instead of inferring it from
-// a short page.
+// NO FOLLOW MODE ON THIS OPERATION, and adding one is not the way to get a
+// push feed: `follow=true` would give one operationId two contracts — two media
+// types, two lifetimes, two limit rules — and a client generated from the
+// document could not describe either. The push feed is a SIBLING operation,
+// events_watch.go, which consumes this same read path. `head` is what makes
+// polling cheap to pace: a consumer that sees its last seq equal to `head`
+// knows it is caught up and can back off, instead of inferring it from a short
+// page.
+//
+// A poller is still the path that is always needed — it is what a dropped
+// stream reconnects through, and it holds nothing between requests — which is
+// why it landed first and why the stream's saturation refusal points back here.
 
 // Journal paging bounds. There is no unlimited read here, unlike the issue
 // listings: a caller resuming from an old checkpoint would otherwise ask one

--- a/internal/httpapi/events_watch.go
+++ b/internal/httpapi/events_watch.go
@@ -1,0 +1,656 @@
+package httpapi
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/steveyegge/beads/internal/eventsjournal"
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+// The events journal, PUSHED. GET /v0/beads/events:watch is the poll read's
+// sibling, not a mode of it: same cursor, same records, same refusals, held
+// open as text/event-stream so a consumer learns about a mutation when it
+// happens instead of on its next interval.
+//
+// THE CURSOR IS STILL THE CONTRACT, and that is the whole design. This server
+// keeps no per-consumer state, remembers no subscription and cannot redeliver;
+// a stream is a sequence of `since` reads this process performs on the client's
+// behalf, and every record carries `id: <seq>` so the client's own checkpoint
+// is the same number it would have held while polling. That is what makes
+// reconnection free: `Last-Event-ID` — the header a browser's EventSource
+// resends by itself — is the same value the `since` parameter takes, so a
+// dropped stream resumes exactly where a poller would have.
+//
+// NOTHING NEW IS READ. The loop below calls the SAME ReadEventsJournalPage the
+// poll handler calls, through the same read-only cursor, with the same
+// truncation contract arriving as the same typed error. There is no follow mode
+// in storage, no notification channel and no new engine surface — a push
+// endpoint that invented its own read path would be a second retention contract
+// with the same failure mode this feature exists to prevent.
+//
+// WHEN TO USE WHICH is a real decision and the document states it: a consumer
+// that can afford its interval should poll, because a poll holds nothing
+// between requests. A stream costs a connection and a goroutine for as long as
+// it stays open, plus a database slot for the moment of each read — which is
+// why there is a hard cap on how many this process will hold at once, and why
+// the refusal past that cap points back at the paged read.
+
+const (
+	// eventsWatchBatch is how many records one pass of the loop may carry. It
+	// is the poll endpoint's DEFAULT rather than its ceiling, and it is not a
+	// parameter: a stream paces itself, so the only thing this number changes
+	// is how a backlog is chunked on the way out.
+	eventsWatchBatch = defaultEventsLimit
+
+	// eventsWatchRetry is the reconnection delay handed to the client in the
+	// stream's first line, in milliseconds. EventSource's own default is
+	// implementation-defined and browsers have shipped values from 500ms up, so
+	// it is stated rather than inherited: three seconds is long enough that a
+	// server restart does not produce a reconnect storm, short enough that a
+	// consumer's lag after one is measured in seconds.
+	eventsWatchRetry = 3000
+
+	// eventsWatchTruncatedRetry is the delay raised in front of the `truncated`
+	// event, in milliseconds. A consumer that respects the event stops and
+	// re-baselines and never uses this; it is for the one that does not — a bare
+	// EventSource will reconnect with the same dead Last-Event-ID and earn a
+	// connect-time 410 forever, and a minute between attempts is the difference
+	// between a slow loop and a hot one.
+	eventsWatchTruncatedRetry = 60000
+
+	// maxWatchStreams bounds concurrent streams, and it sits BELOW the
+	// accepted-connection cap on purpose. Every stream holds a connection and a
+	// goroutine for its whole life, so without a bound the stream surface would
+	// be the one operation on this server with no limit at all — and it is the
+	// one whose requests last hours.
+	//
+	// SIXTEEN CONNECTIONS OF HEADROOM IS WHAT MAKES THE REFUSAL REAL, and this
+	// is the arithmetic. netutil.LimitListener returns a connection slot only
+	// when the connection CLOSES — after the handler has returned, which is
+	// after this counter has already come back down. A cap equal to maxConns
+	// would therefore be unreachable: at sixty-four streams every connection
+	// slot is held by one of them, the sixty-fifth connect is never accepted,
+	// and the 503 this operation documents could not be delivered to anybody.
+	// The paged read, every mutation and a fresh-connection /healthz would park
+	// silently in the kernel accept backlog instead, which is precisely the
+	// failure the cap exists to convert into a status and a log line.
+	//
+	// So the stream surface saturates FIRST, sixteen connections early — one
+	// full complement of the in-flight database requests this server admits —
+	// leaving room for the polls, writes and probes that must keep answering.
+	// Connection saturation at maxConns is still reachable by other means and is
+	// still the silent cliff; the runbook documents it as the worse one.
+	// TestTheStreamCapLeavesConnectionHeadroom pins the relationship.
+	maxWatchStreams = 48
+)
+
+// The stream's two cadences. Both are Server fields at the point of use
+// (orDefault), for the reason semTimeout and writeStall are: a test that had to
+// wait real seconds for a heartbeat would either be slow or would not exist.
+const (
+	// watchPollInterval is how often the loop asks for new records. One second
+	// is what `bd events tail --follow` uses, and the stream is deliberately no
+	// fresher than the CLI's own follow: a tighter loop would multiply database
+	// reads across every open stream to shave a delay nothing here promises.
+	watchPollInterval = time.Second
+
+	// watchHeartbeat is how long a stream may go silent before it emits a
+	// comment line. It is proxy and NAT defense first — an idle connection
+	// through an intermediary that times out silently is the classic way a
+	// stream stops delivering without either end noticing — and liveness second:
+	// a write to a client that has gone away fails, which is how this loop
+	// learns about a disconnect no TCP FIN announced.
+	watchHeartbeat = 20 * time.Second
+
+	// eventsWatchReadDeadline bounds ONE pass of the loop's read, and it is
+	// deliberately much shorter than the requestDeadline this operation is
+	// exempt from.
+	//
+	// It is not really a database budget: a bounded, indexed page of a thousand
+	// journal rows needs nothing like fifteen seconds, and a read that takes
+	// them is a wedge rather than a slow query. It is a LIVENESS budget, and it
+	// bounds two things a stream cannot otherwise bound. A read parked for sixty
+	// seconds suspends this stream's heartbeats for sixty seconds, which reads
+	// to every intermediary between here and the consumer as a dead connection.
+	// And it delays this loop's next look at the shutdown signal by the same
+	// amount, which is three times the drain budget — turning a clean stop into
+	// a forced one.
+	eventsWatchReadDeadline = 15 * time.Second
+)
+
+// lastEventIDHeader is the standard SSE resume header. It is spelled once
+// because it is both read from the request and named in a refusal.
+const lastEventIDHeader = "Last-Event-ID"
+
+// handleWatchEvents answers GET /v0/beads/events:watch.
+//
+// EVERY REFUSAL IS AN ORDINARY PROBLEM RESPONSE, and the ordering below is what
+// makes that true: validation, activation, transport, capacity, and then the
+// first read — all of it before a single stream byte. Once the 200 and its
+// text/event-stream header are on the wire the status is spent, and a
+// truncation discovered after that can only be reported inside the stream (see
+// the `truncated` event). The connect-time half of the contract is therefore
+// byte-identical to the poll endpoint's: same 400s, same 409, same 410.
+func (s *Server) handleWatchEvents(w http.ResponseWriter, r *http.Request) {
+	rec := requestInfo(r.Context())
+	q := newQuery(r.URL.Query())
+	since := q.integer64("since")
+	if !s.acceptQuery(w, r, q) {
+		return
+	}
+
+	// `since` is required here for the reason it is required on the poll read —
+	// an omitted checkpoint defaulted to zero replays the whole retained window
+	// as a flood of duplicates — and it stays required even when the header
+	// below supersedes its value. A browser reconnecting an EventSource re-sends
+	// the ORIGINAL URL with its original `since`, so a stream whose parameter
+	// was optional on reconnect and required on first connect would be one rule
+	// with two spellings.
+	if since == nil || *since < 0 {
+		rec.refuse("since")
+		s.fail(w, r, InvalidArgument("since", ReasonInvalidValue,
+			"since is required and must be zero or a positive sequence number; use 0 to read from the beginning"))
+		return
+	}
+	cursor := *since
+
+	// THE HEADER WINS, because the client that sends it did not choose to. An
+	// EventSource re-sends the URL it was constructed with — a `since` that is
+	// as old as the consumer's process — and attaches Last-Event-ID carrying the
+	// seq it actually reached. Honoring the parameter there would re-deliver
+	// every record since startup on every reconnect, forever.
+	//
+	// An unparseable value is refused rather than ignored, and that is the whole
+	// argument for validating a header this server also emits: a client that
+	// invented its own Last-Event-ID has a broken checkpoint, and silently
+	// falling back to `since` would hand it a stream that looks correct and
+	// starts in the wrong place.
+	if raw := r.Header.Get(lastEventIDHeader); raw != "" {
+		resumed, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil || resumed < 0 {
+			rec.refuse(lastEventIDHeader)
+			s.fail(w, r, InvalidArgument(lastEventIDHeader, ReasonInvalidValue,
+				"Last-Event-ID must be a journal sequence number: zero or a positive 64-bit integer, as this stream emits it"))
+			return
+		}
+		cursor = resumed
+	}
+
+	// The activation gate, before any database work, for the reason the poll
+	// read states: a disabled journal is indistinguishable from an idle one in
+	// the data, so a stream over one would be a connection held open forever
+	// against a workspace that will never emit a record.
+	if !s.cfg.EventsJournalEnabled {
+		s.fail(w, r, EventsJournalDisabled())
+		return
+	}
+
+	// A stream that cannot flush is not a stream: every record would sit in
+	// net/http's buffer until it filled or the handler returned, which for this
+	// operation is never. Refused here, before the cap is charged and before the
+	// status is spent, so a deployment that wrapped this server in a
+	// non-flushing middleware learns about it on the first request instead of
+	// producing streams that deliver nothing.
+	if !canFlush(w) {
+		s.event("events_watch_unflushable", "request_id", rec.id, "writer", fmt.Sprintf("%T", w))
+		s.fail(w, r, newResult(CodeInternal, ""))
+		return
+	}
+
+	release, admitted := s.admitWatchStream(rec)
+	if !admitted {
+		s.fail(w, r, EventsWatchSaturated())
+		return
+	}
+	defer release()
+
+	// THE READ DEADLINE GOES BEFORE THE FIRST READ, not when the stream opens.
+	// http.Server.ReadTimeout is thirty seconds from the start of the request,
+	// and the connect read below is the last thing that happens under it; a
+	// database wedged at that moment would have the deadline expire mid-read,
+	// which net/http reports by canceling the request context — so the wedge
+	// would be booked as `client_closed` and the operator would be looking for a
+	// client that never left. Clearing it here means the connect read is bounded
+	// only by its own deadline (readWatchBatch), which is the one that names the
+	// right condition.
+	clearRequestReadDeadline(w)
+
+	journal, err := s.eventsJournalCursor(r)
+	if err != nil {
+		s.failErr(w, r, err)
+		return
+	}
+
+	// THE FIRST READ HAPPENS BEFORE THE STREAM OPENS. It is what turns a
+	// pruned-past checkpoint into the plain 410 the poll read gives — the same
+	// body, the same code, the same window — rather than into a 200 that
+	// immediately reports its own failure. Every other connect-time error
+	// (busy, unreachable, a backend fault) reaches the wire the same way for the
+	// same reason.
+	page, err := s.readWatchBatch(r.Context(), rec, journal, cursor)
+	if err != nil {
+		s.failErr(w, r, err)
+		return
+	}
+
+	s.streamEvents(w, r, journal, cursor, page)
+}
+
+// streamEvents writes the stream and owns its life.
+//
+// It returns when the client goes away, when the server begins shutting down,
+// when a write fails, or when the journal is pruned out from under the cursor —
+// and on every one of those paths the caller's deferred release gives the
+// stream slot back. There is no other exit.
+func (s *Server) streamEvents(w http.ResponseWriter, r *http.Request, journal storage.EventsJournalCursor, since int64, page storage.EventsJournalPage) {
+	ctx := r.Context()
+	rec := requestInfo(ctx)
+
+	// Everything this stream logs carries the request id, so the one line the
+	// request log already has for it and any line the stream adds join.
+	stream := newEventStream(w, func(name string, kv ...any) {
+		s.event(name, append([]any{"request_id", rec.id}, kv...)...)
+	})
+	stream.open(eventsWatchRetry)
+
+	// The per-pass slot acquisitions are booked against a DETACHED record
+	// carrying this request's id: acquire overwrites sem_wait every time, and
+	// the number worth having on a stream's one request line is the wait at
+	// connect, not the wait on whichever pass happened to be last. Saturation
+	// events stay attributable because the id travels.
+	passes := &reqInfo{id: rec.id}
+
+	// A TIMER RATHER THAN A TICKER, because the interval is jittered per pass.
+	// A ticker would put every stream on the same phase, and the phase is not
+	// random: streams reconnect together after a restart and all take the same
+	// `retry` delay, so a fixed interval marches them into one read burst per
+	// second for the life of the process. watchPollDelay spreads both the first
+	// wait and every later one.
+	interval := orDefault(s.watchPoll, watchPollInterval)
+	poll := time.NewTimer(watchPollDelay(interval))
+	defer poll.Stop()
+	beat := orDefault(s.watchBeat, watchHeartbeat)
+	quiet := time.Now()
+
+	for {
+		for _, row := range page.Rows {
+			if !stream.record(row) {
+				return
+			}
+			// Advanced only past records this loop has WRITTEN, so a failed
+			// write cannot be followed by a read that skips what it dropped.
+			since = row.Seq
+		}
+		switch {
+		case len(page.Rows) > 0:
+			stream.flush()
+			quiet = time.Now()
+		case time.Since(quiet) >= beat:
+			stream.comment("heartbeat")
+			quiet = time.Now()
+		}
+		if stream.failed() {
+			// A broken pipe, or a client that stopped reading long enough to
+			// trip the rolled write deadline. Either way this connection is
+			// finished; the client's reconnect is the recovery and it already
+			// holds the id to resume from.
+			return
+		}
+
+		// A FULL BATCH MEANS THERE IS MORE, so the backlog drains at read speed
+		// instead of one batch per tick. Only a short read waits: that is the
+		// caught-up state, and it is the only state in which this loop sleeps.
+		//
+		// EVERY PASS CHECKS FOR THE EXIT, though, including the draining ones.
+		// A consumer resuming from a week-old checkpoint drains hundreds of
+		// batches back to back, and a loop that only looked at the client and
+		// the shutdown signal on the branch that sleeps would ignore both for
+		// the whole backlog — writing records to a client that hung up long ago,
+		// and holding a graceful shutdown past its drain budget for a stream
+		// nobody is reading. The non-blocking check costs one select per pass.
+		if len(page.Rows) == eventsWatchBatch {
+			select {
+			case <-ctx.Done():
+				return
+			case <-s.closing:
+				return
+			default:
+			}
+		} else {
+			select {
+			case <-ctx.Done():
+				return
+			case <-s.closing:
+				// Graceful shutdown. Returning here is what lets the drain
+				// finish: http.Server.Shutdown waits for active requests, and a
+				// stream that waited for the client to leave would hold every
+				// shutdown open for the whole drain timeout.
+				return
+			case <-poll.C:
+				poll.Reset(watchPollDelay(interval))
+			}
+		}
+
+		var err error
+		page, err = s.readWatchBatch(ctx, passes, journal, since)
+		if err == nil {
+			continue
+		}
+
+		var truncated *storage.EventsJournalTruncatedError
+		switch {
+		case errors.Is(err, ErrBusy):
+			// Slot pressure, not a fault. The refused read left `page` empty, so
+			// the loop simply sleeps and asks again on the next tick. Ending the
+			// stream here would turn a busy minute into a reconnect from every
+			// consumer at once, which is the load the semaphore just refused.
+		case errors.As(err, &truncated):
+			stream.truncate(truncatedFrame(rec, truncated))
+			return
+		case errors.Is(err, context.Canceled):
+			// The client hung up mid-read. Not a server fault and not worth an
+			// error line — the same judgement failErr makes.
+			return
+		default:
+			s.event("events_watch_failed", "request_id", rec.id, "since", since, "error", err.Error())
+			return
+		}
+	}
+}
+
+// readWatchBatch performs one pass of the loop's read, holding a database slot
+// for exactly as long as the read takes.
+//
+// A STREAM MUST NOT HOLD A SLOT WHILE IT WAITS. There are sixteen and this
+// server admits sixty-four streams; one slot per open stream would let a
+// handful of idle consumers starve every other operation on the server for
+// hours, with /healthz green throughout. Taking the slot per read keeps the
+// invariant the semaphore exists for — nothing touches the database without one
+// — while charging a stream only for the moments it actually does.
+//
+// The read carries its own deadline for the same reason the route's per-request
+// one exists. That deadline does not apply to this operation (the response has
+// no bounded length), so without one here a wedged database would park a read,
+// and its slot, for the life of a connection nobody is watching. It is a
+// shorter budget than the route's, and eventsWatchReadDeadline says why.
+func (s *Server) readWatchBatch(ctx context.Context, rec *reqInfo, journal storage.EventsJournalCursor, since int64) (storage.EventsJournalPage, error) {
+	release, err := s.acquire(ctx, rec)
+	if err != nil {
+		return storage.EventsJournalPage{}, err
+	}
+	defer release()
+
+	readCtx, cancel := context.WithTimeout(ctx, eventsWatchReadDeadline)
+	defer cancel()
+	return journal.ReadEventsJournalPage(readCtx, since, eventsWatchBatch)
+}
+
+// watchPollDelay spreads one stream's next read around the poll interval, by up
+// to a tenth of it either way.
+//
+// Streams synchronize by themselves and there is nothing random to break the
+// tie: every consumer reconnecting after a restart is handed the same `retry`
+// delay, so they come back together and, on a fixed interval, read together
+// forever after — one burst of up to maxWatchStreams reads per second against a
+// semaphore that admits sixteen. Jittering every wait rather than only the first
+// keeps them spread even after a pass that took longer than its interval.
+//
+// crypto/rand because it is the one source in this process that needs no seed
+// and no justification; the cost is a two-byte read once per stream per second.
+// A failed read falls back to the flat interval, which is the behavior this
+// function is improving on rather than depending on.
+func watchPollDelay(interval time.Duration) time.Duration {
+	span := interval / 5
+	if span <= 0 {
+		return interval
+	}
+	var b [2]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return interval
+	}
+	offset := time.Duration(int64(span) * int64(binary.BigEndian.Uint16(b[:])) / (1 << 16))
+	return interval - span/2 + offset
+}
+
+// clearRequestReadDeadline drops http.Server.ReadTimeout for this request.
+//
+// ReadTimeout is a deadline on the WHOLE request, and net/http keeps a
+// background read running on the connection while a handler writes — the read
+// that notices a disconnect. When that read hits the deadline, net/http treats
+// it as a dead connection and CANCELS the request context, so a stream would end
+// itself at ReadTimeout with no client involved and nothing in the log to say
+// why. Clearing it is per-request: the next request on a reused connection gets
+// its deadlines set fresh.
+//
+// It does not weaken disconnect detection. A client that goes away still
+// produces a read error, which still cancels the context; what is lost is only
+// the TIME limit, which is the thing SSE requires — a healthy consumer sends
+// nothing for the life of its stream. A peer that vanishes without a FIN or RST
+// is reaped by TCP keepalive, which Go's listener enables by default (see the
+// note in engdocs/SERVE_RUNBOOK.md for the measured window).
+//
+// The WRITE deadline needs no such handling and must not be cleared:
+// statusWriter rolls it forward immediately before every write, so it bounds one
+// stalled write rather than the stream, which is exactly right here.
+//
+// The error is dropped for the reason extendWriteDeadline drops its own: a
+// ResponseWriter with no connection under it (httptest's recorder) has no
+// deadline to clear and nothing to time out.
+func clearRequestReadDeadline(w http.ResponseWriter) {
+	_ = http.NewResponseController(w).SetReadDeadline(time.Time{})
+}
+
+// truncatedFrame is the body the mid-stream `truncated` event carries: the
+// EXACT problem document the connect-time 410 would have carried, request id
+// and all.
+//
+// One shape rather than two. A consumer meets this condition on both surfaces —
+// a 410 when it reconnects, this event when a prune races an open stream — and
+// a second encoding of the same three numbers is a second contract to keep in
+// step. Whatever handles the 410 handles this, unchanged.
+func truncatedFrame(rec *reqInfo, err *storage.EventsJournalTruncatedError) []byte {
+	res := EventsJournalTruncated(err).WithRequestID(rec.id)
+	body, marshalErr := json.Marshal(res.Problem)
+	if marshalErr != nil {
+		// Unreachable: apigen.Problem is plain data. The stream still has to
+		// end, and it ends with something a consumer can parse as this event.
+		return []byte(`{"code":"` + string(CodeEventsJournalTruncated) + `"}`)
+	}
+	return body
+}
+
+// admitWatchStream reserves one of the concurrent-stream slots, or reports that
+// this server is already holding as many as it will.
+//
+// The counter is incremented FIRST and rolled back on refusal, rather than
+// compared and then incremented: two connects arriving together would both read
+// the same count and both be admitted, which is how a cap ends up being
+// advisory. The release the caller defers is the only decrement, so it runs on
+// every exit path a stream has.
+func (s *Server) admitWatchStream(rec *reqInfo) (release func(), admitted bool) {
+	limit := int64(maxWatchStreams)
+	if s.maxWatchStreams > 0 {
+		limit = int64(s.maxWatchStreams)
+	}
+	live := s.watchStreams.Add(1)
+	if live > limit {
+		s.watchStreams.Add(-1)
+		s.event("events_watch_saturated", "request_id", rec.id, "streams", live-1, "max_streams", limit)
+		return nil, false
+	}
+	// The gauge on ADMISSION, not only on refusal. Streams accumulate over hours
+	// and the refusal is the cliff; a line per connect carrying the live count
+	// against the limit is what lets an operator watch the approach instead of
+	// discovering it from a consumer's 503. One line per stream, not per record.
+	s.event("events_watch_admitted", "request_id", rec.id, "streams", live, "max_streams", limit)
+	return func() { s.watchStreams.Add(-1) }, true
+}
+
+// canFlush reports whether w can push bytes to the client before the handler
+// returns, without writing anything to find out.
+//
+// http.ResponseController answers the same question, but only by attempting a
+// Flush — which writes the header and spends the status. This surface has to
+// know before it decides between a 200 stream and a 500, so it walks the
+// wrapper chain the same way the controller does. The bound is against a writer
+// whose Unwrap returns itself; net/http's own walk is unbounded, and a hang in
+// a handler is worse than a missed capability.
+func canFlush(w http.ResponseWriter) bool {
+	for range 8 {
+		if _, ok := w.(http.Flusher); ok {
+			return true
+		}
+		unwrapper, ok := w.(interface{ Unwrap() http.ResponseWriter })
+		if !ok {
+			return false
+		}
+		w = unwrapper.Unwrap()
+	}
+	return false
+}
+
+// eventStream frames one text/event-stream response.
+//
+// It remembers the FIRST write error and turns every later call into a no-op,
+// so the loop above reads like the happy path and still stops at the first
+// broken pipe. There is no buffering: each frame is written and flushed on its
+// way out, because a record held back is a record the consumer has not seen.
+type eventStream struct {
+	w  http.ResponseWriter
+	rc *http.ResponseController
+	// note records a condition the response itself cannot report, because the
+	// status is spent. Exactly one thing uses it — see record — and write
+	// failures deliberately do not: a client hanging up is ordinary and is not a
+	// server event.
+	note func(name string, kv ...any)
+	err  error
+}
+
+func newEventStream(w http.ResponseWriter, note func(name string, kv ...any)) *eventStream {
+	return &eventStream{w: w, rc: http.NewResponseController(w), note: note}
+}
+
+// open writes the response headers and the reconnection delay, and flushes them
+// so a client's connect completes before the first record exists.
+func (e *eventStream) open(retryMillis int) {
+	h := e.w.Header()
+	h.Set("Content-Type", "text/event-stream; charset=utf-8")
+	// Buffering is the one intermediary behavior that silently defeats a
+	// stream: a reverse proxy that accumulates the response delivers every
+	// record at once, late. This is the de-facto header for turning it off.
+	//
+	// Cache-Control is deliberately NOT set here. withRequestContext already
+	// sets `no-store` on every response, which forbids storing the body at all
+	// — strictly stronger than the `no-cache` an SSE example usually shows —
+	// and a second, weaker value would be the only thing this operation
+	// disagreed with the rest of the surface about.
+	h.Set("X-Accel-Buffering", "no")
+
+	// The request read deadline is already gone — clearRequestReadDeadline runs
+	// before the connect read, so that read is bounded by its own deadline and
+	// not by the residue of http.Server.ReadTimeout. Nothing to do here.
+	e.w.WriteHeader(http.StatusOK)
+	e.write(fmt.Sprintf("retry: %d\n\n", retryMillis))
+	e.flush()
+}
+
+// record emits one journal record as one SSE event, and reports whether the
+// stream is still writable.
+//
+// `id:` IS THE CURSOR. It carries the record's seq, which is what a client
+// sends back as Last-Event-ID and what it would have passed as `since` while
+// polling — one checkpoint, three spellings, all the same number.
+//
+// The event is UNNAMED on purpose: the default `message` type is what a bare
+// `es.onmessage` receives, so the ordinary case needs no listener registration
+// at all. The one named event on this stream is `truncated`, and naming only
+// the exception is what lets a consumer treat "an event I do not recognize" as
+// "stop, this is not a record".
+//
+// ONE `data:` LINE, ALWAYS. An SSE frame is line-oriented and a raw newline
+// inside a data line would split one record into two, so the guarantee has to
+// come from the encoding rather than from hope: this is encoding/json output,
+// and the encoder escapes every control character — including U+000A and
+// U+000D — inside every string it writes. The payload members travel as
+// json.RawMessage, so they are not re-encoded here; they are themselves the
+// output of a marshaler for the same reason.
+// TestEventsWatchFramesEveryRecordOnOneLine drives a record whose payloads
+// carry literal newlines and carriage returns and pins that the frame stays one
+// line.
+func (e *eventStream) record(row storage.EventsJournalRow) bool {
+	if e.err != nil {
+		return false
+	}
+	encoded, err := json.Marshal(eventsjournal.NewRecord(row))
+	if err != nil {
+		// Unreachable for a well-formed row, and there is no way to tell the
+		// CLIENT: the 200 is long since on the wire. So it goes in the log
+		// naming the seq, because the alternative is the worst diagnosis on this
+		// surface — a stream that ends silently, and ends again at the same
+		// record on every reconnect, with nothing anywhere to say which row is
+		// unencodable. Ending the stream is still the right behavior; skipping
+		// the record would be silent loss.
+		e.note("events_watch_failed", "seq", row.Seq, "error", err.Error())
+		e.err = err
+		return false
+	}
+	e.write(fmt.Sprintf("id: %d\ndata: %s\n\n", row.Seq, encoded))
+	return e.err == nil
+}
+
+// comment emits a line no consumer sees: an SSE comment, which exists to put
+// bytes on an idle connection.
+func (e *eventStream) comment(text string) {
+	e.write(": " + text + "\n\n")
+	e.flush()
+}
+
+// truncate ends the stream with the one named event it can emit.
+//
+// The reconnection delay is RAISED FIRST, and the order matters: a client that
+// reconnects on this event reaches the connect-time 410 and can do nothing
+// about it, so the last instruction this server gets to give is "come back
+// slowly". A consumer that handles the event properly stops and re-baselines
+// and never spends the delay.
+func (e *eventStream) truncate(body []byte) {
+	e.write(fmt.Sprintf("retry: %d\n\n", eventsWatchTruncatedRetry))
+	e.write(fmt.Sprintf("event: truncated\ndata: %s\n\n", body))
+	e.flush()
+}
+
+func (e *eventStream) write(frame string) {
+	if e.err != nil {
+		return
+	}
+	// gosec's taint analysis flags every direct write to a ResponseWriter as a
+	// possible XSS sink because it cannot see a Content-Type. It is
+	// text/event-stream here, set in open, which no browser parses as a
+	// document: EventSource hands the data to script as a string and renders
+	// nothing. The only caller-derived value that reaches these frames is a
+	// journal record, and it arrives as encoding/json output.
+	//nolint:gosec // G705: text/event-stream body, JSON-encoded content, no HTML sink.
+	if _, err := fmt.Fprint(e.w, frame); err != nil {
+		e.err = err
+	}
+}
+
+func (e *eventStream) flush() {
+	if e.err != nil {
+		return
+	}
+	if err := e.rc.Flush(); err != nil {
+		e.err = err
+	}
+}
+
+// failed reports whether a write has already failed, which is the loop's signal
+// that this connection is over.
+func (e *eventStream) failed() bool { return e.err != nil }

--- a/internal/httpapi/events_watch_test.go
+++ b/internal/httpapi/events_watch_test.go
@@ -1,0 +1,1136 @@
+package httpapi
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+// The journal stream. Half of these cases are about the boundary the poll read
+// does not have: a response whose status is spent while it is still deciding
+// things. Everything before the first byte must be the paged read's answer
+// exactly — the same 400s, the same 409, the same 410 — and the one condition
+// that can arrive after it has to be reportable in band without a consumer
+// mistaking it for a record.
+
+// liveEventsJournal is a journal a case can WRITE to while a stream is open. It
+// is the difference between testing a stream and testing a snapshot: the
+// records that matter here are the ones that did not exist when the client
+// connected.
+type liveEventsJournal struct {
+	mu   sync.Mutex
+	rows []storage.EventsJournalRow
+	// floor is the lowest seq still retained. Zero means nothing was pruned;
+	// setting it is what a prune racing an open stream looks like from here.
+	floor int64
+	// head is the highest seq ever assigned, which survives a prune. It is
+	// tracked separately from the rows for that reason.
+	head  int64
+	reads int
+}
+
+func (j *liveEventsJournal) ReadEventsJournalPage(_ context.Context, since int64, limit int) (storage.EventsJournalPage, error) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	j.reads++
+
+	if j.floor > 0 && since < j.floor-1 {
+		return storage.EventsJournalPage{}, &storage.EventsJournalTruncatedError{
+			Since: since, Floor: j.floor, Head: j.head,
+		}
+	}
+	page := storage.EventsJournalPage{Head: j.head}
+	for _, row := range j.rows {
+		if row.Seq <= since {
+			continue
+		}
+		page.Rows = append(page.Rows, row)
+		if len(page.Rows) == limit {
+			break
+		}
+	}
+	return page, nil
+}
+
+// commit appends one record, as a mutation landing on the served workspace
+// would. It returns the seq it assigned.
+func (j *liveEventsJournal) commit(row storage.EventsJournalRow) int64 {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	j.head++
+	row.Seq = j.head
+	if row.TS == "" {
+		row.TS = "2026-01-02T03:04:05Z"
+	}
+	if row.Op == "" {
+		row.Op = "create"
+	}
+	if row.IssueID == "" {
+		row.IssueID = fmt.Sprintf("bd-%d", row.Seq)
+	}
+	if row.IssueJSON == "" {
+		row.IssueJSON = fmt.Sprintf(`{"id":%q}`, row.IssueID)
+	}
+	j.rows = append(j.rows, row)
+	return row.Seq
+}
+
+// prune drops everything below floor, exactly as `bd events prune` does — and,
+// for these cases, exactly while somebody is reading.
+func (j *liveEventsJournal) prune(floor int64) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	j.floor = floor
+	kept := j.rows[:0]
+	for _, row := range j.rows {
+		if row.Seq >= floor {
+			kept = append(kept, row)
+		}
+	}
+	j.rows = kept
+}
+
+func (j *liveEventsJournal) readCount() int {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return j.reads
+}
+
+// endlessEventsJournal always answers a FULL batch, which is the backlog case:
+// a consumer resuming from a week-old checkpoint drains hundreds of these back
+// to back and the loop never sleeps between them.
+//
+// It refuses after a bounded number of reads so that an implementation which
+// ignores its exits fails a count rather than spinning for the rest of the test
+// binary's life.
+type endlessEventsJournal struct {
+	mu    sync.Mutex
+	reads int
+}
+
+const endlessJournalReadCap = 5000
+
+func (j *endlessEventsJournal) ReadEventsJournalPage(_ context.Context, since int64, limit int) (storage.EventsJournalPage, error) {
+	j.mu.Lock()
+	j.reads++
+	runaway := j.reads > endlessJournalReadCap
+	j.mu.Unlock()
+	if runaway {
+		return storage.EventsJournalPage{}, errors.New("endless journal read cap reached")
+	}
+
+	rows := make([]storage.EventsJournalRow, 0, limit)
+	for i := range limit {
+		seq := since + int64(i) + 1
+		rows = append(rows, storage.EventsJournalRow{
+			Seq: seq, TS: "2026-01-02T03:04:05Z", Op: "create",
+			IssueID: fmt.Sprintf("bd-%d", seq), IssueJSON: fmt.Sprintf(`{"id":"bd-%d"}`, seq),
+		})
+	}
+	return storage.EventsJournalPage{Rows: rows, Head: since + int64(limit) + 1}, nil
+}
+
+func (j *endlessEventsJournal) readCount() int {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return j.reads
+}
+
+// discardWriter is a flushable ResponseWriter that keeps nothing, for the cases
+// that stream a backlog nobody reads.
+type discardWriter struct{ header http.Header }
+
+func (d *discardWriter) Header() http.Header {
+	if d.header == nil {
+		d.header = http.Header{}
+	}
+	return d.header
+}
+func (d *discardWriter) Write(b []byte) (int, error) { return len(b), nil }
+func (d *discardWriter) WriteHeader(int)             {}
+func (d *discardWriter) Flush()                      {}
+
+// watchServer stands up a roles-backed server over one live journal with the
+// cadences shrunk to milliseconds, so a case waits for a heartbeat in the time
+// it takes to run rather than in the time it takes to matter.
+func watchServer(t *testing.T, journal storage.EventsJournalCursor, tune ...func(*Server)) *testServer {
+	t.Helper()
+	tune = append([]func(*Server){func(s *Server) {
+		s.watchPoll = 5 * time.Millisecond
+		s.watchBeat = 40 * time.Millisecond
+	}}, tune...)
+	return newTestServer(t, rolesConfig(Config{EventsJournal: journal, EventsJournalEnabled: true}), tune...)
+}
+
+// watchStream is one open stream plus the handle a case uses to hang up.
+type watchStream struct {
+	resp   *http.Response
+	frames *bufio.Reader
+	cancel context.CancelFunc
+}
+
+// openWatch connects, and fails the case if the connect itself was refused —
+// the refusal legs open their streams with rawWatch instead.
+func openWatch(t *testing.T, ts *testServer, path string, header http.Header) *watchStream {
+	t.Helper()
+	ws := rawWatch(t, ts, path, header)
+	if ws.resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s = %d, want 200: %s", path, ws.resp.StatusCode, readAll(t, ws.resp))
+	}
+	if got := ws.resp.Header.Get("Content-Type"); got != "text/event-stream; charset=utf-8" {
+		t.Errorf("Content-Type = %q, want text/event-stream; charset=utf-8", got)
+	}
+	return ws
+}
+
+// rawWatch issues the request and returns whatever came back, streaming.
+//
+// The request carries its own generous deadline so that a stream this server
+// forgets to end fails the case instead of hanging it, and its cancel is what
+// stands in for a client hanging up.
+func rawWatch(t *testing.T, ts *testServer, path string, header http.Header) *watchStream {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.base+path, nil)
+	if err != nil {
+		cancel()
+		t.Fatalf("new request: %v", err)
+	}
+	for k, vs := range header {
+		for _, v := range vs {
+			req.Header.Add(k, v)
+		}
+	}
+	// A client with no whole-response timeout: the response is the point and it
+	// never completes on its own.
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		cancel()
+		t.Fatalf("GET %s: %v", path, err)
+	}
+	t.Cleanup(func() {
+		cancel()
+		_ = resp.Body.Close()
+	})
+	return &watchStream{resp: resp, frames: bufio.NewReader(resp.Body), cancel: cancel}
+}
+
+// next reads one SSE frame: the lines up to the blank line that terminates it.
+// The trailing newlines are stripped so a case asserts on the frame's content.
+func (ws *watchStream) next(t *testing.T) string {
+	t.Helper()
+	var frame []string
+	for {
+		line, err := ws.frames.ReadString('\n')
+		if err != nil {
+			t.Fatalf("reading the stream after %q: %v", strings.Join(frame, "\\n"), err)
+		}
+		if line == "\n" {
+			return strings.Join(frame, "\n")
+		}
+		frame = append(frame, strings.TrimSuffix(line, "\n"))
+	}
+}
+
+// closed reports that the server ended the stream, which is what the truncated
+// event promises and the only clean end this operation has.
+func (ws *watchStream) closed(t *testing.T) {
+	t.Helper()
+	if _, err := ws.frames.ReadString('\n'); err == nil {
+		t.Error("the stream is still open; a truncated event must be the last thing on it")
+	}
+}
+
+// dataOf pulls the `data:` payload out of a frame, which is where every
+// assertion about content lands.
+func dataOf(t *testing.T, frame string) string {
+	t.Helper()
+	for _, line := range strings.Split(frame, "\n") {
+		if rest, ok := strings.CutPrefix(line, "data: "); ok {
+			return rest
+		}
+	}
+	t.Fatalf("frame has no data line: %q", frame)
+	return ""
+}
+
+// TestEventsWatchDeliversRecordsAsTheyLand is the operation's reason to exist,
+// and the mutations happen AFTER the connect deliberately: a stream that only
+// replayed what already existed would pass every assertion a poll read passes
+// and none of the ones that matter.
+func TestEventsWatchDeliversRecordsAsTheyLand(t *testing.T) {
+	journal := &liveEventsJournal{}
+	ts := watchServer(t, journal)
+
+	ws := openWatch(t, ts, "/v0/beads/events:watch?since=0", nil)
+
+	// The reconnection delay leads, before any record exists, so a client's
+	// backoff is set even if the stream carries nothing for an hour.
+	if got, want := ws.next(t), fmt.Sprintf("retry: %d", eventsWatchRetry); got != want {
+		t.Fatalf("first frame = %q, want %q", got, want)
+	}
+
+	for i := range 3 {
+		journal.commit(storage.EventsJournalRow{IssueID: fmt.Sprintf("bd-live-%d", i)})
+	}
+
+	for i := range 3 {
+		frame := ws.next(t)
+		wantID := fmt.Sprintf("id: %d", i+1)
+		if !strings.HasPrefix(frame, wantID+"\n") {
+			t.Fatalf("frame %d = %q, want it to lead with %q", i, frame, wantID)
+		}
+		// UNNAMED, so a bare onmessage receives it. The one named event on this
+		// stream is the failure.
+		if strings.Contains(frame, "event: ") {
+			t.Errorf("record frame %d names an event type: %q", i, frame)
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(dataOf(t, frame)), &rec); err != nil {
+			t.Fatalf("frame %d data is not JSON: %v", i, err)
+		}
+		// id AND seq, because the whole resume contract is that they are the
+		// same number: the id is what a client sends back as Last-Event-ID.
+		if seq, _ := rec["seq"].(float64); int(seq) != i+1 {
+			t.Errorf("frame %d seq = %v, want %d", i, rec["seq"], i+1)
+		}
+		if got := rec["issue_id"]; got != fmt.Sprintf("bd-live-%d", i) {
+			t.Errorf("frame %d issue_id = %v", i, got)
+		}
+		if _, ok := rec["issue"]; !ok {
+			t.Errorf("frame %d has no `issue` member; the envelope is the paged read's", i)
+		}
+		if _, ok := rec["dep"]; ok {
+			t.Errorf("frame %d carries `dep` on a create", i)
+		}
+	}
+}
+
+// TestEventsWatchFramesEveryRecordOnOneLine is the framing invariant, and it is
+// asserted against payloads that would break it if the encoding were not what
+// this handler claims.
+//
+// A raw newline inside a `data:` line splits one record into two frames, and a
+// raw carriage return does the same (an SSE line ends at CR, LF or CRLF) — so a
+// payload carrying either would either corrupt the stream or, worse, let a
+// crafted issue title inject an `event:` line of its own. The defense is that
+// records are encoding/json output and the encoder escapes every control
+// character; this drives exactly that case rather than trusting it.
+func TestEventsWatchFramesEveryRecordOnOneLine(t *testing.T) {
+	journal := &liveEventsJournal{}
+	ts := watchServer(t, journal)
+
+	ws := openWatch(t, ts, "/v0/beads/events:watch?since=0", nil)
+	ws.next(t) // retry
+
+	// The payload members travel as raw JSON, so this is what a mutation on an
+	// issue whose title contains a newline actually stores.
+	hostile, err := json.Marshal(map[string]string{
+		"id":    "bd-1",
+		"title": "first\nsecond\rthird",
+		"probe": "\n\ndata: {\"seq\":9999}\n\n",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	journal.commit(storage.EventsJournalRow{IssueID: "bd-1", IssueJSON: string(hostile)})
+	journal.commit(storage.EventsJournalRow{IssueID: "bd-2"})
+
+	frame := ws.next(t)
+	lines := strings.Split(frame, "\n")
+	if len(lines) != 2 {
+		t.Fatalf("frame is %d lines, want exactly id: and data:\n%q", len(lines), frame)
+	}
+	var rec struct {
+		Issue json.RawMessage `json:"issue"`
+	}
+	if err := json.Unmarshal([]byte(dataOf(t, frame)), &rec); err != nil {
+		t.Fatalf("data is not JSON: %v", err)
+	}
+	// The payload survives byte for byte, which is the other half: escaping must
+	// not renormalize what the mutation stored.
+	if string(rec.Issue) != string(hostile) {
+		t.Errorf("issue payload = %s, want it unchanged: %s", rec.Issue, hostile)
+	}
+	// And nothing the payload contained became a frame of its own: the very next
+	// frame is the record that was committed after it, not the `data:` line the
+	// payload spelled out.
+	if got := ws.next(t); !strings.HasPrefix(got, "id: 2\n") {
+		t.Errorf("next frame = %q, want the following record; the hostile payload leaked frames into the stream", got)
+	}
+}
+
+// TestEventsWatchHeartbeatsWhileIdle. A stream with nothing to say still has to
+// put bytes on the connection: an intermediary that drops an idle connection
+// does it silently, and a client that stopped reading is only discovered by a
+// write that fails.
+func TestEventsWatchHeartbeatsWhileIdle(t *testing.T) {
+	journal := &liveEventsJournal{}
+	ts := watchServer(t, journal)
+
+	ws := openWatch(t, ts, "/v0/beads/events:watch?since=0", nil)
+	ws.next(t) // retry
+
+	if got := ws.next(t); got != ": heartbeat" {
+		t.Fatalf("idle frame = %q, want a heartbeat comment", got)
+	}
+	// A comment, so a consumer that dispatches on event type never sees it.
+	if got := ws.next(t); !strings.HasPrefix(got, ":") {
+		t.Errorf("second idle frame = %q, want another comment", got)
+	}
+
+	// And a record still arrives on a stream that has been heartbeating.
+	journal.commit(storage.EventsJournalRow{IssueID: "bd-after-beat"})
+	for {
+		frame := ws.next(t)
+		if strings.HasPrefix(frame, ":") {
+			continue
+		}
+		if !strings.HasPrefix(frame, "id: 1\n") {
+			t.Fatalf("frame after the heartbeats = %q, want the record", frame)
+		}
+		return
+	}
+}
+
+// TestEventsWatchLastEventIDOutranksSince is the browser contract. An
+// EventSource reconnects to the URL it was constructed with — carrying the
+// ORIGINAL `since` — and attaches the id it actually reached. A server that
+// preferred the parameter would re-deliver everything since the consumer
+// started, on every reconnect, forever.
+func TestEventsWatchLastEventIDOutranksSince(t *testing.T) {
+	journal := &liveEventsJournal{}
+	ts := watchServer(t, journal)
+	for range 5 {
+		journal.commit(storage.EventsJournalRow{})
+	}
+
+	ws := openWatch(t, ts, "/v0/beads/events:watch?since=0",
+		http.Header{lastEventIDHeader: []string{"3"}})
+	ws.next(t) // retry
+
+	if got := ws.next(t); !strings.HasPrefix(got, "id: 4\n") {
+		t.Fatalf("first frame = %q, want the record after the header's id", got)
+	}
+	if got := ws.next(t); !strings.HasPrefix(got, "id: 5\n") {
+		t.Errorf("second frame = %q, want seq 5", got)
+	}
+}
+
+// TestEventsWatchTreatsAnEmptyLastEventIDAsAbsent is the polarity that must NOT
+// be a refusal, and it is a real client shape rather than a hypothetical: an
+// intermediary or a hand-rolled client that always sets the header sends it
+// empty on the first connect, when there is no id yet. Killing that connect
+// would refuse the one request the header exists to make work, so an empty value
+// means "no id" and `since` decides — the same thing the header being absent
+// means, because it says the same thing.
+func TestEventsWatchTreatsAnEmptyLastEventIDAsAbsent(t *testing.T) {
+	journal := &liveEventsJournal{}
+	ts := watchServer(t, journal)
+	for range 3 {
+		journal.commit(storage.EventsJournalRow{})
+	}
+
+	ws := openWatch(t, ts, "/v0/beads/events:watch?since=1",
+		http.Header{lastEventIDHeader: []string{""}})
+	ws.next(t) // retry
+
+	if got := ws.next(t); !strings.HasPrefix(got, "id: 2\n") {
+		t.Fatalf("first frame = %q, want the record after `since`; an empty header must not override it", got)
+	}
+}
+
+// TestEventsWatchRefusesAnUnusableLastEventID. A client that invented its own
+// id has a broken checkpoint; falling back to `since` would hand it a stream
+// that looks correct and starts in the wrong place, and it would never find
+// out.
+func TestEventsWatchRefusesAnUnusableLastEventID(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		id   string
+	}{
+		{name: "not a number", id: "abc"},
+		{name: "negative", id: "-1"},
+		{name: "fractional", id: "4.5"},
+		{name: "a uuid, as a different producer would mint", id: "0f8fad5b-d9cb-469f-a165-70867728950e"},
+		{name: "hexadecimal", id: "0x4"},
+		// A seq is int64 in the document and in storage; a value past that range
+		// is a broken checkpoint, not a very patient consumer.
+		{name: "past int64", id: "99999999999999999999"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			journal := &liveEventsJournal{}
+			ts := watchServer(t, journal)
+
+			ws := rawWatch(t, ts, "/v0/beads/events:watch?since=0",
+				http.Header{lastEventIDHeader: []string{tc.id}})
+			if ws.resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400", ws.resp.StatusCode)
+			}
+			body := decodeBody(t, ws.resp)
+			if got := body["code"]; got != string(CodeInvalidArgument) {
+				t.Errorf("code = %v, want %q", got, CodeInvalidArgument)
+			}
+			// `param` names the HEADER, because that is what the client has to
+			// fix; naming `since` would send it after the wrong input.
+			if got := body["param"]; got != lastEventIDHeader {
+				t.Errorf("param = %v, want %q", got, lastEventIDHeader)
+			}
+			if n := journal.readCount(); n != 0 {
+				t.Errorf("the journal was read %d times for a refused stream, want 0", n)
+			}
+		})
+	}
+}
+
+// TestEventsWatchRefusesABadCheckpoint: `since` is required on every connect,
+// including the reconnect that also carries a valid header. One rule with two
+// spellings is the kind of thing a client discovers in production.
+func TestEventsWatchRefusesABadCheckpoint(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		query  string
+		header http.Header
+	}{
+		{name: "absent", query: ""},
+		{name: "negative", query: "?since=-1"},
+		{name: "not a number", query: "?since=abc"},
+		{name: "unknown parameter", query: "?since=0&follow=true"},
+		{
+			name:   "absent even with a usable Last-Event-ID",
+			query:  "",
+			header: http.Header{lastEventIDHeader: []string{"7"}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			journal := &liveEventsJournal{}
+			ts := watchServer(t, journal)
+
+			ws := rawWatch(t, ts, "/v0/beads/events:watch"+tc.query, tc.header)
+			if ws.resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400: %s", ws.resp.StatusCode, readAll(t, ws.resp))
+			}
+			if got := decodeBody(t, ws.resp)["code"]; got != string(CodeInvalidArgument) {
+				t.Errorf("code = %v, want %q", got, CodeInvalidArgument)
+			}
+		})
+	}
+}
+
+// TestEventsWatchRefusesWhenTheJournalIsDisabled. A stream over a workspace
+// that records nothing is a connection held open forever against a journal that
+// will never emit, which is worse than the paged read's version of the same
+// mistake rather than better.
+func TestEventsWatchRefusesWhenTheJournalIsDisabled(t *testing.T) {
+	journal := &liveEventsJournal{}
+	ts := newTestServer(t, rolesConfig(Config{EventsJournal: journal, EventsJournalEnabled: false}))
+
+	ws := rawWatch(t, ts, "/v0/beads/events:watch?since=0", nil)
+	if ws.resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status = %d, want 409: %s", ws.resp.StatusCode, readAll(t, ws.resp))
+	}
+	if got := decodeBody(t, ws.resp)["code"]; got != string(CodeEventsJournalDisabled) {
+		t.Errorf("code = %v, want %q", got, CodeEventsJournalDisabled)
+	}
+	if n := journal.readCount(); n != 0 {
+		t.Errorf("the journal was read %d times behind a disabled gate, want 0", n)
+	}
+}
+
+// TestEventsWatchRefusesAStaleCheckpointBeforeOpening is the connect-time half
+// of the truncation contract, and the point is that it is an ORDINARY 410: the
+// status is only spendable before the first byte, so a stale cursor discovered
+// here must never become a 200 that immediately reports its own failure.
+func TestEventsWatchRefusesAStaleCheckpointBeforeOpening(t *testing.T) {
+	journal := &liveEventsJournal{}
+	for range 6 {
+		journal.commit(storage.EventsJournalRow{})
+	}
+	journal.prune(4)
+	ts := watchServer(t, journal)
+
+	ws := rawWatch(t, ts, "/v0/beads/events:watch?since=0", nil)
+	if ws.resp.StatusCode != http.StatusGone {
+		t.Fatalf("status = %d, want 410: %s", ws.resp.StatusCode, readAll(t, ws.resp))
+	}
+	if got := ws.resp.Header.Get("Content-Type"); !strings.HasPrefix(got, "application/problem+json") {
+		t.Errorf("Content-Type = %q, want problem+json — no stream was opened", got)
+	}
+	body := decodeBody(t, ws.resp)
+	if got := body["code"]; got != string(CodeEventsJournalTruncated) {
+		t.Errorf("code = %v, want %q", got, CodeEventsJournalTruncated)
+	}
+	for _, tc := range []struct {
+		member string
+		want   float64
+	}{{"since", 0}, {"floor", 4}, {"head", 6}} {
+		if got := body[tc.member]; got != tc.want {
+			t.Errorf("%s = %v, want %v", tc.member, got, tc.want)
+		}
+	}
+
+	// The header's cursor is the one that gets checked, because it is the one
+	// that would have been used.
+	ws = rawWatch(t, ts, "/v0/beads/events:watch?since=5",
+		http.Header{lastEventIDHeader: []string{"0"}})
+	if ws.resp.StatusCode != http.StatusGone {
+		t.Fatalf("with a stale Last-Event-ID and a live `since`, status = %d, want 410", ws.resp.StatusCode)
+	}
+}
+
+// TestEventsWatchEndsWithATruncatedEventWhenAPruneRacesIt is the one failure
+// this operation can report after its status is spent, and it is the case the
+// whole in-band vocabulary exists for.
+//
+// The stream is already open and 200 when the records it was about to send are
+// deleted. There is no status left to send, so a server that had nothing to say
+// here would either stall silently or skip ahead to the new floor — the silent
+// loss the 410 exists to prevent, wearing a 200.
+func TestEventsWatchEndsWithATruncatedEventWhenAPruneRacesIt(t *testing.T) {
+	journal := &liveEventsJournal{}
+	journal.commit(storage.EventsJournalRow{})
+	ts := watchServer(t, journal)
+
+	ws := openWatch(t, ts, "/v0/beads/events:watch?since=0", nil)
+	ws.next(t) // retry
+	if got := ws.next(t); !strings.HasPrefix(got, "id: 1\n") {
+		t.Fatalf("first record = %q", got)
+	}
+
+	// The prune lands under the open stream, cutting past where it sits.
+	for range 5 {
+		journal.commit(storage.EventsJournalRow{})
+	}
+	journal.prune(5)
+
+	// THE DELAY IS RAISED FIRST. A consumer that ignores the event reconnects
+	// into a connect-time 410 it can never satisfy, so the last instruction this
+	// server gets to give is "come back slowly".
+	if got, want := ws.next(t), fmt.Sprintf("retry: %d", eventsWatchTruncatedRetry); got != want {
+		t.Fatalf("frame before the failure = %q, want %q", got, want)
+	}
+
+	frame := ws.next(t)
+	if !strings.HasPrefix(frame, "event: truncated\n") {
+		t.Fatalf("failure frame = %q, want a named truncated event", frame)
+	}
+	var problem map[string]any
+	if err := json.Unmarshal([]byte(dataOf(t, frame)), &problem); err != nil {
+		t.Fatalf("truncated data is not JSON: %v", err)
+	}
+	// THE SAME BODY THE 410 CARRIES. A consumer meets this condition on both
+	// surfaces, and a second encoding of the same three numbers would be a
+	// second contract to keep in step.
+	if got := problem["code"]; got != string(CodeEventsJournalTruncated) {
+		t.Errorf("code = %v, want %q", got, CodeEventsJournalTruncated)
+	}
+	if got := problem["status"]; got != float64(http.StatusGone) {
+		t.Errorf("status = %v, want 410 — the event carries the refusal it would have been", got)
+	}
+	for _, tc := range []struct {
+		member string
+		want   float64
+	}{{"since", 1}, {"floor", 5}, {"head", 6}} {
+		if got := problem[tc.member]; got != tc.want {
+			t.Errorf("%s = %v, want %v", tc.member, got, tc.want)
+		}
+	}
+	if id, _ := problem["request_id"].(string); id == "" {
+		t.Error("no request_id on the truncated event; it is the only handle on this stream's log line")
+	}
+
+	ws.closed(t)
+}
+
+// TestEventsWatchTruncatedEventCarriesTheGoneBodyExactly makes the sentence
+// above a machine fact rather than a set of assertions that happen to agree
+// with it: the event's data and the 410's body are one encoding of one Result.
+func TestEventsWatchTruncatedEventCarriesTheGoneBodyExactly(t *testing.T) {
+	err := &storage.EventsJournalTruncatedError{Since: 2, Floor: 9, Head: 41}
+	rec := &reqInfo{id: "req-1"}
+
+	inBand := truncatedFrame(rec, err)
+
+	overHTTP := httptest.NewRecorder()
+	Write(overHTTP, EventsJournalTruncated(err).WithRequestID(rec.id))
+
+	// Write's encoder appends the newline that makes a body a line; the SSE
+	// frame cannot carry one, and that is the ONLY difference allowed.
+	if got, want := string(inBand)+"\n", overHTTP.Body.String(); got != want {
+		t.Errorf("the truncated event and the 410 have drifted\n in band: %s\nover HTTP: %s", got, want)
+	}
+}
+
+// TestEventsWatchReleasesItsSlotOnEveryExit. The cap is only a cap if the
+// counter comes back down; a decrement that lived on the happy path would leave
+// a server that has been refusing streams since its last disconnect, and the
+// only symptom is a 503 nobody can explain.
+func TestEventsWatchReleasesItsSlotOnEveryExit(t *testing.T) {
+	journal := &liveEventsJournal{}
+	ts := watchServer(t, journal)
+
+	live := func() int64 { return ts.Server.watchStreams.Load() }
+
+	// A stream the CLIENT ends.
+	ws := openWatch(t, ts, "/v0/beads/events:watch?since=0", nil)
+	ws.next(t)
+	if got := live(); got != 1 {
+		t.Fatalf("open streams = %d, want 1", got)
+	}
+	ws.cancel()
+	waitFor(t, "the disconnected stream to give its slot back", func() bool { return live() == 0 })
+
+	// A stream the SERVER ends, on the truncated path.
+	journal.commit(storage.EventsJournalRow{})
+	ws = openWatch(t, ts, "/v0/beads/events:watch?since=0", nil)
+	ws.next(t)
+	ws.next(t)
+	journal.prune(9)
+	waitFor(t, "the truncated stream to give its slot back", func() bool { return live() == 0 })
+
+	// A stream REFUSED before it opened must not have charged the cap at all.
+	rawWatch(t, ts, "/v0/beads/events:watch?since=-1", nil)
+	if got := live(); got != 0 {
+		t.Errorf("open streams after a refused connect = %d, want 0", got)
+	}
+}
+
+// TestEventsWatchRefusesBeyondTheStreamCap. Streams are the only requests here
+// that last hours, so the limit on how many this process will hold is the one
+// bound that cannot be a deadline — and the refusal has to name a recovery,
+// because "retry" is the wrong advice for a resource that frees on a human
+// timescale.
+func TestEventsWatchRefusesBeyondTheStreamCap(t *testing.T) {
+	journal := &liveEventsJournal{}
+	ts := watchServer(t, journal, func(s *Server) { s.maxWatchStreams = 2 })
+
+	for i := range 2 {
+		ws := openWatch(t, ts, "/v0/beads/events:watch?since=0", nil)
+		if got := ws.next(t); !strings.HasPrefix(got, "retry: ") {
+			t.Fatalf("stream %d did not open: %q", i, got)
+		}
+	}
+
+	refused := rawWatch(t, ts, "/v0/beads/events:watch?since=0", nil)
+	if refused.resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status past the cap = %d, want 503: %s", refused.resp.StatusCode, readAll(t, refused.resp))
+	}
+	if got := refused.resp.Header.Get("Retry-After"); got == "" {
+		t.Error("no Retry-After on a saturated stream cap")
+	}
+	body := decodeBody(t, refused.resp)
+	if got := body["code"]; got != string(CodeEventsWatchSaturated) {
+		t.Errorf("code = %v, want %q", got, CodeEventsWatchSaturated)
+	}
+	// The paged read is the documented way out, and it must keep working while
+	// every stream slot is taken.
+	if detail, _ := body["detail"].(string); !strings.Contains(detail, "/v0/beads/events") {
+		t.Errorf("detail = %q; it must name the read that is not capped this way", detail)
+	}
+	if resp := ts.get(t, "/v0/beads/events?since=0"); resp.StatusCode != http.StatusOK {
+		t.Errorf("the paged read = %d while the stream cap is full, want 200", resp.StatusCode)
+	}
+}
+
+// TestEventsWatchHoldsNoDatabaseSlotBetweenReads is the design this operation
+// could most plausibly have got wrong. There are sixteen slots and sixty-four
+// stream places; a stream that held one for its life would let a handful of
+// idle consumers starve every other operation on the server for hours, with
+// /healthz green throughout.
+//
+// One slot exists here, and it is held by a stream. Every other operation must
+// still answer.
+func TestEventsWatchHoldsNoDatabaseSlotBetweenReads(t *testing.T) {
+	journal := &liveEventsJournal{}
+	ts := watchServer(t, journal, func(s *Server) {
+		s.sem = make(chan struct{}, 1)
+		s.watchPoll = 20 * time.Millisecond
+	})
+
+	ws := openWatch(t, ts, "/v0/beads/events:watch?since=0", nil)
+	ws.next(t)
+	journal.commit(storage.EventsJournalRow{})
+	if got := ws.next(t); !strings.HasPrefix(got, "id: 1\n") {
+		t.Fatalf("the stream is not reading: %q", got)
+	}
+
+	// The paged read needs the same single slot the stream keeps taking and
+	// giving back.
+	if resp := ts.get(t, "/v0/beads/events?since=0"); resp.StatusCode != http.StatusOK {
+		t.Fatalf("a paged read alongside one open stream = %d, want 200: %s",
+			resp.StatusCode, readAll(t, resp))
+	}
+	// And the stream is still live afterwards, so the two are sharing rather
+	// than one having displaced the other.
+	journal.commit(storage.EventsJournalRow{})
+	if got := ws.next(t); !strings.HasPrefix(got, "id: 2\n") {
+		t.Errorf("the stream stopped delivering after a competing read: %q", got)
+	}
+}
+
+// TestTheStreamCapLeavesConnectionHeadroom is the arithmetic that makes the
+// 503 deliverable at all, and it is not obvious from either constant alone.
+//
+// netutil.LimitListener returns a connection slot only when the connection
+// closes — after the handler returns, which is after the stream counter has
+// already come down. So a stream cap AT the connection cap can never be
+// observed: the connect that would have earned the 503 is never accepted, and
+// neither is the paged read the refusal points at, nor a mutation, nor a
+// fresh-connection /healthz. They all park in the kernel accept backlog while
+// the code, the runbook and the user docs promise a status and a retry hint.
+//
+// The relationship is what is pinned, not the number.
+func TestTheStreamCapLeavesConnectionHeadroom(t *testing.T) {
+	if maxWatchStreams >= maxConns {
+		t.Fatalf("maxWatchStreams = %d with maxConns = %d: the stream cap is unreachable, so its 503 can never be delivered and the poll fallback it names cannot be connected to either",
+			maxWatchStreams, maxConns)
+	}
+	if headroom := maxConns - maxWatchStreams; headroom < maxInflight {
+		t.Errorf("stream cap leaves %d connections of headroom, want at least maxInflight (%d) — enough for a full complement of ordinary requests to keep answering while every stream slot is taken",
+			headroom, maxInflight)
+	}
+}
+
+// TestEventsWatchStopsDrainingABacklogWhenAskedTo covers the exit that the
+// sleeping branch does not: a stream draining full batches never waits, so a
+// loop that consulted the client and the shutdown signal only where it sleeps
+// would ignore both for the whole backlog — writing records to a client that
+// hung up long ago, and holding a graceful shutdown past its drain budget.
+//
+// Both stops are asserted the same way and it is deliberately not "the stream
+// ended": it is "the stream ended WITHIN A BATCH OR TWO of being told to". A
+// backlog ends on its own eventually, so only the count separates a loop that
+// listened from one that ran out of records.
+func TestEventsWatchStopsDrainingABacklogWhenAskedTo(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		stop func(s *Server, hangUp context.CancelFunc)
+	}{
+		{name: "the client hangs up", stop: func(_ *Server, hangUp context.CancelFunc) { hangUp() }},
+		{name: "the server shuts down", stop: func(s *Server, _ context.CancelFunc) { s.closeStreams() }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			journal := &endlessEventsJournal{}
+			s := &Server{
+				sem:        make(chan struct{}, 1),
+				semTimeout: 5 * time.Second,
+				closing:    make(chan struct{}),
+				log:        newTestLogger(&lockedBuffer{}),
+			}
+
+			ctx, hangUp := context.WithCancel(context.Background())
+			defer hangUp()
+			req := httptest.NewRequest(http.MethodGet, "/v0/beads/events:watch?since=0", nil).WithContext(ctx)
+			first, err := s.readWatchBatch(ctx, &reqInfo{}, journal, 0)
+			if err != nil {
+				t.Fatalf("connect read: %v", err)
+			}
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				s.streamEvents(&discardWriter{}, req, journal, 0, first)
+			}()
+
+			waitFor(t, "the stream to start draining the backlog", func() bool { return journal.readCount() >= 3 })
+			before := journal.readCount()
+			tc.stop(s, hangUp)
+
+			select {
+			case <-done:
+			case <-time.After(10 * time.Second):
+				t.Fatal("the stream is still draining; it never looked at the exit")
+			}
+			if drained := journal.readCount() - before; drained > 2 {
+				t.Errorf("the stream drained %d more batches after being told to stop, want at most 2 — it is only checking the exit where it sleeps", drained)
+			}
+		})
+	}
+}
+
+// TestWatchPollDelaySpreadsTheInterval. Streams synchronize by themselves and
+// nothing random breaks the tie: consumers reconnecting after a restart are all
+// handed the same `retry`, so they come back together and, on a fixed interval,
+// read together for the life of the process — one burst of up to
+// maxWatchStreams reads per second against a semaphore that admits sixteen.
+func TestWatchPollDelaySpreadsTheInterval(t *testing.T) {
+	const interval = time.Second
+	lo, hi := interval-interval/10, interval+interval/10
+
+	seen := map[time.Duration]bool{}
+	for range 200 {
+		got := watchPollDelay(interval)
+		if got < lo || got > hi {
+			t.Fatalf("watchPollDelay(%s) = %s, want within ±10%%", interval, got)
+		}
+		seen[got] = true
+	}
+	if len(seen) < 50 {
+		t.Errorf("200 draws produced %d distinct delays; streams would still read in lockstep", len(seen))
+	}
+
+	// A degenerate interval must not come back as a zero wait: that would turn
+	// the loop into a spin against the database rather than a poll.
+	for _, interval := range []time.Duration{time.Nanosecond, time.Millisecond, 5 * time.Millisecond} {
+		if got := watchPollDelay(interval); got <= 0 {
+			t.Errorf("watchPollDelay(%s) = %s; a non-positive wait is a spin", interval, got)
+		}
+	}
+}
+
+// TestEventsWatchClosesOnServerShutdown. http.Server.Shutdown waits for active
+// requests without canceling their contexts, so a stream that watched only for
+// its client would hold every graceful shutdown open for the whole drain
+// timeout and then be killed anyway — turning "clean exit" into a twenty-second
+// pause and a forced-close line in the log.
+func TestEventsWatchClosesOnServerShutdown(t *testing.T) {
+	journal := &liveEventsJournal{}
+	stdout := &lockedBuffer{}
+	stderr := &lockedBuffer{}
+	srv, err := Listen(rolesConfig(Config{
+		Addr: "127.0.0.1:0", EventsJournal: journal, EventsJournalEnabled: true,
+		Stdout: stdout, Stderr: stderr,
+	}))
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	srv.watchPoll = 5 * time.Millisecond
+	srv.watchBeat = time.Hour
+
+	ctx, cancel := context.WithCancel(context.Background())
+	served := make(chan error, 1)
+	go func() { served <- srv.Serve(ctx) }()
+
+	base := "http://" + srv.Addr()
+	req, err := http.NewRequest(http.MethodGet, base+"/v0/beads/events:watch?since=0", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	frames := bufio.NewReader(resp.Body)
+	if _, err := frames.ReadString('\n'); err != nil {
+		t.Fatalf("stream did not open: %v", err)
+	}
+
+	cancel()
+	select {
+	case err := <-served:
+		if err != nil {
+			t.Fatalf("Serve: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Serve did not return; the open stream is holding the drain")
+	}
+
+	// The drain completed rather than timing out, which is the whole assertion:
+	// drainTimeout is twenty seconds and this returned in under ten.
+	if log := stderr.String(); strings.Contains(log, "event=shutdown_forced") {
+		t.Errorf("the shutdown was forced, so the stream did not wind up on its own:\n%s", log)
+	}
+	if log := stderr.String(); !strings.Contains(log, "event=shutdown_complete") {
+		t.Errorf("no clean shutdown recorded:\n%s", log)
+	}
+}
+
+// unflushableWriter is a ResponseWriter with no way to push bytes before the
+// handler returns, and no Unwrap to a writer that has one.
+type unflushableWriter struct{ rec *httptest.ResponseRecorder }
+
+func (u unflushableWriter) Header() http.Header         { return u.rec.Header() }
+func (u unflushableWriter) Write(b []byte) (int, error) { return u.rec.Write(b) }
+func (u unflushableWriter) WriteHeader(status int)      { u.rec.WriteHeader(status) }
+
+// TestEventsWatchRefusesAWriterItCannotFlush. Without a flush every record sits
+// in net/http's buffer until it fills or the handler returns, and for this
+// operation the handler never returns — so the stream would look healthy from
+// both ends and deliver nothing. Refusing before the status is spent is what
+// makes that a startup-shaped failure instead of a silent one.
+func TestEventsWatchRefusesAWriterItCannotFlush(t *testing.T) {
+	journal := &liveEventsJournal{}
+	ts := watchServer(t, journal)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v0/beads/events:watch?since=0", nil)
+	ts.Server.handleWatchEvents(unflushableWriter{rec: rec}, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Type"); !strings.HasPrefix(got, "application/problem+json") {
+		t.Errorf("Content-Type = %q, want problem+json", got)
+	}
+	if n := journal.readCount(); n != 0 {
+		t.Errorf("the journal was read %d times for a stream that could not be written, want 0", n)
+	}
+	if got := ts.Server.watchStreams.Load(); got != 0 {
+		t.Errorf("open streams = %d after an unwritable connect, want 0", got)
+	}
+	// httptest.ResponseRecorder DOES flush, so the check has to be able to see
+	// the difference — otherwise this case would pass against a handler that
+	// never looked.
+	if !canFlush(httptest.NewRecorder()) {
+		t.Error("canFlush rejects a recorder; the refusal above proves nothing")
+	}
+}
+
+// deadlineWriter records the read deadlines a handler sets, and flushes, so the
+// stream runs normally around it.
+type deadlineWriter struct {
+	*httptest.ResponseRecorder
+	mu        sync.Mutex
+	deadlines []time.Time
+}
+
+func (d *deadlineWriter) SetReadDeadline(t time.Time) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.deadlines = append(d.deadlines, t)
+	return nil
+}
+
+func (d *deadlineWriter) cleared() bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for _, deadline := range d.deadlines {
+		if deadline.IsZero() {
+			return true
+		}
+	}
+	return false
+}
+
+// deadlineProbeJournal records, for every read it serves, whether the request's
+// read deadline had already been cleared by then. It is how the ORDER of two
+// things in one handler becomes an assertion.
+type deadlineProbeJournal struct {
+	w *deadlineWriter
+
+	mu      sync.Mutex
+	cleared []bool
+}
+
+func (j *deadlineProbeJournal) ReadEventsJournalPage(_ context.Context, _ int64, _ int) (storage.EventsJournalPage, error) {
+	j.mu.Lock()
+	j.cleared = append(j.cleared, j.w.cleared())
+	j.mu.Unlock()
+	return storage.EventsJournalPage{}, nil
+}
+
+func (j *deadlineProbeJournal) clearedAtFirstRead() (bool, bool) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if len(j.cleared) == 0 {
+		return false, false
+	}
+	return j.cleared[0], true
+}
+
+// TestEventsWatchClearsTheRequestReadDeadline is the trap that kills SSE on this
+// server, and it is not the one people look for.
+//
+// There is no WriteTimeout here — statusWriter rolls a per-write deadline
+// instead, which bounds one stalled write rather than a stream. But
+// http.Server.ReadTimeout is a deadline on the WHOLE request, and net/http keeps
+// a background read running on the connection while the handler writes: the read
+// that notices a disconnect. When that read hits the deadline, net/http treats
+// it as a dead connection and cancels the request context — so without this an
+// idle stream would end itself after readTimeout with no client involved and
+// nothing in the log to say why.
+//
+// A wall-clock test would have to wait thirty seconds to see it, so this pins
+// the mechanism: the handler clears the deadline for its own request.
+//
+// WHEN it clears it is the second half, and it is not cosmetic. The connect read
+// happens before any stream byte, and it is the last thing that runs under the
+// inherited ReadTimeout: a database wedged at that moment would have the
+// deadline expire mid-read, which net/http reports by canceling the request
+// context — so the wedge would be booked as `client_closed` and an operator
+// would go looking for a client that never left. The probe journal reports
+// whether the deadline was already gone when the first read reached it.
+func TestEventsWatchClearsTheRequestReadDeadline(t *testing.T) {
+	w := &deadlineWriter{ResponseRecorder: httptest.NewRecorder()}
+	journal := &deadlineProbeJournal{w: w}
+	ts := watchServer(t, journal)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req := httptest.NewRequest(http.MethodGet, "/v0/beads/events:watch?since=0", nil).WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ts.Server.handleWatchEvents(w, req)
+	}()
+
+	waitFor(t, "the stream to clear its read deadline", w.cleared)
+	waitFor(t, "the stream to read the journal", func() bool { _, read := journal.clearedAtFirstRead(); return read })
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the handler did not return after the client went away")
+	}
+
+	cleared, _ := journal.clearedAtFirstRead()
+	if !cleared {
+		t.Error("the connect read ran while the request still carried http.Server.ReadTimeout; a database wedge there is reported as a client disconnect")
+	}
+	if readTimeout <= 0 {
+		t.Fatal("readTimeout is unset, so this handler no longer needs to clear it — delete the clear and this case together")
+	}
+}
+
+// TestStreamingRoutesCarryNoRequestDeadline is the other half of the timeout
+// story, and the half no behavioral test can reach: requestDeadline is sixty
+// seconds, so a stream cut off by it would need a sixty-second case to notice.
+//
+// It drives the lifecycle wrapper directly, with both polarities, because the
+// absence of a deadline is only meaningful against a row that has one.
+func TestStreamingRoutesCarryNoRequestDeadline(t *testing.T) {
+	s := &Server{sem: make(chan struct{}, 1), log: newTestLogger(&lockedBuffer{})}
+
+	deadlineFor := func(rt route) bool {
+		var seen bool
+		rt.handler = func(_ *Server, _ http.ResponseWriter, r *http.Request) {
+			_, seen = r.Context().Deadline()
+		}
+		s.route(rt).ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+		return seen
+	}
+
+	if deadlineFor(route{op: "stream", streaming: true, bypassSemaphore: true}) {
+		t.Error("a streaming row's handler runs under the 60s request deadline; the stream would be severed by it")
+	}
+	if !deadlineFor(route{op: "plain"}) {
+		t.Error("an ordinary row's handler runs with no deadline; the backstop is gone for every operation, not just the stream")
+	}
+}
+
+// waitFor polls cond until it holds, and fails the case rather than hanging
+// when it does not. Everything it waits on here happens in milliseconds; the
+// budget is for a loaded machine, not for the behavior.
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}

--- a/internal/httpapi/problem.go
+++ b/internal/httpapi/problem.go
@@ -111,6 +111,15 @@ const (
 	// still serve, so the recovery (resume from `floor - 1` and accept the gap,
 	// or re-baseline) is a decision the client makes from data rather than prose.
 	CodeEventsJournalTruncated Code = Code(storage.EventsJournalTruncatedCode)
+	// CodeEventsWatchSaturated is this server already holding as many open
+	// journal streams as it will. It is not CodeBusy, even though both are a
+	// 503 with a Retry-After, because the two carry different recoveries: busy
+	// says the database is congested and the same request will work shortly,
+	// while this says a bounded resource is fully subscribed by connections that
+	// may last hours — and the caller has a second recovery available that busy
+	// does not offer, namely the paged read, which holds nothing between
+	// requests and is never refused for this reason.
+	CodeEventsWatchSaturated Code = "events_watch_saturated"
 	// CodeBusy is retryable contention: the transaction retry budget was
 	// exhausted, or the in-flight request limit was saturated.
 	CodeBusy Code = "busy"
@@ -141,6 +150,7 @@ var codeStatus = map[Code]int{
 
 	CodeEventsJournalDisabled:  http.StatusConflict,
 	CodeEventsJournalTruncated: http.StatusGone,
+	CodeEventsWatchSaturated:   http.StatusServiceUnavailable,
 
 	CodeBusy:          http.StatusServiceUnavailable,
 	CodeDBUnavailable: http.StatusServiceUnavailable,
@@ -194,6 +204,12 @@ const (
 	// retryAfterSaturation follows an in-flight-limit wait timeout. Slot
 	// pressure clears quickly.
 	retryAfterSaturation = 1
+	// retryAfterWatchSaturation follows a refused journal stream. Streams are
+	// held for as long as their consumers stay connected — minutes to hours —
+	// so a slot opens on a human timescale rather than a request one, and the
+	// one-second comeback the slot limiter offers would be a busy loop against a
+	// condition that has not changed.
+	retryAfterWatchSaturation = 30
 )
 
 // ErrBusy reports that the in-flight request limiter refused to admit the
@@ -290,11 +306,22 @@ const (
 	// itself assigned, so a consumer's position survives a restart on either
 	// side and is meaningful to `bd events tail` as well.
 	//
-	// It is a READ of a log, not a subscription: v0 has no streaming, no
-	// long-poll and no follow. The retention contract is what makes that safe to
+	// It is a READ of a log, not a subscription: the paged form has no follow
+	// mode and never will. The retention contract is what makes that safe to
 	// publish — a consumer that falls too far behind is told so with
 	// `events_journal_truncated` rather than served a silently shortened history.
 	OpListEvents = "listEvents"
+	// OpWatchEvents pushes the same journal over a held-open text/event-stream
+	// response, resuming from the same checkpoint. It is a sibling of the paged
+	// read rather than a mode of it: the contracts differ in media type,
+	// lifetime, limits and capacity, and one operation carrying both would have
+	// documented two of everything under one operationId.
+	//
+	// It is the surface's ONLY streaming operation, and the only one whose
+	// response can report a failure after its status is written — a prune that
+	// races an open stream arrives as a named event rather than as the 410 the
+	// same condition earns at connect.
+	OpWatchEvents = "watchEvents"
 )
 
 // operationCodes is the per-operation problem vocabulary: exactly the codes
@@ -452,6 +479,21 @@ var operationCodes = map[string][]Code{
 	OpListEvents: {
 		CodeInvalidArgument, CodeEventsJournalDisabled, CodeEventsJournalTruncated,
 		CodeBusy, CodeDBUnavailable, CodeInternal,
+	},
+	// THE PAGED READ'S VOCABULARY PLUS ONE, and the shared part is the point:
+	// every connect-time refusal a poller can earn, a stream earns identically,
+	// because the stream only opens once the same first read has succeeded. The
+	// 410 in particular is a real 410 here and not an in-band event — that
+	// mapping applies to a prune that races an ALREADY OPEN stream, where no
+	// status is left to send.
+	//
+	// events_watch_saturated is the addition, and it is the only code on this
+	// surface that describes a limit on connections rather than on data. Its 503
+	// therefore documents three codes where every other operation's documents
+	// two.
+	OpWatchEvents: {
+		CodeInvalidArgument, CodeEventsJournalDisabled, CodeEventsJournalTruncated,
+		CodeEventsWatchSaturated, CodeBusy, CodeDBUnavailable, CodeInternal,
 	},
 	// NO 404, for a stronger version of the batch create's reason: an edge that
 	// is not there is `removed: false`, and an endpoint id that names nothing
@@ -651,6 +693,18 @@ func EventsJournalDisabled() Result {
 func EventsJournalTruncated(err *storage.EventsJournalTruncatedError) Result {
 	return newResult(CodeEventsJournalTruncated, err.Error()).
 		WithJournalWindow(err.Since, err.Floor, err.Head)
+}
+
+// EventsWatchSaturated builds the 503 for a stream this server will not hold.
+//
+// The detail names the alternative rather than the limit, because unlike every
+// other 503 here this one has a recovery that is not "wait": the paged read
+// answers the same records from the same checkpoint and is not capped this way.
+func EventsWatchSaturated() Result {
+	res := newResult(CodeEventsWatchSaturated,
+		"this server is already holding as many journal streams as it will; retry later, or read the same records from the same checkpoint with GET /v0/beads/events")
+	res.RetryAfterSeconds = retryAfterWatchSaturation
+	return res
 }
 
 // MemoryNotFound builds the 404 for a key this workspace holds no memory under.

--- a/internal/httpapi/routes.go
+++ b/internal/httpapi/routes.go
@@ -98,10 +98,24 @@ type route struct {
 	// ContextResponse.capabilities, or "" for operations outside that
 	// vocabulary. A stub contributes nothing whatever this says.
 	capability string
-	// bypassSemaphore exempts an operation from the database slot limit. Only
-	// legitimate for handlers that touch no database: liveness and identity
-	// must stay answerable while every slot is held by a long scan.
+	// bypassSemaphore exempts an operation from the request-wide database slot.
+	// Legitimate for handlers that touch no database — liveness and identity
+	// must stay answerable while every slot is held by a long scan — and for a
+	// streaming row, which takes a slot around each of its reads instead. It is
+	// never a way to skip the limit while touching the database.
 	bypassSemaphore bool
+	// streaming marks an operation whose response is held open indefinitely
+	// rather than written and finished. Such a row is exempt from
+	// requestDeadline, which for every other operation is the backstop that
+	// stops a request from holding resources forever and here would simply cut
+	// the stream off mid-flight; the handler bounds its own reads and exits on
+	// client disconnect or shutdown (see streamEvents).
+	//
+	// A streaming row must also set bypassSemaphore: holding one of the sixteen
+	// database slots for the life of a connection is the starvation the deadline
+	// used to prevent, so the slot moves to the individual reads.
+	// TestStreamingRowsAreTheDocumentsStreamingOps pins the pair.
+	streaming bool
 	// implemented gates the capability list, so a release between slices never
 	// advertises an operation that does not work. Every v0 operation is
 	// implemented as of the read-endpoints slice; the flag stays because the
@@ -432,6 +446,28 @@ var routeTable = []route{
 		capability:  "events.list",
 		implemented: true,
 		handler:     (*Server).handleListEvents,
+	},
+	{
+		op:     OpWatchEvents,
+		method: http.MethodGet,
+		// A collection-level custom method on the journal, spelled the way
+		// ready:count is: both segments are LITERAL, so pattern and specPath
+		// agree and the router registers the documented path itself.
+		//
+		// It cannot collide with the paged read above — ServeMux matches the
+		// whole path and these two differ — and it is a SIBLING of it rather
+		// than a mode of it deliberately: the two answer different media types
+		// with different lifetimes and different limits, and a `follow=true`
+		// parameter would have made one operation that is two contracts.
+		pattern:    "/v0/beads/events:watch",
+		capability: "events.watch",
+		// The stream lives until the client leaves, so the request deadline
+		// does not apply and the database slot moves to the individual reads.
+		// See the field comments above; readWatchBatch is the other half.
+		streaming:       true,
+		bypassSemaphore: true,
+		implemented:     true,
+		handler:         (*Server).handleWatchEvents,
 	},
 	{
 		op:     OpForgetMemory,

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -17,6 +17,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 	"unicode/utf8"
@@ -289,13 +290,30 @@ type Server struct {
 	// sem bounds handlers that touch the database. Buffered channel rather
 	// than sync.Semaphore so the acquisition can select on a timer.
 	sem chan struct{}
-	// semTimeout, semWarn and writeStall default to the constants above. They
-	// are fields rather than constants at the point of use so the queueing and
-	// stalled-write behavior can be exercised in milliseconds instead of tens of
-	// seconds.
+	// semTimeout, semWarn, writeStall, watchPoll and watchBeat default to the
+	// constants above. They are fields rather than constants at the point of use
+	// so the queueing, stalled-write and streaming behavior can be exercised in
+	// milliseconds instead of tens of seconds.
 	semTimeout time.Duration
 	semWarn    time.Duration
 	writeStall time.Duration
+	watchPoll  time.Duration
+	watchBeat  time.Duration
+
+	// closing is closed when a graceful shutdown begins, and it is the ONLY
+	// notice a streaming handler gets: http.Server.Shutdown waits for active
+	// requests without canceling their contexts, so a stream that watched only
+	// for a client disconnect would hold every shutdown open for the whole drain
+	// timeout and then be killed anyway. Registered on the http.Server (which
+	// calls it exactly once) and guarded so a second call cannot close twice.
+	closing     chan struct{}
+	closingOnce sync.Once
+
+	// watchStreams is the live count of open events:watch streams and
+	// maxWatchStreams mirrors the constant, so a test can saturate the cap
+	// without opening sixty-four of them.
+	watchStreams    atomic.Int64
+	maxWatchStreams int
 
 	log     *log.Logger
 	stdout  io.Writer
@@ -400,6 +418,9 @@ func Listen(cfg Config) (*Server, error) {
 		semTimeout: semAcquireTimeout,
 		semWarn:    saturationWarn,
 
+		closing:         make(chan struct{}),
+		maxWatchStreams: maxWatchStreams,
+
 		log:      log.New(cfg.Stderr, "bd serve: ", log.LstdFlags|log.LUTC),
 		stdout:   cfg.Stdout,
 		ctxBody:  contextResponse(cfg.Workspace, cfg.SchemaVersion, Capabilities()),
@@ -423,6 +444,11 @@ func Listen(cfg Config) (*Server, error) {
 		ErrorLog:          log.New(cfg.Stderr, "bd serve: http: ", log.LstdFlags|log.LUTC),
 		ConnState:         s.connState,
 	}
+	// Tell the streams to wind up as soon as a drain starts. Without it a
+	// graceful shutdown waits out the whole drain timeout on any open stream and
+	// then reports itself forced, which is the one shutdown signal an operator
+	// is meant to be able to trust.
+	s.http.RegisterOnShutdown(s.closeStreams)
 
 	// Bound what a burst of requests can open on the database. The knob is
 	// optional on the interface, so say so out loud when a provider does not
@@ -1222,6 +1248,13 @@ func (s *Server) dispatchCustomMethod(rows []route) http.Handler {
 	})
 }
 
+// closeStreams signals every streaming handler that this server is shutting
+// down. Idempotent: http.Server calls its registered hooks once per Shutdown,
+// and a second Shutdown must not panic on an already-closed channel.
+func (s *Server) closeStreams() {
+	s.closingOnce.Do(func() { close(s.closing) })
+}
+
 // route wraps one operation with the limits that apply to it: the per-request
 // deadline, and — unless the operation is exempt — a database slot.
 func (s *Server) route(rt route) http.Handler {
@@ -1229,12 +1262,19 @@ func (s *Server) route(rt route) http.Handler {
 		rec := requestInfo(r.Context())
 		rec.op = rt.op
 
-		ctx, cancel := context.WithTimeout(r.Context(), requestDeadline)
-		defer cancel()
-		r = r.WithContext(ctx)
+		// A STREAMING OPERATION GETS NO DEADLINE. For every other row this is
+		// the backstop that stops a request from holding resources forever; on a
+		// held-open response it would do nothing but sever the stream at sixty
+		// seconds. What replaces it is per-read: streamEvents holds no slot
+		// between passes and bounds each read on its own.
+		if !rt.streaming {
+			ctx, cancel := context.WithTimeout(r.Context(), requestDeadline)
+			defer cancel()
+			r = r.WithContext(ctx)
+		}
 
 		if !rt.bypassSemaphore {
-			release, err := s.acquire(ctx, rec)
+			release, err := s.acquire(r.Context(), rec)
 			if err != nil {
 				s.failErr(w, r, err)
 				return

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -204,7 +204,12 @@ func (l *lockedBuffer) String() string {
 	return l.b.String()
 }
 
-func newTestServer(t *testing.T, cfg Config) *testServer {
+// newTestServer binds and serves one server for a case. The optional tune
+// functions run between Listen and the first accepted connection, which is
+// where the millisecond-scale knobs (semTimeout, writeStall, the stream
+// cadences and the stream cap) belong: they are fields rather than Config
+// members precisely because they are not deployment configuration.
+func newTestServer(t *testing.T, cfg Config, tune ...func(*Server)) *testServer {
 	t.Helper()
 	stdout := &bytes.Buffer{}
 	stderr := &lockedBuffer{}
@@ -223,6 +228,9 @@ func newTestServer(t *testing.T, cfg Config) *testServer {
 	srv, err := Listen(cfg)
 	if err != nil {
 		t.Fatalf("Listen: %v", err)
+	}
+	for _, apply := range tune {
+		apply(srv)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -588,7 +596,7 @@ func TestCapabilitiesAdvertiseEveryImplementedOperation(t *testing.T) {
 	want := []string{
 		"config.get", "config.list", "dependencies.add", "dependencies.blocking",
 		"dependencies.cycles", "dependencies.list", "dependencies.remove",
-		"dependencies.tree", "events.list", "issues.batchCreate",
+		"dependencies.tree", "events.list", "events.watch", "issues.batchCreate",
 		"issues.claim", "issues.close", "issues.delete", "issues.get", "issues.list",
 		"issues.query", "issues.reopen", "issues.sweep", "issues.update",
 		"memories.forget", "memories.get",

--- a/internal/httpapi/spec/openapi.v0.yaml
+++ b/internal/httpapi/spec/openapi.v0.yaml
@@ -38,10 +38,18 @@ info:
     ## Media types
 
 
-    Success bodies are `application/json; charset=utf-8`. EVERY non-2xx body,
-    from every route and from the middleware in front of them, is
-    `application/problem+json` carrying the `Problem` schema — there is exactly
-    one error shape on this surface.
+    Success bodies are `application/json; charset=utf-8`, with ONE exception:
+    `watchEvents` answers `text/event-stream; charset=utf-8`, because its
+    response is a stream held open for the life of a connection rather than a
+    document. It is the only streaming operation here and the only non-JSON
+    success body; its individual events carry JSON, and the schemas they carry
+    are the ones the paged read already publishes.
+
+
+    EVERY non-2xx body, from every route and from the middleware in front of
+    them, is `application/problem+json` carrying the `Problem` schema — there is
+    exactly one error shape on this surface, and `watchEvents` is no exception:
+    it decides every refusal before opening its stream.
 
 
     ## Three 400s cut across operations, and are documented here once
@@ -2702,11 +2710,20 @@ paths:
         redeliver.
 
 
-        POLL; THERE IS NO STREAMING, no long poll and no `follow` in v0. `head`
-        is what makes polling cheap to pace: when the last record's `seq`
+        THIS OPERATION POLLS; there is no long poll and no `follow` parameter.
+        `head` is what makes polling cheap to pace: when the last record's `seq`
         equals `head` you are caught up and can back off until your next
         interval. A caught-up read is a 200 with an EMPTY `records` array, never
         a 404 — "nothing new yet" is an ordinary answer about a log.
+
+
+        FOR A PUSH FEED USE `watchEvents`, the sibling operation at
+        `GET /v0/beads/events:watch`, which streams the same records from the
+        same `since` as `text/event-stream`. It is a separate operation rather
+        than a mode of this one because the two differ in media type, lifetime
+        and capacity; a client that streams still needs this operation, because
+        this is the one that is never refused for capacity and the one a stream
+        falls back to.
 
 
         SCOPE IS PER REPLICA AND PER BRANCH, and this is the part that most
@@ -2909,6 +2926,229 @@ paths:
           $ref: '#/components/responses/InternalError'
         '503':
           $ref: '#/components/responses/Unavailable'
+
+  /v0/beads/events:watch:
+    get:
+      operationId: watchEvents
+      summary: Stream the durable events journal
+      description: >-
+        The same journal as `listEvents`, PUSHED: a held-open
+        `text/event-stream` response that emits each committed mutation as it
+        lands, so a consumer learns about a write when it happens rather than
+        on its next interval.
+
+
+        THE CURSOR IS STILL THE CONTRACT. This is not a subscription — the
+        server keeps no per-consumer state, remembers nothing between
+        connections and cannot redeliver. A stream is the reads you would have
+        performed yourself, performed on your behalf, and every event carries
+        `id:` set to the record's `seq`: the same number `since` takes, the same
+        number `bd events tail --since` takes. Advance your own checkpoint only
+        after your write lands, exactly as on the paged read.
+
+
+        RECONNECTION IS THE NORMAL CASE and it is free. When a stream drops, a
+        client re-requests this operation with the standard `Last-Event-ID`
+        header carrying the last `seq` it processed; that header WINS over the
+        `since` query parameter, which is what makes a browser's `EventSource`
+        correct without any code — it re-sends the original URL, and its
+        original `since` would otherwise replay everything since the consumer
+        started. `since` is still required on every connect, because the header
+        is absent on the first one.
+
+
+        WATCH OR POLL is a real choice and the answer is usually poll. A stream
+        costs a connection and a goroutine for its whole life, and this server
+        holds a bounded number of them; a poller holds nothing between requests
+        and can never be refused for capacity. Stream when the delay between a
+        mutation and your reaction is the point — a live mirror, an agent
+        waiting on a gate — and poll for anything that can afford its interval.
+        A backlog is drained at read speed either way, so a stream is not a
+        faster way to catch up, only a shorter wait once you have.
+
+
+        THE STREAM ONLY OPENS ON A SERVABLE CURSOR. Every refusal below is an
+        ordinary `application/problem+json` response with its documented status,
+        decided BEFORE any stream byte — including the 410 for a checkpoint that
+        has been pruned past, which is the same body `listEvents` returns for
+        the same condition. There is exactly one failure a client can meet after
+        the status is spent: see the `truncated` event.
+
+
+        EVERYTHING THE PAGED READ SAYS ABOUT THE RECORDS APPLIES UNCHANGED —
+        they are the same `EventRecord` objects from the same projection; scope
+        is per replica and per branch, so a checkpoint is meaningful only
+        against the server that issued it; merges and `bd sql` are not
+        journaled; and `events.watch` in `ContextResponse.capabilities` says
+        this BUILD serves the operation, not that this workspace has a journal.
+      parameters:
+        - name: since
+          in: query
+          required: true
+          description: >-
+            Emit records with `seq` strictly greater than this value. Pass `0`
+            to stream from the beginning of the retained journal.
+
+
+            REQUIRED on every connect, including a reconnect that also carries
+            `Last-Event-ID`, and refused when negative — both for the reasons
+            `listEvents` gives. When the header is present this value is
+            ignored, but it is still validated: one rule, one spelling, whether
+            or not the client is a browser.
+          schema:
+            type: integer
+            format: int64
+            minimum: 0
+        - name: Last-Event-ID
+          in: header
+          required: false
+          description: >-
+            The last `seq` this client processed, as emitted in the `id:` field
+            of a previous event. Present, it REPLACES `since` as the resume
+            point.
+
+
+            This is the standard SSE reconnection header and browsers attach it
+            automatically, which is the whole reason it outranks the query
+            parameter: an `EventSource` reconnects to the URL it was built with,
+            so honoring `since` there would re-deliver every record since the
+            consumer started on every reconnect.
+
+
+            A NONEMPTY value that is not a non-negative 64-bit integer is a 400
+            `invalid_argument` naming this header, rather than a silent fallback
+            to `since`: a client that invented its own id has a broken
+            checkpoint, and a stream that quietly started somewhere else would
+            look correct and lose records.
+
+
+            An EMPTY value is treated exactly as an absent one — `since`
+            decides — because it says the same thing: no id yet. A client or
+            intermediary that always sets the header sends it empty on the first
+            connect, and refusing that would break the one request this header
+            exists to make work.
+          schema:
+            type: integer
+            format: int64
+            minimum: 0
+      responses:
+        '200':
+          description: >-
+            An open event stream. It ends when the client disconnects, when the
+            server shuts down, or with the `truncated` event below; there is no
+            end-of-stream marker otherwise, and a client is expected to
+            reconnect.
+
+
+            FRAMES, in the order a client meets them:
+
+
+            `retry: 3000` — the reconnection delay, stated once at the top so it
+            does not depend on the client's default.
+
+
+            `id: <seq>` + `data: <EventRecord>` — one record, as an UNNAMED
+            (default `message`) event, so a bare `onmessage` receives it. The
+            `data` payload is exactly one line: a single JSON object identical
+            to an element of `listEvents`'s `records` array
+            (`#/components/schemas/EventRecord`).
+
+
+            `: heartbeat` — a comment line every ~20 seconds of silence. It
+            carries no information and exists to keep idle connections alive
+            through intermediaries; clients ignore comments by construction.
+
+
+            `event: truncated` + `data: <Problem>` — the ONE in-band failure,
+            emitted when a prune removes the records this stream was about to
+            send. Its data is a `#/components/schemas/Problem` object with code
+            `events_journal_truncated`, carrying the same `since` / `floor` /
+            `head` window and the same `detail` a 410 for that condition
+            carries. It is the 410's body in the same encoding, on one line
+            (an SSE `data:` field cannot contain the newline an HTTP body ends
+            with); `request_id` is this STREAM's id, not a reconnect's, since no
+            second request has happened. Whatever parses the 410 parses this
+            unchanged. The stream closes immediately after it, behind a raised
+            `retry`.
+
+
+            TREAT `truncated` AS STOP-AND-RE-BASELINE. The recovery is the
+            410's: resume from `floor - 1` and accept a known gap, or rebuild
+            from a full export. It is deliberately a NAMED event, so a client
+            that registered only `onmessage` never mistakes it for a record —
+            but such a client will simply reconnect and then meet a
+            connect-time 410 on every attempt, which is why the delay is raised
+            to a minute first. A consumer that ignores this event does not lose
+            records silently; it stalls loudly.
+          content:
+            text/event-stream:
+              schema:
+                type: string
+        '400':
+          description: >-
+            Invalid request: `since` absent, negative or unparseable, a
+            `Last-Event-ID` header that is not a non-negative sequence number,
+            or an unknown query parameter.
+          x-bd-codes: [invalid_argument]
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '409':
+          description: >-
+            The durable events journal is NOT ENABLED on this workspace, so
+            there is nothing to stream and never will be until an operator turns
+            it on (`events-journal true`, or `BD_EVENTS_JOURNAL=1` in the
+            server's environment) and restarts the server. Identical in every
+            respect to `listEvents`'s 409, and refused before the stream opens.
+          x-bd-codes: [events_journal_disabled]
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '410':
+          description: >-
+            The resume point — `Last-Event-ID` if present, otherwise `since` —
+            has fallen BELOW the retained window, so the records that came next
+            were pruned and this server cannot serve them. The body is
+            `listEvents`'s 410 exactly, carrying the same `since` / `floor` /
+            `head` window and the same recoveries, and no stream is opened.
+
+
+            A CLIENT THAT RECONNECTS BLINDLY LOOPS HERE. This is the status a
+            consumer earns after ignoring a `truncated` event, and retrying with
+            the same id can never succeed; re-baseline instead.
+          x-bd-codes: [events_journal_truncated]
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '500':
+          $ref: '#/components/responses/InternalError'
+        '503':
+          description: >-
+            The stream could not be opened right now and may be retried:
+            `events_watch_saturated` (this server is already holding as many
+            concurrent streams as it will), `db_unavailable`, or `busy`.
+
+
+            `events_watch_saturated` is the one code here that is about
+            CONNECTIONS rather than data, and the one with a recovery that is
+            not waiting: `GET /v0/beads/events` answers the same records from
+            the same checkpoint and is never refused for this reason. The cap
+            exists because a stream is the only request on this server that can
+            last hours, and streams are held until their consumers leave — so
+            `Retry-After` here is a human-scale hint, not a request-scale one.
+          x-bd-codes: [busy, db_unavailable, events_watch_saturated]
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
 
 components:
 
@@ -3950,22 +4190,22 @@ components:
             `dependencies.list`, `dependencies.blocking`, `dependencies.tree`,
             `dependencies.add`, `dependencies.remove`,
             `memories.list`, `memories.get`, `memories.remember`,
-            `memories.forget`, `events.list`;
+            `memories.forget`, `events.list`, `events.watch`;
             it grows additively, and an operation never
             appears here unless it is fully implemented. This is how a client
             checks for an operation — never the version string.
 
 
             THIS LIST IS BUILD-LEVEL, NOT WORKSPACE-LEVEL. It says which
-            operations this binary serves, and for every entry but one that is
-            the whole answer. `events.list` is the exception: the durable events
-            journal is a per-workspace setting that is OFF by default, so a
-            server that advertises `events.list` may still refuse every request
-            to it with 409 `events_journal_disabled` — correctly, because the
-            operation exists and the workspace has no journal. A consumer of that
-            operation MUST treat the capability as "this server speaks it" and
-            the 409 as "not on this workspace", and must not read the capability
-            as a promise that records will arrive.
+            operations this binary serves, and for every entry but two that is
+            the whole answer. `events.list` and `events.watch` are the
+            exceptions: the durable events journal is a per-workspace setting
+            that is OFF by default, so a server that advertises them may still
+            refuse every request to both with 409 `events_journal_disabled` —
+            correctly, because the operations exist and the workspace has no
+            journal. A consumer of either MUST treat the capability as "this
+            server speaks it" and the 409 as "not on this workspace", and must
+            not read the capability as a promise that records will arrive.
           items:
             type: string
 
@@ -5364,7 +5604,7 @@ components:
             `dependency_cycle` (409), `dependency_exists` (409),
             `events_journal_disabled` (409), `events_journal_truncated` (410),
             `busy` (503),
-            `db_unavailable` (503),
+            `db_unavailable` (503), `events_watch_saturated` (503),
             `internal` (500). Renaming or removing a status+code pair is a
             breaking change; ADDING one is not, so clients MUST default-branch
             on unknown values and fall back to the status class (unknown 4xx →

--- a/internal/httpapi/spec_parity_test.go
+++ b/internal/httpapi/spec_parity_test.go
@@ -29,6 +29,18 @@ var httpVerbs = map[string]bool{
 	"head": true, "options": true, "trace": true,
 }
 
+// streamingOps are the operations whose success body is a stream rather than a
+// document, and therefore the only ones exempt from the application/json rule.
+//
+// It is a literal here and a `streaming` column in the route table, which is
+// the drift this pairing catches: TestStreamingRowsAreTheDocumentsStreamingOps
+// requires the two to name the same operations, so a row that starts streaming
+// without saying so in the document — or a document that promises a stream no
+// row holds open — fails.
+var streamingOps = map[string]bool{
+	OpWatchEvents: true,
+}
+
 type specOp struct {
 	path   string
 	method string
@@ -164,6 +176,19 @@ func TestSpecGovernance(t *testing.T) {
 				t.Errorf("%s %s: %d media types, want exactly 1", id, status, len(content))
 			}
 			if strings.HasPrefix(status, "2") {
+				if streamingOps[id] {
+					// The one carve-out, and it is an allowlist rather than a
+					// relaxed rule: a response held open for the life of a
+					// connection cannot be a JSON document, but every OTHER
+					// operation must still fail here if it grows a second media
+					// type or drifts off application/json. A new streaming
+					// operation costs a line in this map and a paragraph in the
+					// document's Media types section, which is the point.
+					if _, ok := content["text/event-stream"]; !ok {
+						t.Errorf("%s %s: a streaming operation's success body is text/event-stream", id, status)
+					}
+					continue
+				}
 				if _, ok := content["application/json"]; !ok {
 					t.Errorf("%s %s: success bodies are application/json", id, status)
 				}
@@ -269,6 +294,38 @@ func TestSpecRouteParity(t *testing.T) {
 	// request after a deploy.
 	if h := (&Server{}).handler(); h == nil {
 		t.Fatal("handler() returned nil")
+	}
+}
+
+// TestStreamingRowsAreTheDocumentsStreamingOps ties the route table's
+// `streaming` column to the media-type carve-out above.
+//
+// The two describe one property of an operation from opposite ends: the column
+// decides that the request gets no deadline and takes its database slot per
+// read, and the document decides that clients are told to expect a stream. An
+// operation that gained one without the other is either a JSON handler running
+// without the backstop that bounds every other request, or a documented stream
+// that the router will cut off at sixty seconds — and neither has any other
+// test that can see it.
+func TestStreamingRowsAreTheDocumentsStreamingOps(t *testing.T) {
+	routed := map[string]bool{}
+	for _, rt := range routeTable {
+		if rt.streaming {
+			routed[rt.op] = true
+		}
+		// A streaming row that still queued for the request-wide slot would hold
+		// one of sixteen for the life of a connection. The pairing is stated on
+		// the field and enforced here.
+		if rt.streaming && !rt.bypassSemaphore {
+			t.Errorf("%s streams but holds the request-wide database slot; a stream must take its slot per read", rt.op)
+		}
+	}
+
+	if missing := diff(routed, streamingOps); len(missing) > 0 {
+		t.Errorf("route table streams %v, the document does not describe them as streaming operations", missing)
+	}
+	if extra := diff(streamingOps, routed); len(extra) > 0 {
+		t.Errorf("the document treats %v as streaming, but no route row is marked streaming", extra)
 	}
 }
 


### PR DESCRIPTION
Adds the push half of the events-journal HTTP surface (stacked on #5454): **`GET /v0/beads/events:watch?since=<seq>`** — Server-Sent Events, one event per journal record (`id:` = seq, `data:` = the exact envelope the golden pins), heartbeat comments on idle, capability `events.watch`.

## The cursor stays the contract

The stream is a convenience wrapper over the same read path as the poll endpoint — zero engine/storage changes. Resume is `Last-Event-ID` (wins over `since` when present and parseable; empty = absent, documented; nonempty-garbage = 400). A stale cursor at connect gets a plain **410** problem+json before any stream bytes — identical body to the poll endpoint's, so one handler parses both. A prune racing an *open* stream gets `retry: 60000` then a named `event: truncated` carrying that same body, then close: consumers stop and re-baseline; a naive `EventSource` degrades to a slow loop of connect-time 410s. Delivery is **at-least-once against your checkpoint**: exactly-once and seq-ordered within a stream, duplicates only across reconnects — stated in the docs.

## What a streaming surface has to get right (all pinned by tests)

- **The three lifetime killers found and fixed**: the 60s request-deadline context (streams are exempt via a route-table column; each *read* carries its own 15s deadline instead, so a wedged database still can't park a slot), the 30s `ReadTimeout` whose background read kills idle streams (cleared per-request, *before* the connect-phase read — ordering pinned), and `Server.Shutdown` waiting on streams without cancelling them (streams register a closing signal; backlog drains check it every batch).
- **Capacity is honest**: at most **48** concurrent streams — deliberately below the 64-connection listener cap, so a saturated workspace still answers polls, mutations, health checks, *and the 503 itself* (`events_watch_saturated`, `Retry-After`, admit-time gauge log). The council proved a cap equal to `maxConns` makes the refusal arithmetically unreachable — the invariant test pins the relationship, not the literal. Connection-level saturation (64) remains the distinct, silent, worse cliff and the runbook says so.
- **Framing is proven, not assumed**: an injection test commits a payload containing literal newlines and a forged `data:` frame and asserts two-line framing with byte-identical round-trip. Poll phase is jittered ±10% (crypto/rand) so a mass reconnect can't synchronize N streams into permanent 1s read bursts.
- **Vanished peers**: no read deadline (SSE clients legitimately send nothing — a deadline would kill healthy streams). Measured on this fleet: Go's default TCP keepalive reaps a silently-gone idle peer in ~150s, ~15min mid-write via retransmission — runbook documents the numbers and date.

## Verification

Handler suite + `-race`; e2e through real `bd serve` (stream opened *before* the mutations exist, records must arrive within 10s; reconnect leg honors `Last-Event-ID`; disabled-journal refusal); eleven mutation-verified guards across both waves; both capability censuses updated; spec governance grew an explicit `streamingOps` allowlist tied to the route table rather than a relaxed JSON rule; `make api-check`/docs/runbook-freshness clean. Review: one three-lens adversarially-verified council — 1 confirmed major (the cap arithmetic above), fixed with rulings applied across ten follow-on items, zero refuted.

The exposure contract is unchanged from #5454 and applies identically: this streams retained history — including since-edited and since-deleted content — to anyone who can reach the bind address.

Tracking: bd-opisf.

_claude-code-claude-fable-5[1m]-max on behalf of julianknutsen_
