### PR TITLE
Migrate the vocabulary and dependency audit cases, including the edge that bricks bd list

### DIFF
--- a/backend/conformance/dependency_editor_contract.go
+++ b/backend/conformance/dependency_editor_contract.go
@@ -1837,6 +1837,15 @@ func RunDependencyEditorRelatesToAddLeavesItsSourceUnblocked(t *testing.T, ctx c
 // diamond back onto its own root and requires ErrDependencyCycle with nothing
 // written. Acceptance and refusal over one fixture is what makes either one
 // mean anything.
+//
+// THE LAST ARM IS THE ONE THAT WALKS THE CONVERGENCE. Both gates search FROM
+// the new edge's target, so while the target is the diamond's foot the walk
+// finds a sink and never meets a node twice — the acceptance above would
+// survive a gate that mistook a second visit for a loop. An edge pointing INTO
+// the diamond's head makes the search start at the root and reach the foot down
+// both shoulders, so the second visit happens on a graph with no cycle in it,
+// and the gate's visited-set (issueops.CycleThroughEdgesInGraph's BFS) is what
+// has to tell those apart.
 func RunDependencyEditorAcceptsADiamond(t *testing.T, ctx context.Context, fixture DependencyEditorFixture) {
 	t.Helper()
 	root := fixture.IssuePrefix + "-diamond-root"
@@ -1884,6 +1893,19 @@ func RunDependencyEditorAcceptsADiamond(t *testing.T, ctx context.Context, fixtu
 		t.Fatalf("closing the diamond back onto its root: error = %v, want ErrDependencyCycle — the accepting half above is only meaningful beside a gate that still fires", err)
 	}
 	assertDependencyEditorNoEdgesFrom(t, ctx, fixture, foot)
+
+	// An edge into the HEAD of the diamond, from an issue the diamond cannot
+	// reach. The gate searches from the target, so this is the arm whose search
+	// runs down both shoulders and arrives at the foot twice.
+	outsider := fixture.IssuePrefix + "-diamond-outsider"
+	seedDependencyEditorIssue(t, ctx, fixture, outsider)
+	if _, err := fixture.Editor.AddDependencies(ctx, publicops.AddDependenciesRequest{
+		Actor: "writer",
+		Edges: []publicops.DependencyEdge{{IssueID: outsider, DependsOnID: root, Type: publicops.DepBlocks}},
+	}); err != nil {
+		t.Fatalf("gating an outside issue on the head of a diamond: %v — reaching one node by two paths is convergence, not a loop", err)
+	}
+	assertDependencyEdgeTypedCount(t, ctx, fixture, "dependencies", outsider, root, string(publicops.DepBlocks), 1)
 }
 
 // RunDependencyEditorGateScopeFollowsTheEdgeType pins which edges the ADD-TIME

--- a/backend/conformance/dependency_editor_contract.go
+++ b/backend/conformance/dependency_editor_contract.go
@@ -1728,10 +1728,311 @@ func RunDependencyEditorClosedChildAddSatisfiesAnAnyChildrenGate(t *testing.T, c
 	}
 }
 
