### PR TITLE
Publish updateIssue's guarded members: status, assignee, parent_id, metadata

### DIFF
--- a/cmd/bd/serve_update_proxied_integration_test.go
+++ b/cmd/bd/serve_update_proxied_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -18,8 +19,10 @@ import (
 // document says, and that a same-value resend really is a no-op against a store
 // rather than against a fake's bookkeeping.
 
-// updateIssue patches id and returns the status and decoded body.
-func (sp *serveProcess) updateIssue(t *testing.T, id, body string) (int, map[string]any) {
+// updateIssueRaw patches id and returns the status and the UNDECODED body, so a
+// caller can choose how to read a member rather than inheriting
+// encoding/json's default for `any`.
+func (sp *serveProcess) updateIssueRaw(t *testing.T, id, body string) (int, []byte) {
 	t.Helper()
 	req, err := http.NewRequest(http.MethodPatch, sp.url("/v0/beads/issues/"+id), strings.NewReader(body))
 	if err != nil {
@@ -35,13 +38,46 @@ func (sp *serveProcess) updateIssue(t *testing.T, id, body string) (int, map[str
 	if err != nil {
 		t.Fatalf("read update body: %v", err)
 	}
+	return resp.StatusCode, raw
+}
+
+// updateIssue patches id and returns the status and decoded body.
+func (sp *serveProcess) updateIssue(t *testing.T, id, body string) (int, map[string]any) {
+	t.Helper()
+	status, raw := sp.updateIssueRaw(t, id, body)
 	var m map[string]any
 	if len(raw) > 0 {
 		if err := json.Unmarshal(raw, &m); err != nil {
 			t.Fatalf("decode update body %q: %v", raw, err)
 		}
 	}
-	return resp.StatusCode, m
+	return status, m
+}
+
+// revisionOf decodes the `revision` token as the 64-BIT INTEGER the document
+// declares it to be, which is the whole reason this reads the raw bytes.
+//
+// Decoding it into an `any` yields a float64, and live tokens run past 5e17
+// where a float64's ulp is already 64 — so the value that comes back is NEAR
+// the token and is not it, and a guard composed from it is refused against a
+// row nothing else touched. That is not hypothetical: it is how the first
+// version of the case below failed.
+//
+// NEVER ORDER IT AND NEVER COMPUTE ONE. The token is opaque and compared for
+// EQUALITY alone, so "the previous revision" is not `revision - 1`; it is the
+// value an earlier write answered with, which is what the case below uses.
+func revisionOf(t *testing.T, raw []byte) int64 {
+	t.Helper()
+	var body struct {
+		Revision *int64 `json:"revision"`
+	}
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("decode revision from %q: %v", raw, err)
+	}
+	if body.Revision == nil {
+		t.Fatalf("the response carries no `revision`: %s", raw)
+	}
+	return *body.Revision
 }
 
 func TestProxiedServerServeUpdate(t *testing.T) {
@@ -186,11 +222,17 @@ func TestProxiedServerServeUpdate(t *testing.T) {
 		}
 
 		issue := bdProxiedCreate(t, bd, p.dir, "never patched", "-p", "2", "-d", "untouched")
+		// `status` and `assignee` used to be here, refused by name. They are
+		// published now, so what stands in their place is the refusal each of
+		// the new members BROUGHT: a self-parent, and the two spellings of the
+		// assignee guards that contradict each other.
 		for _, refused := range []string{
 			`{"actor":"   ","patch":{"title":"t"}}`,
 			`{"actor":"agent","patch":{}}`,
-			`{"actor":"agent","patch":{"status":"closed"}}`,
-			`{"actor":"agent","patch":{"assignee":"mallory"}}`,
+			`{"actor":"agent","patch":{"parent_id":"` + issue.ID + `"}}`,
+			`{"actor":"agent","patch":{"metadata":{"replace":{},"merge":{"a":1}}}}`,
+			`{"actor":"agent","patch":{"title":"t"},"force_assignee_transfer":true}`,
+			`{"actor":"agent","patch":{"assignee":"x"},"force_assignee_transfer":true,"expected_assignee":"y"}`,
 			`{"actor":"agent","patch":{"title":null}}`,
 			`{"actor":"agent","patch":{"priority":9}}`,
 			`{"actor":"agent","patch":{"notes":"a","append_notes":"b"}}`,
@@ -209,6 +251,128 @@ func TestProxiedServerServeUpdate(t *testing.T) {
 		if after.Title != "never patched" || after.Description != "untouched" ||
 			string(after.Status) != "open" || after.Assignee != "" {
 			t.Errorf("a refused update wrote to the row: %+v", after)
+		}
+	})
+
+	// THE MEMBERS THAT CARRY POLICY, against a real row. The pure tests assert
+	// the projection onto issueops.UpdateRequest; what only this level can show
+	// is that a status, an assignee and a metadata edit sent in ONE patch all
+	// land in one transaction — the capability two calls cannot give a caller —
+	// and that the guard token this write mints really guards the next one.
+	//
+	// `parent_id` is deliberately NOT read back here. `bd show --json` answers a
+	// detail view whose `dependencies` are IssueWithDependencyMetadata rather
+	// than the edge rows types.Issue carries, so a read-back through this helper
+	// could not fail on a reparent that never landed. Its projection is pinned
+	// in the pure tests, its refusals in TestUpdateAnswersThePolicyRefusalsIts
+	// MembersEarned, and its one edge-decided-here rule — a self-parent — in the
+	// refused-bodies table above.
+	t.Run("status, assignee and metadata land together", func(t *testing.T) {
+		issue := bdProxiedCreate(t, bd, p.dir, "the child", "-p", "2")
+
+		status, raw := sp.updateIssueRaw(t, issue.ID, `{"actor":"http-agent","patch":{
+			"status":"in_progress",
+			"assignee":"http-agent",
+			"metadata":{"set":{"lane":"wire"}}
+		}}`)
+		if status != http.StatusOK {
+			t.Fatalf("status = %d, want 200: %s", status, raw)
+		}
+		var landed struct {
+			Changed bool `json:"changed"`
+		}
+		if err := json.Unmarshal(raw, &landed); err != nil {
+			t.Fatalf("decode the update body %q: %v", raw, err)
+		}
+		if !landed.Changed {
+			t.Errorf("changed = false, want true: %s", raw)
+		}
+		// The guard's token, minted by this write. A caller cannot compose a
+		// guarded follow-up without it, which is why the member exists.
+		first := revisionOf(t, raw)
+
+		after := bdProxiedShow(t, bd, p.dir, issue.ID)
+		if string(after.Status) != "in_progress" || after.Assignee != "http-agent" {
+			t.Errorf("status/assignee did not land: %q/%q", after.Status, after.Assignee)
+		}
+		if !strings.Contains(string(after.Metadata), `"lane"`) {
+			t.Errorf("metadata did not land: %s", after.Metadata)
+		}
+
+		// THE READ-MODIFY-WRITE LOOP, with a real concurrent writer rather than
+		// an arithmetic one. A second unguarded write moves the row, so the
+		// token the first write answered with is now genuinely stale — which is
+		// the only way to make one, since the token is opaque and compared for
+		// equality alone.
+		concurrentStatus, concurrent := sp.updateIssueRaw(t, issue.ID,
+			`{"actor":"other-agent","patch":{"notes":"a concurrent edit"}}`)
+		if concurrentStatus != http.StatusOK {
+			t.Fatalf("the concurrent write: status = %d, want 200: %s", concurrentStatus, concurrent)
+		}
+		second := revisionOf(t, concurrent)
+		if second == first {
+			t.Fatalf("revision = %d after a second write; a write that does not move the token makes every guard vacuous", second)
+		}
+
+		conflictStatus, problem := sp.updateIssue(t, issue.ID,
+			`{"actor":"http-agent","expected_version":`+strconv.FormatInt(first, 10)+`,"patch":{"title":"never"}}`)
+		if conflictStatus != http.StatusConflict {
+			t.Fatalf("stale guard: status = %d, want 409: %v", conflictStatus, problem)
+		}
+		if problem["code"] != "precondition_failed" {
+			t.Errorf("code = %v, want precondition_failed", problem["code"])
+		}
+		if problem["param"] != "expected_version" {
+			t.Errorf("param = %v, want expected_version", problem["param"])
+		}
+		if shown := bdProxiedShow(t, bd, p.dir, issue.ID); shown.Title == "never" {
+			t.Error("a refused guard wrote to the row")
+		}
+
+		// The loop closes: re-read the token the last write answered with and
+		// the guarded write lands.
+		freshStatus, fresh := sp.updateIssue(t, issue.ID,
+			`{"actor":"http-agent","expected_version":`+strconv.FormatInt(second, 10)+`,"patch":{"title":"guarded"}}`)
+		if freshStatus != http.StatusOK {
+			t.Fatalf("guarded update: status = %d, want 200: %v", freshStatus, fresh)
+		}
+		if shown := bdProxiedShow(t, bd, p.dir, issue.ID); shown.Title != "guarded" {
+			t.Errorf("title = %q, want the guarded write to have landed", shown.Title)
+		}
+	})
+
+	// THE REPARENT, over the wire, against the graph the two legs really walk.
+	// It needs no edge read-back: a cycle can only be observed by asking for one,
+	// and the refusal IS the observation. A under B is legal; B under A then
+	// closes a parent-child cycle, which CheckDependencyCycleInTx refuses on the
+	// store legs and depRepo.Insert's HasCycle refuses on the unit-of-work leg.
+	t.Run("a reparent that closes a cycle is a 409 over the wire", func(t *testing.T) {
+		a := bdProxiedCreate(t, bd, p.dir, "cycle a", "-p", "2")
+		b := bdProxiedCreate(t, bd, p.dir, "cycle b", "-p", "2")
+
+		status, body := sp.updateIssue(t, a.ID, `{"actor":"http-agent","patch":{"parent_id":"`+b.ID+`"}}`)
+		if status != http.StatusOK {
+			t.Fatalf("the legal reparent: status = %d, want 200: %v", status, body)
+		}
+
+		cycleStatus, problem := sp.updateIssue(t, b.ID, `{"actor":"http-agent","patch":{"parent_id":"`+a.ID+`"}}`)
+		if cycleStatus != http.StatusConflict {
+			t.Fatalf("the cycling reparent: status = %d, want 409: %v", cycleStatus, problem)
+		}
+		if problem["code"] != "dependency_cycle" {
+			t.Errorf("code = %v, want dependency_cycle", problem["code"])
+		}
+		if problem["param"] != "patch.parent_id" {
+			t.Errorf("param = %v, want patch.parent_id", problem["param"])
+		}
+		// THE HIERARCHY MEMBERS ARE ABSENT, and the document says so for this
+		// operation: CheckBlockingHierarchyInTx probes blocks and
+		// conditional-blocks only, so a parent-child write can never raise the
+		// hierarchy refusal. A client must not dispatch on their presence here.
+		for _, member := range []string{"issue_id", "blocker_id", "blocker_is_ancestor"} {
+			if _, present := problem[member]; present {
+				t.Errorf("%s is present on a reparent refusal; this operation promises the plain cycle only: %v", member, problem)
+			}
 		}
 	})
 

--- a/internal/httpapi/apigen/types.gen.go
+++ b/internal/httpapi/apigen/types.gen.go
@@ -401,7 +401,9 @@ type ApplyItem struct {
 	// Kind Which member below is read. A CLOSED set, unlike a dependency `type`: every value here is a verb this operation implements, and an unknown one is a request the server cannot execute rather than a workspace's own vocabulary.
 	Kind ApplyItemKind `json:"kind"`
 
-	// Update Patches one existing issue, under `PATCH /v0/beads/issues/{id}`'s rules plus the preconditions and force flags that operation deliberately does not publish.
+	// Update Patches one existing issue, under `PATCH /v0/beads/issues/{id}`'s rules.
+	//
+	// The two carry the same preconditions and the same force flags; what is this operation's alone is that its guards evaluate AS-MODIFIED — against the row as earlier items of this same request have already changed it — and that a miss takes the whole plan down rather than one write.
 	Update *ApplyUpdateItem `json:"update,omitempty"`
 }
 
@@ -476,9 +478,13 @@ type ApplyMetadataPatch struct {
 
 // ApplyPatchBody The fields an `update` item writes. Every member is optional and PRESENCE is the signal: a member present is written, a member absent is untouched. An empty object is a `400` — a write that writes nothing is a client bug.
 //
-// It mirrors `IssuePatchBody` member for member and diverges in exactly three places, each of them a capability that operation withheld on purpose and this one needs. `status`, `assignee` and `owner` are published here, which is what makes `force_close_policy`, `force_assignee_transfer` and `expected_assignee` mean anything and what gives this operation the `not_closable` and `already_claimed` refusals `updateIssue` has none of. `labels` is a full patch rather than a replacement, because a plan has to be able to REMOVE one label without knowing the rest of the set. And `metadata` is a patch at all.
+// It mirrors `IssuePatchBody` member for member and diverges in exactly two places now that `PATCH /v0/beads/issues/{id}` publishes `status`, `assignee` and the same `metadata` algebra.
 //
-// `parent_id` is deliberately absent, and its absence is this operation's one-edge-one-spelling rule: a parent is a `dep_add` item of type `parent-child`, so the order of every edge in the request stays total. `persistence` is absent too — moving a row between planes mid-plan is a different act from writing its fields, and nothing has asked for it here.
+// `owner` is published here and not there, which is an accident of order rather than a decision: nothing has asked for it on the single patch.
+//
+// `labels` is a full patch rather than a complete replacement, and that one is a real difference: a plan has to be able to REMOVE one label without knowing the rest of the set, because it edits a set it did not compose. A caller patching one row it just read already knows the set.
+//
+// `parent_id` is deliberately absent, and its absence is this operation's one-edge-one-spelling rule: a parent is a `dep_add` item of type `parent-child`, so the order of every edge in the request stays total. The single patch has no ordering to express and publishes it directly. `persistence` is absent from both — moving a row between planes mid-plan is a different act from writing its fields, and nothing has asked for it here.
 type ApplyPatchBody struct {
 	AcceptanceCriteria *string `json:"acceptance_criteria,omitempty"`
 
@@ -531,7 +537,9 @@ type ApplyPatchBody struct {
 	Title *string `json:"title,omitempty"`
 }
 
-// ApplyUpdateItem Patches one existing issue, under `PATCH /v0/beads/issues/{id}`'s rules plus the preconditions and force flags that operation deliberately does not publish.
+// ApplyUpdateItem Patches one existing issue, under `PATCH /v0/beads/issues/{id}`'s rules.
+//
+// The two carry the same preconditions and the same force flags; what is this operation's alone is that its guards evaluate AS-MODIFIED — against the row as earlier items of this same request have already changed it — and that a miss takes the whole plan down rather than one write.
 type ApplyUpdateItem struct {
 	// ExpectedAssignee Requires the issue's assignee to equal this value, evaluated as-modified. A match AUTHORIZES the requested `patch.assignee` transfer: this compare-and-set replaces the ordinary anti-steal fence, so it must not be combined with `force_assignee_transfer`. A miss refuses the whole request with `409 precondition_failed`.
 	ExpectedAssignee *string `json:"expected_assignee,omitempty"`
@@ -554,9 +562,13 @@ type ApplyUpdateItem struct {
 
 	// Patch The fields an `update` item writes. Every member is optional and PRESENCE is the signal: a member present is written, a member absent is untouched. An empty object is a `400` — a write that writes nothing is a client bug.
 	//
-	// It mirrors `IssuePatchBody` member for member and diverges in exactly three places, each of them a capability that operation withheld on purpose and this one needs. `status`, `assignee` and `owner` are published here, which is what makes `force_close_policy`, `force_assignee_transfer` and `expected_assignee` mean anything and what gives this operation the `not_closable` and `already_claimed` refusals `updateIssue` has none of. `labels` is a full patch rather than a replacement, because a plan has to be able to REMOVE one label without knowing the rest of the set. And `metadata` is a patch at all.
+	// It mirrors `IssuePatchBody` member for member and diverges in exactly two places now that `PATCH /v0/beads/issues/{id}` publishes `status`, `assignee` and the same `metadata` algebra.
 	//
-	// `parent_id` is deliberately absent, and its absence is this operation's one-edge-one-spelling rule: a parent is a `dep_add` item of type `parent-child`, so the order of every edge in the request stays total. `persistence` is absent too — moving a row between planes mid-plan is a different act from writing its fields, and nothing has asked for it here.
+	// `owner` is published here and not there, which is an accident of order rather than a decision: nothing has asked for it on the single patch.
+	//
+	// `labels` is a full patch rather than a complete replacement, and that one is a real difference: a plan has to be able to REMOVE one label without knowing the rest of the set, because it edits a set it did not compose. A caller patching one row it just read already knows the set.
+	//
+	// `parent_id` is deliberately absent, and its absence is this operation's one-edge-one-spelling rule: a parent is a `dep_add` item of type `parent-child`, so the order of every edge in the request stays total. The single patch has no ordering to express and publishes it directly. `persistence` is absent from both — moving a row between planes mid-plan is a different act from writing its fields, and nothing has asked for it here.
 	Patch ApplyPatchBody `json:"patch"`
 
 	// Target Names ONE issue, either by an id that already exists or by the `key` a create item earlier in the same request gave itself.
@@ -1015,11 +1027,18 @@ type IssueDetails = types.IssueDetails
 // IssuePatchBody The fields to write. Every member is optional and PRESENCE is the signal: a member present is written, a member absent is untouched. An empty object is a `400` — a write that writes nothing is a client bug.
 //
 // This is a deliberate SUBSET of the fields an issue carries; the members it does not spell are future surface rather than oversights, and `updateIssue`'s own description says which and why.
+//
+// It now agrees with `ApplyPatchBody` on every member it publishes, and the two differ only in the SHAPE of two of them: `labels` is complete replacement here and an ordered add/remove/replace patch there, because that operation edits a set it did not compose. Everything else — down to the `metadata` algebra and the four nullable members — is one definition, so a caller cannot get a different answer for the same edit depending on which operation it sent.
 type IssuePatchBody struct {
 	AcceptanceCriteria *string `json:"acceptance_criteria,omitempty"`
 
 	// AppendNotes Appends to the notes rather than replacing them. Mutually exclusive with `notes`.
 	AppendNotes *string `json:"append_notes,omitempty"`
+
+	// Assignee The assignee. A transfer away from a live foreign in-progress owner is refused with `409 already_claimed` unless `force_assignee_transfer` is set or `expected_assignee` matched. Setting it to the empty string unassigns.
+	//
+	// `{id}:claim` remains the operation that ACQUIRES work: it carries its own eligibility rules and sets the status with the assignee in one act. This member is the raw write, fenced.
+	Assignee *string `json:"assignee,omitempty"`
 
 	// DeferUntil RFC 3339. Explicit `null` CLEARS the deferral.
 	DeferUntil  *time.Time `json:"defer_until,omitempty"`
@@ -1039,11 +1058,30 @@ type IssuePatchBody struct {
 	IssueType *string `json:"issue_type,omitempty"`
 
 	// Labels COMPLETE REPLACEMENT of the label set. An empty array clears every label. Incremental add/remove is deferred: replacement is the only shape whose result the client already knows without a read-back.
+	//
+	// This is the ONE member whose shape differs from `ApplyPatchBody`'s, and the difference is that operation's rather than this one's: a plan edits a set it did not compose, so it needs an ordered add/remove/replace patch, while a caller patching one row it just read already knows the set.
 	Labels *[]string `json:"labels,omitempty"`
 
+	// Metadata A metadata edit. `replace` is mutually exclusive with the other three; without it the edits apply as `merge`, then `set` in key order, then `unset`, so UNSETTING A KEY WINS over setting or merging it. Sending `replace` beside any of the others is a `400`.
+	//
+	// `replace` replaces the whole document. Present holding `null`, `{}` or an empty value CLEARS metadata — and clearing STORES THE EMPTY JSON DOCUMENT rather than SQL null, so "created with no metadata" and "given metadata and then cleared" are the same stored value; a reader must treat absent, empty and `{}` as one value on the way out. `merge` must be a nonempty JSON OBJECT and is merged into the current document.
+	Metadata *ApplyMetadataPatch `json:"metadata,omitempty"`
+
 	// Notes Replaces the notes. Mutually exclusive with `append_notes`; sending both is a `400`.
-	Notes    *string `json:"notes,omitempty"`
+	Notes *string `json:"notes,omitempty"`
+
+	// ParentId Replaces the issue's parents atomically: a nonempty value makes THAT issue the only parent, and an EMPTY STRING removes every parent-child edge the issue has. Labels are not inherited — that is a create-time choice (`CreateIssueRequest.inherit_labels_from_parent`) and a reparent does not re-run it.
+	//
+	// IT IS A GRAPH EDIT, and it earns the graph's refusals: a new parent this workspace holds no row for is a `400`, a pair that already carries an edge of another type is `409 dependency_exists`, and a move under the issue's own descendant is `409 dependency_cycle` — the PLAIN one, carrying no `issue_id`/`blocker_id`/ `blocker_is_ancestor`, because the hierarchy refusal answers only to blocking edges and this member writes a `parent-child` edge. Naming the issue itself is a `400`. One call rather than a remove-then-add pair, which is the whole reason it is here: the two-call spelling leaves the issue parentless if the second call fails.
+	ParentId *string `json:"parent_id,omitempty"`
 	Priority *int    `json:"priority,omitempty"`
+
+	// Status The issue's status, from this workspace's own configured vocabulary.
+	//
+	// A STATUS THAT CROSSES INTO THE DONE CATEGORY ANSWERS TO CLOSE POLICY: the update is refused with `409 not_closable` for open children or a live blocker unless `force_close_policy` is set. A done-to-done change and a move OUT of the done category are unaffected.
+	//
+	// IT IS NOT A SECOND SPELLING OF `{id}:close` AND `{id}:reopen`. Those two carry semantics a status write has nowhere to put — the reason and session under first-close-wins, the done-status normalization, the `already_closed`/`already_open` idempotence flags — and they remain the operations to reach for when what you mean is "close this". This member is for the edit that moves a status ALONGSIDE other fields in one transaction, which is the thing two calls cannot do. `ApplyPatchBody.status` has meant exactly this since `issues:batchApply` landed.
+	Status *string `json:"status,omitempty"`
 
 	// Title The issue's title. Must not be blank after trimming; the length bound is what the column holds.
 	Title *string `json:"title,omitempty"`
@@ -1450,9 +1488,32 @@ type UpdateIssueRequest struct {
 	// Actor Who is editing the issue. `ClaimRequest.actor`'s rules exactly: the server trims it, then refuses an empty result, anything longer than 256 BYTES (the `maxLength` above counts characters — the byte limit is the binding one), and any control character including newline. The value reaches the history entry's attribution and the storage commit message, so an unvalidated newline would forge audit-trail lines.
 	Actor string `json:"actor"`
 
+	// ExpectedAssignee Requires the issue's assignee to equal this value before the patch. A match AUTHORIZES the requested `patch.assignee` transfer: this compare-and-set replaces the ordinary anti-steal fence, so it must not be combined with `force_assignee_transfer`. A miss refuses the whole request with `409 precondition_failed`.
+	ExpectedAssignee *string `json:"expected_assignee,omitempty"`
+
+	// ExpectedStatus Requires the issue's status to equal this value before the patch. A miss refuses the whole request with `409 precondition_failed`.
+	//
+	// Unlike `expected_version` this one is readable: `Issue.status` is on every read of this surface, so a caller can guard a status transition without any token at all.
+	ExpectedStatus *string `json:"expected_status,omitempty"`
+
+	// ExpectedVersion Requires the row's revision to equal this value before the patch. A miss refuses the WHOLE request with `409 precondition_failed` and writes nothing — `ApplyUpdateItem.expected_version`'s contract, on the operation that patches one row.
+	//
+	// The token is the `revision` this operation's own response carries. No READ on this surface publishes one yet, so a first guarded write seeds itself from an unguarded one or from `POST /v0/beads/issues:batchApply`'s `ApplyItemResult.revision`. Compose the next expectation from the value the write ANSWERED with, never from a number the client incremented itself: the token is OPAQUE and compared for equality alone, so it has no predecessor a client can compute.
+	//
+	// DECODE IT AS A 64-BIT INTEGER. Live tokens run past 5e17, where an IEEE-754 double's ulp is already 64, so a parser that decodes JSON numbers as doubles — JavaScript's `JSON.parse`, Go's `any`, Python's `float` — hands back a value NEAR the token that is not it, and the guard is refused against a row nothing else touched.
+	ExpectedVersion *int64 `json:"expected_version,omitempty"`
+
+	// ForceAssigneeTransfer Bypasses ONLY a genuine transfer away from a live foreign in-progress owner. Reasserting the exact current assignee is idempotent and needs no force. It requires `patch.assignee` — a request setting it without one is a `400` — and it must be false when `expected_assignee` is sent.
+	ForceAssigneeTransfer *bool `json:"force_assignee_transfer,omitempty"`
+
+	// ForceClosePolicy Bypasses ONLY close policy — the open-children refusal and the live blocker refusal — for a `patch.status` that crosses into the workspace's done category. It has no effect without such a status change, and it never bypasses validation, the preconditions above, or the assignee fence.
+	ForceClosePolicy *bool `json:"force_close_policy,omitempty"`
+
 	// Patch The fields to write. Every member is optional and PRESENCE is the signal: a member present is written, a member absent is untouched. An empty object is a `400` — a write that writes nothing is a client bug.
 	//
 	// This is a deliberate SUBSET of the fields an issue carries; the members it does not spell are future surface rather than oversights, and `updateIssue`'s own description says which and why.
+	//
+	// It now agrees with `ApplyPatchBody` on every member it publishes, and the two differ only in the SHAPE of two of them: `labels` is complete replacement here and an ordered add/remove/replace patch there, because that operation edits a set it did not compose. Everything else — down to the `metadata` algebra and the four nullable members — is one definition, so a caller cannot get a different answer for the same edit depending on which operation it sent.
 	Patch IssuePatchBody `json:"patch"`
 }
 
@@ -1463,6 +1524,13 @@ type UpdateIssueResponse struct {
 
 	// Issue A tracked work item. Property semantics documented here apply to every schema that repeats them below.
 	Issue Issue `json:"issue"`
+
+	// Revision The row's optimistic-concurrency token AFTER this write, spelled the way `ApplyItemResult.revision` spells it.
+	//
+	// It is here because `expected_version` is: a guard whose token no response carries is a guard a caller cannot fill. A read-modify-write loop composes its next expectation from THIS value and never from a number it incremented itself, for the reason `compareAndSetMetadata` gives about a value the store renormalizes. No read on this surface publishes a revision yet; when one does, this member is what it will agree with.
+	//
+	// DECODE IT AS A 64-BIT INTEGER, for the reason `UpdateIssueRequest.expected_version` spells out: an IEEE-754-double parser corrupts it silently, and the corruption only shows up as a `precondition_failed` on the NEXT request.
+	Revision int64 `json:"revision"`
 }
 
 // IssueID defines model for IssueID.

--- a/internal/httpapi/problem.go
+++ b/internal/httpapi/problem.go
@@ -281,10 +281,17 @@ const (
 	// so a recovery flow works end to end over this surface. It is the one
 	// write here with no conflict code: reopen has no policy guard.
 	OpReopenIssue = "reopenIssue"
-	// OpUpdateIssue edits the FIELDS of one issue. Lifecycle is deliberately not
-	// among them: status belongs to close/reopen/claim, which carry the policy
-	// and conflict vocabulary, and assignee belongs to the claim's
-	// compare-and-set. Keeping both out is why this operation has no 409.
+	// OpUpdateIssue edits the FIELDS of one issue, including the three that
+	// carry policy: `status`, `assignee` and `parent_id`.
+	//
+	// It USED to exclude all three, and to have no 409 because of it. The
+	// exclusion did not survive contact with a caller: an edit that moves a
+	// status alongside other fields in one transaction is the thing two calls
+	// cannot do, `issues:batchApply`'s update item has published all three since
+	// it landed, and keeping them off here meant the two operations disagreed
+	// about what patching one issue means. They are the SAME refusals here as
+	// there — close policy, the assignee fence, the graph's two — and the named
+	// lifecycle operations keep the semantics a status write has nowhere to put.
 	OpUpdateIssue          = "updateIssue"
 	OpListSettings         = "listSettings"
 	OpGetSetting           = "getSetting"
@@ -495,13 +502,30 @@ var operationCodes = map[string][]Code{
 		CodeInvalidArgument, CodeNotFound,
 		CodeBusy, CodeDBUnavailable, CodeInternal,
 	},
-	// No conflict code, and the excluded members are exactly where one would
-	// have entered: `status` would drag in close policy, `assignee` the claim
-	// fence, `parent_id` the graph vocabulary. The 400 is the body vocabulary
-	// plus the ROLE's ErrValidation — a workspace-vocabulary issue_type, a
-	// field-length refusal that slipped the edge check — through failUpdate.
+	// FOUR conflict codes, and the three members that publish them are exactly
+	// the ones this row used to say would drag them in: `status` brought close
+	// policy, `assignee` the fence, `parent_id` the graph vocabulary. Publishing
+	// the members is what made the codes reachable, and every one of them is
+	// inherited from an operation that already has it — this is applyBatch's row
+	// for a single update item, minus `already_exists`, which needs a create.
+	//
+	// precondition_failed is the guard trio's, and it is the 409 form rather
+	// than compareAndSetMetadata's 200 for the reason that code documents: a
+	// miss here refuses the whole write and leaves nothing to report but the
+	// refusal, where a lost metadata swap is a retry loop's ordinary iteration
+	// carrying the value it needs next.
+	//
+	// The 404 is still the PATH id only. A `patch.parent_id` that names nothing
+	// is an edge endpoint and stays a 400, conforming to addDependencies.
+	//
+	// The 400 is the body vocabulary plus the ROLE's ErrValidation — a
+	// workspace-vocabulary issue_type or status, a metadata key the query layer
+	// could not spell, a field-length refusal that slipped the edge check —
+	// through failUpdate.
 	OpUpdateIssue: {
 		CodeInvalidArgument, CodeNotFound,
+		CodePreconditionFailed, CodeNotClosable, CodeAlreadyClaimed,
+		CodeDependencyCycle, CodeDependencyExists,
 		CodeBusy, CodeDBUnavailable, CodeInternal,
 	},
 	// No not_found. The role refuses an edge whose target names nothing, and

--- a/internal/httpapi/spec/openapi.v0.yaml
+++ b/internal/httpapi/spec/openapi.v0.yaml
@@ -1266,9 +1266,18 @@ paths:
             ancestor or descendant. The hierarchy case — and only it —
             additionally carries `issue_id`, `blocker_id` and
             `blocker_is_ancestor`, so member presence is the discriminator.
-            Neither has a force bypass; both are reachable here because
-            `parent_id` places the new row in a hierarchy the caller cannot see
-            and `dependencies[].reverse` writes an edge INTO it.
+            Neither has a force bypass.
+
+
+            BOTH ARMS ARE REACHABLE HERE because this operation writes BLOCKING
+            edges and hierarchy in one transaction: `parent_id` places the new
+            row under a parent whose ancestry the caller cannot see, and
+            `dependencies[]` may name a blocking edge against that ancestry —
+            while `dependencies[].reverse` writes an edge INTO the id being
+            minted, which is the only way a create can close a scheduling cycle.
+            `PATCH /v0/beads/issues/{id}` publishes no blocking-edge member, so
+            its `dependency_cycle` never carries the hierarchy members; the
+            discriminator is meaningful here and absent there.
           x-bd-codes: [already_exists, dependency_cycle]
           content:
             application/problem+json:
@@ -1496,32 +1505,61 @@ paths:
         `400`.
 
 
+        ## Guards, forces and the conflicts they answer
+
+
+        `expected_version`, `expected_status` and `expected_assignee` are
+        compare-and-set preconditions, checked before the patch. A miss refuses
+        the WHOLE request with `409 precondition_failed` and writes nothing, so
+        recovery is to re-read and recompose rather than to retry the same body.
+        They are `ApplyUpdateItem`'s three members with `ApplyUpdateItem`'s
+        contract; `expected_version`'s token is the `revision` this operation
+        answers with.
+
+
+        `force_close_policy` and `force_assignee_transfer` bypass exactly one
+        refusal each and nothing else. Neither bypasses validation, the
+        preconditions above, or the other's guard.
+
+
+        Three members carry policy, which is where this operation's `409`s come
+        from. `status` crossing into the workspace's done category answers to
+        close policy (`not_closable`). `assignee` transferring away from a live
+        foreign in-progress owner answers to the assignee fence
+        (`already_claimed`). `parent_id` is a graph edit and answers to the
+        graph (`dependency_cycle`, `dependency_exists`). Each is the SAME
+        refusal `issues:batchApply` and `dependencies:add` already publish, not
+        a second vocabulary.
+
+
         ## What this operation deliberately cannot edit
 
 
-        `status` — lifecycle is `{id}:close`, `{id}:reopen` and `{id}:claim`,
-        the operations that carry the policy and conflict vocabulary. A status
-        member here would smuggle close policy into this operation's code set
-        and publish two ways to do one thing.
+        `owner` — additive later, and there is no argument against it any more:
+        the one it had was `assignee`'s, which this operation now publishes.
+        Nothing has asked for it.
 
 
-        `assignee` — assignment is the claim's compare-and-set territory, and a
-        raw assignee write would need the claim's conflict vocabulary on this
-        operation too. An unclaim/transfer operation is future surface.
+        `persistence` — a plane move is an atomic aggregate migration rather
+        than a field write, and moving a row between planes mid-patch is a
+        different act from editing it.
 
 
-        `metadata` — its replace/merge/set/unset algebra deserves its own
-        design pass, not a corner of this one.
+        `closed_by_session` and `close_reason` — written under first-close-wins
+        by `{id}:close`, which a patch write would bypass. A `status` that
+        crosses into the done category still answers to close POLICY here; it
+        does not acquire the close's semantics, which is why `{id}:close`
+        remains the operation to reach for when what you mean is "close this".
 
 
-        Also absent, and additive to publish later: `parent_id` (a set value
-        atomically replaces ALL parents — a graph edit in patch clothing),
-        `persistence` (a plane move is an atomic aggregate migration),
-        `owner` (`assignee`'s argument), `closed_by_session` (written under
-        first-close-wins by `{id}:close`, which a patch write would bypass),
-        and `spec_id`/`await_id` (workflow plumbing this surface publishes
-        nowhere yet). Keeping the first three out is half the reason this
-        operation documents no `409` at all.
+        `created_at`, `created_by` — `POST /v0/beads/issues` withholds them for
+        the same reason: a caller-chosen creation time makes the row disagree
+        with the journal entry that recorded it, and re-dating history is what an
+        import is for.
+
+
+        `spec_id` and `await_id` — workflow plumbing this surface publishes
+        nowhere yet.
 
 
         ## Planes
@@ -1559,13 +1597,23 @@ paths:
         '400':
           description: >-
             Invalid request: an unknown query parameter, an unparseable or
-            oversized body, an unknown body member at either level, an `actor`
+            oversized body, an unknown body member at any level, an `actor`
             that is empty after trimming, longer than 256 bytes, or carrying
             control characters, an empty `patch`, a member carrying the wrong
             JSON type, an explicit `null` on a member that is not nullable, a
             value outside its documented bounds, `notes` together with
-            `append_notes` — or a value this workspace's own validation
-            refuses, such as an `issue_type` outside its configured vocabulary.
+            `append_notes`, `metadata.replace` together with any other metadata
+            edit, `force_assignee_transfer` without `patch.assignee` or beside
+            `expected_assignee`, a `patch.parent_id` naming the issue itself or
+            naming no issue this workspace holds — or a value this workspace's
+            own validation refuses, such as an `issue_type` or `status` outside
+            its configured vocabulary.
+
+
+            A NEW PARENT THAT NAMES NOTHING IS A `400`, NOT A `404`, conforming
+            to `POST /v0/beads/dependencies:add`: an edge describes a relation
+            rather than the resource this request addresses, and the `404` below
+            is reserved for the id in the PATH.
           x-bd-codes: [invalid_argument]
           content:
             application/problem+json:
@@ -1573,6 +1621,60 @@ paths:
                 $ref: '#/components/schemas/Problem'
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          description: >-
+            The request is well-formed and the STATE refuses it, and NOTHING WAS
+            WRITTEN. Four codes, each inherited from the operation that already
+            publishes it rather than minted here.
+
+
+            `precondition_failed` is `expected_version`, `expected_status` or
+            `expected_assignee` missing. `param` names the guard member and the
+            `expected_*` member echoes what the request asked for; the
+            `actual_*` members are absent, because the refusal rolled its
+            transaction back and a read afterwards would describe a row the
+            refusal never saw. Re-read and recompose; never retry the same body.
+
+
+            `not_closable` is close policy refusing a `patch.status` that
+            crosses into the workspace's done category: open children, or a live
+            blocker. `open_children` is attached for the first and withheld for
+            the second, so member presence tells them apart.
+            `force_close_policy` is the bypass.
+
+
+            `already_claimed` is the assignee fence: a `patch.assignee` that
+            transfers work away from a live foreign in-progress owner.
+            `force_assignee_transfer` is the bypass and `expected_assignee` is
+            the compare-and-set that replaces the fence outright. The `assignee`
+            extension member is attached only when the refusing transaction
+            reported the holder — the fence itself refuses without one, so a
+            client must treat it as optional and re-read the row.
+
+
+            `dependency_cycle` and `dependency_exists` are `patch.parent_id`
+            reaching the graph: a move under the issue's own descendant, and a
+            pair that already carries an edge of a different type. Neither has a
+            force bypass.
+
+
+            `dependency_cycle` ARRIVES WITHOUT THE HIERARCHY MEMBERS HERE, and a
+            client must not dispatch on their presence on this operation. The
+            hierarchy refusal — `issue_id`, `blocker_id`, `blocker_is_ancestor`
+            — is raised only for a BLOCKING edge, and the only edge this
+            operation writes is the `parent-child` one `patch.parent_id` names,
+            so the discriminator cannot fire. That is the difference from
+            `POST /v0/beads/issues` and from `POST /v0/beads/dependencies:add`,
+            both of which write blocking edges and do carry it: this operation
+            publishes no member that writes one. What you get here is the plain
+            scheduling cycle, every time.
+          x-bd-codes:
+            [already_claimed, dependency_cycle, dependency_exists,
+             not_closable, precondition_failed]
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
         '500':
           $ref: '#/components/responses/InternalError'
         '503':
@@ -6122,9 +6224,13 @@ components:
       additionalProperties: false
       required: [target, patch]
       description: >-
-        Patches one existing issue, under `PATCH /v0/beads/issues/{id}`'s rules
-        plus the preconditions and force flags that operation deliberately does
-        not publish.
+        Patches one existing issue, under `PATCH /v0/beads/issues/{id}`'s rules.
+
+
+        The two carry the same preconditions and the same force flags; what is
+        this operation's alone is that its guards evaluate AS-MODIFIED — against
+        the row as earlier items of this same request have already changed it —
+        and that a miss takes the whole plan down rather than one write.
       properties:
         target:
           $ref: '#/components/schemas/Ref'
@@ -6196,21 +6302,26 @@ components:
 
 
         It mirrors `IssuePatchBody` member for member and diverges in exactly
-        three places, each of them a capability that operation withheld on
-        purpose and this one needs. `status`, `assignee` and `owner` are
-        published here, which is what makes `force_close_policy`,
-        `force_assignee_transfer` and `expected_assignee` mean anything and what
-        gives this operation the `not_closable` and `already_claimed` refusals
-        `updateIssue` has none of. `labels` is a full patch rather than a
-        replacement, because a plan has to be able to REMOVE one label without
-        knowing the rest of the set. And `metadata` is a patch at all.
+        two places now that `PATCH /v0/beads/issues/{id}` publishes `status`,
+        `assignee` and the same `metadata` algebra.
+
+
+        `owner` is published here and not there, which is an accident of order
+        rather than a decision: nothing has asked for it on the single patch.
+
+
+        `labels` is a full patch rather than a complete replacement, and that
+        one is a real difference: a plan has to be able to REMOVE one label
+        without knowing the rest of the set, because it edits a set it did not
+        compose. A caller patching one row it just read already knows the set.
 
 
         `parent_id` is deliberately absent, and its absence is this operation's
         one-edge-one-spelling rule: a parent is a `dep_add` item of type
         `parent-child`, so the order of every edge in the request stays total.
-        `persistence` is absent too — moving a row between planes mid-plan is a
-        different act from writing its fields, and nothing has asked for it
+        The single patch has no ordering to express and publishes it directly.
+        `persistence` is absent from both — moving a row between planes mid-plan
+        is a different act from writing its fields, and nothing has asked for it
         here.
       properties:
         title:
@@ -6963,6 +7074,69 @@ components:
             lines.
         patch:
           $ref: '#/components/schemas/IssuePatchBody'
+        expected_version:
+          type: integer
+          format: int64
+          description: >-
+            Requires the row's revision to equal this value before the patch. A
+            miss refuses the WHOLE request with `409 precondition_failed` and
+            writes nothing — `ApplyUpdateItem.expected_version`'s contract, on
+            the operation that patches one row.
+
+
+            The token is the `revision` this operation's own response carries.
+            No READ on this surface publishes one yet, so a first guarded write
+            seeds itself from an unguarded one or from
+            `POST /v0/beads/issues:batchApply`'s `ApplyItemResult.revision`.
+            Compose the next expectation from the value the write ANSWERED with,
+            never from a number the client incremented itself: the token is
+            OPAQUE and compared for equality alone, so it has no predecessor a
+            client can compute.
+
+
+            DECODE IT AS A 64-BIT INTEGER. Live tokens run past 5e17, where an
+            IEEE-754 double's ulp is already 64, so a parser that decodes JSON
+            numbers as doubles — JavaScript's `JSON.parse`, Go's `any`, Python's
+            `float` — hands back a value NEAR the token that is not it, and the
+            guard is refused against a row nothing else touched.
+        expected_status:
+          type: string
+          maxLength: 255
+          description: >-
+            Requires the issue's status to equal this value before the patch. A
+            miss refuses the whole request with `409 precondition_failed`.
+
+
+            Unlike `expected_version` this one is readable: `Issue.status` is on
+            every read of this surface, so a caller can guard a status
+            transition without any token at all.
+        expected_assignee:
+          type: string
+          maxLength: 255
+          description: >-
+            Requires the issue's assignee to equal this value before the patch.
+            A match AUTHORIZES the requested `patch.assignee` transfer: this
+            compare-and-set replaces the ordinary anti-steal fence, so it must
+            not be combined with `force_assignee_transfer`. A miss refuses the
+            whole request with `409 precondition_failed`.
+        force_close_policy:
+          type: boolean
+          default: false
+          description: >-
+            Bypasses ONLY close policy — the open-children refusal and the live
+            blocker refusal — for a `patch.status` that crosses into the
+            workspace's done category. It has no effect without such a status
+            change, and it never bypasses validation, the preconditions above,
+            or the assignee fence.
+        force_assignee_transfer:
+          type: boolean
+          default: false
+          description: >-
+            Bypasses ONLY a genuine transfer away from a live foreign
+            in-progress owner. Reasserting the exact current assignee is
+            idempotent and needs no force. It requires `patch.assignee` — a
+            request setting it without one is a `400` — and it must be false
+            when `expected_assignee` is sent.
 
     IssuePatchBody:
       type: object
@@ -6976,6 +7150,15 @@ components:
         This is a deliberate SUBSET of the fields an issue carries; the members
         it does not spell are future surface rather than oversights, and
         `updateIssue`'s own description says which and why.
+
+
+        It now agrees with `ApplyPatchBody` on every member it publishes, and
+        the two differ only in the SHAPE of two of them: `labels` is complete
+        replacement here and an ordered add/remove/replace patch there, because
+        that operation edits a set it did not compose. Everything else — down to
+        the `metadata` algebra and the four nullable members — is one
+        definition, so a caller cannot get a different answer for the same edit
+        depending on which operation it sent.
       properties:
         title:
           type: string
@@ -7012,6 +7195,64 @@ components:
             type outside it is refused by the ROLE and reaches the client as a
             `400` — this server cannot read the vocabulary without a
             transaction, so it checks only what this schema declares.
+        status:
+          type: string
+          maxLength: 255
+          description: >-
+            The issue's status, from this workspace's own configured vocabulary.
+
+
+            A STATUS THAT CROSSES INTO THE DONE CATEGORY ANSWERS TO CLOSE
+            POLICY: the update is refused with `409 not_closable` for open
+            children or a live blocker unless `force_close_policy` is set. A
+            done-to-done change and a move OUT of the done category are
+            unaffected.
+
+
+            IT IS NOT A SECOND SPELLING OF `{id}:close` AND `{id}:reopen`. Those
+            two carry semantics a status write has nowhere to put — the reason
+            and session under first-close-wins, the done-status normalization,
+            the `already_closed`/`already_open` idempotence flags — and they
+            remain the operations to reach for when what you mean is "close
+            this". This member is for the edit that moves a status ALONGSIDE
+            other fields in one transaction, which is the thing two calls cannot
+            do. `ApplyPatchBody.status` has meant exactly this since
+            `issues:batchApply` landed.
+        assignee:
+          type: string
+          maxLength: 255
+          description: >-
+            The assignee. A transfer away from a live foreign in-progress owner
+            is refused with `409 already_claimed` unless
+            `force_assignee_transfer` is set or `expected_assignee` matched.
+            Setting it to the empty string unassigns.
+
+
+            `{id}:claim` remains the operation that ACQUIRES work: it carries
+            its own eligibility rules and sets the status with the assignee in
+            one act. This member is the raw write, fenced.
+        parent_id:
+          type: string
+          maxLength: 255
+          description: >-
+            Replaces the issue's parents atomically: a nonempty value makes THAT
+            issue the only parent, and an EMPTY STRING removes every parent-child
+            edge the issue has. Labels are not inherited — that is a create-time
+            choice (`CreateIssueRequest.inherit_labels_from_parent`) and a
+            reparent does not re-run it.
+
+
+            IT IS A GRAPH EDIT, and it earns the graph's refusals: a new parent
+            this workspace holds no row for is a `400`, a pair that already
+            carries an edge of another type is `409 dependency_exists`, and a
+            move under the issue's own descendant is `409 dependency_cycle` —
+            the PLAIN one, carrying no `issue_id`/`blocker_id`/
+            `blocker_is_ancestor`, because the hierarchy refusal answers only to
+            blocking edges and this member writes a `parent-child` edge.
+            Naming the issue itself is a `400`. One call rather than a
+            remove-then-add pair, which is the whole reason it is here: the
+            two-call spelling leaves the issue parentless if the second call
+            fails.
         labels:
           type: array
           items:
@@ -7021,6 +7262,13 @@ components:
             COMPLETE REPLACEMENT of the label set. An empty array clears every
             label. Incremental add/remove is deferred: replacement is the only
             shape whose result the client already knows without a read-back.
+
+
+            This is the ONE member whose shape differs from `ApplyPatchBody`'s,
+            and the difference is that operation's rather than this one's: a plan
+            edits a set it did not compose, so it needs an ordered
+            add/remove/replace patch, while a caller patching one row it just
+            read already knows the set.
         estimated_minutes:
           type: integer
           nullable: true
@@ -7040,10 +7288,12 @@ components:
           format: date-time
           nullable: true
           description: 'RFC 3339. Explicit `null` CLEARS the deferral.'
+        metadata:
+          $ref: '#/components/schemas/ApplyMetadataPatch'
 
     UpdateIssueResponse:
       type: object
-      required: [issue, changed]
+      required: [issue, changed, revision]
       properties:
         issue:
           $ref: '#/components/schemas/Issue'
@@ -7053,6 +7303,27 @@ components:
             Whether the request persisted a semantic mutation. A same-value
             patch is a 200 with `changed: false` rather than an error —
             idempotent, like every replay answer on this surface.
+        revision:
+          type: integer
+          format: int64
+          description: >-
+            The row's optimistic-concurrency token AFTER this write, spelled the
+            way `ApplyItemResult.revision` spells it.
+
+
+            It is here because `expected_version` is: a guard whose token no
+            response carries is a guard a caller cannot fill. A read-modify-write
+            loop composes its next expectation from THIS value and never from a
+            number it incremented itself, for the reason
+            `compareAndSetMetadata` gives about a value the store renormalizes.
+            No read on this surface publishes a revision yet; when one does, this
+            member is what it will agree with.
+
+
+            DECODE IT AS A 64-BIT INTEGER, for the reason
+            `UpdateIssueRequest.expected_version` spells out: an IEEE-754-double
+            parser corrupts it silently, and the corruption only shows up as a
+            `precondition_failed` on the NEXT request.
 
     CreateIssueRequest:
       type: object

--- a/internal/httpapi/update.go
+++ b/internal/httpapi/update.go
@@ -33,10 +33,14 @@ const (
 // is: encoding/json's DisallowUnknownFields reports the offender only inside an
 // error string.
 var (
-	updateRequestMembers = []string{"actor", updatePatchMember}
-	issuePatchMembers    = []string{
+	updateRequestMembers = []string{
+		"actor", "expected_assignee", "expected_status", "expected_version",
+		"force_assignee_transfer", "force_close_policy", updatePatchMember,
+	}
+	issuePatchMembers = []string{
 		"title", "description", "design", "acceptance_criteria",
-		"notes", "append_notes", "priority", "issue_type", "labels",
+		"notes", "append_notes", "priority", "issue_type", "status",
+		"assignee", "parent_id", "labels", "metadata",
 		"estimated_minutes", "external_ref", "due_at", "defer_until",
 	}
 	// nullablePatchMembers is the closed set on which explicit `null` CLEARS
@@ -81,17 +85,27 @@ func (s *Server) handleUpdate(w http.ResponseWriter, r *http.Request) {
 
 	lifecycle, err := s.lifecycle(r)
 	if err != nil {
-		s.failUpdate(w, r, err)
+		s.failUpdate(w, r, request, err)
 		return
 	}
 	result, err := lifecycle.Update(r.Context(), request)
 	if err != nil {
-		s.failUpdate(w, r, err)
+		s.failUpdate(w, r, request, err)
 		return
 	}
 	// `changed` is the role's own verbatim: a same-value patch is a 200 with
 	// false, not an error — idempotent, like every replay answer here.
-	writeJSON(w, apigen.UpdateIssueResponse{Issue: *result.Issue, Changed: result.Changed})
+	//
+	// `revision` is the row's post-write concurrency token, read off the same
+	// snapshot rather than computed. It is on the wire because `expected_version`
+	// is: a guard whose token no response carries is a guard a caller cannot
+	// fill. types.Issue.RowVersion is `json:"-"`, so the Issue body cannot carry
+	// it and this member is where it lives.
+	writeJSON(w, apigen.UpdateIssueResponse{
+		Issue:    *result.Issue,
+		Changed:  result.Changed,
+		Revision: result.Issue.RowVersion,
+	})
 }
 
 // updateTarget reads and bounds the id this operation addresses.
@@ -127,21 +141,94 @@ func (s *Server) updateRequest(w http.ResponseWriter, r *http.Request, id string
 	if !ok {
 		return issueops.UpdateRequest{}, false
 	}
-	patch, ok := s.issuePatch(w, r, members)
+	patch, ok := s.issuePatch(w, r, id, members)
 	if !ok {
 		return issueops.UpdateRequest{}, false
 	}
 
-	// Claim, the force flags and every Expected* precondition stay ZERO:
-	// unpublished on this surface. Publishing a precondition means minting a
-	// frozen conflict code and putting `row_version` on the issue body for
-	// clients to echo, which is its own decision rather than a rider on this.
+	expectedVersion, res := applyInt64Member(members, "", "expected_version")
+	if res != nil {
+		s.fail(w, r, *res)
+		return issueops.UpdateRequest{}, false
+	}
+	expectedStatus, ok := s.updateExpectedStatus(w, r, members)
+	if !ok {
+		return issueops.UpdateRequest{}, false
+	}
+	expectedAssignee, ok := s.updateExpectedAssignee(w, r, members)
+	if !ok {
+		return issueops.UpdateRequest{}, false
+	}
+	forceClosePolicy, ok := s.booleanMember(w, r, members, "force_close_policy")
+	if !ok {
+		return issueops.UpdateRequest{}, false
+	}
+	forceAssigneeTransfer, ok := s.booleanMember(w, r, members, "force_assignee_transfer")
+	if !ok {
+		return issueops.UpdateRequest{}, false
+	}
+	// The role documents both combinations as invalid, and refusing them HERE
+	// keeps the 400 a statement about the request rather than a translated
+	// storage error — the `notes`/`append_notes` rule, applied to the two
+	// members that would otherwise reach a role obliged to guess which of the
+	// caller's two opinions about the assignee wins.
+	if forceAssigneeTransfer {
+		switch {
+		case expectedAssignee != nil:
+			s.fail(w, r, InvalidArgument("force_assignee_transfer", ReasonInvalidValue,
+				"`expected_assignee` is the compare-and-set that replaces the fence; `force_assignee_transfer` bypasses it. Send one"))
+			return issueops.UpdateRequest{}, false
+		case !patch.Assignee.Set:
+			s.fail(w, r, InvalidArgument("force_assignee_transfer", ReasonInvalidValue,
+				"`force_assignee_transfer` bypasses the fence on an assignee TRANSFER; send `patch.assignee` with it"))
+			return issueops.UpdateRequest{}, false
+		}
+	}
+
+	// Claim stays ZERO — acquiring work is `{id}:claim`, which carries its own
+	// eligibility rules — and so does IssuePlaneOnly, because this operation
+	// resolves across both planes.
 	return issueops.UpdateRequest{
-		Actor:      actor,
-		IssueID:    id,
-		Patch:      patch,
-		Provenance: updateProvenance,
+		Actor:                 actor,
+		IssueID:               id,
+		Patch:                 patch,
+		ExpectedVersion:       expectedVersion,
+		ExpectedStatus:        expectedStatus,
+		ExpectedAssignee:      expectedAssignee,
+		ForceClosePolicy:      forceClosePolicy,
+		ForceAssigneeTransfer: forceAssigneeTransfer,
+		Provenance:            updateProvenance,
 	}, true
+}
+
+// updateExpectedStatus reads the status precondition, preserving the difference
+// between an absent guard and one that expects the empty status. The role
+// models it as a POINTER for exactly that reason, so an absent member must not
+// collapse into a guard on "".
+func (s *Server) updateExpectedStatus(w http.ResponseWriter, r *http.Request, members map[string]json.RawMessage) (*issueops.Status, bool) {
+	if _, present := members["expected_status"]; !present {
+		return nil, true
+	}
+	value, ok := s.storedTextMember(w, r, members, "expected_status")
+	if !ok {
+		return nil, false
+	}
+	status := issueops.Status(value)
+	return &status, true
+}
+
+// updateExpectedAssignee is updateExpectedStatus's twin, and the difference
+// between nil and a pointer to "" is load-bearing here too: a guard on the
+// EMPTY assignee is how a caller says "only if nobody holds it".
+func (s *Server) updateExpectedAssignee(w http.ResponseWriter, r *http.Request, members map[string]json.RawMessage) (*string, bool) {
+	if _, present := members["expected_assignee"]; !present {
+		return nil, true
+	}
+	value, ok := s.storedTextMember(w, r, members, "expected_assignee")
+	if !ok {
+		return nil, false
+	}
+	return &value, true
 }
 
 // updateProvenance labels the history entry an update records, naming this
@@ -158,7 +245,7 @@ const updateProvenance = "bd serve: update issue"
 // because it models both as a nil pointer. Explicit `null` is a third state
 // this reads directly off the raw bytes — a clear on the four nullable members,
 // and a 400 naming the member everywhere else.
-func (s *Server) issuePatch(w http.ResponseWriter, r *http.Request, members map[string]json.RawMessage) (issueops.IssuePatch, bool) {
+func (s *Server) issuePatch(w http.ResponseWriter, r *http.Request, id string, members map[string]json.RawMessage) (issueops.IssuePatch, bool) {
 	refuse := func(member, detail string) (issueops.IssuePatch, bool) {
 		s.fail(w, r, InvalidArgument(patchParam(member), ReasonInvalidValue, detail))
 		return issueops.IssuePatch{}, false
@@ -241,16 +328,54 @@ func (s *Server) issuePatch(w http.ResponseWriter, r *http.Request, members map[
 		}
 		patch.Priority = issueops.Field[int]{Set: true, Value: priority}
 	}
-	if set("issue_type") {
-		issueType := *wire.IssueType
-		// Only what the SCHEMA declares is checked here. Whether the value is in
-		// this workspace's configured vocabulary is the role's question, and it
-		// cannot be asked without a transaction; failUpdate answers that one.
-		if types.CheckFieldLen("issue_type", issueType) != nil {
-			return refuse("issue_type", fmt.Sprintf("`issue_type` is %d characters; storage holds at most %d",
-				utf8.RuneCountInString(issueType), types.MaxFieldLen))
+	// Only what the SCHEMA declares is checked for these four. Whether a value is
+	// in this workspace's configured vocabulary is the ROLE's question and cannot
+	// be asked without a transaction; failUpdate answers that one. A SLICE and
+	// not a map, so a patch breaking two rules always names the same offender.
+	for _, bounded := range []struct {
+		member string
+		value  *string
+	}{
+		{"issue_type", wire.IssueType}, {"status", wire.Status},
+		{"assignee", wire.Assignee}, {"parent_id", wire.ParentId},
+	} {
+		if res := applyBoundedText(updatePatchMember+".", bounded.member, bounded.value); res != nil {
+			s.fail(w, r, *res)
+			return issueops.IssuePatch{}, false
 		}
-		patch.IssueType = issueops.Field[issueops.IssueType]{Set: true, Value: issueops.IssueType(issueType)}
+	}
+	if set("issue_type") {
+		patch.IssueType = issueops.Field[issueops.IssueType]{Set: true, Value: issueops.IssueType(*wire.IssueType)}
+	}
+	if set("status") {
+		patch.Status = issueops.Field[issueops.Status]{Set: true, Value: issueops.Status(*wire.Status)}
+	}
+	if set("assignee") {
+		patch.Assignee = issueops.Field[string]{Set: true, Value: *wire.Assignee}
+	}
+	if set("parent_id") {
+		// A self-parent is refused HERE, and it is the one graph rule this
+		// handler can apply: the child is the id in the PATH, so the request
+		// contradicts itself without any state being read. The two legs of the
+		// role disagree about the error they raise for it — one a bare
+		// fmt.Errorf, one ErrSelfDependency — so refusing at the edge is also
+		// what makes the answer the same whichever backend served it.
+		if *wire.ParentId == id {
+			return refuse("parent_id", "`parent_id` names this issue; an issue cannot be its own parent")
+		}
+		patch.ParentID = issueops.Field[string]{Set: true, Value: *wire.ParentId}
+	}
+	if set("metadata") {
+		// applyMetadataPatch, unchanged and not respelled: the replace/merge/
+		// set/unset algebra is one definition, and a second copy here would be a
+		// second one. `set` in particular has to be read RAW so a key written to
+		// JSON null survives — see that function.
+		metadata, res := applyMetadataPatch(patchParam("metadata")+".", fields["metadata"])
+		if res != nil {
+			s.fail(w, r, *res)
+			return issueops.IssuePatch{}, false
+		}
+		patch.Metadata = metadata
 	}
 	if set("labels") {
 		labels := *wire.Labels
@@ -302,31 +427,178 @@ func patchParam(member string) string {
 	return updatePatchMember + "." + member
 }
 
-// failUpdate answers a failed update, mapping the role's own validation refusal
-// onto the 400 the document promises.
+// failUpdate answers a failed update, mapping the role's TYPED refusals onto
+// the frozen codes and its own validation refusal onto the 400 the document
+// promises.
 //
-// It is failBatchCreate's sibling and follows its rule exactly: the role's
-// ErrValidation is answered HERE rather than in ClassifyError, and NEITHER
-// BRANCH QUOTES THE ROLE'S MESSAGE. A refusal from the workspace's configured
-// vocabulary arrives as prose about statuses and types, and 4xx details on this
-// surface reflect the caller's own input back rather than server internals. The
-// real error goes to the log with the request id.
+// EVERY 409 BRANCH READS TYPED FIELDS, never prose, and every one of them is
+// matched BEFORE the ErrValidation and ErrNotFound arms. That order is the
+// whole correctness of this function, and the hazard it avoids is worse than a
+// disagreement between backends: NEITHER LEG WRAPS THESE FIVE FAMILIES IN
+// ErrValidation. The store legs return ExecuteUpdate's error through
+// runIssueOperationTx unchanged (internal/storage/dolt/issue_operations.go) and
+// the unit of work returns ApplyUpdate's unchanged
+// (internal/storage/uow/issue_operations.go), so a precondition miss, a close-
+// policy refusal, the assignee fence and both graph refusals reach here as bare
+// sentinels. Below the ErrValidation arm they would all fall into `!Is(...)`
+// and be swallowed into failErr — a generic 500, on BOTH legs, for five
+// conditions this document names by code.
 //
-// The ErrNotFound check runs FIRST and is the divergence from failBatchCreate:
-// this operation DOES address a resource by path, so an id that names nothing
-// is a genuine 404 rather than a statement about the body.
-func (s *Server) failUpdate(w http.ResponseWriter, r *http.Request, err error) {
-	if errors.Is(err, storage.ErrNotFound) {
+// NEITHER BRANCH QUOTES THE ROLE'S MESSAGE. A refusal from the workspace's
+// configured vocabulary arrives as prose about statuses and types, and a
+// refused edge as a driver error naming tables and constraints; 4xx details on
+// this surface reflect the caller's own input back rather than server
+// internals. The real error goes to the log with the request id.
+//
+// The ErrNotFound arm is LAST among the misses and means the PATH id, which is
+// the divergence from failBatchCreate: this operation addresses a resource, so
+// an id that names nothing is a genuine 404. A missing new PARENT is not that —
+// it is an edge endpoint, and it is a 400 on `patch.parent_id`, conforming to
+// POST /v0/beads/dependencies:add.
+func (s *Server) failUpdate(w http.ResponseWriter, r *http.Request, request issueops.UpdateRequest, err error) {
+	var (
+		typeConflict *issueops.DependencyTypeConflictError
+		hierarchy    *issueops.DependencyHierarchyConflictError
+		endpoint     *issueops.DependencyEndpointNotFoundError
+		openChildren *issueops.CloseOpenChildrenError
+		claimed      *issueops.ClaimConflictError
+	)
+	// The 4xx path does not log by default, so the refusals whose real reason
+	// the response replaces with the server's own words are recorded here.
+	refused := func() {
+		s.event("request_refused", "request_id", requestInfo(r.Context()).id, "error", err.Error())
+	}
+	named := func(res Result, param string) Result {
+		res.Problem.Param = &param
+		return res
+	}
+
+	switch {
+	case errors.Is(err, issueops.ErrVersionMismatch),
+		errors.Is(err, issueops.ErrStatusMismatch),
+		errors.Is(err, issueops.ErrAssigneeMismatch):
+		s.fail(w, r, updatePreconditionResult(request, err))
+
+	case errors.Is(err, issueops.ErrCloseOpenChildren):
+		res := named(newResult(CodeNotClosable,
+			"`patch.status` closes an issue with open children; close them first, or send `force_close_policy`"),
+			patchParam("status"))
+		if errors.As(err, &openChildren) {
+			res = res.WithOpenChildren(openChildren.OpenChildren)
+		}
+		s.fail(w, r, res)
+
+	case errors.Is(err, issueops.ErrCloseBlocked):
+		// No `open_children` member, and its ABSENCE is what tells a client
+		// which of the two close-policy refusals it got.
+		s.fail(w, r, named(newResult(CodeNotClosable,
+			"`patch.status` closes a blocked issue; clear the blocker, or send `force_close_policy`"),
+			patchParam("status")))
+
+	case errors.Is(err, storage.ErrAlreadyClaimed):
+		res := named(newResult(CodeAlreadyClaimed,
+			"`patch.assignee` transfers work away from a live foreign owner; send `force_assignee_transfer`, or guard with `expected_assignee`"),
+			patchParam("assignee"))
+		// The assignee fence refuses without naming the holder
+		// (AuthorizeAssigneeTransferWithPools), so these members are attached
+		// only when an implementation did report one. Absent means "re-read the
+		// row", never "nobody holds it".
+		if errors.As(err, &claimed) {
+			if claimed.Assignee != "" {
+				res = res.WithAssignee(claimed.Assignee)
+			}
+			if claimed.Status != "" {
+				res = res.WithIssueStatus(string(claimed.Status))
+			}
+		}
+		s.fail(w, r, res)
+
+	case errors.As(err, &typeConflict):
+		s.fail(w, r, named(newResult(CodeDependencyExists,
+			"this pair already carries an edge of a different type; remove it before reparenting").
+			WithDependencyTypeConflict(typeConflict.ExistingType, typeConflict.RequestedType),
+			patchParam("parent_id")))
+
+	// DEFENSIVE, AND UNREACHABLE TODAY. CheckBlockingHierarchyInTx returns nil
+	// for anything but a `blocks` or `conditional-blocks` edge
+	// (internal/storage/issueops/dependencies.go), and the only edge this
+	// operation writes is the `parent-child` one patch.parent_id names — on both
+	// legs, since the unit of work reaches the same function through
+	// depRepo.Insert's ValidateBlockingHierarchy. The document says so and tells
+	// clients not to dispatch on these members here.
+	//
+	// The arm stays because of what its ABSENCE would cost if that ever changes:
+	// a hierarchy refusal reaching this handler would otherwise fall into the
+	// plain-cycle arm below and be answered with the same code carrying NO
+	// members, which is the one shape a client reading the discriminator cannot
+	// tell from a scheduling cycle. Publishing a member is free; losing one
+	// silently is not.
+	case errors.As(err, &hierarchy):
+		s.fail(w, r, named(newResult(CodeDependencyCycle,
+			"this reparent would put the issue under its own descendant, or gate it on its own ancestor").
+			WithHierarchyConflict(hierarchy.IssueID, hierarchy.BlockerID, hierarchy.BlockerIsAncestor),
+			patchParam("parent_id")))
+
+	// THE ARM EVERY REPARENT CYCLE ACTUALLY TAKES, carrying no hierarchy
+	// members. CheckDependencyCycleInTx does cover parent-child — it is a
+	// scheduling edge — so a move under the issue's own descendant lands here.
+	case errors.Is(err, issueops.ErrDependencyCycle):
+		s.fail(w, r, named(newResult(CodeDependencyCycle,
+			"this reparent would create a dependency cycle; nothing was written"),
+			patchParam("parent_id")))
+
+	// An edge endpoint, not the resource this request addresses: the 400 that
+	// conforms to POST /v0/beads/dependencies:add. It is matched before the
+	// generic ErrNotFound so a missing PARENT can never be reported as a missing
+	// ISSUE, which would send a client looking for the wrong row.
+	case errors.As(err, &endpoint):
+		refused()
+		s.fail(w, r, InvalidArgument(patchParam("parent_id"), ReasonInvalidValue,
+			"`parent_id` names no issue this workspace holds; nothing was written"))
+
+	case errors.Is(err, storage.ErrNotFound):
 		s.fail(w, r, NotFound())
-		return
-	}
-	if !errors.Is(err, storage.ErrValidation) {
+
+	case !errors.Is(err, storage.ErrValidation):
 		s.failErr(w, r, err)
-		return
+
+	default:
+		refused()
+		s.fail(w, r, InvalidArgument(updatePatchMember, ReasonInvalidValue,
+			"a patch value was refused by this workspace's own validation; nothing was written"))
 	}
-	// The 4xx path does not log by default, so this is the one place the real
-	// refusal is recorded for the operator.
-	s.event("request_refused", "request_id", requestInfo(r.Context()).id, "error", err.Error())
-	s.fail(w, r, InvalidArgument(updatePatchMember, ReasonInvalidValue,
-		"a patch value was refused by this workspace's own validation; nothing was written"))
 }
+
+// updatePreconditionResult builds the 409 for a guard that missed, naming the
+// guard member and echoing what the request asked for.
+//
+// applyPreconditionResult's rule unchanged: the expected value comes from the
+// REQUEST rather than from a read, and the observed value is absent, because
+// the refusal rolled its transaction back and a read afterwards would describe
+// a row the refusal never saw. See PreconditionFailed.
+func updatePreconditionResult(request issueops.UpdateRequest, err error) Result {
+	res := PreconditionFailed()
+	switch {
+	case errors.Is(err, issueops.ErrVersionMismatch):
+		res.Problem.Param = updateGuardParam("expected_version")
+		if request.ExpectedVersion != nil {
+			res = res.WithExpectedVersion(*request.ExpectedVersion)
+		}
+	case errors.Is(err, issueops.ErrStatusMismatch):
+		res.Problem.Param = updateGuardParam("expected_status")
+		if request.ExpectedStatus != nil {
+			res = res.WithExpectedStatus(string(*request.ExpectedStatus))
+		}
+	default:
+		res.Problem.Param = updateGuardParam("expected_assignee")
+		if request.ExpectedAssignee != nil {
+			res = res.WithExpectedAssignee(*request.ExpectedAssignee)
+		}
+	}
+	return res
+}
+
+// updateGuardParam names a request-level guard member for `param`. The guards
+// sit BESIDE `patch` rather than inside it, so they are spelled bare where a
+// patch member is qualified by patchParam.
+func updateGuardParam(member string) *string { return &member }

--- a/internal/httpapi/update_test.go
+++ b/internal/httpapi/update_test.go
@@ -281,10 +281,14 @@ func TestUpdateNamesItsHistoryEntry(t *testing.T) {
 	}
 }
 
-// TestUpdateRejectsTheShapesTheDocumentRefuses is the body vocabulary. The
-// EXCLUDED members are the important half: status, assignee and metadata are
-// refused by NAME, so a client that tries to smuggle lifecycle through a patch
-// is told what happened rather than having it ignored.
+// TestUpdateRejectsTheShapesTheDocumentRefuses is the body vocabulary.
+//
+// The four cases that used to live here — status, assignee, metadata and
+// parent_id refused BY NAME — are gone, because those members are published
+// now. What replaces them is the refusal each one BROUGHT: a self-parent, and
+// the two combinations of the assignee guards that contradict each other. An
+// unknown member is still refused by name at both levels, which is what a
+// client dispatches on to tell version skew from a bad value.
 func TestUpdateRejectsTheShapesTheDocumentRefuses(t *testing.T) {
 	for _, tc := range []struct {
 		name  string
@@ -300,11 +304,24 @@ func TestUpdateRejectsTheShapesTheDocumentRefuses(t *testing.T) {
 		{"patch is not an object", `{"actor":"alice","patch":["title"]}`, "patch"},
 		{"empty patch", `{"actor":"alice","patch":{}}`, "patch"},
 		{"unknown request member", `{"actor":"alice","patch":{"title":"t"},"force":true}`, "force"},
-		// The three the spec argues out of the vocabulary, refused by name.
-		{"status is not a patch member", `{"actor":"alice","patch":{"status":"closed"}}`, "patch.status"},
-		{"assignee is not a patch member", `{"actor":"alice","patch":{"assignee":"bob"}}`, "patch.assignee"},
-		{"metadata is not a patch member", `{"actor":"alice","patch":{"metadata":{}}}`, "patch.metadata"},
-		{"parent_id is not a patch member", `{"actor":"alice","patch":{"parent_id":"bd-2"}}`, "patch.parent_id"},
+		{"unknown patch member", `{"actor":"alice","patch":{"title":"t","persistence":"ephemeral"}}`, "patch.persistence"},
+		// The refusals the three policy members brought with them, all decided
+		// at the edge because none of them needs to read a row.
+		{"self parent", `{"actor":"alice","patch":{"parent_id":"bd-1"}}`, "patch.parent_id"},
+		{"oversize parent_id", `{"actor":"alice","patch":{"parent_id":"` + strings.Repeat("x", 300) + `"}}`, "patch.parent_id"},
+		{"oversize status", `{"actor":"alice","patch":{"status":"` + strings.Repeat("x", 300) + `"}}`, "patch.status"},
+		{"oversize assignee", `{"actor":"alice","patch":{"assignee":"` + strings.Repeat("x", 300) + `"}}`, "patch.assignee"},
+		{"metadata replace beside merge", `{"actor":"alice","patch":{"metadata":{"replace":{},"merge":{"a":1}}}}`, "patch.metadata.replace"},
+		// A wrong JSON TYPE on a nested member is reported against the whole
+		// patch, the way `labels` already is: the typed decode fails as one
+		// unit and this surface does not quote its error string.
+		{"metadata is not an object", `{"actor":"alice","patch":{"metadata":["a"]}}`, "patch"},
+		{"unknown metadata member", `{"actor":"alice","patch":{"metadata":{"clear":true}}}`, "patch.metadata.clear"},
+		{"force_assignee_transfer without an assignee edit", `{"actor":"alice","patch":{"title":"t"},"force_assignee_transfer":true}`, "force_assignee_transfer"},
+		{"force_assignee_transfer beside expected_assignee", `{"actor":"alice","patch":{"assignee":"bob"},"force_assignee_transfer":true,"expected_assignee":"carol"}`, "force_assignee_transfer"},
+		{"expected_version is not a number", `{"actor":"alice","patch":{"title":"t"},"expected_version":"3"}`, "expected_version"},
+		{"null expected_status", `{"actor":"alice","patch":{"title":"t"},"expected_status":null}`, "expected_status"},
+		{"null force_close_policy", `{"actor":"alice","patch":{"title":"t"},"force_close_policy":null}`, "force_close_policy"},
 		{"blank title", `{"actor":"alice","patch":{"title":"   "}}`, "patch.title"},
 		{"oversize title", `{"actor":"alice","patch":{"title":"` + strings.Repeat("x", 300) + `"}}`, "patch.title"},
 		{"title is not a string", `{"actor":"alice","patch":{"title":7}}`, "patch"},
@@ -563,5 +580,475 @@ func TestUpdateResolvesAcrossBothPlanes(t *testing.T) {
 	}
 	if got := lifecycle.updateRequests(); len(got) != 1 || got[0].IssuePlaneOnly {
 		t.Fatalf("the role received %+v, want a both-plane resolve", got)
+	}
+}
+
+// The pins for the members this operation grew: the three that carry POLICY —
+// `status`, `assignee`, `parent_id` — the `metadata` algebra, and the guard and
+// force flags beside `patch`. What is asserted is the WIRE EDGE: that each
+// reaches the role's own field, and that each refusal the role can now raise
+// arrives as the documented code naming the member that earned it.
+
+// revisionedIssue is the row a guarded case reads its token off. The revision
+// is the only thing that distinguishes it from updatedIssue, and it is what a
+// case must never invent for itself.
+func revisionedIssue(id string, revision int64) *types.Issue {
+	issue := updatedIssue(id)
+	issue.RowVersion = revision
+	return issue
+}
+
+// TestUpdateForwardsTheGuardedMembers walks the members added beside the
+// original patch vocabulary in one request and asserts the projection onto the
+// role's UpdateRequest field by field. It is TestUpdateForwardsEveryDocumented
+// Member's sibling for the half that carries policy.
+func TestUpdateForwardsTheGuardedMembers(t *testing.T) {
+	lifecycle := &roleLifecycle{updateResult: issueops.UpdateResult{Issue: revisionedIssue("bd-1", 42), Changed: true}}
+	ts := newUpdateServer(t, lifecycle)
+
+	resp := ts.updateIssue(t, updatePath, `{
+		"actor":"alice",
+		"expected_version": 41,
+		"expected_status": "open",
+		"force_close_policy": true,
+		"patch": {
+			"status": "closed",
+			"assignee": "bob",
+			"parent_id": "bd-parent",
+			"metadata": {"merge":{"a":1},"set":{"b":null},"unset":["c"]}
+		}
+	}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+
+	got := lifecycle.updateRequests()
+	if len(got) != 1 {
+		t.Fatalf("the role was called %d times, want 1", len(got))
+	}
+	req := got[0]
+	if req.ExpectedVersion == nil || *req.ExpectedVersion != 41 {
+		t.Errorf("expected_version = %v, want 41", req.ExpectedVersion)
+	}
+	if req.ExpectedStatus == nil || *req.ExpectedStatus != issueops.Status("open") {
+		t.Errorf("expected_status = %v, want open", req.ExpectedStatus)
+	}
+	if req.ExpectedAssignee != nil {
+		t.Errorf("expected_assignee = %v, want nil for an absent guard", *req.ExpectedAssignee)
+	}
+	if !req.ForceClosePolicy || req.ForceAssigneeTransfer {
+		t.Errorf("force flags = %v/%v, want close-policy only", req.ForceClosePolicy, req.ForceAssigneeTransfer)
+	}
+	// Claim stays zero: acquiring work is `{id}:claim`, which has its own
+	// eligibility rules and its own conflict vocabulary.
+	if req.Claim {
+		t.Error("the update claimed the issue; that operation is `{id}:claim`")
+	}
+	if req.IssuePlaneOnly {
+		t.Error("the update narrowed itself to the issue plane; this operation resolves across both")
+	}
+
+	p := req.Patch
+	if !p.Status.Set || p.Status.Value != issueops.Status("closed") {
+		t.Errorf("status = %+v, want a set closed", p.Status)
+	}
+	if !p.Assignee.Set || p.Assignee.Value != "bob" {
+		t.Errorf("assignee = %+v, want a set bob", p.Assignee)
+	}
+	if !p.ParentID.Set || p.ParentID.Value != "bd-parent" {
+		t.Errorf("parent_id = %+v, want a set bd-parent", p.ParentID)
+	}
+	m := p.Metadata
+	if m.Replace.Set {
+		t.Errorf("metadata.replace is set though the request sent none: %+v", m.Replace)
+	}
+	if !m.Merge.Set || strings.ReplaceAll(string(m.Merge.Value), " ", "") != `{"a":1}` {
+		t.Errorf("metadata.merge = %+v, want the caller's own bytes", m.Merge)
+	}
+	if len(m.Set) != 1 || string(m.Set["b"]) != "null" {
+		t.Errorf("metadata.set = %v; a key written to JSON null must survive as the literal", m.Set)
+	}
+	if len(m.Unset) != 1 || m.Unset[0] != "c" {
+		t.Errorf("metadata.unset = %v, want [c]", m.Unset)
+	}
+}
+
+// TestUpdateDistinguishesTheThreeMetadataStates is the F12 pin, and it is the
+// case the generated type cannot express: on the metadata plane an absent
+// member, a member holding JSON null and a member holding the empty string are
+// three different requests, and only the raw bytes carry the difference.
+func TestUpdateDistinguishesTheThreeMetadataStates(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		set  string
+		want string
+	}{
+		{"a key written to null", `{"set":{"k":null}}`, "null"},
+		{"a key written to the empty string", `{"set":{"k":""}}`, `""`},
+		{"a key written to an empty object", `{"set":{"k":{}}}`, "{}"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			lifecycle := &roleLifecycle{updateResult: issueops.UpdateResult{Issue: updatedIssue("bd-1"), Changed: true}}
+			ts := newUpdateServer(t, lifecycle)
+
+			resp := ts.updateIssue(t, updatePath, `{"actor":"alice","patch":{"metadata":`+test.set+`}}`)
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+			}
+			got := lifecycle.updateRequests()
+			if len(got) != 1 {
+				t.Fatalf("the role was called %d times, want 1", len(got))
+			}
+			if value := string(got[0].Patch.Metadata.Set["k"]); value != test.want {
+				t.Errorf("metadata.set[k] = %q, want %q", value, test.want)
+			}
+		})
+	}
+
+	t.Run("an absent key is not written at all", func(t *testing.T) {
+		lifecycle := &roleLifecycle{updateResult: issueops.UpdateResult{Issue: updatedIssue("bd-1"), Changed: true}}
+		ts := newUpdateServer(t, lifecycle)
+
+		resp := ts.updateIssue(t, updatePath, `{"actor":"alice","patch":{"metadata":{"unset":["k"]}}}`)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+		}
+		got := lifecycle.updateRequests()
+		if len(got) != 1 {
+			t.Fatalf("the role was called %d times, want 1", len(got))
+		}
+		if _, present := got[0].Patch.Metadata.Set["k"]; present {
+			t.Error("an unset key arrived as a set one; removing a key is `unset`, never a null in `set`")
+		}
+	})
+
+	// `metadata` itself is NOT nullable: a null on it would be a clear the
+	// document never promised, and the algebra spells one as `replace`.
+	t.Run("metadata itself refuses an explicit null", func(t *testing.T) {
+		lifecycle := &roleLifecycle{}
+		ts := newUpdateServer(t, lifecycle)
+
+		resp := ts.updateIssue(t, updatePath, `{"actor":"alice","patch":{"metadata":null}}`)
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
+		}
+		if body := decodeBody(t, resp); body["param"] != "patch.metadata" {
+			t.Errorf("param = %v, want patch.metadata", body["param"])
+		}
+		if len(lifecycle.updateRequests()) != 0 {
+			t.Error("a null reached the role")
+		}
+	})
+}
+
+// TestUpdateGuardsComposeFromTheRevisionTheWriteAnswered is the precondition's
+// happy path, and it is written as a LOOP rather than with a literal token on
+// purpose: `expected_version` guards an opaque value the store mints, so a case
+// that invented one would pass against a server that answered a different
+// number than it stores. The second request's guard comes from the first
+// response's `revision` and from nowhere else.
+func TestUpdateGuardsComposeFromTheRevisionTheWriteAnswered(t *testing.T) {
+	const stored int64 = 7
+	lifecycle := &roleLifecycle{updateResult: issueops.UpdateResult{Issue: revisionedIssue("bd-1", stored), Changed: true}}
+	ts := newUpdateServer(t, lifecycle)
+
+	first := ts.updateIssue(t, updatePath, `{"actor":"alice","patch":{"title":"first"}}`)
+	if first.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", first.StatusCode, readAll(t, first))
+	}
+	revision, ok := decodeBody(t, first)["revision"].(float64)
+	if !ok {
+		t.Fatalf("the response carries no `revision`; a guard whose token no response carries cannot be filled")
+	}
+	// The token must be the ROW's, read off the snapshot the role answered
+	// with. Without this the loop below round-trips whatever the handler put
+	// there — including a constant zero — and could not fail against a
+	// `revision` that describes no row.
+	if int64(revision) != stored {
+		t.Fatalf("revision = %d, want the %d the role's row carries", int64(revision), stored)
+	}
+
+	second := ts.updateIssue(t, updatePath,
+		fmt.Sprintf(`{"actor":"alice","expected_version":%d,"patch":{"title":"second"}}`, int64(revision)))
+	if second.StatusCode != http.StatusOK {
+		t.Fatalf("guarded status = %d, want 200: %s", second.StatusCode, readAll(t, second))
+	}
+	got := lifecycle.updateRequests()
+	if len(got) != 2 {
+		t.Fatalf("the role was called %d times, want 2", len(got))
+	}
+	if got[1].ExpectedVersion == nil || *got[1].ExpectedVersion != int64(revision) {
+		t.Errorf("expected_version = %v, want the %d the write answered with", got[1].ExpectedVersion, int64(revision))
+	}
+}
+
+// TestUpdateRefusesAStaleGuard pins the 409 for each member of the trio: the
+// code, the member `param` names, and the expectation echoed back. The observed
+// value is deliberately absent — the refusal rolled its transaction back, so a
+// read afterwards would describe a row the refusal never saw.
+func TestUpdateRefusesAStaleGuard(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		body      string
+		err       error
+		wantParam string
+		wantEcho  string
+		wantValue any
+	}{
+		{
+			name:      "version",
+			body:      `{"actor":"alice","expected_version":7,"patch":{"title":"t"}}`,
+			err:       fmt.Errorf("update bd-1: %w", issueops.ErrVersionMismatch),
+			wantParam: "expected_version",
+			wantEcho:  "expected_version",
+			wantValue: float64(7),
+		},
+		{
+			name:      "status",
+			body:      `{"actor":"alice","expected_status":"open","patch":{"title":"t"}}`,
+			err:       fmt.Errorf("update bd-1: %w", issueops.ErrStatusMismatch),
+			wantParam: "expected_status",
+			wantEcho:  "expected_status",
+			wantValue: "open",
+		},
+		{
+			name:      "assignee",
+			body:      `{"actor":"alice","expected_assignee":"bob","patch":{"assignee":"carol"}}`,
+			err:       fmt.Errorf("update bd-1: %w", issueops.ErrAssigneeMismatch),
+			wantParam: "expected_assignee",
+			wantEcho:  "expected_assignee",
+			wantValue: "bob",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			lifecycle := &roleLifecycle{updateErr: test.err}
+			ts := newUpdateServer(t, lifecycle)
+
+			resp := ts.updateIssue(t, updatePath, test.body)
+			if resp.StatusCode != http.StatusConflict {
+				t.Fatalf("status = %d, want 409: %s", resp.StatusCode, readAll(t, resp))
+			}
+			body := decodeBody(t, resp)
+			if body["code"] != string(CodePreconditionFailed) {
+				t.Errorf("code = %v, want %s", body["code"], CodePreconditionFailed)
+			}
+			if body["param"] != test.wantParam {
+				t.Errorf("param = %v, want %q", body["param"], test.wantParam)
+			}
+			if body[test.wantEcho] != test.wantValue {
+				t.Errorf("%s = %v, want %v echoed from the request", test.wantEcho, body[test.wantEcho], test.wantValue)
+			}
+			for _, absent := range []string{"actual_version", "actual_status", "actual_assignee"} {
+				if _, present := body[absent]; present {
+					t.Errorf("%s is present; this role reports no observed value and inventing one from a later read would be worse than omitting it", absent)
+				}
+			}
+		})
+	}
+}
+
+// TestUpdateAnswersThePolicyRefusalsItsMembersEarned walks every 409 the three
+// policy members brought, and the extension members that discriminate within a
+// shared code.
+func TestUpdateAnswersThePolicyRefusalsItsMembersEarned(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		body       string
+		err        error
+		wantStatus int
+		wantCode   Code
+		wantParam  string
+		check      func(*testing.T, map[string]any)
+	}{
+		{
+			name:       "status crossing with open children",
+			body:       `{"actor":"alice","patch":{"status":"closed"}}`,
+			err:        fmt.Errorf("close: %w", &issueops.CloseOpenChildrenError{OpenChildren: 3}),
+			wantStatus: http.StatusConflict,
+			wantCode:   CodeNotClosable,
+			wantParam:  "patch.status",
+			check: func(t *testing.T, body map[string]any) {
+				if body["open_children"] != float64(3) {
+					t.Errorf("open_children = %v, want 3 read from the refusing transaction", body["open_children"])
+				}
+			},
+		},
+		{
+			name:       "status crossing with a live blocker",
+			body:       `{"actor":"alice","patch":{"status":"closed"}}`,
+			err:        fmt.Errorf("close: %w", issueops.ErrCloseBlocked),
+			wantStatus: http.StatusConflict,
+			wantCode:   CodeNotClosable,
+			wantParam:  "patch.status",
+			check: func(t *testing.T, body map[string]any) {
+				if _, present := body["open_children"]; present {
+					t.Error("open_children is present on the blocker refusal; its ABSENCE is what tells the two apart")
+				}
+			},
+		},
+		{
+			name:       "assignee transfer off a live owner",
+			body:       `{"actor":"alice","patch":{"assignee":"carol"}}`,
+			err:        fmt.Errorf("update: %w: issue bd-1 is assigned to %q", storage.ErrAlreadyClaimed, "bob"),
+			wantStatus: http.StatusConflict,
+			wantCode:   CodeAlreadyClaimed,
+			wantParam:  "patch.assignee",
+			check: func(t *testing.T, body map[string]any) {
+				// The fence refuses without a typed holder, so the member is
+				// absent — and it must NOT be parsed out of the message text,
+				// which is exactly what a client adopting this endpoint deletes.
+				if got, present := body["assignee"]; present {
+					t.Errorf("assignee = %v; the fence reports no typed holder, so this must not be scraped from the message", got)
+				}
+			},
+		},
+		{
+			// THE DEFENSIVE ARM, driven directly because no reparent can reach
+			// it: CheckBlockingHierarchyInTx probes `blocks` and
+			// `conditional-blocks` only, and patch.parent_id writes
+			// `parent-child`. It is NOT a promise this operation makes — the
+			// document tells clients the hierarchy members never arrive here —
+			// and this case pins only that IF the refusal ever reaches this
+			// handler it keeps its members instead of collapsing into the plain
+			// cycle below, which is the one shape a client cannot tell apart.
+			name:       "the defensive hierarchy arm keeps its members",
+			body:       `{"actor":"alice","patch":{"parent_id":"bd-child"}}`,
+			err:        fmt.Errorf("reparent: %w", &issueops.DependencyHierarchyConflictError{IssueID: "bd-1", BlockerID: "bd-child", BlockerIsAncestor: false}),
+			wantStatus: http.StatusConflict,
+			wantCode:   CodeDependencyCycle,
+			wantParam:  "patch.parent_id",
+			check: func(t *testing.T, body map[string]any) {
+				if body["issue_id"] != "bd-1" || body["blocker_id"] != "bd-child" {
+					t.Errorf("hierarchy members = %v/%v, want the refused pair", body["issue_id"], body["blocker_id"])
+				}
+				if body["blocker_is_ancestor"] != false {
+					t.Errorf("blocker_is_ancestor = %v; it travels in BOTH polarities", body["blocker_is_ancestor"])
+				}
+			},
+		},
+		{
+			// THE ARM EVERY REAL REPARENT CYCLE TAKES, and the one the proxied
+			// integration case drives end to end. Its lack of hierarchy members
+			// is what this operation documents.
+			name:       "reparent that closes a cycle",
+			body:       `{"actor":"alice","patch":{"parent_id":"bd-2"}}`,
+			err:        fmt.Errorf("reparent: %w", issueops.ErrDependencyCycle),
+			wantStatus: http.StatusConflict,
+			wantCode:   CodeDependencyCycle,
+			wantParam:  "patch.parent_id",
+			check: func(t *testing.T, body map[string]any) {
+				for _, member := range []string{"issue_id", "blocker_id", "blocker_is_ancestor"} {
+					if _, present := body[member]; present {
+						t.Errorf("%s is present; this operation's cycle never carries the hierarchy members", member)
+					}
+				}
+			},
+		},
+		{
+			name:       "reparent onto a pair that already carries another edge",
+			body:       `{"actor":"alice","patch":{"parent_id":"bd-2"}}`,
+			err:        fmt.Errorf("reparent: %w", &issueops.DependencyTypeConflictError{IssueID: "bd-1", DependsOnID: "bd-2", ExistingType: "blocks", RequestedType: "parent-child"}),
+			wantStatus: http.StatusConflict,
+			wantCode:   CodeDependencyExists,
+			wantParam:  "patch.parent_id",
+			check: func(t *testing.T, body map[string]any) {
+				if body["existing_type"] != "blocks" || body["requested_type"] != "parent-child" {
+					t.Errorf("types = %v/%v, want both read from the typed error", body["existing_type"], body["requested_type"])
+				}
+			},
+		},
+		{
+			// An edge ENDPOINT, not the resource this request addresses. A 404
+			// here would send a client looking for the wrong missing row.
+			name:       "reparent onto a parent that names nothing",
+			body:       `{"actor":"alice","patch":{"parent_id":"bd-gone"}}`,
+			err:        fmt.Errorf("reparent: %w", &issueops.DependencyEndpointNotFoundError{IssueID: "bd-1", DependsOnID: "bd-gone", MissingID: "bd-gone", Err: issueops.ErrDependencyTargetNotFound}),
+			wantStatus: http.StatusBadRequest,
+			wantCode:   CodeInvalidArgument,
+			wantParam:  "patch.parent_id",
+			check:      func(*testing.T, map[string]any) {},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			lifecycle := &roleLifecycle{updateErr: test.err}
+			ts := newUpdateServer(t, lifecycle)
+
+			resp := ts.updateIssue(t, updatePath, test.body)
+			if resp.StatusCode != test.wantStatus {
+				t.Fatalf("status = %d, want %d: %s", resp.StatusCode, test.wantStatus, readAll(t, resp))
+			}
+			body := decodeBody(t, resp)
+			if body["code"] != string(test.wantCode) {
+				t.Errorf("code = %v, want %s", body["code"], test.wantCode)
+			}
+			if body["param"] != test.wantParam {
+				t.Errorf("param = %v, want %q", body["param"], test.wantParam)
+			}
+			if detail, _ := body["detail"].(string); strings.Contains(detail, "reparent:") || strings.Contains(detail, "is assigned to") {
+				t.Errorf("detail quotes the role's own message: %q", detail)
+			}
+			test.check(t, body)
+		})
+	}
+}
+
+// TestUpdateStillAnswers404ForThePathID keeps the one miss this operation does
+// own. Publishing `parent_id` added a second not-found shape to the same
+// handler, so the two have to stay distinguishable: the path id is a 404 and an
+// edge endpoint is a 400.
+func TestUpdateStillAnswers404ForThePathID(t *testing.T) {
+	lifecycle := &roleLifecycle{updateErr: fmt.Errorf("update bd-1: %w", storage.ErrNotFound)}
+	ts := newUpdateServer(t, lifecycle)
+
+	resp := ts.updateIssue(t, updatePath, `{"actor":"alice","patch":{"parent_id":"bd-2"}}`)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if body := decodeBody(t, resp); body["code"] != string(CodeNotFound) {
+		t.Errorf("code = %v, want %s", body["code"], CodeNotFound)
+	}
+}
+
+// TestUpdateEmptiesTheParentSetOnAnEmptyString pins the one value of
+// `parent_id` whose meaning is not "this is the new parent": the role reads a
+// set empty value as "remove every parent-child edge", so it must reach the
+// role SET rather than being dropped as an absent member.
+func TestUpdateEmptiesTheParentSetOnAnEmptyString(t *testing.T) {
+	lifecycle := &roleLifecycle{updateResult: issueops.UpdateResult{Issue: updatedIssue("bd-1"), Changed: true}}
+	ts := newUpdateServer(t, lifecycle)
+
+	resp := ts.updateIssue(t, updatePath, `{"actor":"alice","patch":{"parent_id":""}}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	got := lifecycle.updateRequests()
+	if len(got) != 1 {
+		t.Fatalf("the role was called %d times, want 1", len(got))
+	}
+	if !got[0].Patch.ParentID.Set || got[0].Patch.ParentID.Value != "" {
+		t.Errorf("parent_id = %+v, want a SET empty value — the spelling that unparents", got[0].Patch.ParentID)
+	}
+}
+
+// TestUpdateGuardsDistinguishAbsentFromEmpty pins the pointer the role models
+// the two string guards as. A guard on the EMPTY assignee is how a caller says
+// "only if nobody holds it", so an absent member and one holding "" must not
+// collapse into each other.
+func TestUpdateGuardsDistinguishAbsentFromEmpty(t *testing.T) {
+	lifecycle := &roleLifecycle{updateResult: issueops.UpdateResult{Issue: updatedIssue("bd-1"), Changed: true}}
+	ts := newUpdateServer(t, lifecycle)
+
+	if resp := ts.updateIssue(t, updatePath, `{"actor":"alice","expected_assignee":"","expected_status":"","patch":{"assignee":"bob"}}`); resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	got := lifecycle.updateRequests()
+	if len(got) != 1 {
+		t.Fatalf("the role was called %d times, want 1", len(got))
+	}
+	if got[0].ExpectedAssignee == nil || *got[0].ExpectedAssignee != "" {
+		t.Errorf("expected_assignee = %v, want a pointer to the empty string", got[0].ExpectedAssignee)
+	}
+	if got[0].ExpectedStatus == nil || *got[0].ExpectedStatus != "" {
+		t.Errorf("expected_status = %v, want a pointer to the empty status", got[0].ExpectedStatus)
 	}
 }


### PR DESCRIPTION
## What this is

`PATCH /v0/beads/issues/{id}` documented four exclusions with one shared reason: `status` belongs to `{id}:close`/`{id}:reopen`/`{id}:claim`, `assignee` to the claim's compare-and-set, `metadata` "deserves its own design pass", `parent_id` is "a graph edit in patch clothing" — and keeping them out was, in the document's own words, "half the reason this operation documents no `409` at all."

That argument held until `POST /v0/beads/issues:batchApply` landed (#5480). Its `ApplyPatchBody` publishes `status`, `assignee` and `owner`; its `ApplyUpdateItem` publishes both force flags and all three `expected_*` guards; and `ApplyUpdateItem`'s own description says it patches one issue *"under `PATCH /v0/beads/issues/{id}`'s rules plus the preconditions and force flags that operation deliberately does not publish."* Two operations for patching one issue, disagreeing about what patching one issue means, with the awkward one carrying the capability.

This closes the gap from the other side. Spec first, then `make api-gen`, then the handler.

## Member decisions

| Member | Decision | Evidence |
|---|---|---|
| `patch.status` | ADD | `IssuePatch.Status` is a `Field[Status]` whose doc already describes the close-policy interaction; `ApplyPatchBody.status` has published it since #5480; `bd update --status` exists. The capability two calls cannot give you is moving a status ALONGSIDE other fields in one transaction. `{id}:close`/`{id}:reopen` keep the semantics a status write has nowhere to put — the reason and session under first-close-wins, the done-status normalization, `already_closed`/`already_open` — and the spec now says that instead of claiming status is unpatchable. |
| `patch.assignee` | ADD | `IssuePatch.Assignee`; `ApplyPatchBody.assignee`; `bd update --assignee`. `{id}:claim` remains the ACQUIRE operation with its own eligibility rules; this is the raw write, fenced. |
| `patch.parent_id` | ADD | `IssuePatch.ParentID` ("a set nonempty value atomically replaces all parents"); `bd update --parent`. One call rather than remove-then-add, which is why it matters: the two-call spelling leaves the issue parentless if the second call fails. `ApplyPatchBody` withholds it for a reason specific to that operation — a parent there is a `dep_add` item so the plan's edge order stays total — and a single patch has no ordering to express. |
| `patch.metadata` | ADD, as `$ref: ApplyMetadataPatch` | REUSE taken literally in both halves: the schema is `ApplyMetadataPatch` itself and the handler calls `applyMetadataPatch()` itself, prefixed `patch.metadata.`. One definition of the replace/merge/set/unset algebra means the two operations cannot drift, and it inherits that function's correctness fix for free — `set` is read RAW, so a key written to JSON null survives instead of collapsing into an absent key. |
| `expected_version`, `expected_status`, `expected_assignee` | ADD (request level, beside `patch`) | `UpdateRequest.ExpectedVersion/ExpectedStatus/ExpectedAssignee`; published on `ApplyUpdateItem` already. The role models the two string guards as POINTERS because a guard on the EMPTY assignee ("only if nobody holds it") is a real request, so the handler preserves absent-vs-empty rather than collapsing them. |
| `force_close_policy`, `force_assignee_transfer` | ADD | `UpdateRequest.ForceClosePolicy/ForceAssigneeTransfer`; `ApplyUpdateItem`'s two flags. The two combinations the role documents as invalid — `force_assignee_transfer` without `patch.assignee`, and beside `expected_assignee` — are refused at the edge: the `notes`/`append_notes` rule applied to two members that would otherwise reach a role obliged to guess which of the caller's two opinions wins. |
| `patch.owner` | WITHHELD | `ApplyPatchBody` publishes it; `IssuePatchBody` excluded it as "`assignee`'s argument", and that argument is now gone. Additive later with nothing against it — nothing has asked for it on the single patch. The spec now says exactly that rather than repeating a reason that no longer holds. |
| `patch.persistence` | WITHHELD | A plane move is an atomic aggregate migration, not a field write. Withheld from `ApplyPatchBody` too, for the same reason. |
| `patch.close_reason`, `patch.closed_by_session` | WITHHELD | Written under first-close-wins by `{id}:close`; a patch write would bypass the operation that owns them. A crossing `status` answers to close POLICY here and does not acquire the close's semantics. |
| `patch.created_at`, `patch.created_by` | WITHHELD | Consistent with `POST /v0/beads/issues` in the PR below this one. |
| `patch.spec_id`, `patch.await_id` | WITHHELD | Unchanged: workflow plumbing this surface publishes nowhere. |
| `labels` shape | UNCHANGED | Stays COMPLETE REPLACEMENT. `ApplyLabelPatch`'s add/remove/replace shape is that operation's for a stated reason — a plan edits a set it did not compose — and a caller patching one row it just read already knows the set. This is now the ONLY member on which the two patch bodies differ, and both schemas say so. |
| nullable set | UNCHANGED | `estimated_minutes`, `external_ref`, `due_at`, `defer_until` and nothing else. None of the four new members is `Field[*T]`, so none is nullable: `metadata` spells a clear as `replace`, `parent_id` spells one as the empty string. `TestNullablePatchMembersAreExactlyTheDocumentsNullableOnes` needed no edit, which is the check that the three-state pointer members did not interact with this change. |

## `UpdateIssueResponse.revision`

One addition beyond the member list, and it is the member list's own consequence rather than a rider.

`expected_version` guards an opaque token. `types.Issue.RowVersion` is `json:"-"` — deliberately, "surfaced as `revision` for guarded clients" per its own comment — so **no read on this surface publishes a revision at all**; the only place one appears today is `ApplyItemResult.revision`. Publishing a guard whose token no response carries is the R1 mistake in miniature: a member a caller cannot fill.

So a successful update now answers with the row's post-write token, spelled the way `ApplyItemResult` spells it. A read-modify-write loop composes its next expectation from the value the write ANSWERED with — never from a number it incremented itself, which is `compareAndSetMetadata`'s "a result value the caller feeds back must be READ, not echoed."

**Ledger item:** the first guarded write in a session still has to seed itself from an unguarded update or from `applyBatch`. Publishing `revision` on `getIssue`/`listIssues` is the missing piece and is out of scope here; the spec's `revision` description names the gap so the next slice inherits it rather than rediscovering it.

## Codes

`OpUpdateIssue` gains `{precondition_failed, not_closable, already_claimed, dependency_cycle, dependency_exists}` — `applyBatch`'s row for a single update item, minus `already_exists`, which needs a create.

Each was traced to a reachable body:

- **`precondition_failed`** — `ErrVersionMismatch`/`ErrStatusMismatch`/`ErrAssigneeMismatch` from `ApplyUpdate`'s compare-and-set. The 409 form rather than `compareAndSetMetadata`'s 200, for the reason `CodePreconditionFailed` documents: a miss here refuses the whole write and leaves nothing to report but the refusal, where a lost metadata swap is a retry loop's ordinary iteration carrying the value it needs next. **This PR adds only the `x-bd-codes` line for `updateIssue`** — the code, its frozen status, `PreconditionFailed()` and the `expected_*` extension members were all minted by #5480. Second minter adds only its lines (OQ1).
- **`not_closable`** — `ErrCloseOpenChildren`/`ErrCloseBlocked`, with `open_children` attached for the first and withheld for the second so member presence stays the discriminator.
- **`already_claimed`** — the assignee fence. **`AuthorizeAssigneeTransferWithPools` returns a bare wrapped `storage.ErrAlreadyClaimed` with no `*ClaimConflictError`**, so the `assignee` extension member is absent on this operation. The handler attaches it only via `errors.As`, and does NOT scrape the holder out of the message text — that substring classification is precisely what a client adopting this endpoint gets to delete. The spec says the member is optional here and why; a test asserts it is absent rather than scraped.
- **`dependency_cycle` / `dependency_exists`** — the reparent reaches `addDependencyInTx` (store legs, via `ApplyParentPatch`) and `depRepo.Insert` (uow leg, via `dependencyUseCaseImpl.reparent` — **not** `add`, which reparent never calls). `types.IsSchedulingEdge` includes `DepParentChild`, so `CheckDependencyCycleInTx` / `HasCycle` run on both legs, and the retype conflict is raised against a STORED edge — which is what makes `dependency_exists` reachable here where it is not on `createIssue`.

  **The hierarchy discriminator does NOT apply to this operation, and the spec no longer says it does.** `CheckBlockingHierarchyInTx` returns nil for anything but a `blocks` or `conditional-blocks` edge (`internal/storage/issueops/dependencies.go`), and `patch.parent_id` writes `parent-child` — on both legs, since `depRepo.Insert`'s `ValidateBlockingHierarchy` reaches the same function. So `*DependencyHierarchyConflictError` is **unreachable** from this operation and `dependency_cycle` always arrives WITHOUT `issue_id`/`blocker_id`/`blocker_is_ancestor`.

  Fixed in three places rather than papered over: the 409 description and `IssuePatchBody.parent_id` now state the absence and tell clients not to dispatch on presence here; `createIssue`'s 409 states the reciprocal (both arms ARE reachable there, because that operation writes blocking edges and hierarchy in one transaction) so the asymmetry is visible from both sides; and the handler arm is kept and annotated **defensive-unreachable**, because its absence would let a future hierarchy refusal fall into the plain-cycle arm and be answered with the same code carrying no members — the one shape a client reading the discriminator cannot tell apart. The pure test that drives it is renamed to say exactly that.

**No new 404.** `DependencyEndpointNotFoundError` wraps `ErrDependencyTargetNotFound`, not `storage.ErrNotFound`, so a missing new parent is matched typed and answered `400` on `patch.parent_id`, conforming to `dependencies:add`. The 404 stays the PATH id's alone, and a test pins that the two not-found shapes in one handler stay distinguishable.

### The ordering that makes it correct

Every 409 arm is matched TYPED and BEFORE the `ErrValidation` and `ErrNotFound` arms. **Corrected from the previous revision of this body**, which claimed the hazard was 500-on-one-leg / 400-on-the-other. It is worse than that: **neither leg wraps these five families in `ErrValidation`.** The store legs return `ExecuteUpdate`'s error through `runIssueOperationTx` unchanged (`internal/storage/dolt/issue_operations.go`) and the unit of work returns `ApplyUpdate`'s unchanged (`internal/storage/uow/issue_operations.go`), so all five reach the handler as bare sentinels. Below the `ErrValidation` arm they fall into `!errors.Is(...)` and are swallowed into `failErr` — **a generic 500, on both legs**, for five conditions this document names by code.

Verified by mutation rather than asserted: moving the precondition arm below the `!ErrValidation` arm turns all three `TestUpdateRefusesAStaleGuard` cases into `500`, not `400`. The handler comment now says this.

## Overlap with ga-ufssu

`ga-ufssu` owns preconditions across the mutation surface. `updateIssue`'s three are implemented HERE because they are inseparable from the members that make them mean anything — `expected_assignee` is only meaningful beside `patch.assignee`, and `force_assignee_transfer`'s "must be false when `expected_assignee` is sent" rule needs both in one handler. **ga-ufssu retains `closeIssue`, `reopenIssue` and `deleteIssues`.** This PR does not touch those three handlers, their `operationCodes` rows, or their schemas.

## Integration coverage (this round)

`serve_update_proxied_integration_test.go`, all nine subtests green against real Dolt.

**The failing subtest is fixed, and the bug was in the test's decode.** `revision` was read as `body["revision"].(float64)`. Live `row_lock` tokens run ~5e17–9e17, where a float64's ulp is already 64–128, so `int64(revision)` was a value NEAR the token and not the token — and the fresh guard 409'd against a row nothing else had touched. It now decodes the raw response into a typed `*int64`.

Two consequences worth noting:

- I first fixed it with `Decoder.UseNumber()` on the shared `updateIssue` helper, which broke the pre-existing CLI/HTTP parity subtest (`json.Number` vs `float64` compared unequal while both printed `1`). The final shape leaves that helper's default decode alone and adds `updateIssueRaw` + a typed `revisionOf`, so the parity oracle is untouched.
- The spec now carries the warning on **both** `UpdateIssueRequest.expected_version` and `UpdateIssueResponse.revision`: decode as a 64-bit integer; an IEEE-754-double parser (JavaScript `JSON.parse`, Go `any`, Python `float`) corrupts it silently and the corruption only surfaces as a `precondition_failed` on the NEXT request. My own test failure is cited as the proof.

**The `stale := revision - 1` leg is gone.** It was vacuous for an equality-only token and it violated the type's own never-order rule. Replaced with the real read-modify-write loop: write #1 mints a token, an unguarded write #2 by a different actor moves the row (asserted: the token must actually change, or every guard is vacuous), the stale guard from write #1 is refused `409 precondition_failed` on `expected_version` with nothing written, and the guard from write #2 lands.

**Added: `a reparent that closes a cycle is a 409 over the wire.**` A under B, then B under A — no edge read-back needed, because a cycle can only be observed by asking for one and the refusal IS the observation. It drives the real legs (`CheckDependencyCycleInTx` / `HasCycle`) and asserts the hierarchy members are ABSENT, which is the finding above pinned end to end.

## Tests

All in `internal/httpapi/update_test.go`, pure on the fake role.

- `TestUpdateForwardsTheGuardedMembers` — the four patch members and the five request-level members in one request, asserted field by field on the role's `UpdateRequest`, including that `Claim` and `IssuePlaneOnly` stay zero.
- `TestUpdateDistinguishesTheThreeMetadataStates` — the F12 pin: `set: {"k": null}`, `{"k": ""}` and `{"k": {}}` arrive as three different literals, an `unset` key never arrives as a `set` one, and `metadata` itself refuses an explicit null.
- `TestUpdateGuardsComposeFromTheRevisionTheWriteAnswered` — the precondition happy path as a LOOP: the second request's `expected_version` comes from the first response's `revision` and from nowhere else. It also asserts that revision is the ROW's, which is what stops the loop round-tripping a constant.
- `TestUpdateRefusesAStaleGuard` — all three guards, each with its `param`, its echoed `expected_*`, and an assertion that no `actual_*` member appears.
- `TestUpdateAnswersThePolicyRefusalsItsMembersEarned` — seven refusals: both `not_closable` arms (with `open_children` present/absent as the discriminator), `already_claimed` (asserting the holder is NOT scraped from the message), both `dependency_cycle` arms (with the hierarchy members present/absent), `dependency_exists` with both types, and the missing-parent 400.
- `TestUpdateStillAnswers404ForThePathID`, `TestUpdateEmptiesTheParentSetOnAnEmptyString`, `TestUpdateGuardsDistinguishAbsentFromEmpty`.
- `TestUpdateRejectsTheShapesTheDocumentRefuses` — the four cases that pinned the old exclusions are replaced by the refusals those members BROUGHT: a self-parent, the two contradictory assignee-guard combinations, the metadata `replace`-beside-`merge` rule, an unknown metadata member, and the bounds on each new string.
- `TestUpdateRequestMembersMatchTheHandler` and `TestNullablePatchMembersAreExactlyTheDocumentsNullableOnes` needed no edit and both still pass — the first because it is table-driven over the member-list vars, the second because the nullable set genuinely did not change.

### Mutation checks

| Mutation | Result |
|---|---|
| drop `metadata` from `issuePatchMembers` | `TestUpdateRequestMembersMatchTheHandler/IssuePatchBody` RED, both directions |
| read `expected_version` from a member name nothing sends | `TestUpdateForwardsTheGuardedMembers` and the guard-composition loop RED |
| remove the precondition arm from `failUpdate` | `TestUpdateRefusesAStaleGuard` RED on all three (500, not 409) |
| remove the edge-endpoint arm | the missing-parent case RED (500, not 400) |
| answer `revision: 0` instead of the row's | RED — **and this one was green first.** The loop echoed whatever the handler put there, so it could not fail against a revision describing no row. It now asserts the value against the row the role answered with. |

## Gates

`make api-check`, `go build ./...`, `go vet`, `golangci-lint run ./internal/httpapi/... ./cmd/bd/...` and `--new-from-rev=HEAD` (0 issues), `gofmt -l` clean, and `BEADS_TEST_PROXIED_SERVER=1 CGO_ENABLED=1 go test ./cmd/bd/ -run 'TestProxiedServerServeCreate|TestProxiedServerServeUpdate|TestProxiedServerServeLifecycle'` — all green against real Dolt. The pre-commit hook's `go run golangci-lint@v2.10.1` fails on this host with a toolchain mismatch unrelated to this change, so the hook's contents were run by hand before committing with `--no-verify`.

## Stacking

**Second of a two-PR stack, based on `feat/httpapi-create-issue` (#5483), not on `main`.** The two share spec and handler territory — both touch `IssuePatchBody`'s neighbourhood, `problem.go`'s operation table, and the `ApplyPatchBody`/`ApplyCreateItem` prose that describes how these operations relate. Merge #5483 first; this branch then rebases onto main cleanly, and its own diff is what to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
