### PR TITLE
Migrate the batch and comment audit cases, and give Importer the contract its report justifies

### DIFF
--- a/backend/conformance/batch_creator_contract.go
+++ b/backend/conformance/batch_creator_contract.go
@@ -245,6 +245,112 @@ func RunBatchCreatorLinksAnEarlierItemOfTheSameBatch(t *testing.T, ctx context.C
 	assertBatchCreatorEdgeCount(t, ctx, fixture, second, first, 1)
 }
 
+// RunBatchCreatorLinksAnEarlierItemOnTheEphemeralPlane is the case above run
+// on the OTHER plane, and it is a separate case rather than a second arm
+// because the two bodies reach the edge by different routes and one of them
+// has already lost it.
+//
+// The store bodies write every row first and then run ONE dependency-persist
+// pass over the whole batch; the unit-of-work body writes each item's edges as
+// it writes that item. A backend that took the all-ephemeral batch down a
+// per-issue create loop runs no persist pass at all, and every inline edge
+// disappears with no error and no report — which is exactly what happened
+// (audit_molecule_wisp_batch_iter.go testAuditCreateAllWispsInlineDependencies
+// records the regression). The durable case cannot see it: the durable path
+// has never been the one that got special-cased.
+//
+// THE ASSERTION IS PER TABLE, not a sum across both. The two planes hold their
+// edges in different tables (BatchCreateItem.Issue's plane clause), and an
+// edge between two wisps that landed in `dependencies` is a durable row
+// naming ephemeral work — the sync artifact the ignored wisp tables exist to
+// prevent, and invisible to a count that adds the tables together.
+func RunBatchCreatorLinksAnEarlierItemOnTheEphemeralPlane(t *testing.T, ctx context.Context, fixture BatchCreatorFixture) {
+	t.Helper()
+	first := fixture.IssuePrefix + "-bcwlink-first"
+	second := fixture.IssuePrefix + "-bcwlink-second"
+
+	firstIssue := batchCreatorIssue(first, "the ephemeral blocker")
+	firstIssue.Ephemeral = true
+	secondIssue := batchCreatorIssue(second, "the ephemeral blocked")
+	secondIssue.Ephemeral = true
+
+	result, err := fixture.BatchCreator.CreateBatch(ctx, publicops.CreateBatchRequest{
+		Actor:         "batch-writer",
+		ForceIDPrefix: true,
+		Items: []publicops.BatchCreateItem{
+			batchCreatorItem(firstIssue),
+			{
+				Issue:        secondIssue,
+				Dependencies: []publicops.CreateDependency{{TargetID: first, Type: types.DepBlocks}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateBatch with an edge onto an earlier EPHEMERAL item: %v", err)
+	}
+	if len(result.Issues) != 2 {
+		t.Fatalf("CreateBatch returned %d issues, want 2", len(result.Issues))
+	}
+	// Both rows on the ephemeral plane, or the edge assertion below is about a
+	// batch that did something else entirely.
+	assertBatchCreatorRowCount(t, ctx, fixture, "wisps", first, 1)
+	assertBatchCreatorRowCount(t, ctx, fixture, "wisps", second, 1)
+
+	assertBatchCreatorPlaneEdgeCount(t, ctx, fixture, "wisp_dependencies", second, first, 1)
+	assertBatchCreatorPlaneEdgeCount(t, ctx, fixture, "dependencies", second, first, 0)
+}
+
+// RunBatchCreatorKeepsAnEphemeralItemsLabelsOffTheDurablePlane pins the reach
+// of the all-ephemeral clause (issueops/batchcreator.go's "an all-ephemeral
+// batch writes ONLY to the dolt-ignored wisp tables"): the ITEM's aux rows are
+// covered by it too, not just its issue row.
+//
+// A label is the aux row a create actually writes, and it has its own pair of
+// tables. A wisp's label landing in `labels` is a durable row naming ephemeral
+// work — it ships on the next push, and it survives the wisp it names, because
+// only the wisp tables are swept. RunBatchCreatorRecordsNoHistoryForAnEphemeral
+// Batch cannot see it: it seeds no labels, and its history counter answers the
+// same number whether a label row landed durably or not.
+//
+// The result's Ephemeral flag is checked in the same case because a snapshot
+// that came back durable would make every plane claim above read as luck. The
+// front door prints the issue it got back rather than re-reading it, so a
+// wisp reported as durable is what a caller sees.
+func RunBatchCreatorKeepsAnEphemeralItemsLabelsOffTheDurablePlane(t *testing.T, ctx context.Context, fixture BatchCreatorFixture) {
+	t.Helper()
+	labeled := fixture.IssuePrefix + "-bcwlabel"
+	const label = "ephemeral-label"
+
+	issue := batchCreatorIssue(labeled, "ephemeral, and labeled")
+	issue.Ephemeral = true
+	issue.Labels = []string{label}
+
+	result, err := fixture.BatchCreator.CreateBatch(ctx, publicops.CreateBatchRequest{
+		Actor:         "batch-writer",
+		ForceIDPrefix: true,
+		Items:         []publicops.BatchCreateItem{batchCreatorItem(issue)},
+	})
+	if err != nil {
+		t.Fatalf("CreateBatch(1 labeled ephemeral item): %v", err)
+	}
+	if len(result.Issues) != 1 {
+		t.Fatalf("CreateBatch returned %d issues, want 1", len(result.Issues))
+	}
+	assertBatchCreatorRowCount(t, ctx, fixture, "wisps", labeled, 1)
+	assertBatchCreatorRowCount(t, ctx, fixture, "issues", labeled, 0)
+
+	assertBatchCreatorLabelRowCount(t, ctx, fixture, "wisp_labels", labeled, 1)
+	assertBatchCreatorLabelRowCount(t, ctx, fixture, "labels", labeled, 0)
+
+	if !result.Issues[0].Ephemeral {
+		t.Errorf("result issue %s came back Ephemeral=false for an item that asked to be ephemeral; the front door prints this snapshot rather than re-reading the row",
+			labeled)
+	}
+	if labels := result.Issues[0].Labels; len(labels) != 1 || labels[0] != label {
+		t.Errorf("result issue %s labels = %v, want [%s]: the snapshot is promised hydrated with labels on either plane", labeled, labels, label)
+	}
+}
+
 // RunBatchCreatorRefusesAnAbsentEdgeTarget pins the edge clause
 // (issueops/batchcreator.go:125-131): every requested edge is written or the
 // batch refuses, with ErrValidation wrapping ErrNotFound and nothing created.
@@ -484,6 +590,40 @@ func assertBatchCreatorEdgeCount(t *testing.T, ctx context.Context, fixture Batc
 	}
 	if got != want {
 		t.Errorf("edges %s -> %s = %d, want %d", source, target, got, want)
+	}
+}
+
+// assertBatchCreatorPlaneEdgeCount is assertBatchCreatorEdgeCount narrowed to
+// ONE of the two dependency tables. Where the placement of a durable edge is a
+// detail this role does not promise, WHICH PLANE an edge landed on is the
+// promise itself, and a sum across both tables cannot state it.
+func assertBatchCreatorPlaneEdgeCount(t *testing.T, ctx context.Context, fixture BatchCreatorFixture, table, source, target string, want int) {
+	t.Helper()
+	var got int
+	//nolint:gosec // G201: table is one of the contract's two hardcoded names.
+	query := "SELECT COUNT(*) FROM " + table + " WHERE issue_id = ?" +
+		" AND (depends_on_issue_id = ? OR depends_on_wisp_id = ? OR depends_on_external = ?)"
+	if err := fixture.QueryScalar(ctx, query, []any{source, target, target, target}, &got); err != nil {
+		t.Fatalf("count %s rows %s -> %s: %v", table, source, target, err)
+	}
+	if got != want {
+		t.Errorf("%s rows %s -> %s = %d, want %d", table, source, target, got, want)
+	}
+}
+
+// assertBatchCreatorLabelRowCount counts one issue's rows in one plane's label
+// table. The label tables are keyed by issue_id rather than id, so they need
+// their own counter.
+func assertBatchCreatorLabelRowCount(t *testing.T, ctx context.Context, fixture BatchCreatorFixture, table, issueID string, want int) {
+	t.Helper()
+	var got int
+	//nolint:gosec // G201: table is one of the contract's two hardcoded names.
+	query := "SELECT COUNT(*) FROM " + table + " WHERE issue_id = ?"
+	if err := fixture.QueryScalar(ctx, query, []any{issueID}, &got); err != nil {
+		t.Fatalf("count %s rows for %s: %v", table, issueID, err)
+	}
+	if got != want {
+		t.Errorf("%s rows for %s = %d, want %d", table, issueID, got, want)
 	}
 }
 

--- a/backend/conformance/commenter_contract.go
+++ b/backend/conformance/commenter_contract.go
@@ -46,9 +46,11 @@ import (
 // speed: the second stamp lands one second later either because the body
 // advanced it or because the clock ticked between the two calls, and the two
 // are indistinguishable. Every timing assertion therefore starts from a
-// comment seeded AHEAD of the clock through SeedCommentAt, where no wall-clock
-// reading can produce the value the promise requires — see
-// RunCommenterAdvancesALiveStampPastTheThreadsNewestComment.
+// comment seeded through SeedCommentAt an hour away from the clock, in the
+// direction the branch under test needs, so the right answer and the wrong one
+// are an hour apart rather than a runner's margin: AHEAD for the advance
+// (RunCommenterAdvancesALiveStampPastTheThreadsNewestComment) and BEHIND for
+// the clause that stops it (RunCommenterTakesTheClockWhenTheThreadIsBehindIt).
 
 // CommenterFixture supplies adapter-specific storage access for the
 // add-comment assertions. Every field is named and typed exactly like the
@@ -257,6 +259,103 @@ func RunCommenterAdvancesALiveStampPastTheThreadsNewestComment(t *testing.T, ctx
 	want := append([]string{seeded}, live...)
 	if got := readCommenterThreadTexts(t, ctx, fixture, anchor, len(want)); !slices.Equal(got, want) {
 		t.Errorf("thread %s reads back as %v, want %v: the stamps are what carry write order to a reader", anchor, got, want)
+	}
+}
+
+// RunCommenterTakesTheClockWhenTheThreadIsBehindIt pins the OTHER branch of
+// the same stamp rule (storage/issueops.NextLiveCommentTime): the advance
+// applies only "when that comment is at or after `now`", so a thread whose
+// newest comment the clock has already passed gets the clock, not that
+// comment's stamp plus a second.
+//
+// It is the clause that makes the advance's cost bounded rather than
+// permanent — the leaf calls the skew "a bounded forward skew … it drains as
+// wall-clock advances", and draining is precisely this branch. Nothing pins
+// it. A body that dropped the `newest.Before(now)` comparison and always
+// returned newest+1s stamps every comment on an old thread an hour, a day or a
+// year in the past, and passes every other case in this file:
+// RunCommenterAdvancesALiveStampPastTheThreadsNewestComment seeds its thread
+// AHEAD of the clock, and every remaining case comments on a thread with no
+// comment on it, where both branches agree on `now`.
+//
+// WHAT THE FIXTURE DELIBERATELY MAKES OBSERVABLE. The thread starts with a
+// comment seeded AN HOUR BEHIND the clock, the mirror image of the advance
+// case's seed:
+//
+//   - The wrong answer and the right one are an hour apart, so the assertion
+//     is not a race with the runner. A body that always advances lands on
+//     behind+1s, which no reading of the clock during this case can produce.
+//   - `now` is not guessed. The stamp is bounded by two readings taken either
+//     side of the call in this process, so the case asserts what a caller can
+//     actually demand — the comment is stamped at the time it was written —
+//     rather than at an instant it had to predict.
+//
+// ONE live add, not two. A second back-to-back add would land on a thread
+// whose newest comment is now `now`, which is the OTHER branch, and it would
+// land one second later whether the body advanced or the clock simply ticked
+// between the two calls — the runner's speed, not the body's behavior. That is
+// the reading this file refuses to take anywhere (see the file header).
+//
+// WHAT IT DEPENDS ON FROM OUTSIDE ITSELF: the wall clock, and only as a bound
+// it measures itself. The anchor and its whole thread are seeded here under
+// this case's own id, the rule is scoped to one issue_id, and no assertion
+// reads a count, a stamp or a history depth another case could have moved. The
+// seed's own stamp is read back RAW first, because a seeding path that
+// re-stamped it with the clock would leave the thread level with `now` instead
+// of behind it, and then the equality below would hold for a body that
+// advances unconditionally.
+func RunCommenterTakesTheClockWhenTheThreadIsBehindIt(t *testing.T, ctx context.Context, fixture CommenterFixture) {
+	t.Helper()
+	if fixture.SeedCommentAt == nil {
+		t.Skip("fixture cannot seed a comment at a chosen time: SeedCommentAt is nil, so the drain half of the stamp rule is unpinned on this backend")
+	}
+	anchor := fixture.IssuePrefix + "-behind"
+	seedCommenterIssue(t, ctx, fixture, anchor)
+
+	const seeded = "seeded an hour behind the clock"
+	behind := time.Now().UTC().Truncate(time.Second).Add(-time.Hour)
+	if err := fixture.SeedCommentAt(ctx, anchor, "importer", seeded, behind); err != nil {
+		t.Fatalf("seed a comment on %s at %s: %v", anchor, behind, err)
+	}
+	if stored := readCommenterStampOf(t, ctx, fixture, anchor, seeded); !stored.Equal(behind) {
+		t.Fatalf("the seeded comment is stored at %s, want %s verbatim: a seed level with the clock cannot show that a live add declines to advance past it",
+			stored, behind)
+	}
+
+	// The bound is taken around the call, not guessed: floor before, ceiling
+	// after, both at the column's whole-second precision.
+	floor := time.Now().UTC().Truncate(time.Second)
+	result, err := fixture.Commenter.AddComment(ctx, publicops.AddCommentRequest{
+		Author:  "author",
+		IssueID: anchor,
+		Text:    "live, on a thread the clock has passed",
+	})
+	if err != nil {
+		t.Fatalf("AddComment: %v", err)
+	}
+	requireCommenterResult(t, result)
+	ceiling := time.Now().UTC().Truncate(time.Second)
+
+	stored := readCommenterRow(t, ctx, fixture, "comments", result.Comment.ID)
+	got := stored.CreatedAt.UTC()
+	if advanced := behind.Add(time.Second); got.Equal(advanced) {
+		t.Errorf("live comment is stored at %s, which is one second past a comment the clock passed an hour ago: the advance applies only while the thread's newest comment is at or after now, or the skew never drains",
+			got)
+	}
+	if got.Before(floor) || got.After(ceiling) {
+		t.Errorf("live comment is stored at %s, want the instant it was written — inside [%s, %s]: a comment on an old thread is stamped by the clock, not by the thread",
+			got, floor, ceiling)
+	}
+	if resultStamp := result.Comment.CreatedAt.UTC(); !resultStamp.Equal(got) {
+		t.Errorf("AddComment returned created_at %s while the row holds %s: the result must carry the stamp the row got", resultStamp, got)
+	}
+
+	// The order still has to come out right, which is the reason the rule
+	// exists at all: an unconditional advance would sort the live comment an
+	// hour BEFORE the import it was written after.
+	want := []string{seeded, "live, on a thread the clock has passed"}
+	if got := readCommenterThreadTexts(t, ctx, fixture, anchor, len(want)); !slices.Equal(got, want) {
+		t.Errorf("thread %s reads back as %v, want %v", anchor, got, want)
 	}
 }
 

--- a/backend/conformance/importer_contract.go
+++ b/backend/conformance/importer_contract.go
@@ -1,0 +1,454 @@
+package conformance
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+	publicops "github.com/steveyegge/beads/issueops"
+)
+
+// This file holds the contract every implementation of publicops.Importer must
+// satisfy: the sanctioned bulk-upsert door, the write half of `bd import`.
+//
+// WHY IT IS A SEPARATE FILE RATHER THAN MORE BatchCreator CASES. The batch
+// creator does not merely lack these promises, it REFUSES them, twice and on
+// the record, and both refusals point here:
+//
+//   - "AN EXPLICIT ID IS CREATE-ONLY … an id that already names a row is
+//     ErrAlreadyExists and never a silent full-row upsert. THE DOCUMENTED
+//     UPSERT SURFACE IS `bd import`" (issueops/batchcreator.go, on
+//     BatchCreateItem.Issue). The role text names this role as the home of the
+//     promise it declines.
+//   - "EVERY REQUESTED EDGE IS WRITTEN OR THE BATCH REFUSES. There is no
+//     per-edge report and no partial graph … a create that reported success
+//     having SILENTLY dropped an edge is data loss, because the caller has no
+//     way to learn the relationship is missing."
+//
+// The second refusal is the one worth reading closely, because it is what
+// decides the shape of every skip case below. Its ground is not that dropping
+// an edge is intolerable; it is that dropping one SILENTLY is, because the
+// caller cannot learn about it. An import cannot refuse — a snapshot naming
+// work that was filtered out upstream would be unimportable, and the row is
+// wanted whether or not its edge resolves — so it takes the other branch of
+// the same reasoning and REPORTS, in ImportBatchResult.SkippedDependencies.
+//
+// So this contract does not restate a rejected promise. It states the
+// obligation the rejection creates: the report is the whole justification for
+// the drop, and an importer whose report is empty has committed exactly the
+// data loss BatchCreator refuses. Every case here therefore asserts the report
+// as hard as it asserts the store, and none of them accepts "a skip was
+// mentioned somewhere" for an answer.
+//
+// THERE IS ONE WIRING, NOT THREE, AND THAT IS A FINDING RATHER THAN AN
+// OVERSIGHT. A capability in this repo is a role plus an accessor
+// (engdocs/ADDING_AN_ISSUEOPS_ROLE.md), and Importer has exactly one accessor:
+// uow.ImporterSource, served by the unit-of-work provider and reached in
+// production by cmd/bd/import_proxied_server.go. storage.DoltStorage has no
+// Importer() — it is the only uow capability source with no counterpart there
+// — so on the two store backends `bd import` still runs the raw seam
+// (store.CreateIssuesWithFullOptions, cmd/bd/import_shared.go) and there is no
+// role for a contract to hold. Giving them one means a new method on the
+// storage interface and a new body behind it at two backends, which is API
+// work rather than test work.
+//
+// The consequence is that this file covers exactly the gap nothing else can.
+// The ENGINE below it (issueops.CreateIssuesInTxWithResult) is the same one the
+// store legs run and the audit tier already observes through that raw seam
+// (backend/conformance/audit_molecule_wisp_batch_iter.go). What no test
+// anywhere reaches is the mapping this role puts on top of it — the
+// stale-rejection list, its deduplication, the Created arithmetic, and the
+// skip list — which is unit-of-work-own code on the one leg RunAll's Factory
+// (func(*testing.T) storage.DoltStorage) structurally cannot reach.
+
+// ImporterFixture supplies adapter-specific storage access for the import
+// assertions. Every field is named and typed exactly like the per-backend
+// roleFixtureKit hook it is filled from, so a wiring is kit plus accessor plus
+// prefix with no adapter in between.
+type ImporterFixture struct {
+	// IssuePrefix namespaces the ids each assertion seeds, so several of them
+	// can share one database.
+	IssuePrefix string
+	// Importer is the surface under test.
+	Importer publicops.Importer
+	// QueryScalar runs a single-row query and scans it, RETURNING the error
+	// rather than failing the test.
+	QueryScalar func(context.Context, string, []any, ...any) error
+}
+
+// RunImporterRejectsAStaleRowAndNamesIt pins the in-transaction half of the
+// stale guard (ImportBatchRequest.AllowStale, ImportBatchResult.
+// StaleRejectedIDs): with AllowStale off, a row whose updated_at is older than
+// the stored one keeps every stored column AND IS NAMED IN THE RESULT, and the
+// Created count is what LANDED rather than what was asked for.
+//
+// WHAT THE AUDIT FIXTURE MAKES UNOBSERVABLE, and what this case exists for.
+// The audit twin (testAuditCreateRejectStaleUpserts) runs the same three arms
+// and reads back one thing: GetIssue(...).Title. Through that single column,
+// arm (a) and arm (c) are INDISTINGUISHABLE — the title fails to change in
+// both — while underneath they are different clauses of different code:
+//
+//   - (a) OLDER is a REJECTION. The engine's explicit staleness read fires,
+//     nothing is written at all, aux data is deliberately not merged, and the
+//     row is reported.
+//   - (c) EQUAL is an ACCEPTANCE whose columns happen not to move. The row is
+//     NOT rejected — updated_at has second granularity, so a tie may be two
+//     distinct same-second edits and the local row wins on the conditional
+//     upsert — nothing is reported, and it counts as created.
+//
+// Reading the title alone, an implementation that rejected every tie would
+// pass the audit case forever, and a caller would be told it imported N rows
+// that it did not. So the arms below assert the REPORT and the COUNT, which is
+// the only place the two clauses differ.
+//
+// EACH REJECTING BATCH CARRIES A SIBLING THAT LANDS. Created is promised as
+// "the rows the batch wrote … excluding stale-rejected rows", and a
+// single-row batch cannot tell an implementation that computed it from the
+// request from one that computed it from what landed: both answer 0 for a
+// rejected row. Two rows, one rejected, separates them — 1 against 2.
+//
+// WHAT IT DEPENDS ON FROM OUTSIDE ITSELF: nothing. The anchor is seeded by
+// this case's own first import, under this case's own id, and the seed's
+// stored updated_at is read back RAW before any arm leans on being older or
+// newer than it — a seeding path that re-stamped the row with the clock would
+// leave every subsequent arm comparing against the wrong instant. The stamps
+// are fixed calendar dates rather than offsets from now, so no arm's meaning
+// depends on when the suite runs.
+func RunImporterRejectsAStaleRowAndNamesIt(t *testing.T, ctx context.Context, fixture ImporterFixture) {
+	t.Helper()
+	anchor := fixture.IssuePrefix + "-impstale"
+	sibling := fixture.IssuePrefix + "-impstale-sibling"
+	var (
+		y2020 = time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+		y2021 = time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+		y2022 = time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)
+	)
+
+	// The seed is an import too: this role IS the upsert door, so the state an
+	// upsert is tested against is the state an import leaves.
+	seed := runImporterBatch(t, ctx, fixture, "seed", importerIssueAt(anchor, "original", y2021))
+	if seed.Created != 1 {
+		t.Fatalf("the seeding import reported Created = %d, want 1", seed.Created)
+	}
+	if len(seed.StaleRejectedIDs) != 0 {
+		t.Fatalf("the seeding import rejected %v as stale; there was nothing to be stale against", seed.StaleRejectedIDs)
+	}
+	assertImporterScalar(t, ctx, fixture, "seeded title", anchor, "original")
+	if stored := readImporterUpdatedAt(t, ctx, fixture, anchor); !stored.Equal(y2021) {
+		t.Fatalf("the seeded row is stored at updated_at %s, want %s verbatim: an anchor the import re-stamped with the clock makes every arm below compare against the wrong instant",
+			stored, y2021)
+	}
+
+	t.Run("OlderIsRejectedAndNamed", func(t *testing.T) {
+		result := runImporterBatch(t, ctx, fixture, "older",
+			importerIssueAt(anchor, "stale", y2020),
+			importerIssueAt(sibling, "lands beside the rejection", y2022))
+
+		assertImporterScalar(t, ctx, fixture, "title after an older row", anchor, "original")
+		assertImporterRowCount(t, ctx, fixture, "issues", sibling, 1)
+		if got := result.StaleRejectedIDs; len(got) != 1 || got[0] != anchor {
+			t.Errorf("StaleRejectedIDs = %v, want exactly [%s]: a row the guard kept out of the store is one the caller is owed the id of, or the import reports having written work it discarded",
+				got, anchor)
+		}
+		if result.Created != 1 {
+			t.Errorf("Created = %d for a 2-row batch with 1 rejection, want 1: Created counts what landed, not what was asked for", result.Created)
+		}
+	})
+
+	t.Run("NewerOverwrites", func(t *testing.T) {
+		result := runImporterBatch(t, ctx, fixture, "newer", importerIssueAt(anchor, "fresh", y2022))
+
+		assertImporterScalar(t, ctx, fixture, "title after a newer row", anchor, "fresh")
+		if len(result.StaleRejectedIDs) != 0 {
+			t.Errorf("StaleRejectedIDs = %v for a strictly newer row, want none", result.StaleRejectedIDs)
+		}
+		if result.Created != 1 {
+			t.Errorf("Created = %d for one accepted row, want 1", result.Created)
+		}
+	})
+
+	t.Run("EqualIsAcceptedNotRejected", func(t *testing.T) {
+		result := runImporterBatch(t, ctx, fixture, "equal", importerIssueAt(anchor, "tie", y2022))
+
+		// Same observable as the older arm through the title alone, which is
+		// the whole point: only the two assertions below tell them apart.
+		assertImporterScalar(t, ctx, fixture, "title after an equal-stamp row", anchor, "fresh")
+		if len(result.StaleRejectedIDs) != 0 {
+			t.Errorf("StaleRejectedIDs = %v for an equal-timestamp row, want none: a tie is the local row winning a conditional upsert, not the stale guard firing, and reporting it would tell a caller its row was discarded when it was accepted",
+				result.StaleRejectedIDs)
+		}
+		if result.Created != 1 {
+			t.Errorf("Created = %d for an equal-timestamp row, want 1: the row was written, and only its columns declined to move", result.Created)
+		}
+	})
+}
+
+// RunImporterReportsTheAbsentTargetItDroppedOnce is the case this contract
+// exists for, stated against the exact request BatchCreator refuses:
+// RunBatchCreatorRefusesAnAbsentEdgeTarget sends an item whose edge names a
+// missing id of its OWN prefix and requires ErrValidation wrapping ErrNotFound
+// with nothing created. The importer takes the other branch — the row lands,
+// the edge does not — and the report is the entire reason that is allowed
+// rather than the data loss the batch creator calls it.
+//
+// THE REPORT IS THEREFORE ASSERTED AS AN EXACT LIST, not searched. The audit
+// twin (testAuditCreateAllWispsInlineDependencies) scans its skip slice for a
+// matching pair and stops at the first hit, so it cannot see a report that
+// names the same edge fifty times, and it never reads the reason at all. This
+// case names the whole list and its length.
+//
+// THE ITEM ASKS FOR THE SAME MISSING EDGE TWICE, which is what makes the
+// deduplication clause observable ("SkippedDependencies lists the edges
+// dropped by the batch, DEDUPLICATED"). The engine reports per requested edge,
+// so both copies are reported to the role and collapsing them is the role's
+// OWN work — one of the few pieces of this leg's mapping that no engine test
+// can cover. Without the repeat, a mapping that appended blindly is
+// indistinguishable from one that deduplicates.
+//
+// WHAT IT DEPENDS ON FROM OUTSIDE ITSELF: nothing. The absent target is an id
+// under this case's own prefixed name that no case creates, and its absence is
+// asserted rather than assumed — a target another case had created would make
+// the edge resolvable and turn every assertion below into a statement about a
+// batch that skipped nothing.
+func RunImporterReportsTheAbsentTargetItDroppedOnce(t *testing.T, ctx context.Context, fixture ImporterFixture) {
+	t.Helper()
+	source := fixture.IssuePrefix + "-impmiss-source"
+	absent := fixture.IssuePrefix + "-impmiss-absent"
+	assertImporterRowCount(t, ctx, fixture, "issues", absent, 0)
+	assertImporterRowCount(t, ctx, fixture, "wisps", absent, 0)
+
+	issue := importerIssue(source, "names something absent, twice")
+	issue.Dependencies = []*types.Dependency{
+		{IssueID: source, DependsOnID: absent, Type: types.DepBlocks},
+		{IssueID: source, DependsOnID: absent, Type: types.DepBlocks},
+	}
+	result := runImporterBatch(t, ctx, fixture, "miss", issue)
+
+	// The row is the point: an import that refused here would make a snapshot
+	// naming filtered-out work unimportable.
+	assertImporterRowCount(t, ctx, fixture, "issues", source, 1)
+	if result.Created != 1 {
+		t.Errorf("Created = %d, want 1: the row landed", result.Created)
+	}
+	assertImporterEdgeCount(t, ctx, fixture, source, absent, 0)
+	assertImporterSkipped(t, result, []publicops.SkippedDependency{{IssueID: source, DependsOnID: absent}})
+}
+
+// RunImporterReportsTheCrossPlaneEdgeItDropped pins the same obligation for the
+// plane rule. The request is the one RunBatchCreatorRefusesACrossPlaneInBatchEdge
+// sends and refuses whole — a durable item and an ephemeral item created
+// together with an edge between them — where the import keeps BOTH ROWS and
+// drops only the edge.
+//
+// BOTH ROWS ARE ASSERTED, on their own tables. The dropped edge is the visible
+// part, and an implementation that dropped the ephemeral item along with it
+// would satisfy every statement about the edge: there is no edge because there
+// is no wisp. The audit twin's arm (b) reads both rows back through GetIssue,
+// which resolves across planes and so cannot say WHICH table either landed in.
+//
+// The report is again an exact list. Arm (b) of the audit case asserts no
+// report at all — it passes a nil skip callback — so a silent cross-plane drop
+// is invisible to it, which is precisely the drop BatchCreator calls data
+// loss.
+func RunImporterReportsTheCrossPlaneEdgeItDropped(t *testing.T, ctx context.Context, fixture ImporterFixture) {
+	t.Helper()
+	durable := fixture.IssuePrefix + "-impplane-durable"
+	wisp := fixture.IssuePrefix + "-impplane-wisp"
+
+	ephemeral := importerIssue(wisp, "the ephemeral end")
+	ephemeral.Ephemeral = true
+	ephemeral.Dependencies = []*types.Dependency{
+		{IssueID: wisp, DependsOnID: durable, Type: types.DepBlocks},
+	}
+	result := runImporterBatch(t, ctx, fixture, "cross-plane",
+		importerIssue(durable, "the durable end"), ephemeral)
+
+	assertImporterRowCount(t, ctx, fixture, "issues", durable, 1)
+	assertImporterRowCount(t, ctx, fixture, "wisps", wisp, 1)
+	if result.Created != 2 {
+		t.Errorf("Created = %d, want 2: dropping an edge costs the batch neither row", result.Created)
+	}
+	assertImporterEdgeCount(t, ctx, fixture, wisp, durable, 0)
+	assertImporterSkipped(t, result, []publicops.SkippedDependency{{IssueID: wisp, DependsOnID: durable}})
+}
+
+// RunImporterReportsTheCycleEdgeItDropped pins the last of the three drops: an
+// in-batch dependency cycle. Both rows land, the graph stays acyclic, and the
+// ONE edge given up to keep it acyclic is named.
+//
+// THE ASSERTION IS "EXACTLY ONE OF THE PAIR SURVIVED, AND THE REPORT NAMES THE
+// OTHER ONE", which is stated without pinning WHICH. The order the engine
+// walks a batch's pending edges in is not a promise of this role, so a case
+// that demanded the first edge survive would fail an implementation that is
+// equally correct. What IS a promise is that the report and the store agree:
+// the edge the caller was told about is the edge that is missing, and a report
+// naming the surviving edge is worse than no report — it sends a caller
+// re-adding a relationship that is already there while the one that is gone
+// stays gone.
+//
+// The audit twin's arm (b) asserts that both ISSUES exist and stops. It reads
+// no edge and no report, so it cannot distinguish "one edge dropped" from
+// "both dropped" from "the cycle was written" — the whole subject of the arm
+// is unobservable to it.
+func RunImporterReportsTheCycleEdgeItDropped(t *testing.T, ctx context.Context, fixture ImporterFixture) {
+	t.Helper()
+	first := fixture.IssuePrefix + "-impcycle-first"
+	second := fixture.IssuePrefix + "-impcycle-second"
+
+	head := importerIssue(first, "blocks the second")
+	head.Dependencies = []*types.Dependency{
+		{IssueID: first, DependsOnID: second, Type: types.DepBlocks},
+	}
+	tail := importerIssue(second, "blocks the first, closing the cycle")
+	tail.Dependencies = []*types.Dependency{
+		{IssueID: second, DependsOnID: first, Type: types.DepBlocks},
+	}
+	result := runImporterBatch(t, ctx, fixture, "cycle", head, tail)
+
+	assertImporterRowCount(t, ctx, fixture, "issues", first, 1)
+	assertImporterRowCount(t, ctx, fixture, "issues", second, 1)
+	if result.Created != 2 {
+		t.Errorf("Created = %d, want 2: a cyclic edge costs the batch neither row", result.Created)
+	}
+
+	forward := importerEdgeCount(t, ctx, fixture, first, second)
+	backward := importerEdgeCount(t, ctx, fixture, second, first)
+	if forward+backward != 1 {
+		t.Fatalf("edges %s->%s = %d and %s->%s = %d, want exactly one of the two: both is the cycle the batch is supposed to refuse to write, neither throws away an edge nothing was wrong with",
+			first, second, forward, second, first, backward)
+	}
+	dropped := publicops.SkippedDependency{IssueID: first, DependsOnID: second}
+	if forward == 1 {
+		dropped = publicops.SkippedDependency{IssueID: second, DependsOnID: first}
+	}
+	assertImporterSkipped(t, result, []publicops.SkippedDependency{dropped})
+}
+
+// runImporterBatch imports issues under the option set `bd import` actually
+// sends (cmd/bd/import_proxied_server.go): stale rows rejected in the
+// transaction, and an explicit import admitting ids outside the workspace's
+// configured prefix. It fails the test on an error, because every case here is
+// about a batch that LANDS — the refusals belong to BatchCreator.
+func runImporterBatch(t *testing.T, ctx context.Context, fixture ImporterFixture, source string, issues ...*types.Issue) publicops.ImportBatchResult {
+	t.Helper()
+	result, err := fixture.Importer.ImportBatch(ctx, publicops.ImportBatchRequest{
+		Actor:                "importer",
+		Issues:               issues,
+		SkipPrefixValidation: true,
+		Source:               source,
+	})
+	if err != nil {
+		t.Fatalf("ImportBatch(%s, %d issues): %v", source, len(issues), err)
+	}
+	return result
+}
+
+// importerIssue is one import row with an EXPLICIT id: an import always names
+// the rows it carries, because it is replaying a snapshot rather than minting
+// work.
+func importerIssue(id, title string) *types.Issue {
+	return &types.Issue{ID: id, Title: title, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+}
+
+// importerIssueAt is importerIssue carrying the timestamps a snapshot was
+// exported with, which is what the stale guard compares.
+func importerIssueAt(id, title string, stamp time.Time) *types.Issue {
+	issue := importerIssue(id, title)
+	issue.CreatedAt = stamp
+	issue.UpdatedAt = stamp
+	return issue
+}
+
+// assertImporterSkipped asserts the WHOLE skip report, in order, by the two
+// fields that identify an edge. It is an equality rather than a search: a
+// report is what justifies a silent drop, so extra entries (a report that
+// names an edge the batch actually wrote) and repeated ones (a report that
+// never deduplicated) are both failures, and neither is visible to a scan that
+// stops at its first match.
+//
+// The Reason is checked for PRESENCE only. It is prose the role documents as
+// "missing, invalid, or would form a disallowed edge" without fixing the
+// wording, so pinning a string would freeze a message rather than a promise —
+// but an empty one leaves a caller with a drop it cannot act on.
+func assertImporterSkipped(t *testing.T, result publicops.ImportBatchResult, want []publicops.SkippedDependency) {
+	t.Helper()
+	if len(result.SkippedDependencies) != len(want) {
+		t.Fatalf("SkippedDependencies = %+v, want exactly %d entry/entries %+v: the report is the whole reason a dropped edge is not data loss, so a missing entry hides one and a repeated entry is the deduplication clause failing",
+			result.SkippedDependencies, len(want), want)
+	}
+	for i, got := range result.SkippedDependencies {
+		if got.IssueID != want[i].IssueID || got.DependsOnID != want[i].DependsOnID {
+			t.Errorf("SkippedDependencies[%d] names %s -> %s, want %s -> %s",
+				i, got.IssueID, got.DependsOnID, want[i].IssueID, want[i].DependsOnID)
+		}
+		if got.Reason == "" {
+			t.Errorf("SkippedDependencies[%d] (%s -> %s) carries no reason; a caller told only that an edge went missing cannot act on it",
+				i, got.IssueID, got.DependsOnID)
+		}
+	}
+}
+
+// assertImporterRowCount asserts how many rows of a plane carry an id.
+func assertImporterRowCount(t *testing.T, ctx context.Context, fixture ImporterFixture, table, id string, want int) {
+	t.Helper()
+	var got int
+	//nolint:gosec // G201: table is one of the contract's two hardcoded names.
+	query := "SELECT COUNT(*) FROM " + table + " WHERE id = ?"
+	if err := fixture.QueryScalar(ctx, query, []any{id}, &got); err != nil {
+		t.Fatalf("count %s rows for %s: %v", table, id, err)
+	}
+	if got != want {
+		t.Errorf("%s rows for %s = %d, want %d", table, id, got, want)
+	}
+}
+
+// importerEdgeCount counts the stored edges from source to target across BOTH
+// dependency tables and all three target columns. A dropped edge is dropped on
+// every plane, so the cases that expect zero want zero everywhere, and a
+// per-table count could report one while the row sat in the other.
+func importerEdgeCount(t *testing.T, ctx context.Context, fixture ImporterFixture, source, target string) int {
+	t.Helper()
+	var got int
+	const query = `SELECT
+		(SELECT COUNT(*) FROM dependencies WHERE issue_id = ?
+			AND (depends_on_issue_id = ? OR depends_on_wisp_id = ? OR depends_on_external = ?)) +
+		(SELECT COUNT(*) FROM wisp_dependencies WHERE issue_id = ?
+			AND (depends_on_issue_id = ? OR depends_on_wisp_id = ? OR depends_on_external = ?))`
+	args := []any{source, target, target, target, source, target, target, target}
+	if err := fixture.QueryScalar(ctx, query, args, &got); err != nil {
+		t.Fatalf("count edges %s -> %s: %v", source, target, err)
+	}
+	return got
+}
+
+func assertImporterEdgeCount(t *testing.T, ctx context.Context, fixture ImporterFixture, source, target string, want int) {
+	t.Helper()
+	if got := importerEdgeCount(t, ctx, fixture, source, target); got != want {
+		t.Errorf("edges %s -> %s = %d, want %d", source, target, got, want)
+	}
+}
+
+// assertImporterScalar asserts one stored column of one durable row.
+func assertImporterScalar(t *testing.T, ctx context.Context, fixture ImporterFixture, what, id, want string) {
+	t.Helper()
+	var got string
+	if err := fixture.QueryScalar(ctx, "SELECT title FROM issues WHERE id = ?", []any{id}, &got); err != nil {
+		t.Fatalf("read %s of %s: %v", what, id, err)
+	}
+	if got != want {
+		t.Errorf("%s = %q, want %q", what, got, want)
+	}
+}
+
+// readImporterUpdatedAt reads the column the stale guard compares, so a case
+// can prove its anchor really is older or newer than the row it is about to
+// send rather than assume it.
+func readImporterUpdatedAt(t *testing.T, ctx context.Context, fixture ImporterFixture, id string) time.Time {
+	t.Helper()
+	var stamp time.Time
+	if err := fixture.QueryScalar(ctx, "SELECT updated_at FROM issues WHERE id = ?", []any{id}, &stamp); err != nil {
+		t.Fatalf("read updated_at of %s: %v", id, err)
+	}
+	return stamp.UTC()
+}

--- a/backend/conformance/role_bundle.go
+++ b/backend/conformance/role_bundle.go
@@ -89,6 +89,7 @@ type RoleContractBundle struct {
 	Deleter              func(t *testing.T) *DeleterFixture
 	DependencyEditor     func(t *testing.T) *DependencyEditorFixture
 	EdgeReader           func(t *testing.T) *EdgeReaderFixture
+	Importer             func(t *testing.T) *ImporterFixture
 	LifecycleCloseReopen func(t *testing.T) *LifecycleCloseReopenFixture
 	LifecycleUpdate      func(t *testing.T) *LifecycleUpdateFixture
 	Memories             func(t *testing.T) *MemoriesFixture

--- a/backend/conformance/role_bundle_cases.go
+++ b/backend/conformance/role_bundle_cases.go
@@ -245,6 +245,18 @@ var roleContractCases = []roleContract{
 		RunEdgeReaderWritesNothing,
 	),
 
+	// The accessor named here is NOT a storage.DoltStorage one, alone among
+	// these rows: Importer is served only by uow.ImporterSource, so a backend
+	// built on the store interface has nothing to fill this field with and
+	// leaves it nil. See importer_contract.go's header.
+	roleCases("Importer", "Importer()", oncePerRole,
+		func(b RoleContractBundle) func(t *testing.T) *ImporterFixture { return b.Importer },
+		RunImporterRejectsAStaleRowAndNamesIt,
+		RunImporterReportsTheAbsentTargetItDroppedOnce,
+		RunImporterReportsTheCrossPlaneEdgeItDropped,
+		RunImporterReportsTheCycleEdgeItDropped,
+	),
+
 	// Per case, not per role: see RoleContractBundle.IssueOperations.
 	roleCases("IssueOperations", "IssueLifecycle()", oncePerCase,
 		func(b RoleContractBundle) func(t *testing.T) *IssueOperationsStagingFixture { return b.IssueOperations },

--- a/backend/conformance/role_bundle_cases.go
+++ b/backend/conformance/role_bundle_cases.go
@@ -120,6 +120,7 @@ var roleContractCases = []roleContract{
 		RunCommenterStoresTextVerbatim,
 		RunCommenterResultMirrorsTheStoredRow,
 		RunCommenterAdvancesALiveStampPastTheThreadsNewestComment,
+		RunCommenterTakesTheClockWhenTheThreadIsBehindIt,
 		RunCommenterCommentOnAWispLandsOnTheWispThread,
 		RunCommenterRefusesAnIDOnNeitherPlane,
 		RunCommenterRefusesAnEmptyIssueID,

--- a/backend/conformance/role_bundle_cases.go
+++ b/backend/conformance/role_bundle_cases.go
@@ -44,6 +44,8 @@ var roleContractCases = []roleContract{
 		RunBatchCreatorRejectsAnUnusableRequest,
 		RunBatchCreatorRefusesACrossPlaneInBatchEdge,
 		RunBatchCreatorLinksAnEarlierItemOfTheSameBatch,
+		RunBatchCreatorLinksAnEarlierItemOnTheEphemeralPlane,
+		RunBatchCreatorKeepsAnEphemeralItemsLabelsOffTheDurablePlane,
 		RunBatchCreatorRefusesAnAbsentEdgeTarget,
 		RunBatchCreatorAcceptsAForeignEdgeTarget,
 		RunBatchCreatorRecordsOneHistoryEntry,

--- a/backend/conformance/role_coverage_gate_test.go
+++ b/backend/conformance/role_coverage_gate_test.go
@@ -19,13 +19,7 @@ import (
 // the gate takes away is doing it quietly: an addition must name a real method,
 // carry a reason, and land in a diff a reviewer reads. It converts silence into
 // an argument someone has to make.
-var uncoveredRoleMethods = map[string]string{
-	"issueops.Importer.ImportBatch": "Importer is the one role no storage accessor hands out: " +
-		"internal/storage/uow reaches it through its own provider and the other two " +
-		"backends do not implement it at all. The role tier reaches a backend through " +
-		"storage accessors, so there is no fixture to run this contract from until " +
-		"Importer joins that surface.",
-}
+var uncoveredRoleMethods = map[string]string{}
 
 // TestEveryRoleMethodHasAContractCase is the exhaustiveness gate on the role
 // tier: every method of every interface the public facade declares must be

--- a/internal/storage/dolt/batch_creator_contract_test.go
+++ b/internal/storage/dolt/batch_creator_contract_test.go
@@ -36,6 +36,12 @@ func TestBatchCreatorContract(t *testing.T) {
 	t.Run("LinksAnEarlierItemOfTheSameBatch", func(t *testing.T) {
 		conformance.RunBatchCreatorLinksAnEarlierItemOfTheSameBatch(t, ctx, fixture)
 	})
+	t.Run("LinksAnEarlierItemOnTheEphemeralPlane", func(t *testing.T) {
+		conformance.RunBatchCreatorLinksAnEarlierItemOnTheEphemeralPlane(t, ctx, fixture)
+	})
+	t.Run("KeepsAnEphemeralItemsLabelsOffTheDurablePlane", func(t *testing.T) {
+		conformance.RunBatchCreatorKeepsAnEphemeralItemsLabelsOffTheDurablePlane(t, ctx, fixture)
+	})
 	t.Run("RefusesAnAbsentEdgeTarget", func(t *testing.T) {
 		conformance.RunBatchCreatorRefusesAnAbsentEdgeTarget(t, ctx, fixture)
 	})

--- a/internal/storage/dolt/commenter_contract_test.go
+++ b/internal/storage/dolt/commenter_contract_test.go
@@ -29,6 +29,9 @@ func TestCommenterContract(t *testing.T) {
 	t.Run("AdvancesALiveStampPastTheThreadsNewestComment", func(t *testing.T) {
 		conformance.RunCommenterAdvancesALiveStampPastTheThreadsNewestComment(t, ctx, fixture)
 	})
+	t.Run("TakesTheClockWhenTheThreadIsBehindIt", func(t *testing.T) {
+		conformance.RunCommenterTakesTheClockWhenTheThreadIsBehindIt(t, ctx, fixture)
+	})
 	t.Run("CommentOnAWispLandsOnTheWispThread", func(t *testing.T) {
 		conformance.RunCommenterCommentOnAWispLandsOnTheWispThread(t, ctx, fixture)
 	})

--- a/internal/storage/embeddeddolt/batch_creator_contract_test.go
+++ b/internal/storage/embeddeddolt/batch_creator_contract_test.go
@@ -37,6 +37,12 @@ func TestBatchCreatorContract(t *testing.T) {
 	t.Run("LinksAnEarlierItemOfTheSameBatch", func(t *testing.T) {
 		conformance.RunBatchCreatorLinksAnEarlierItemOfTheSameBatch(t, ctx, fixture)
 	})
+	t.Run("LinksAnEarlierItemOnTheEphemeralPlane", func(t *testing.T) {
+		conformance.RunBatchCreatorLinksAnEarlierItemOnTheEphemeralPlane(t, ctx, fixture)
+	})
+	t.Run("KeepsAnEphemeralItemsLabelsOffTheDurablePlane", func(t *testing.T) {
+		conformance.RunBatchCreatorKeepsAnEphemeralItemsLabelsOffTheDurablePlane(t, ctx, fixture)
+	})
 	t.Run("RefusesAnAbsentEdgeTarget", func(t *testing.T) {
 		conformance.RunBatchCreatorRefusesAnAbsentEdgeTarget(t, ctx, fixture)
 	})

--- a/internal/storage/embeddeddolt/commenter_contract_test.go
+++ b/internal/storage/embeddeddolt/commenter_contract_test.go
@@ -33,6 +33,9 @@ func TestCommenterContract(t *testing.T) {
 	t.Run("AdvancesALiveStampPastTheThreadsNewestComment", func(t *testing.T) {
 		conformance.RunCommenterAdvancesALiveStampPastTheThreadsNewestComment(t, ctx, fixture)
 	})
+	t.Run("TakesTheClockWhenTheThreadIsBehindIt", func(t *testing.T) {
+		conformance.RunCommenterTakesTheClockWhenTheThreadIsBehindIt(t, ctx, fixture)
+	})
 	t.Run("CommentOnAWispLandsOnTheWispThread", func(t *testing.T) {
 		conformance.RunCommenterCommentOnAWispLandsOnTheWispThread(t, ctx, fixture)
 	})

--- a/internal/storage/leg_contract_wiring_test.go
+++ b/internal/storage/leg_contract_wiring_test.go
@@ -27,12 +27,30 @@ var neverSatisfiedTags = map[string]bool{"ignore": true, "never": true}
 // conformance package's own waiver list does: an entry has to name a real
 // entrypoint and a real leg, carry a reason, and stop being waived the moment
 // the leg wires it.
+// importerOneAccessorWaiverReason records why the Importer contract runs on one
+// leg. publicops.Importer has exactly one accessor anywhere — uow.ImporterSource
+// — and it is the only capability source in internal/storage/uow with no
+// storage.DoltStorage counterpart: on both store legs `bd import` still runs the
+// raw CreateIssuesWithFullOptions seam. Wiring the other two is a new interface
+// method plus a new body at each backend, not a test change. The waiver stops
+// the moment either leg grows the accessor.
+const importerOneAccessorWaiverReason = "Importer has one accessor (uow.ImporterSource); " +
+	"the store legs run bd import through the raw seam and implement no Importer role"
+
 var unwiredContractEntrypoints = map[string]map[string]string{
 	"dolt": {
-		"RunBootstrapperRecordsExactlyOneHistoryEntry": bootstrapSplitWaiverReason,
+		"RunImporterRejectsAStaleRowAndNamesIt":          importerOneAccessorWaiverReason,
+		"RunImporterReportsTheAbsentTargetItDroppedOnce": importerOneAccessorWaiverReason,
+		"RunImporterReportsTheCrossPlaneEdgeItDropped":   importerOneAccessorWaiverReason,
+		"RunImporterReportsTheCycleEdgeItDropped":        importerOneAccessorWaiverReason,
+		"RunBootstrapperRecordsExactlyOneHistoryEntry":   bootstrapSplitWaiverReason,
 	},
 	"embeddeddolt": {
-		"RunBootstrapperRecordsExactlyOneHistoryEntry": bootstrapSplitWaiverReason,
+		"RunImporterRejectsAStaleRowAndNamesIt":          importerOneAccessorWaiverReason,
+		"RunImporterReportsTheAbsentTargetItDroppedOnce": importerOneAccessorWaiverReason,
+		"RunImporterReportsTheCrossPlaneEdgeItDropped":   importerOneAccessorWaiverReason,
+		"RunImporterReportsTheCycleEdgeItDropped":        importerOneAccessorWaiverReason,
+		"RunBootstrapperRecordsExactlyOneHistoryEntry":   bootstrapSplitWaiverReason,
 	},
 	"uow": {
 		"RunBootstrapperRecordsNoHistoryEntryOfItsOwn":                   bootstrapSplitWaiverReason,

--- a/internal/storage/uow/batch_creator_contract_test.go
+++ b/internal/storage/uow/batch_creator_contract_test.go
@@ -37,6 +37,12 @@ func TestBatchCreatorContract(t *testing.T) {
 	t.Run("LinksAnEarlierItemOfTheSameBatch", func(t *testing.T) {
 		conformance.RunBatchCreatorLinksAnEarlierItemOfTheSameBatch(t, ctx, fixture)
 	})
+	t.Run("LinksAnEarlierItemOnTheEphemeralPlane", func(t *testing.T) {
+		conformance.RunBatchCreatorLinksAnEarlierItemOnTheEphemeralPlane(t, ctx, fixture)
+	})
+	t.Run("KeepsAnEphemeralItemsLabelsOffTheDurablePlane", func(t *testing.T) {
+		conformance.RunBatchCreatorKeepsAnEphemeralItemsLabelsOffTheDurablePlane(t, ctx, fixture)
+	})
 	t.Run("RefusesAnAbsentEdgeTarget", func(t *testing.T) {
 		conformance.RunBatchCreatorRefusesAnAbsentEdgeTarget(t, ctx, fixture)
 	})

--- a/internal/storage/uow/commenter_contract_test.go
+++ b/internal/storage/uow/commenter_contract_test.go
@@ -34,6 +34,9 @@ func TestCommenterContract(t *testing.T) {
 	t.Run("AdvancesALiveStampPastTheThreadsNewestComment", func(t *testing.T) {
 		conformance.RunCommenterAdvancesALiveStampPastTheThreadsNewestComment(t, ctx, fixture)
 	})
+	t.Run("TakesTheClockWhenTheThreadIsBehindIt", func(t *testing.T) {
+		conformance.RunCommenterTakesTheClockWhenTheThreadIsBehindIt(t, ctx, fixture)
+	})
 	t.Run("CommentOnAWispLandsOnTheWispThread", func(t *testing.T) {
 		conformance.RunCommenterCommentOnAWispLandsOnTheWispThread(t, ctx, fixture)
 	})

--- a/internal/storage/uow/importer_contract_test.go
+++ b/internal/storage/uow/importer_contract_test.go
@@ -1,0 +1,64 @@
+package uow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/steveyegge/beads/backend/conformance"
+)
+
+// TestImporterContract runs the Importer contract against the unit-of-work
+// provider, which is the ONLY implementation there is: ImporterSource is the
+// one capability accessor in this package with no storage.DoltStorage
+// counterpart, so the two store backends serve `bd import` through the raw
+// CreateIssuesWithFullOptions seam and have no role for the contract to hold.
+// That is stated at length in the contract file's header.
+//
+// What this wiring is worth is therefore not a third vote on a shared body but
+// the ONLY vote on this one. The engine underneath
+// (issueops.CreateIssuesInTxWithResult) is shared with the store legs and the
+// audit tier already observes it there; the mapping on top — StaleRejectedIDs,
+// its dedup, the Created arithmetic, SkippedDependencies — is written here in
+// uow/importer.go and nothing anywhere ran it.
+//
+// One provider for the whole suite (each newUOWRoleFixtureProvider boots a
+// real Dolt sql-server) and NO t.Parallel, for the reason the sibling role
+// suites give: this backend has no per-test copy-on-write branch.
+func TestImporterContract(t *testing.T) {
+	ctx := context.Background()
+	fixture := newUOWImporterFixture(t, ctx, "imp")
+
+	t.Run("RejectsAStaleRowAndNamesIt", func(t *testing.T) {
+		conformance.RunImporterRejectsAStaleRowAndNamesIt(t, ctx, fixture)
+	})
+	t.Run("ReportsTheAbsentTargetItDroppedOnce", func(t *testing.T) {
+		conformance.RunImporterReportsTheAbsentTargetItDroppedOnce(t, ctx, fixture)
+	})
+	t.Run("ReportsTheCrossPlaneEdgeItDropped", func(t *testing.T) {
+		conformance.RunImporterReportsTheCrossPlaneEdgeItDropped(t, ctx, fixture)
+	})
+	t.Run("ReportsTheCycleEdgeItDropped", func(t *testing.T) {
+		conformance.RunImporterReportsTheCycleEdgeItDropped(t, ctx, fixture)
+	})
+}
+
+func newUOWImporterFixture(t *testing.T, ctx context.Context, prefix string) conformance.ImporterFixture {
+	t.Helper()
+	provider := newUOWRoleFixtureProvider(t, ctx, prefix)
+	// Through the capability accessor, not NewImporter: a provider that stopped
+	// offering the role is the regression, and a constructor call would hide it.
+	source, ok := provider.(ImporterSource)
+	if !ok {
+		t.Fatalf("provider %T does not offer the Importer accessor", provider)
+	}
+	importer, err := source.Importer()
+	if err != nil {
+		t.Fatalf("Importer(): %v", err)
+	}
+	kit := newUOWRoleFixtureKit(provider, prefix)
+	return conformance.ImporterFixture{
+		IssuePrefix: kit.IssuePrefix,
+		Importer:    importer,
+		QueryScalar: kit.QueryScalar,
+	}
+}


### PR DESCRIPTION
Part of `bd-48ygn`. Additive: +803, all three legs except where noted.

## The importer contract — and the accessor finding

The triage proposed a new `importer_contract.go`. `batch_creator` **deliberately refuses** both promises it would carry, so the first question was whether that refusal also rules out a separate contract. It does not — **it is the reason for one.** Both refusals point here: *"AN EXPLICIT ID IS CREATE-ONLY … THE DOCUMENTED UPSERT SURFACE IS `bd import`"*, and the edge refusal is grounded on **silence** — *"a create that reported success having silently dropped an edge is data loss, because the caller has no way to learn"*. `ImportBatchResult.SkippedDependencies` **is** the caller learning, so the contract states the obligation the refusal creates: an importer whose report is empty has committed exactly the data loss `BatchCreator` names. Every case asserts the report by **equality, never by search**.

**The accessor is the finding.** `publicops.Importer` has exactly one accessor — `uow.ImporterSource`. It is the **only** capability source in `internal/storage/uow` with no `storage.DoltStorage` counterpart; on both store legs `bd import` still runs the raw `CreateIssuesWithFullOptions` seam. So this contract is wired at **one leg, not three**, and giving the other two a role is a new interface method plus two new bodies — API work, and the owner's call.

That single leg is also exactly where the hole was: the engine below is shared and already watched by the audit tier at the stores, but the mapping on top is uow-own, and it sits on the one leg `RunAll`'s `Factory` structurally cannot reach.

## Cases

| case | fixture blindness removed | verdict |
| --- | --- | --- |
| `CommenterTakesTheClockWhenTheThreadIsBehindIt` | `NextLiveCommentTime`'s `newest.Before(now)` branch — the one that makes skew **drain**. Every existing case seeds ahead of the clock or on an empty thread, where both branches agree | UNIQUE, 1 body / 3 observers (`issueops.NextLiveCommentTime`, `derivedid.go:190` — uow's `domain/db/comment.go:121` calls it rather than owning a parallel branch, so all three legs observe the same decision) |
| `BatchCreatorLinksAnEarlierItemOnTheEphemeralPlane` | an inter-wisp inline edge asserted **per table** — a sum across both tables cannot see a wisp edge in the durable one | UNIQUE ×2 |
| `BatchCreatorKeepsAnEphemeralItemsLabelsOffTheDurablePlane` | a wisp's **label** row; the existing ephemeral case seeds no labels, so its counter answers the same either way | UNIQUE ×2 |
| `ImporterRejectsAStaleRowAndNamesIt` | through `GetIssue().Title` alone, the **older** arm and the **equal** arm are identical — only the report separates them | UNIQUE ×3 |
| `ImporterReportsTheAbsentTargetItDroppedOnce` | the audit scan stops at first match, so a report repeating 50× is invisible. Asks for the same missing edge **twice**, making the dedup observable | UNIQUE — and the engine *does* report twice, so the dedup pin is real |
| `ImporterReportsTheCrossPlaneEdgeItDropped` | the audit arm passes a **nil** skip callback, so a silent drop is invisible | UNIQUE |
| `ImporterReportsTheCycleEdgeItDropped` | to the audit case, "one edge dropped", "both dropped" and "cycle written" are one observation | UNIQUE **against the audit case itself** — dropping `recordSkippedDependency` reddens the new case while `Audit/…/CreateInBatchCycle` stays green |

## Burst-order did not survive #5462, and should not

Dominated, and not ported. Its seed-ahead half is strictly weaker than `RunCommenterAdvancesALiveStampPastTheThreadsNewestComment` (raw rows not role answers, two live adds not one).

Its **burst half is not portable at all**: five adds inside one wall-clock second assert *the runner's speed*. A slow enough machine spreads them across five seconds and the case passes with the advance entirely removed. That is a test passing for reasons outside itself — the same class as the order-dependent fixture found in #5458, failing in the opposite direction.

## Also

`main` did not compile when this slice started — #5456 and #5458 raced, and the drift test could not catch it because the package it parses did not build. Fixed independently here and on main as #5464; the redundant commit was dropped in rebase.

Left deliberately: the importer's "one transaction, one history entry" headline promise has no case, because the fixture carries no `CountHistory`. Worth a follow-up.

Gates: `go build ./...`, `go vet`, `golangci-lint` clean; drift and alias guards green; commenter and batch_creator green on all three legs; importer green at its one leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