+// RunDependencyEditorRelatesToAddLeavesItsSourceUnblocked pins the term of
+// issueops.BlockedStateInvariant's first clause that names the EDGE TYPE: a row
+// is blocked when it has a blocks or conditional-blocks edge onto a live
+// target, so an edge of any other type onto the same live target leaves the
+// stored flag exactly where it was.
+//
+// IT IS THE TWIN RunDependencyEditorAddMarksItsSourceInTheSameVerb DOES NOT
+// HAVE. That case varies the TARGET'S STATUS and holds the type fixed, so
+// every zero it observes is attributable to a closed target; nothing in this
+// package has ever observed a zero attributable to the type. The add path is
+// where the type decides — issueops/dependencies.go reaches
+// markDirectBlockingDependencySourceInTx only for the two blocking types, and
+// internal/storage/domain/db/dependency.go's Insert carries a hand-mirrored
+// copy of that decision — so this is a genuine second vote, on the body whose
+// mirror already dropped one clause once (bd-6dnrw.44 item 3).
+//
+// THE READ IS RAW. The audit-tier ancestor of this case asked GetReadyWork and
+// IsBlocked whether the source was blocked; both compute the answer from the
+// live edge set, so they answer correctly against a backend that never writes
+// the column at all — and is_blocked is derived AND PERSISTED, read straight
+// off the row by every ready query. A role answer is not a substitute for the
+// column here.
+//
+// WHAT THE FIXTURE MAKES OBSERVABLE. The non-scheduling sources carry that edge
+// AND NOTHING ELSE, asserted by counting their blocks/conditional-blocks edges
+// at zero: a source that also had a blocking edge would read 1 for a reason
+// this case is not about, and the term it is named for would be invisible —
+// the same shape the conditional-blocks case in issue_operations_contract.go
+// guards against from the other side. Their target is asserted OPEN, so the
+// zero is not the closed-target answer wearing this case's name. And the
+// blocking edge in the SAME request is the must-flip term: it proves the
+// marking machinery ran in this very transaction, so a zero beside it is a
+// decision rather than a body that marked nothing.
+//
+// Both non-scheduling spellings ride in, because the type lists in the mark
+// templates are enumerations of what DOES block and a body that had heard of
+// one and not the other is exactly the drift a single-type case misses.
+func RunDependencyEditorRelatesToAddLeavesItsSourceUnblocked(t *testing.T, ctx context.Context, fixture DependencyEditorFixture) {
+	t.Helper()
+	target := fixture.IssuePrefix + "-bsrel-target"
+	relatesTo := fixture.IssuePrefix + "-bsrel-relatesto"
+	related := fixture.IssuePrefix + "-bsrel-related"
+	mustFlip := fixture.IssuePrefix + "-bsrel-blocks"
+	control := fixture.IssuePrefix + "-bsrel-control"
+	for _, id := range []string{target, relatesTo, related, mustFlip, control} {
+		seedDependencyEditorIssue(t, ctx, fixture, id)
+	}
+
+	probe := newBlockedStateProbe(ctx, fixture.QueryScalar)
+	flip := probe.watchFlip(t,
+		[]blockedStateRow{blockedIssue(mustFlip)},
+		[]blockedStateRow{blockedIssue(relatesTo), blockedIssue(related), blockedIssue(control)})
+
+	if _, err := fixture.Editor.AddDependencies(ctx, publicops.AddDependenciesRequest{
+		Actor: "writer",
+		Edges: []publicops.DependencyEdge{
+			{IssueID: relatesTo, DependsOnID: target, Type: types.DepRelatesTo},
+			{IssueID: related, DependsOnID: target, Type: publicops.DepRelated},
+			{IssueID: mustFlip, DependsOnID: target, Type: publicops.DepBlocks},
+		},
+	}); err != nil {
+		t.Fatalf("AddDependencies for the non-scheduling add case: %v", err)
+	}
+
+	flip.requireFlippedTo(t, 1,
+		"the blocking edge in the same request is the must-flip term: without it a zero on the others could be a body that marks nothing")
+	probe.requireBlockedByOpenBlocker(t, blockedIssue(mustFlip), blockedIssue(target),
+		"the postcondition is the flag AND the live blocker behind it")
+
+	// The zeros are only worth anything if the edges landed, the sources carry
+	// no blocking edge of their own, and the shared target is live.
+	for _, edge := range []struct {
+		source  string
+		depType publicops.DependencyType
+	}{
+		{relatesTo, types.DepRelatesTo},
+		{related, publicops.DepRelated},
+	} {
+		assertDependencyEdgeTypedCount(t, ctx, fixture, "dependencies", edge.source, target, string(edge.depType), 1)
+		if got := probe.directBlockerEdges(t, blockedIssue(edge.source)); got != 0 {
+			t.Fatalf("%s carries %d blocking edges of its own, want 0: a %s source that is also blocked cannot show that %s does not block",
+				edge.source, got, edge.depType, edge.depType)
+		}
+	}
+	if status := probe.rawStatus(t, blockedIssue(target)); status != string(types.StatusOpen) {
+		t.Fatalf("the shared target %s has status %q, want %q: onto a closed target every type answers zero and this case would mean nothing",
+			target, status, types.StatusOpen)
+	}
+}
+
+// RunDependencyEditorAcceptsADiamond pins the half of the add-time cycle gate
+// that says YES. Every other cycle case in this file asserts a refusal, so a
+// gate that refused any target it could reach by more than one path — the
+// difference between a reachability test and a visited-node count — passes all
+// of them, and the shape it would refuse is the ordinary one: two pieces of
+// work that both have to land before a third can start.
+//
+// THE TWO CONVERGING EDGES LAND IN ONE REQUEST, which is the arm that matters:
+// the gate checks each edge against the graph INCLUDING the edges the same
+// request has already applied, so the second edge is probed against a graph
+// that already reaches the same node by another route. Adding them one at a
+// time — what the audit-tier ancestor of this case did — never puts a second
+// path in front of the probe at all.
+//
+// THE REFUSAL IS ON THE SAME GRAPH. A body that answered "no cycle" to
+// everything would pass the acceptance half alone, so the case closes the
+// diamond back onto its own root and requires ErrDependencyCycle with nothing
+// written. Acceptance and refusal over one fixture is what makes either one
+// mean anything.
+func RunDependencyEditorAcceptsADiamond(t *testing.T, ctx context.Context, fixture DependencyEditorFixture) {
+	t.Helper()
+	root := fixture.IssuePrefix + "-diamond-root"
+	left := fixture.IssuePrefix + "-diamond-left"
+	right := fixture.IssuePrefix + "-diamond-right"
+	foot := fixture.IssuePrefix + "-diamond-foot"
+	for _, id := range []string{root, left, right, foot} {
+		seedDependencyEditorIssue(t, ctx, fixture, id)
+	}
+
+	if _, err := fixture.Editor.AddDependencies(ctx, publicops.AddDependenciesRequest{
+		Actor: "writer",
+		Edges: []publicops.DependencyEdge{
+			{IssueID: root, DependsOnID: left, Type: publicops.DepBlocks},
+			{IssueID: root, DependsOnID: right, Type: publicops.DepBlocks},
+		},
+	}); err != nil {
+		t.Fatalf("seed the two shoulders of the diamond: %v", err)
+	}
+
+	// Both feet in ONE request: the second is probed against a graph in which
+	// the request itself has already made foot reachable from root.
+	result, err := fixture.Editor.AddDependencies(ctx, publicops.AddDependenciesRequest{
+		Actor: "writer",
+		Edges: []publicops.DependencyEdge{
+			{IssueID: left, DependsOnID: foot, Type: publicops.DepBlocks},
+			{IssueID: right, DependsOnID: foot, Type: publicops.DepBlocks},
+		},
+	})
+	if err != nil {
+		t.Fatalf("closing a diamond is not a cycle: AddDependencies = %v, want both edges accepted", err)
+	}
+	if len(result.Added) != 2 {
+		t.Fatalf("Added = %#v, want both converging edges", result.Added)
+	}
+	assertDependencyEdgeTypedCount(t, ctx, fixture, "dependencies", left, foot, string(publicops.DepBlocks), 1)
+	assertDependencyEdgeTypedCount(t, ctx, fixture, "dependencies", right, foot, string(publicops.DepBlocks), 1)
+	assertDependencyEditorOutgoingCount(t, ctx, fixture, "dependencies", root, 2)
+
+	// The same graph, closed: foot reaches root through either shoulder.
+	if _, err := fixture.Editor.AddDependencies(ctx, publicops.AddDependenciesRequest{
+		Actor: "writer",
+		Edges: []publicops.DependencyEdge{{IssueID: foot, DependsOnID: root, Type: publicops.DepBlocks}},
+	}); !errors.Is(err, publicops.ErrDependencyCycle) {
+		t.Fatalf("closing the diamond back onto its root: error = %v, want ErrDependencyCycle — the accepting half above is only meaningful beside a gate that still fires", err)
+	}
+	assertDependencyEditorNoEdgesFrom(t, ctx, fixture, foot)
+}
+
+// RunDependencyEditorGateScopeFollowsTheEdgeType pins which edges the ADD-TIME
+// gate walks, from the side that accepts.
+//
+// cycle_detector_contract.go pins edge-type scope for the REPORT, over a
+// raw-seeded graph, and RunDependencyEditorRefusesACycleThroughAParentChildHop
+// pins that the gate walks one type the report does not. Neither shows the
+// gate DECLINING to walk a type: a mutual pair of non-scheduling edges is not a
+// scheduling cycle and has to be accepted, because that is what `bd dep add
+// --type relates-to` writes in both directions between two issues that
+// reference each other.
+//
+// The parent-child arm is the same fixture from the other side. A pure
+// parent-child two-cycle — an issue that is its own parent's parent — is a
+// scheduling cycle with no blocking edge anywhere in it, and is refused. Two
+// arms over one shape is what separates "walks the scheduling types" from
+// "walks everything" and from "walks blocks only": the first arm fails the
+// former, the second fails the latter.
+func RunDependencyEditorGateScopeFollowsTheEdgeType(t *testing.T, ctx context.Context, fixture DependencyEditorFixture) {
+	t.Helper()
+	relatedA := fixture.IssuePrefix + "-gscope-rel-a"
+	relatedB := fixture.IssuePrefix + "-gscope-rel-b"
+	parent := fixture.IssuePrefix + "-gscope-pc-parent"
+	child := fixture.IssuePrefix + "-gscope-pc-child"
+	for _, id := range []string{relatedA, relatedB, parent, child} {
+		seedDependencyEditorIssue(t, ctx, fixture, id)
+	}
+
+	// Two requests, not one: a mutual pair written in a single request could be
+	// collapsed or reordered, and the claim is about the SECOND edge meeting a
+	// stored first one.
+	if _, err := fixture.Editor.AddDependencies(ctx, publicops.AddDependenciesRequest{
+		Actor: "writer",
+		Edges: []publicops.DependencyEdge{{IssueID: relatedA, DependsOnID: relatedB, Type: types.DepRelatesTo}},
+	}); err != nil {
+		t.Fatalf("seed the first half of the mutual non-scheduling pair: %v", err)
+	}
+	if _, err := fixture.Editor.AddDependencies(ctx, publicops.AddDependenciesRequest{
+		Actor: "writer",
+		Edges: []publicops.DependencyEdge{{IssueID: relatedB, DependsOnID: relatedA, Type: types.DepRelatesTo}},
+	}); err != nil {
+		t.Fatalf("closing a mutual %s pair is not a scheduling cycle: AddDependencies = %v, want it accepted", types.DepRelatesTo, err)
+	}
+	assertDependencyEdgeTypedCount(t, ctx, fixture, "dependencies", relatedA, relatedB, string(types.DepRelatesTo), 1)
+	assertDependencyEdgeTypedCount(t, ctx, fixture, "dependencies", relatedB, relatedA, string(types.DepRelatesTo), 1)
+
+	// The other side of the same shape: parent-child IS in the walk, so its own
+	// two-cycle is refused even with no blocking edge anywhere in the graph.
+	if _, err := fixture.Editor.AddDependencies(ctx, publicops.AddDependenciesRequest{
+		Actor: "writer",
+		Edges: []publicops.DependencyEdge{{IssueID: child, DependsOnID: parent, Type: publicops.DepParentChild}},
+	}); err != nil {
+		t.Fatalf("seed the hierarchy edge: %v", err)
+	}
+	if _, err := fixture.Editor.AddDependencies(ctx, publicops.AddDependenciesRequest{
+		Actor: "writer",
+		Edges: []publicops.DependencyEdge{{IssueID: parent, DependsOnID: child, Type: publicops.DepParentChild}},
+	}); !errors.Is(err, publicops.ErrDependencyCycle) {
+		t.Fatalf("reversing a parent-child edge: error = %v, want ErrDependencyCycle — parent-child is inside the gate's walk", err)
+	}
+	assertDependencyEditorNoEdgesFrom(t, ctx, fixture, parent)
+}
+
+// RunDependencyEditorAcceptsBlockingAcrossIssueTypes pins bd-wg7ve: the
+// blocking-hierarchy guard is about an issue's HIERARCHY LINE, never about its
+// issue TYPE. An epic may be gated on a task it does not contain, and a task on
+// an epic it does not belong to.
+//
+// EVERY OTHER SEED IN THIS FILE IS A TASK. That is what makes the rule
+// unobservable here today: a guard rewritten to refuse "a blocking edge between
+// an epic and a task" — the plausible misreading of the ancestor/descendant
+// refusal, and one a reviewer would wave through — passes the whole contract,
+// because no two seeds anywhere in it have different types.
+//
+// THE REFUSAL ARM USES THE SAME TWO TYPES. Its epic and task are a real parent
+// and child, so the pair differs from the accepting arm in the hierarchy
+// relationship and in nothing else, and the two together say the guard reads
+// the edge and not the row: a body that refused on type fails the acceptance, a
+// body that dropped the ancestry walk fails the refusal, and neither can be
+// made to pass by weakening the other.
+func RunDependencyEditorAcceptsBlockingAcrossIssueTypes(t *testing.T, ctx context.Context, fixture DependencyEditorFixture) {
+	t.Helper()
+	epic := fixture.IssuePrefix + "-xtype-epic"
+	task := fixture.IssuePrefix + "-xtype-task"
+	other := fixture.IssuePrefix + "-xtype-othertask"
+	seedDependencyEditorIssueOfType(t, ctx, fixture, epic, types.TypeEpic)
+	seedDependencyEditorIssueOfType(t, ctx, fixture, task, types.TypeTask)
+	seedDependencyEditorIssueOfType(t, ctx, fixture, other, types.TypeTask)
+
+	// Both directions across the type boundary, between issues with no
+	// hierarchy relationship at all.
+	if _, err := fixture.Editor.AddDependencies(ctx, publicops.AddDependenciesRequest{
+		Actor: "writer",
+		Edges: []publicops.DependencyEdge{
+			{IssueID: epic, DependsOnID: task, Type: publicops.DepBlocks},
+			{IssueID: other, DependsOnID: epic, Type: publicops.DepBlocks},
+		},
+	}); err != nil {
+		t.Fatalf("gating an epic on an unrelated task and a task on an unrelated epic: %v — the guard is about the hierarchy line, not the type", err)
+	}
+	assertDependencyEdgeTypedCount(t, ctx, fixture, "dependencies", epic, task, string(publicops.DepBlocks), 1)
+	assertDependencyEdgeTypedCount(t, ctx, fixture, "dependencies", other, epic, string(publicops.DepBlocks), 1)
+	assertDependencyEditorIssueType(t, ctx, fixture, epic, types.TypeEpic)
+	assertDependencyEditorIssueType(t, ctx, fixture, task, types.TypeTask)
+
+	// The same two types, now a real parent and child: refused.
+	hierEpic := fixture.IssuePrefix + "-xtype-hier-epic"
+	hierTask := fixture.IssuePrefix + "-xtype-hier-task"
+	seedDependencyEditorIssueOfType(t, ctx, fixture, hierEpic, types.TypeEpic)
+	seedDependencyEditorIssueOfType(t, ctx, fixture, hierTask, types.TypeTask)
+	if _, err := fixture.Editor.AddDependencies(ctx, publicops.AddDependenciesRequest{
+		Actor: "writer",
+		Edges: []publicops.DependencyEdge{{IssueID: hierTask, DependsOnID: hierEpic, Type: publicops.DepParentChild}},
+	}); err != nil {
+		t.Fatalf("seed the epic/task hierarchy: %v", err)
+	}
+	_, err := fixture.Editor.AddDependencies(ctx, publicops.AddDependenciesRequest{
+		Actor: "writer",
+		Edges: []publicops.DependencyEdge{{IssueID: hierTask, DependsOnID: hierEpic, Type: publicops.DepBlocks}},
+	})
+	var conflict *publicops.DependencyHierarchyConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("gating a task on the epic it belongs to: error = %v, want *DependencyHierarchyConflictError", err)
+	}
+	if !conflict.BlockerIsAncestor {
+		t.Errorf("conflict = %#v, want BlockerIsAncestor true", conflict)
+	}
+	assertDependencyEdgeTypedCount(t, ctx, fixture, "dependencies", hierTask, hierEpic, string(publicops.DepBlocks), 0)
+}
+
 func seedDependencyEditorIssue(t *testing.T, ctx context.Context, fixture DependencyEditorFixture, id string) {
 	t.Helper()
 	if err := fixture.CreateIssue(ctx, dependencyEditorSeed(id, false), "seed"); err != nil {
 		t.Fatalf("seed issue %s: %v", id, err)
+	}
+}
+
+// seedDependencyEditorIssueOfType seeds a durable issue carrying an ISSUE TYPE
+// other than the file's default task. Only the cross-type case needs one, and
+// it asserts the type landed rather than trusting the seed: a create that
+// normalized the type away would leave that case comparing two tasks and
+// quietly testing nothing.
+func seedDependencyEditorIssueOfType(t *testing.T, ctx context.Context, fixture DependencyEditorFixture, id string, issueType types.IssueType) {
+	t.Helper()
+	seed := dependencyEditorSeed(id, false)
+	seed.IssueType = issueType
+	if err := fixture.CreateIssue(ctx, seed, "seed"); err != nil {
+		t.Fatalf("seed issue %s of type %q: %v", id, issueType, err)
 	}
 }
 
