### PR TITLE
ci: give storage domain/uow jobs explicit timeout budgets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -609,6 +609,9 @@ jobs:
     name: Test (storage domain + uow)
     runs-on: ubuntu-latest
     needs: build-artifacts
+    # The race-enabled storage package has outgrown Go's implicit 10-minute
+    # timeout. Keep both per-package deadlines inside one finite job budget.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 
@@ -652,7 +655,7 @@ jobs:
       - name: Test domain + uow + tracker
         env:
           BEADS_TEST_BD_BINARY: ${{ github.workspace }}/ci-build-artifacts/bd-linux-gms-pure
-        run: go test -tags gms_pure_go -race -count=1 -v ./internal/storage/domain/... ./internal/storage/uow/... ./internal/tracker/...
+        run: go test -tags gms_pure_go -race -count=1 -timeout 15m -v ./internal/storage/domain/... ./internal/storage/uow/... ./internal/tracker/...
 
       # The doctor/fix DB-backed suite spins its own Dolt container in
       # TestMain. BEADS_FIX_REQUIRE_DOLT=1 turns a missing container into a
@@ -662,7 +665,7 @@ jobs:
         env:
           BEADS_TEST_BD_BINARY: ${{ github.workspace }}/ci-build-artifacts/bd-linux-gms-pure
           BEADS_FIX_REQUIRE_DOLT: "1"
-        run: go test -tags gms_pure_go -race -count=1 -v ./cmd/bd/doctor/fix/
+        run: go test -tags gms_pure_go -race -count=1 -timeout 10m -v ./cmd/bd/doctor/fix/
 
   main-linux-integration-packages:
     name: Main Linux integration packages (${{ matrix.shard }}/6)

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -550,6 +550,9 @@ jobs:
     name: Test (storage domain + uow)
     runs-on: ubuntu-latest
     needs: build-artifacts
+    # The race-enabled storage package has outgrown Go's implicit 10-minute
+    # timeout. Keep both per-package deadlines inside one finite job budget.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 
@@ -593,7 +596,7 @@ jobs:
       - name: Test domain + uow + tracker
         env:
           BEADS_TEST_BD_BINARY: ${{ github.workspace }}/ci-build-artifacts/bd-linux-gms-pure
-        run: go test -tags gms_pure_go -race -count=1 -v ./internal/storage/domain/... ./internal/storage/uow/... ./internal/tracker/...
+        run: go test -tags gms_pure_go -race -count=1 -timeout 15m -v ./internal/storage/domain/... ./internal/storage/uow/... ./internal/tracker/...
 
       # The doctor/fix DB-backed suite spins its own Dolt container in
       # TestMain. BEADS_FIX_REQUIRE_DOLT=1 turns a missing container into a
@@ -603,7 +606,7 @@ jobs:
         env:
           BEADS_TEST_BD_BINARY: ${{ github.workspace }}/ci-build-artifacts/bd-linux-gms-pure
           BEADS_FIX_REQUIRE_DOLT: "1"
-        run: go test -tags gms_pure_go -race -count=1 -v ./cmd/bd/doctor/fix/
+        run: go test -tags gms_pure_go -race -count=1 -timeout 10m -v ./cmd/bd/doctor/fix/
 
   # macOS-only regressions were landing on main undetected: main.yml's Test
   # (macos-latest) leg only runs `if: github.event_name == 'push' &&

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -60,6 +60,37 @@ func TestPRCIGateRequiresPolicyAndLintWrappers(t *testing.T) {
 	}
 }
 