@@ -1820,6 +2121,21 @@ func assertDependencyEditorTargetColumn(t *testing.T, ctx context.Context, fixtu
 			t.Errorf("%s.%s rows %s -> %s = %d, want %d: the target belongs in %s — %s",
 				table, column, source, target, got, want, wantColumn, why)
 		}
+	}
+}
+
+// assertDependencyEditorIssueType reads the stored issue_type of a durable row.
+// The cross-type case is the only caller: its whole claim is that two rows have
+// DIFFERENT types, and a seed whose type never landed would leave it comparing
+// two of the file's default tasks and asserting nothing.
+func assertDependencyEditorIssueType(t *testing.T, ctx context.Context, fixture DependencyEditorFixture, id string, want types.IssueType) {
+	t.Helper()
+	var got string
+	if err := fixture.QueryScalar(ctx, "SELECT issue_type FROM issues WHERE id = ?", []any{id}, &got); err != nil {
+		t.Fatalf("read the issue_type of %s: %v", id, err)
+	}
+	if got != string(want) {
+		t.Fatalf("%s has issue_type %q, want %q: this case is about two rows of different types and the seed did not produce them", id, got, want)
 	}
 }
 

--- a/backend/conformance/role_bundle_cases.go
+++ b/backend/conformance/role_bundle_cases.go
@@ -222,6 +222,10 @@ var roleContractCases = []roleContract{
 		RunDependencyEditorRemoveUnmarksItsSourceAndDescendants,
 		RunDependencyEditorMaintainsBlockedStateAcrossPlanes,
 		RunDependencyEditorClosedChildAddSatisfiesAnAnyChildrenGate,
+		RunDependencyEditorRelatesToAddLeavesItsSourceUnblocked,
+		RunDependencyEditorAcceptsADiamond,
+		RunDependencyEditorGateScopeFollowsTheEdgeType,
+		RunDependencyEditorAcceptsBlockingAcrossIssueTypes,
 	),
 
 	roleCases("EdgeReader", "EdgeReader()", oncePerRole,

--- a/backend/conformance/role_bundle_cases.go
+++ b/backend/conformance/role_bundle_cases.go
@@ -526,5 +526,10 @@ var roleContractCases = []roleContract{
 		RunWorkspaceConfigProjectsCustomTypes,
 		RunWorkspaceConfigUnsetLeavesTheProjectionBehind,
 		RunWorkspaceConfigARefusedWriteRecordsNoHistory,
+		RunWorkspaceConfigKeysAreCaseSensitive,
+		RunWorkspaceConfigCustomStatusReadsAreOrderedByName,
+		RunWorkspaceConfigCustomTypeReadsAreOrderedByName,
+		RunWorkspaceConfigConfiguredInfraTypesReplaceTheDefaultSet,
+		RunWorkspaceConfigUnconfiguredVocabularyReadsAreEmptyNotErrors,
 	),
 }

--- a/backend/conformance/workspaceconfig_contract.go
+++ b/backend/conformance/workspaceconfig_contract.go
@@ -3,10 +3,13 @@ package conformance
 import (
 	"context"
 	"errors"
+	"maps"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/storage/kvkeys"
+	"github.com/steveyegge/beads/internal/types"
 	publicops "github.com/steveyegge/beads/issueops"
 )
 
@@ -62,6 +65,104 @@ type WorkspaceConfigFixture struct {
 	// A nil hook means "this backend cannot observe history", and the case that
 	// needs it SKIPS with that reason rather than passing quietly.
 	CountHistory func(context.Context) (int, error)
+	// Vocabulary reads the workspace vocabulary back. A nil hook means "this
+	// backend cannot read the vocabulary its own writes configure", and the
+	// cases that need it SKIP with that reason rather than passing quietly.
+	Vocabulary *WorkspaceVocabularyReader
+}
+
+// WorkspaceVocabularyReader is the READ half of the two projected keys, which
+// this role deliberately has no verb for: SetSetting rewrites custom_statuses
+// and custom_types and nothing on publicops.WorkspaceConfig reads them back.
+//
+// IT IS SHAPED LIKE THE CONSUMER, NOT LIKE ANY ONE BACKEND. The three methods
+// are workapi.ConfigSource method for method, because that is the seam
+// workapi.LoadListConfig reads through, and what LoadListConfig does with an
+// error is the whole reason these cases exist: it loads all three UP FRONT and
+// wraps ANY failure, with no degraded path. `bd list`, `bd ready` and every
+// other list-shaped command call it before they can render a single row, so a
+// vocabulary read that answers an ERROR where the workspace has simply not
+// configured anything does not degrade — it takes out the entire family of
+// commands, on the first one a fresh workspace runs.
+//
+// THE THREE LEGS FILL IT FROM GENUINELY DIFFERENT BODIES. The two stores answer
+// from GetCustomStatusesDetailed / GetCustomTypes / GetInfraTypes, which read
+// through a per-store cache that SetConfig drops by key; the unit-of-work
+// backend answers from its ConfigUseCase, which has no cache, unions custom
+// types with the workspace YAML and resolves the infra DEFAULT in its own code
+// (internal/storage/domain/config.go) rather than in
+// issueops.ResolveInfraTypesInTx. So these cases are two votes on the value and
+// three on the shape of the answer.
+//
+// DoltStorage.GetCustomStatuses — the names-only spelling — is deliberately
+// absent. It is types.CustomStatusNames of the detailed slice off the same
+// cached load, so its order cannot differ, and the unit-of-work role has no
+// counterpart to it at all.
+type WorkspaceVocabularyReader struct {
+	// CustomStatuses reads the statuses status.custom projects, WITH their
+	// categories. Store legs: GetCustomStatusesDetailed.
+	CustomStatuses func(context.Context) ([]types.CustomStatus, error)
+	// CustomTypes reads the types types.custom projects.
+	CustomTypes func(context.Context) ([]string, error)
+	// InfraTypes reads the resolved infrastructure-type set — the types whose
+	// issues route to the wisps plane instead of the versioned one.
+	InfraTypes func(context.Context) (map[string]bool, error)
+}
+
+// workspaceConfigDefaultInfraTypes is the infra set a workspace that has
+// configured none resolves to.
+//
+// SPELLED OUT rather than read from the production constant: this suite is the
+// contract, and asserting the answer against the same place the implementation
+// reads it from would assert nothing.
+var workspaceConfigDefaultInfraTypes = map[string]bool{"agent": true, "role": true, "message": true}
+
+// workspaceConfigVocabulary returns the vocabulary reader or skips loudly.
+func workspaceConfigVocabulary(t *testing.T, fixture WorkspaceConfigFixture) *WorkspaceVocabularyReader {
+	t.Helper()
+	if fixture.Vocabulary == nil {
+		t.Skip("fixture.Vocabulary is nil: this backend cannot read the vocabulary its own writes project, " +
+			"so the three reads workapi.LoadListConfig makes before any list-shaped command renders a row are unobservable here")
+	}
+	return fixture.Vocabulary
+}
+
+func readWorkspaceConfigCustomStatuses(t *testing.T, ctx context.Context, vocabulary *WorkspaceVocabularyReader, when string) []types.CustomStatus {
+	t.Helper()
+	statuses, err := vocabulary.CustomStatuses(ctx)
+	if err != nil {
+		t.Fatalf("read the custom statuses %s: %v — LoadListConfig wraps this error and every list-shaped command fails with it", when, err)
+	}
+	return statuses
+}
+
+func readWorkspaceConfigCustomTypes(t *testing.T, ctx context.Context, vocabulary *WorkspaceVocabularyReader, when string) []string {
+	t.Helper()
+	custom, err := vocabulary.CustomTypes(ctx)
+	if err != nil {
+		t.Fatalf("read the custom types %s: %v — LoadListConfig wraps this error and every list-shaped command fails with it", when, err)
+	}
+	return custom
+}
+
+func readWorkspaceConfigInfraTypes(t *testing.T, ctx context.Context, vocabulary *WorkspaceVocabularyReader, when string) map[string]bool {
+	t.Helper()
+	infra, err := vocabulary.InfraTypes(ctx)
+	if err != nil {
+		t.Fatalf("read the infra types %s: %v — LoadListConfig wraps this error and every list-shaped command fails with it", when, err)
+	}
+	return infra
+}
+
+// workspaceConfigStatusPairs renders statuses as "name:category" IN ORDER, for
+// a failure message that reads. It does NOT sort: order is what two of these
+// cases are about.
+func workspaceConfigStatusPairs(statuses []types.CustomStatus) []string {
+	out := make([]string, len(statuses))
+	for i, status := range statuses {
+		out[i] = status.Name + ":" + string(status.Category)
+	}
+	return out
 }
 
 // RunWorkspaceConfigStoresAValueVerbatim pins workspaceconfig.go:93-100: a