+func TestStorageDomainUOWJobsUseNestedTimeoutBudgets(t *testing.T) {
+	const (
+		storageCommand = "go test -tags gms_pure_go -race -count=1 -timeout 15m -v ./internal/storage/domain/... ./internal/storage/uow/... ./internal/tracker/..."
+		doctorCommand  = "go test -tags gms_pure_go -race -count=1 -timeout 10m -v ./cmd/bd/doctor/fix/"
+		jobTimeout     = 30
+	)
+
+	for _, workflowName := range []string{"pr.yml", "main.yml"} {
+		t.Run(workflowName, func(t *testing.T) {
+			job := readCIWorkflow(t, workflowName).job(t, "test-domain-uow")
+			if job.TimeoutMinutes != jobTimeout {
+				t.Errorf("test-domain-uow timeout = %d minutes, want %d", job.TimeoutMinutes, jobTimeout)
+			}
+			assertStepRunsExactly(t, job, "Test domain + uow + tracker", storageCommand)
+			assertStepRunsExactly(t, job, "Test doctor/fix (Dolt-backed, hard-require container)", doctorCommand)
+		})
+	}
+
+	gate := readCIWorkflow(t, "pr.yml").job(t, "ci-gate")
+	gateEnv := gate.step(t, "Evaluate CI gate").Env
+	if !contains(gate.Needs, "test-domain-uow") {
+		t.Errorf("ci-gate needs test-domain-uow: %v", gate.Needs)
+	}
+	if got, want := gateEnv["TEST_DOMAIN_UOW"], "${{ needs.test-domain-uow.result }}"; got != want {
+		t.Errorf("ci-gate TEST_DOMAIN_UOW = %q, want %q", got, want)
+	}
+	if !contains(strings.Fields(gateEnv["CI_GATE_REQUIRED"]), "TEST_DOMAIN_UOW") {
+		t.Errorf("ci-gate CI_GATE_REQUIRED does not include TEST_DOMAIN_UOW: %q", gateEnv["CI_GATE_REQUIRED"])
+	}
+}
+
 func TestMacOSTestJobsReuseWorkspaceBDBinary(t *testing.T) {
 	const (
 		workspaceBDBinary = "${{ github.workspace }}/bd"
@@ -594,10 +625,11 @@ type ciWorkflow struct {
 }
 
 type ciWorkflowJob struct {
-	Needs    ciWorkflowStringList `yaml:"needs"`
-	Steps    []ciWorkflowStep     `yaml:"steps"`
-	RunsOn   string               `yaml:"runs-on"`
-	Strategy ciWorkflowStrategy   `yaml:"strategy"`
+	Needs          ciWorkflowStringList `yaml:"needs"`
+	Steps          []ciWorkflowStep     `yaml:"steps"`
+	RunsOn         string               `yaml:"runs-on"`
+	TimeoutMinutes int                  `yaml:"timeout-minutes"`
+	Strategy       ciWorkflowStrategy   `yaml:"strategy"`
 }
 
 type ciWorkflowStrategy struct {


### PR DESCRIPTION
## What

- give the race-enabled domain/UOW/tracker invocation an explicit 15-minute Go timeout
- preserve doctor/fix's existing 10-minute behavior explicitly
- bound their sequential job at 30 minutes in both PR and main workflows
- add a structural regression test for both mirrors, both exact commands, the outer budget, and required-gate wiring

## Why

Fixes #5487.

The UOW package now runs close enough to Go's implicit 10-minute deadline that ordinary CI variance can fail unrelated changes: one run timed out at 600.051 seconds, its same-head rerun passed, and another successful run took 584.153 seconds.

The nested budget remains finite. The long tier gets 50% headroom over the former alarm; the following tier keeps its old limit; and the job gets five additional minutes beyond the two sequential tier budgets. This does not add retries, skips, or reduced coverage.

## Verification

- `go test ./scripts` (full scripts package)
- `go vet -tags gms_pure_go ./scripts`
- `actionlint .github/workflows/pr.yml .github/workflows/main.yml`
- `make ci-pr-lint`
- real-Go parser/package-resolution probes for both complete timeout forms (six storage packages and one doctor/fix package)
- independent exact-head contract review and publication classification against current `main`

The broad native-Windows `ci-pr-core` baseline remains red in unrelated packages on current main; the changed `scripts` package passed there. The required hosted Linux `PR Core (wrapper timing)`, real storage job, and `CI Gate / Required` remain the authoritative exact-head checks for this PR.

_codex-gpt-5-unknown-reasoning on behalf of Ewen Cuthiell_