@@ -408,6 +509,237 @@ func RunWorkspaceConfigARefusedWriteRecordsNoHistory(t *testing.T, ctx context.C
 	}
 	if after != before {
 		t.Fatalf("history entries went %d -> %d across three refused writes, want no change", before, after)
+	}
+}
+
+// RunWorkspaceConfigKeysAreCaseSensitive pins the collation of the key column
+// this plane stores under: two keys differing only in case are two SETTINGS,
+// each holding its own value, and both are enumerated.
+//
+// GetSettingRequest.Key states it from the other end — a key is used
+// "verbatim: there is no namespace completion, no case folding" — and until now
+// nothing held any backend to it. The stake is silent data loss in one
+// direction and a wrong answer in the other: under a case-insensitive
+// collation the second write REPLACES the first (the store bodies write with
+// REPLACE INTO / an upsert on the key), so `bd config set myKey` would quietly
+// destroy `mykey`, and every reader of either would get whichever row survived.
+//
+// BOTH READ PATHS ARE ASSERTED, because they are different SQL: GetSetting
+// matches one key with `WHERE key = ?` and ListSettings enumerates the table.
+// A collation that folded would break them differently — one answers the wrong
+// row, the other returns one row where two were written — and the raw count
+// below is what says which.
+func RunWorkspaceConfigKeysAreCaseSensitive(t *testing.T, ctx context.Context, fixture WorkspaceConfigFixture) {
+	t.Helper()
+	lower := workspaceConfigKey(fixture, "casefold")
+	upper := workspaceConfigKey(fixture, "CaseFold")
+	if !strings.EqualFold(lower, upper) || lower == upper {
+		t.Fatalf("the two probe keys %q and %q must differ, and differ ONLY in case; this case tests nothing otherwise", lower, upper)
+	}
+
+	setWorkspaceConfigSetting(t, ctx, fixture, lower, "lower")
+	setWorkspaceConfigSetting(t, ctx, fixture, upper, "upper")
+
+	// The lowercase write went FIRST, so a folding collation leaves "upper"
+	// under both spellings and this is the assertion that names it.
+	assertWorkspaceConfigValue(t, ctx, fixture, lower, "lower")
+	assertWorkspaceConfigValue(t, ctx, fixture, upper, "upper")
+
+	settings := listWorkspaceConfigSettings(t, ctx, fixture)
+	folded := 0
+	for key := range settings {
+		if strings.EqualFold(key, lower) {
+			folded++
+		}
+	}
+	if folded != 2 {
+		t.Fatalf("ListSettings carries %d keys case-folding to %q, want 2 — the two spellings are two settings", folded, lower)
+	}
+
+	// And the row count itself, because the role's two answers are both derived
+	// from the table and a body that de-duplicated in Go would satisfy neither
+	// half above for the right reason.
+	var rows int
+	if err := fixture.QueryScalar(ctx, "SELECT COUNT(*) FROM config WHERE LOWER(`key`) = ?", []any{strings.ToLower(lower)}, &rows); err != nil {
+		t.Fatalf("count the config rows case-folding to %q: %v", lower, err)
+	}
+	if rows != 2 {
+		t.Fatalf("the config table holds %d rows case-folding to %q, want 2: the second write replaced the first", rows, lower)
+	}
+}
+
+// RunWorkspaceConfigCustomStatusReadsAreOrderedByName pins the READ side of the
+// projection RunWorkspaceConfigProjectsCustomStatuses pins the write side of:
+// the statuses come back ORDERED BY NAME, alphabetically, independent of the
+// order the config string listed them, each carrying its own category.
+//
+// The order is not cosmetic. It is the order `bd list`'s status vocabulary is
+// built in (internal/workapi/list.go LoadListConfig), so it is the order every
+// list-shaped command renders and groups by.
+//
+// THE FIXTURE IS WRITTEN OUT OF ORDER ON BOTH AXES — "zebra" before "alpha",
+// and the alphabetically-first entry carrying the category that sorts LAST — so
+// neither a body that preserved the config string's order nor one that ordered
+// by category passes. The audit-tier ancestor of this case compared the
+// detailed read as a SORTED set, which made its ordering half unobservable;
+// this one compares the slice.
+//
+// It leaves the vocabulary CLEARED, which is the only direction a shared
+// workspace can safely be left in: status.custom is workspace-global and a bare
+// status installed here is claim-eligibility vocabulary a sibling never asked
+// for.
+func RunWorkspaceConfigCustomStatusReadsAreOrderedByName(t *testing.T, ctx context.Context, fixture WorkspaceConfigFixture) {
+	t.Helper()
+	vocabulary := workspaceConfigVocabulary(t, fixture)
+
+	setWorkspaceConfigSetting(t, ctx, fixture, publicops.SettingKeyStatusCustom, "zebra:wip,alpha:done")
+	assertWorkspaceConfigTableCount(t, ctx, fixture, "custom_statuses", 2)
+
+	statuses := readWorkspaceConfigCustomStatuses(t, ctx, vocabulary, "after configuring two of them out of alphabetical order")
+	want := []types.CustomStatus{
+		{Name: "alpha", Category: types.CategoryDone},
+		{Name: "zebra", Category: types.CategoryWIP},
+	}
+	if !slices.Equal(statuses, want) {
+		t.Fatalf("the custom statuses read back as %v, want %v — ordered by NAME, and each carrying the category it was configured with",
+			workspaceConfigStatusPairs(statuses), workspaceConfigStatusPairs(want))
+	}
+
+	setWorkspaceConfigSetting(t, ctx, fixture, publicops.SettingKeyStatusCustom, "")
+	assertWorkspaceConfigTableCount(t, ctx, fixture, "custom_statuses", 0)
+}
+
+// RunWorkspaceConfigCustomTypeReadsAreOrderedByName is the same pin for
+// types.custom, and it is a separate case rather than an arm of the one above
+// because the two projections are two tables written by two syncs and read by
+// two queries — a failure has to name which.
+//
+// The value is a JSON array in the order a caller would naturally write it, so
+// the alphabetical answer cannot be the array's own order.
+func RunWorkspaceConfigCustomTypeReadsAreOrderedByName(t *testing.T, ctx context.Context, fixture WorkspaceConfigFixture) {
+	t.Helper()
+	vocabulary := workspaceConfigVocabulary(t, fixture)
+
+	setWorkspaceConfigSetting(t, ctx, fixture, publicops.SettingKeyTypesCustom, `["zebra","alpha"]`)
+	assertWorkspaceConfigTableCount(t, ctx, fixture, "custom_types", 2)
+
+	custom := readWorkspaceConfigCustomTypes(t, ctx, vocabulary, "after configuring two of them out of alphabetical order")
+	if want := []string{"alpha", "zebra"}; !slices.Equal(custom, want) {
+		t.Fatalf("the custom types read back as %v, want %v — ordered by NAME, not by the order the value listed them", custom, want)
+	}
+
+	setWorkspaceConfigSetting(t, ctx, fixture, publicops.SettingKeyTypesCustom, "")
+	assertWorkspaceConfigTableCount(t, ctx, fixture, "custom_types", 0)
+}
+
+// RunWorkspaceConfigConfiguredInfraTypesReplaceTheDefaultSet pins that a
+// configured types.infra REPLACES the default infrastructure set outright
+// rather than adding to it.
+//
+// Infra types decide which issue types route to the wisps plane instead of the
+// versioned issues one, so a body that unioned the configured names with the
+// built-in agent/role/message would keep versioning rows a workspace asked to
+// keep ephemeral, and one that ignored the key would keep routing away rows it
+// asked to version. The configured names are deliberately DISJOINT from the
+// defaults, which is what makes "replaced" and "unioned" different answers; the
+// case that reaches this key elsewhere in this package configures a name that
+// is already in the default set, so it cannot tell them apart.
+//
+// THE PRE-VALUE IS READ AND ASSERTED, so the case cannot pass against a reader
+// that answers the same thing however the key is set — and on the store legs it
+// is what drives the CACHE: GetInfraTypes memoizes per store handle and only
+// SetConfig drops it, so reading before and after is the only shape that
+// exercises the invalidation. Restored to the default set on the way out.
+func RunWorkspaceConfigConfiguredInfraTypesReplaceTheDefaultSet(t *testing.T, ctx context.Context, fixture WorkspaceConfigFixture) {
+	t.Helper()
+	vocabulary := workspaceConfigVocabulary(t, fixture)
+	const key = "types.infra"
+
+	before := readWorkspaceConfigInfraTypes(t, ctx, vocabulary, "before anything configures the key")
+	if !maps.Equal(before, workspaceConfigDefaultInfraTypes) {
+		t.Fatalf("the infra types read %v before this case configured any, want the default %v: "+
+			"the replacement below is only observable against a known starting set", before, workspaceConfigDefaultInfraTypes)
+	}
+
+	setWorkspaceConfigSetting(t, ctx, fixture, key, "gate,probe")
+	configured := readWorkspaceConfigInfraTypes(t, ctx, vocabulary, "after configuring gate,probe")
+	if want := map[string]bool{"gate": true, "probe": true}; !maps.Equal(configured, want) {
+		t.Fatalf("the infra types read %v after configuring %q, want exactly %v — a configured set REPLACES the default one",
+			configured, "gate,probe", want)
+	}
+
+	setWorkspaceConfigSetting(t, ctx, fixture, key, "")
+	restored := readWorkspaceConfigInfraTypes(t, ctx, vocabulary, "after clearing the key again")
+	if !maps.Equal(restored, workspaceConfigDefaultInfraTypes) {
+		t.Fatalf("the infra types read %v after the key was cleared, want the default %v back", restored, workspaceConfigDefaultInfraTypes)
+	}
+}
+
+// RunWorkspaceConfigUnconfiguredVocabularyReadsAreEmptyNotErrors pins the
+// success path a workspace takes on its very first list-shaped command.
+//
+// THIS IS THE EDGE THAT BRICKS `bd list`. internal/workapi/list.go's
+// LoadListConfig loads all three of these reads UP FRONT and wraps any error —
+// "load custom statuses: %w" and its two siblings — with no degraded path, and
+// every list-shaped front door calls it before it can render a row. So on a
+// workspace that has configured no vocabulary the answer has to be a VALUE:
+// empty with a nil error for the two projections, and the DEFAULT infra set for
+// the third. A backend that answers a scan error, a table-missing error or a
+// nil-map surprise for the state a workspace is in the moment it is created
+// does not degrade — it takes out `bd list`, `bd ready` and the rest at once,
+// and every existing vocabulary case configures the vocabulary first, so none
+// of them would notice.
+//
+// IT INSTALLS ITS OWN PRECONDITION AND THEN CLEARS IT, rather than assuming the
+// workspace arrives unconfigured. Two things follow, and both are the point:
+// the case depends on NOTHING a sibling left behind, and the emptiness it
+// asserts is a value the reads MOVED to — asserted non-empty first — instead of
+// one they were already sitting on, which is how a hook wired to a constant
+// empty answer would pass.
+//
+// IT CLEARS BY WRITING THE EMPTY VALUE, NOT BY UNSETTING, and that is forced:
+// removing one of these keys deliberately leaves its projection standing
+// (bd-yby99.33, pinned by RunWorkspaceConfigUnsetLeavesTheProjectionBehind), so
+// an unset workspace is not an unconfigured one. An empty value and an absent
+// row are the same state to every reader here —
+// RunWorkspaceConfigConflatesAnUnsetKeyWithAnEmptyValue pins that at the role —
+// and the raw table counts below are what say the projections really are empty
+// before the reads are asked.
+func RunWorkspaceConfigUnconfiguredVocabularyReadsAreEmptyNotErrors(t *testing.T, ctx context.Context, fixture WorkspaceConfigFixture) {
+	t.Helper()
+	vocabulary := workspaceConfigVocabulary(t, fixture)
+
+	setWorkspaceConfigSetting(t, ctx, fixture, publicops.SettingKeyStatusCustom, "awaiting_review:active")
+	setWorkspaceConfigSetting(t, ctx, fixture, publicops.SettingKeyTypesCustom, "research")
+	setWorkspaceConfigSetting(t, ctx, fixture, "types.infra", "gate")
+	if got := readWorkspaceConfigCustomStatuses(t, ctx, vocabulary, "while one is configured"); len(got) != 1 {
+		t.Fatalf("the custom statuses read %v with one configured, want exactly it: the emptiness below is only meaningful as a change",
+			workspaceConfigStatusPairs(got))
+	}
+	if got := readWorkspaceConfigCustomTypes(t, ctx, vocabulary, "while one is configured"); len(got) != 1 {
+		t.Fatalf("the custom types read %v with one configured, want exactly it: the emptiness below is only meaningful as a change", got)
+	}
+	if got := readWorkspaceConfigInfraTypes(t, ctx, vocabulary, "while the key is configured"); !maps.Equal(got, map[string]bool{"gate": true}) {
+		t.Fatalf("the infra types read %v with gate configured, want exactly it: the default below is only meaningful as a change", got)
+	}
+
+	for _, key := range []string{publicops.SettingKeyStatusCustom, publicops.SettingKeyTypesCustom, "types.infra"} {
+		setWorkspaceConfigSetting(t, ctx, fixture, key, "")
+	}
+	// The projections are EMPTY, read raw, so the answers below are earned by
+	// the state rather than by a reader that never consulted it.
+	assertWorkspaceConfigTableCount(t, ctx, fixture, "custom_statuses", 0)
+	assertWorkspaceConfigTableCount(t, ctx, fixture, "custom_types", 0)
+
+	if got := readWorkspaceConfigCustomStatuses(t, ctx, vocabulary, "on an unconfigured workspace"); len(got) != 0 {
+		t.Errorf("the custom statuses read %v on an unconfigured workspace, want empty", workspaceConfigStatusPairs(got))
+	}
+	if got := readWorkspaceConfigCustomTypes(t, ctx, vocabulary, "on an unconfigured workspace"); len(got) != 0 {
+		t.Errorf("the custom types read %v on an unconfigured workspace, want empty", got)
+	}
+	if got := readWorkspaceConfigInfraTypes(t, ctx, vocabulary, "on an unconfigured workspace"); !maps.Equal(got, workspaceConfigDefaultInfraTypes) {
+		t.Errorf("the infra types read %v on an unconfigured workspace, want the default %v — an empty answer here silently un-routes every ephemeral type",
+			got, workspaceConfigDefaultInfraTypes)
 	}
 }
 

--- a/internal/storage/dolt/dependency_editor_contract_test.go
+++ b/internal/storage/dolt/dependency_editor_contract_test.go
@@ -217,6 +217,30 @@ func TestDependencyEditorClosedChildAddSatisfiesAnAnyChildrenGate(t *testing.T) 
 	conformance.RunDependencyEditorClosedChildAddSatisfiesAnAnyChildrenGate(t, ctx, fixture)
 }
 
+func TestDependencyEditorRelatesToAddLeavesItsSourceUnblocked(t *testing.T) {
+	fixture, ctx, cleanup := newDoltDependencyEditorFixture(t, "bsrel")
+	defer cleanup()
+	conformance.RunDependencyEditorRelatesToAddLeavesItsSourceUnblocked(t, ctx, fixture)
+}
+
+func TestDependencyEditorAcceptsADiamond(t *testing.T) {
+	fixture, ctx, cleanup := newDoltDependencyEditorFixture(t, "diamond")
+	defer cleanup()
+	conformance.RunDependencyEditorAcceptsADiamond(t, ctx, fixture)
+}
+
+func TestDependencyEditorGateScopeFollowsTheEdgeType(t *testing.T) {
+	fixture, ctx, cleanup := newDoltDependencyEditorFixture(t, "gscope")
+	defer cleanup()
+	conformance.RunDependencyEditorGateScopeFollowsTheEdgeType(t, ctx, fixture)
+}
+
+func TestDependencyEditorAcceptsBlockingAcrossIssueTypes(t *testing.T) {
+	fixture, ctx, cleanup := newDoltDependencyEditorFixture(t, "xtype")
+	defer cleanup()
+	conformance.RunDependencyEditorAcceptsBlockingAcrossIssueTypes(t, ctx, fixture)
+}
+
 // newDoltDependencyEditorFixture composes the backend's role fixture kit with
 // the accessor under test. Every hook but the accessor comes from the kit, so
 // the seeding and scalar-query plumbing stays identical to the other roles'.

--- a/internal/storage/dolt/workspace_config_contract_test.go
+++ b/internal/storage/dolt/workspace_config_contract_test.go
@@ -66,6 +66,21 @@ func TestWorkspaceConfigContract(t *testing.T) {
 	t.Run("ARefusedWriteRecordsNoHistory", func(t *testing.T) {
 		conformance.RunWorkspaceConfigARefusedWriteRecordsNoHistory(t, ctx, fixture)
 	})
+	t.Run("KeysAreCaseSensitive", func(t *testing.T) {
+		conformance.RunWorkspaceConfigKeysAreCaseSensitive(t, ctx, fixture)
+	})
+	t.Run("CustomStatusReadsAreOrderedByName", func(t *testing.T) {
+		conformance.RunWorkspaceConfigCustomStatusReadsAreOrderedByName(t, ctx, fixture)
+	})
+	t.Run("CustomTypeReadsAreOrderedByName", func(t *testing.T) {
+		conformance.RunWorkspaceConfigCustomTypeReadsAreOrderedByName(t, ctx, fixture)
+	})
+	t.Run("ConfiguredInfraTypesReplaceTheDefaultSet", func(t *testing.T) {
+		conformance.RunWorkspaceConfigConfiguredInfraTypesReplaceTheDefaultSet(t, ctx, fixture)
+	})
+	t.Run("UnconfiguredVocabularyReadsAreEmptyNotErrors", func(t *testing.T) {
+		conformance.RunWorkspaceConfigUnconfiguredVocabularyReadsAreEmptyNotErrors(t, ctx, fixture)
+	})
 }
 
 func newDoltWorkspaceConfigFixture(t *testing.T, prefix string) (conformance.WorkspaceConfigFixture, context.Context, func()) {
@@ -92,9 +107,26 @@ func newDoltWorkspaceConfigFixture(t *testing.T, prefix string) (conformance.Wor
 		SetConfig:       kit.SetConfig,
 		QueryScalar:     kit.QueryScalar,
 		CountHistory:    kit.CountHistory,
+		Vocabulary:      doltWorkspaceVocabularyReader(store),
 	}
 	return fixture, ctx, func() {
 		cancel()
 		storeCleanup()
+	}
+}
+
+// doltWorkspaceVocabularyReader is this backend's half of the vocabulary the
+// role writes and gives no verb to read. It reaches the store's own methods,
+// which is what the front doors reach through workapi.NewStoreConfigSource —
+// including GetInfraTypes, whose signature carries NO error, so on this leg the
+// list-shaped commands cannot be bricked by that read failing. The unit-of-work
+// leg's can.
+func doltWorkspaceVocabularyReader(store *DoltStore) *conformance.WorkspaceVocabularyReader {
+	return &conformance.WorkspaceVocabularyReader{
+		CustomStatuses: store.GetCustomStatusesDetailed,
+		CustomTypes:    store.GetCustomTypes,
+		InfraTypes: func(ctx context.Context) (map[string]bool, error) {
+			return store.GetInfraTypes(ctx), nil
+		},
 	}
 }

--- a/internal/storage/embeddeddolt/dependency_editor_contract_test.go
+++ b/internal/storage/embeddeddolt/dependency_editor_contract_test.go
@@ -219,6 +219,30 @@ func TestEmbeddedDependencyEditorClosedChildAddSatisfiesAnAnyChildrenGate(t *tes
 	conformance.RunDependencyEditorClosedChildAddSatisfiesAnAnyChildrenGate(t, ctx, newEmbeddedDependencyEditorFixture(t, ctx, "bsgate"))
 }
 
+func TestEmbeddedDependencyEditorRelatesToAddLeavesItsSourceUnblocked(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	ctx := t.Context()
+	conformance.RunDependencyEditorRelatesToAddLeavesItsSourceUnblocked(t, ctx, newEmbeddedDependencyEditorFixture(t, ctx, "bsrel"))
+}
+
+func TestEmbeddedDependencyEditorAcceptsADiamond(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	ctx := t.Context()
+	conformance.RunDependencyEditorAcceptsADiamond(t, ctx, newEmbeddedDependencyEditorFixture(t, ctx, "diamond"))
+}
+
+func TestEmbeddedDependencyEditorGateScopeFollowsTheEdgeType(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	ctx := t.Context()
+	conformance.RunDependencyEditorGateScopeFollowsTheEdgeType(t, ctx, newEmbeddedDependencyEditorFixture(t, ctx, "gscope"))
+}
+
+func TestEmbeddedDependencyEditorAcceptsBlockingAcrossIssueTypes(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	ctx := t.Context()
+	conformance.RunDependencyEditorAcceptsBlockingAcrossIssueTypes(t, ctx, newEmbeddedDependencyEditorFixture(t, ctx, "xtype"))
+}
+
 // newEmbeddedDependencyEditorFixture composes the backend's role fixture kit
 // with the accessor under test. Every hook but the accessor comes from the kit,
 // so the seeding and scalar-query plumbing stays identical to the other roles'.

--- a/internal/storage/embeddeddolt/workspace_config_contract_test.go
+++ b/internal/storage/embeddeddolt/workspace_config_contract_test.go
@@ -3,6 +3,7 @@
 package embeddeddolt_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/steveyegge/beads/backend/conformance"
@@ -68,6 +69,21 @@ func TestWorkspaceConfigContract(t *testing.T) {
 	t.Run("ARefusedWriteRecordsNoHistory", func(t *testing.T) {
 		conformance.RunWorkspaceConfigARefusedWriteRecordsNoHistory(t, ctx, fixture)
 	})
+	t.Run("KeysAreCaseSensitive", func(t *testing.T) {
+		conformance.RunWorkspaceConfigKeysAreCaseSensitive(t, ctx, fixture)
+	})
+	t.Run("CustomStatusReadsAreOrderedByName", func(t *testing.T) {
+		conformance.RunWorkspaceConfigCustomStatusReadsAreOrderedByName(t, ctx, fixture)
+	})
+	t.Run("CustomTypeReadsAreOrderedByName", func(t *testing.T) {
+		conformance.RunWorkspaceConfigCustomTypeReadsAreOrderedByName(t, ctx, fixture)
+	})
+	t.Run("ConfiguredInfraTypesReplaceTheDefaultSet", func(t *testing.T) {
+		conformance.RunWorkspaceConfigConfiguredInfraTypesReplaceTheDefaultSet(t, ctx, fixture)
+	})
+	t.Run("UnconfiguredVocabularyReadsAreEmptyNotErrors", func(t *testing.T) {
+		conformance.RunWorkspaceConfigUnconfiguredVocabularyReadsAreEmptyNotErrors(t, ctx, fixture)
+	})
 }
 
 func newEmbeddedWorkspaceConfigFixture(t *testing.T, te *testEnv, prefix string) conformance.WorkspaceConfigFixture {
@@ -88,5 +104,15 @@ func newEmbeddedWorkspaceConfigFixture(t *testing.T, te *testEnv, prefix string)
 		SetConfig:       kit.SetConfig,
 		QueryScalar:     kit.QueryScalar,
 		CountHistory:    kit.CountHistory,
+		Vocabulary: &conformance.WorkspaceVocabularyReader{
+			// The same three reads the server-backed store answers, and the
+			// same body behind them: the difference between the two stores is
+			// below storage.DoltStorage, not above it.
+			CustomStatuses: te.store.GetCustomStatusesDetailed,
+			CustomTypes:    te.store.GetCustomTypes,
+			InfraTypes: func(ctx context.Context) (map[string]bool, error) {
+				return te.store.GetInfraTypes(ctx), nil
+			},
+		},
 	}
 }

--- a/internal/storage/uow/dependency_editor_contract_test.go
+++ b/internal/storage/uow/dependency_editor_contract_test.go
@@ -58,6 +58,10 @@ func TestUOWDependencyEditorContract(t *testing.T) {
 		{name: "RemoveUnmarksItsSourceAndDescendants", run: conformance.RunDependencyEditorRemoveUnmarksItsSourceAndDescendants},
 		{name: "MaintainsBlockedStateAcrossPlanes", run: conformance.RunDependencyEditorMaintainsBlockedStateAcrossPlanes},
 		{name: "ClosedChildAddSatisfiesAnAnyChildrenGate", run: conformance.RunDependencyEditorClosedChildAddSatisfiesAnAnyChildrenGate},
+		{name: "RelatesToAddLeavesItsSourceUnblocked", run: conformance.RunDependencyEditorRelatesToAddLeavesItsSourceUnblocked},
+		{name: "AcceptsADiamond", run: conformance.RunDependencyEditorAcceptsADiamond},
+		{name: "GateScopeFollowsTheEdgeType", run: conformance.RunDependencyEditorGateScopeFollowsTheEdgeType},
+		{name: "AcceptsBlockingAcrossIssueTypes", run: conformance.RunDependencyEditorAcceptsBlockingAcrossIssueTypes},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			test.run(t, ctx, fixture)

--- a/internal/storage/uow/workspace_config_contract_test.go
+++ b/internal/storage/uow/workspace_config_contract_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/steveyegge/beads/backend/conformance"
+	"github.com/steveyegge/beads/internal/types"
 )
 
 // TestWorkspaceConfigContract runs the WorkspaceConfig contract against the
@@ -69,6 +70,21 @@ func TestWorkspaceConfigContract(t *testing.T) {
 	t.Run("ARefusedWriteRecordsNoHistory", func(t *testing.T) {
 		conformance.RunWorkspaceConfigARefusedWriteRecordsNoHistory(t, ctx, fixture)
 	})
+	t.Run("KeysAreCaseSensitive", func(t *testing.T) {
+		conformance.RunWorkspaceConfigKeysAreCaseSensitive(t, ctx, fixture)
+	})
+	t.Run("CustomStatusReadsAreOrderedByName", func(t *testing.T) {
+		conformance.RunWorkspaceConfigCustomStatusReadsAreOrderedByName(t, ctx, fixture)
+	})
+	t.Run("CustomTypeReadsAreOrderedByName", func(t *testing.T) {
+		conformance.RunWorkspaceConfigCustomTypeReadsAreOrderedByName(t, ctx, fixture)
+	})
+	t.Run("ConfiguredInfraTypesReplaceTheDefaultSet", func(t *testing.T) {
+		conformance.RunWorkspaceConfigConfiguredInfraTypesReplaceTheDefaultSet(t, ctx, fixture)
+	})
+	t.Run("UnconfiguredVocabularyReadsAreEmptyNotErrors", func(t *testing.T) {
+		conformance.RunWorkspaceConfigUnconfiguredVocabularyReadsAreEmptyNotErrors(t, ctx, fixture)
+	})
 }
 
 func newUOWWorkspaceConfigFixture(t *testing.T, ctx context.Context, prefix string) conformance.WorkspaceConfigFixture {
@@ -93,5 +109,38 @@ func newUOWWorkspaceConfigFixture(t *testing.T, ctx context.Context, prefix stri
 		SetConfig:       kit.SetConfig,
 		QueryScalar:     kit.QueryScalar,
 		CountHistory:    kit.CountHistory,
+		Vocabulary:      newUOWWorkspaceVocabularyReader(provider),
+	}
+}
+
+// newUOWWorkspaceVocabularyReader is this backend's half of the vocabulary the
+// role writes and gives no verb to read. It goes through ConfigUseCase, which
+// is what workapi.NewUOWConfigSource goes through, and which is a genuinely
+// different body from the stores': no per-handle cache, a YAML union on the
+// custom types, and the infra DEFAULT resolved in
+// internal/storage/domain/config.go rather than in
+// issueops.ResolveInfraTypesInTx.
+//
+// It is also the leg on which the bricking edge is REACHABLE: here the infra
+// read returns an error, where the store method's signature has none, so this
+// is the wiring that can carry a failed vocabulary read up into
+// workapi.LoadListConfig the way production would.
+func newUOWWorkspaceVocabularyReader(provider UnitOfWorkProvider) *conformance.WorkspaceVocabularyReader {
+	return &conformance.WorkspaceVocabularyReader{
+		CustomStatuses: func(ctx context.Context) ([]types.CustomStatus, error) {
+			return RunTxRead(ctx, provider, func(ctx context.Context, uw UnitOfWork) ([]types.CustomStatus, error) {
+				return uw.ConfigUseCase().GetCustomStatuses(ctx)
+			})
+		},
+		CustomTypes: func(ctx context.Context) ([]string, error) {
+			return RunTxRead(ctx, provider, func(ctx context.Context, uw UnitOfWork) ([]string, error) {
+				return uw.ConfigUseCase().GetCustomTypes(ctx)
+			})
+		},
+		InfraTypes: func(ctx context.Context) (map[string]bool, error) {
+			return RunTxRead(ctx, provider, func(ctx context.Context, uw UnitOfWork) (map[string]bool, error) {
+				return uw.ConfigUseCase().GetInfraTypes(ctx)
+			})
+		},
 	}
 }


### PR DESCRIPTION
Part of `bd-48ygn`. Additive only: +838, nothing deleted, all three legs.

## The `bd list`-bricking edge, precisely

`workapi.LoadListConfig` loads three vocabulary reads **up front** and wraps any error — `load custom statuses: %w` and its two siblings — with **no degraded path**. Every list-shaped front door calls it before rendering a row.

So on a workspace that has configured no vocabulary, the read must return a **value** — empty, plus the *default* infra set — never an error. An error there does not degrade `bd list`; it removes `bd list`, `bd ready` and the rest at once, **on the first command a fresh workspace runs**.

Every pre-existing vocabulary case configures first, so none could see it, and `GetInfraTypes` had no owning proof on any leg.

The new case installs, observes, then **clears** — so emptiness is a state it moved *to*, not a state it started in, and it depends on no sibling. It clears by empty write rather than unset, since unset leaves the projection.

Also established: the vocabulary read is **three bodies, not two** — dolt caches through `resolveCustomStatusesFromTableInTx`, embedded reads `ResolveCustomStatusesDetailedInTx`, uow reads `domain/db`.

## Cases, each with the fixture blindness it removes

| case | mutation | verdict |
| --- | --- | --- |
| `UnconfiguredVocabularyReadsAreEmptyNotAnError` | drop the infra default, `domain/config.go` and `issueops.ResolveInfraTypesInTx` | UNIQUE on both |
| `CustomStatusReadsAreOrderedByName` | `ORDER BY name DESC` in each resolver | UNIQUE at uow(+embedded) and dolt — the audit compared a **sorted set**, so its order half was unobservable |
| `CustomTypeReadsAreOrderedByName` | same, both bodies | UNIQUE at uow, embedded |
| `ConfiguredInfraTypesReplaceTheDefaultSet` | pre-seed the result with defaults (union rather than replace) | UNIQUE — the audit's names *overlap* the defaults; these are disjoint, and the before/after read drives cache invalidation |
| `KeysAreCaseSensitive` | `ToLower` the read key | UNIQUE at uow, embedded |
| `RelatesToAddLeavesItsSourceUnblocked` | add `DepRelatesTo` to the mark condition, both bodies | UNIQUE — **raw** `is_blocked`, zero blocking edges on the subjects, with a same-request `blocks` edge as the must-flip term |
| `AcceptsADiamond` | `reachPath` revisit → cycle | UNIQUE |
| `GateScopeFollowsTheEdgeType` | relates-to into `isSchedulingEdge` | UNIQUE (store); uow INCONCLUSIVE — the type scope lives wholly in shared SQL, so this is one body plus wiring, and is reported that way |
| `AcceptsBlockingAcrossIssueTypes` | make the hierarchy check consult the source's `issue_type` | UNIQUE — one shared guard |

## A case that could not fail, caught by its own author

`AcceptsADiamond`'s first version **could not fail**: both cycle gates search from the *target*, so the convergence was never walked and the mutation came back clean. Measurement forced an outsider→head arm, in a separate commit. That is the ninth case of this class in this programme and the second caught before review.

## Declined

The S-DEPS idempotency-arms row is dominated by `SameTypeReAddIsIdempotent` and `RetypeRefusalLeavesTheOriginalEdge`; the metadata-upsert residue is unreachable, since `DependencyEdge` carries no `Metadata`. No code for either.

Gates: `go build ./...`, `go vet`, `golangci-lint` clean; both contracts green on all three legs; every new case confirmed executing by name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)