### PR TITLE
Retire bd label's proxied use-case bypass, and lint the door shut (ga-26w10)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -149,6 +149,23 @@ linters:
         # the bypass it was written for. Reaching a use case requires a unit of
         # work, opening one requires uow.RunTx, and THAT is an import.
         #
+        # THIS RULE COVERS THE IMPORT SPELLING AND ONLY THE IMPORT SPELLING, and
+        # by itself it is NOT sufficient. cmd/bd is one package, so
+        # proxiedOpenReadUOW (cmd/bd/show_proxied_server.go) hands any file in
+        # it a uow.UnitOfWork with no import of its own — measured: a label.go
+        # calling proxiedOpenReadUOW(ctx) and then uw.LabelUseCase().AddLabel()
+        # compiles and passes this rule. An import-scoped guard cannot see a
+        # bypass routed through an in-package helper, and pretending otherwise
+        # would be worse than no rule, because the next reader greps for the
+        # guard, finds one, and stops looking.
+        #
+        # What closes that route is the forbidigo `LabelUseCase` rule below,
+        # scoped to this same file. The two are a PAIR and neither is
+        # decorative: forbidigo names the call and depguard names the package,
+        # so a caller that reached the domain through some third spelling —
+        # a helper returning a use case directly, say — still trips the import.
+        # Both were verified by mutation, one bypass each.
+        #
         # cmd/bd/label.go holds every label decision now — the arg split, the
         # reserved-prefix refusal, the patch, the report — and reaches storage
         # only through issueops.Lifecycle and issueops.Reader.
@@ -267,6 +284,8 @@ linters:
     forbidigo:
       analyze-types: true
       forbid:
+        - pattern: 'LabelUseCase$'
+          msg: "reach the label plane through issueops.Lifecycle (Patch.Labels) and issueops.Reader, never the domain use case - see openIssueLifecycle in cmd/bd/label.go"
         - pattern: '^types\.(IssueFilter|WorkFilter)$'
           pkg: '^github\.com/steveyegge/beads/internal/types$'
           msg: "do not write a filter here: take one back from a builder in internal/workapi, or pass the whole request to issueops.Reader. internal/httpapi may never name these types; cmd/bd denies them by default and lists the files that legitimately build their own, with the reason for each, in .golangci.yml - see issueops/reader.go"
@@ -296,13 +315,34 @@ linters:
 
   exclusions:
     rules:
-      # forbidigo holds exactly one rule - the filter-construction guard - and
-      # the entries from here to the test exemption are its entire scope. This
-      # one keeps it off the rest of the tree; the settings block above says
-      # why. A second forbidigo rule would need this widened or replaced, and
-      # nothing else about the config would tell you that, so it is written
-      # here rather than left implicit.
+      # forbidigo holds TWO rules - the filter-construction guard and the
+      # label-plane guard - and the entries from here to the test exemption are
+      # their entire scope. This one keeps both off the rest of the tree; the
+      # settings block above says why.
+      #
+      # The previous version of this comment said there was exactly one rule and
+      # that a second "would need this widened or replaced". That came true, and
+      # what it cost is the two entries below plus a `text:` on ONE of the
+      # per-path holes. Every hole from here down is written for the FILTER rule
+      # and predates the label one, so a hole that names only a path silently
+      # opens both. That is fine wherever the file never reaches a label use
+      # case, and it is not fine for cmd/bd/label.go, which is the one file the
+      # label rule exists for - see the `text:`-scoped entry at the label family
+      # below.
       - path-except: '^(internal/httpapi/|cmd/bd/)'
+        linters:
+          - forbidigo
+      # The label-plane rule is deny-by-default across cmd/bd like its sibling,
+      # and this narrows it to the ONE file whose front door has been migrated.
+      # Every other caller of a label use case in cmd/bd is a command this slice
+      # did not move - `bd create --labels`' dry-run preview, the mutate and
+      # show proxied routes, and label.go's own list-all and propagate twins in
+      # label_proxied_server.go - and holding them to a rule written for a
+      # migration they have not had would be a lint that has to be waived on
+      # sight. Each one drops off this exemption as its command reaches the
+      # role, which is the same shrink-by-migration the filter holes above do.
+      - path-except: '^cmd/bd/label\.go$'
+        text: 'reach the label plane through issueops'
         linters:
           - forbidigo
       # Inside cmd/bd the rule is deny-by-default, so each entry below is a
@@ -368,7 +408,17 @@ linters:
       # provider's capability accessor. `gc` stays — it is a different command
       # that still selects its own closed beads, and it now shares only the pure
       # recheck (workapi.FilterSweepCandidates) with the role.
+      # `text:` HERE AND NOWHERE ELSE, and the asymmetry is deliberate rather
+      # than an oversight to tidy up later. This is the only hole in the list
+      # whose files include one the LABEL rule must bite in - cmd/bd/label.go,
+      # which still names types.IssueFilter for list-all and propagate and
+      # therefore still needs its filter exemption. Without the text scope this
+      # entry would exempt that file from every forbidigo rule there will ever
+      # be, including the one written to guard it. The other holes name no such
+      # file, so widening them now would be churn asserting nothing; the next
+      # rule that overlaps one of them adds its own text scope the same way.
       - path: '^cmd/bd/(close|duplicates|find_duplicates|gate|gc|graph|info|label|orphans|purge|search|todo|wisp|human)(_proxied_server)?\.go$'
+        text: 'do not write a filter here'
         linters:
           - forbidigo
       # Molecule reporting: each selects the members of one molecule.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -134,6 +134,42 @@ linters:
           deny:
             - pkg: github.com/steveyegge/beads/internal/storage/domain
               desc: "internal/httpapi is transport only: a handler reaches storage through an issueops role accessor on the provider, never through the domain use cases - see internal/httpapi/claim.go"
+        # The same boundary, transposed onto the front door that was last past
+        # it. cmd/bd cannot be closed to the domain wholesale — thirty of its
+        # non-test files import internal/storage/domain today and unpicking
+        # them is a program, not a rule — so this closes it ONE COMMAND AT A
+        # TIME, and `bd label` is the first entry.
+        #
+        # It denies internal/storage/uow as well as internal/storage/domain,
+        # and the second package is the one that does the work here. depguard
+        # matches IMPORTS, and a file can call uw.LabelUseCase().AddLabel(...)
+        # without importing domain at all — the method call needs no import for
+        # the inferred type. That is exactly what cmd/bd/label_proxied_server.go
+        # did, so a domain-only deny would have been a rule that could not see
+        # the bypass it was written for. Reaching a use case requires a unit of
+        # work, opening one requires uow.RunTx, and THAT is an import.
+        #
+        # cmd/bd/label.go holds every label decision now — the arg split, the
+        # reserved-prefix refusal, the patch, the report — and reaches storage
+        # only through issueops.Lifecycle and issueops.Reader.
+        # cmd/bd/label_proxied_server.go is NOT on this list and legitimately
+        # imports uow: it is where the route's capability accessors live, and
+        # it still holds `list-all` and `propagate`, whose questions no role
+        # answers yet. It joins the list when they move.
+        #
+        # The list grows by one file per command whose front doors reach the
+        # roles, the way cmd-bd-role-constructors grows by one package per
+        # shared body.
+        cmd-bd-domain-boundary:
+          list-mode: lax
+          files:
+            - "**/cmd/bd/label.go"
+            - "!$test"
+          deny:
+            - pkg: github.com/steveyegge/beads/internal/storage/domain
+              desc: "bd label reaches storage through an issueops role accessor, never through the domain use cases - see openIssueLifecycle in cmd/bd/label.go"
+            - pkg: github.com/steveyegge/beads/internal/storage/uow
+              desc: "bd label does not open a unit of work: the route fork is the accessor (openIssueLifecycle/openIssueReader), and a unit of work here is how a use-case call gets back in - see cmd/bd/label.go"
         # store.IssueReader() is the door to the reader role, and a store wears
         # decorators (telemetry spans, hook firing) that each add their layer in
         # their OWN accessor. A command holding the storage.DoltStorage

--- a/cmd/bd/label.go
+++ b/cmd/bd/label.go
@@ -75,6 +75,37 @@ func resolveLabelTarget(ctx context.Context, id string) (string, error) {
 // ephemeral row's labels land in the ephemeral table — which is the four-way
 // switch the proxied route used to hand-roll, and the one place a front door
 // could put a wisp's label in the durable table by getting a boolean backwards.
+//
+// WHAT THE LOOP COSTS, stated in full because it is the one place this
+// migration is not free. Both routes used to put the whole edit in ONE
+// transaction — the direct one through transactHonoringAutoCommit, the proxied
+// one through uow.RunTx — and a per-issue role call cannot. So for N issues:
+//
+//   - N history entries where there was one, each naming its own issue;
+//   - under `--dolt-auto-commit on`, which is the DEFAULT, N Dolt version
+//     commits where the old transaction made one. Batch mode still makes zero,
+//     via issueOpsContext above, so the multiplication is only on the mode
+//     that was already committing per command;
+//   - a failure on the third id leaves the first two written, where the old
+//     shape rolled the good ones back with the bad one.
+//
+// PARTIAL APPLICATION IS ACCEPTABLE HERE, and that is an argument rather than
+// a shrug. issueops.ApplyLabelPatch computes the TARGET SET and returns
+// Changed false without writing when it equals the existing one, so an add and
+// a remove are both idempotent: re-running the same command over the same ids
+// is a no-op on the ids that already landed and does the remaining work on the
+// ids that did not. A partial batch therefore CONVERGES on retry, which is the
+// property that makes "landed some" a recoverable state rather than a
+// corrupted one. It would not be acceptable for an edit whose replay is not
+// the identity — which is exactly why this is stated here and not generalized.
+//
+// THE ATOMIC SHAPE IS EXPRESSIBLE ON THE FACADE ALREADY and is the named
+// follow-up, not a vague later: issueops.BatchApplier.ApplyBatch takes one
+// ItemUpdate per issue carrying this same IssuePatch, applies them in order and
+// commits them together, so the N calls collapse back to one transaction and
+// one history entry with no new role and no new request type. It is not in this
+// slice because it needs a cmd/bd accessor of its own and because its end gate
+// runs a hierarchy and cycle walk a label-only request has no use for.
 func applyLabelEdit(ctx context.Context, issueIDs []string, labels []string, operation string) error {
 	lifecycle, err := openIssueLifecycle()
 	if err != nil {
@@ -97,19 +128,18 @@ func applyLabelEdit(ctx context.Context, issueIDs []string, labels []string, ope
 		patch.Labels.Add = labels
 	}
 	for _, issueID := range issueIDs {
-		_, uerr := lifecycle.Update(ctx, issueops.UpdateRequest{
+		if _, uerr := lifecycle.Update(ctx, issueops.UpdateRequest{
 			Actor:   actor,
 			IssueID: issueID,
 			Patch:   patch,
-		})
-		// Marked per issue rather than once at the end: the edits land one
-		// call at a time, so a request that failed on its third id has still
-		// written its first two and the deferred commit has to know.
-		commandDidWrite.Store(true)
-		if uerr != nil {
+		}); uerr != nil {
 			return HandleErrorRespectJSON("label %s: %s label '%s' on %s: %v",
 				operation, operation, strings.Join(labels, "', '"), issueID, uerr)
 		}
+		// Marked per issue rather than once after the loop: the edits land one
+		// call at a time, so a request that failed on its third id has still
+		// written its first two and the deferred commit has to know about them.
+		commandDidWrite.Store(true)
 	}
 	return reportLabelEdit(issueIDs, labels, operation, jsonOutput)
 }
@@ -448,9 +478,14 @@ func runLabelAdd(ctx context.Context, args []string) error {
 	if len(labels) == 0 {
 		return HandleErrorRespectJSON("label cannot be empty")
 	}
-	// The reserved-prefix refusal is checked BEFORE anything is resolved, so a
-	// caller that both typo'd an id and reached for a reserved label is told
-	// about the label — the one of the two this command will never accept.
+	// The reserved-prefix refusal is checked BEFORE anything is resolved, and
+	// that ORDER CHANGED: the direct route used to resolve every id first and
+	// refuse the label afterwards. A caller that both typo'd an id and reached
+	// for a reserved label is now told about the label — the one of the two
+	// this command will never accept, at any id — rather than being sent to fix
+	// an id that was never going to be labeled. The proxied route already
+	// checked in this order, so this is the two routes agreeing on the earlier
+	// of the two answers rather than a new rule.
 	for _, label := range labels {
 		if strings.HasPrefix(label, "provides:") {
 			return HandleErrorRespectJSON("'provides:' labels are reserved for cross-project capabilities. Hint: use 'bd ship %s' instead", strings.TrimPrefix(label, "provides:"))

--- a/cmd/bd/label.go
+++ b/cmd/bd/label.go
@@ -13,6 +13,7 @@ import (
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
 	"github.com/steveyegge/beads/internal/utils"
+	"github.com/steveyegge/beads/issueops"
 )
 
 var labelCmd = &cobra.Command{
@@ -21,25 +22,100 @@ var labelCmd = &cobra.Command{
 	Short:   "Manage issue labels",
 }
 
-func processBatchLabelOperation(issueIDs []string, labels []string, operation string, jsonOut bool,
-	txFunc func(context.Context, storage.Transaction, string, string, string) error) error {
-	ctx := rootCtx
-	labelDesc := strings.Join(labels, "', '")
-	commitMsg := fmt.Sprintf("bd: label %s '%s' on %d issue(s)", operation, labelDesc, len(issueIDs))
-	err := transactHonoringAutoCommit(ctx, store, commitMsg, func(tx storage.Transaction) error {
-		for _, issueID := range issueIDs {
-			for _, label := range labels {
-				if err := txFunc(ctx, tx, issueID, label, actor); err != nil {
-					return fmt.Errorf("%s label '%s' on %s: %w", operation, label, issueID, err)
-				}
-			}
-		}
-		return nil
-	})
-	if err != nil {
-		return HandleErrorRespectJSON("label %s: %v", operation, err)
+// openIssueLifecycle hands back the guarded write role for whichever route this
+// invocation is on, each through its own capability accessor. Neither branch
+// opens a unit of work, names a use case or composes a transaction: the label
+// edit is a patch, and the role is what applies it.
+func openIssueLifecycle() (issueops.Lifecycle, error) {
+	if usesProxiedServer() {
+		return proxiedIssueLifecycle()
 	}
-	commandDidWrite.Store(true)
+	return store.IssueLifecycle()
+}
+
+// openIssueReader hands back the read role the same way. `bd label list` is a
+// detail read whose answer is already hydrated — issueops.Reader.Get returns
+// IssueDetails with Labels on it — so there is nothing here for a label-shaped
+// read surface to add.
+func openIssueReader() (issueops.Reader, error) {
+	if usesProxiedServer() {
+		return proxiedIssueReader()
+	}
+	return store.IssueReader()
+}
+
+// resolveLabelTarget turns one positional argument into the EXACT id the roles
+// take, on whichever route this invocation is on.
+//
+// This is the ONE fork left in this command, and it is a fork over how a route
+// REACHES the store rather than over what it does once it has an answer. The
+// proxied arm is not a second policy: it is the same exact-then-wisp lookup
+// internal/workapi already defines for every proxied front door, and its
+// not-found is normalized to the same message shape.
+func resolveLabelTarget(ctx context.Context, id string) (string, error) {
+	if usesProxiedServer() {
+		return resolveLabelTargetProxied(ctx, id)
+	}
+	return utils.ResolvePartialID(ctx, store, id)
+}
+
+// applyLabelEdit applies ONE label patch to each named issue through
+// issueops.Lifecycle, and is the whole of what `bd label add` and
+// `bd label remove` do differently.
+//
+// ONE CALL PER ISSUE, AND ONE PATCH PER CALL. Every label of the request goes
+// into a single LabelPatch, so an N-issue, M-label edit is N calls rather than
+// the N*M raw writes both routes used to make. The role is what makes that
+// safe to say: LabelPatch applies Replace, then Add, then Remove, de-duplicates
+// within an edit, drops an empty entry rather than storing it, and refuses an
+// over-length label with ErrFieldTooLong before anything is written.
+//
+// The wisp plane needs no branch here. UpdateRequest.IssuePlaneOnly stays
+// false, so the role resolves the plane INSIDE its own transaction and an
+// ephemeral row's labels land in the ephemeral table — which is the four-way
+// switch the proxied route used to hand-roll, and the one place a front door
+// could put a wisp's label in the durable table by getting a boolean backwards.
+func applyLabelEdit(ctx context.Context, issueIDs []string, labels []string, operation string) error {
+	lifecycle, err := openIssueLifecycle()
+	if err != nil {
+		return HandleErrorRespectJSON("%v", err)
+	}
+	patch := issueops.IssuePatch{}
+	if operation == labelOperationRemoved {
+		patch.Labels.Remove = labels
+	} else {
+		patch.Labels.Add = labels
+	}
+	for _, issueID := range issueIDs {
+		_, uerr := lifecycle.Update(ctx, issueops.UpdateRequest{
+			Actor:   actor,
+			IssueID: issueID,
+			Patch:   patch,
+		})
+		// Marked per issue rather than once at the end: the edits land one
+		// call at a time, so a request that failed on its third id has still
+		// written its first two and the deferred commit has to know.
+		commandDidWrite.Store(true)
+		if uerr != nil {
+			return HandleErrorRespectJSON("label %s: %s label '%s' on %s: %v",
+				operation, operation, strings.Join(labels, "', '"), issueID, uerr)
+		}
+	}
+	return reportLabelEdit(issueIDs, labels, operation, jsonOutput)
+}
+
+// The two label edits this command performs, spelled once. They are the words
+// the JSON "status" member and the human line both carry, so they are constants
+// rather than two string literals that have to agree.
+const (
+	labelOperationAdded   = "added"
+	labelOperationRemoved = "removed"
+)
+
+// reportLabelEdit prints what landed, in the shape both routes have always
+// printed it: one JSON row per (issue, label) pair, or one human line per issue
+// naming every label at once.
+func reportLabelEdit(issueIDs []string, labels []string, operation string, jsonOut bool) error {
 	if jsonOut {
 		results := make([]map[string]interface{}, 0, len(issueIDs)*len(labels))
 		for _, issueID := range issueIDs {
@@ -53,16 +129,15 @@ func processBatchLabelOperation(issueIDs []string, labels []string, operation st
 		}
 		return outputJSON(results)
 	}
-	verb := "Added"
-	prep := "to"
-	if operation == "removed" {
-		verb = "Removed"
-		prep = "from"
+	verb, prep := "Added", "to"
+	if operation == labelOperationRemoved {
+		verb, prep = "Removed", "from"
 	}
 	noun := "label"
 	if len(labels) > 1 {
 		noun = "labels"
 	}
+	labelDesc := strings.Join(labels, "', '")
 	for _, issueID := range issueIDs {
 		fmt.Printf("%s %s %s '%s' %s %s\n", ui.RenderPass("✓"), verb, noun, labelDesc, prep, issueID)
 	}
@@ -91,15 +166,24 @@ func splitLabelArg(arg string) []string {
 	return labels
 }
 
-// resolveLabelIssueIDs resolves every issue-ID positional arg, failing hard on
-// the first arg that doesn't resolve. Labels come last on the command line, so
-// when several ID-position args fail the caller almost certainly passed labels
-// space-separated ("bd label add bd-123 a b c"); the error hints at the
-// comma-separated form instead of silently skipping the bad args (bd-vu5kv).
+// resolveLabelIssueIDs resolves every issue-ID positional arg to the EXACT id
+// the role takes, failing hard on the first arg that doesn't resolve.
+//
+// Resolution stays a front-door job and does not move behind the role:
+// GetRequest.ID and UpdateRequest.IssueID are both exact by contract, for the
+// reason those docs give — an affordance that can resolve to a different issue
+// than the caller named has no place on a contract two front doors share. This
+// is therefore the ONE thing that still forks by route, and it forks on how a
+// route reaches the store rather than on what it then does with the answer.
+//
+// Labels come last on the command line, so when several ID-position args fail
+// the caller almost certainly passed labels space-separated ("bd label add
+// bd-123 a b c"); the error hints at the comma-separated form instead of
+// silently skipping the bad args (bd-vu5kv).
 func resolveLabelIssueIDs(ctx context.Context, subcommand string, issueIDs []string) ([]string, error) {
 	resolved := make([]string, 0, len(issueIDs))
 	for _, id := range issueIDs {
-		fullID, err := utils.ResolvePartialID(ctx, store, id)
+		fullID, err := resolveLabelTarget(ctx, id)
 		if err != nil {
 			if len(issueIDs) > 1 {
 				return nil, fmt.Errorf("resolving issue ID %q: %w (to %s multiple labels, pass one comma-separated argument: bd label %s <issue-id> label1,label2)",
@@ -130,30 +214,7 @@ var labelAddCmd = &cobra.Command{
 			}
 		}()
 
-		if usesProxiedServer() {
-			return runLabelAddProxiedServer(rootCtx, args)
-		}
-
-		issueIDs, labels := parseLabelArgs(args)
-		if len(labels) == 0 {
-			return HandleErrorRespectJSON("label cannot be empty")
-		}
-		ctx := rootCtx
-		issueIDs, err := resolveLabelIssueIDs(ctx, "add", issueIDs)
-		if err != nil {
-			return HandleErrorRespectJSON("%v", err)
-		}
-
-		for _, label := range labels {
-			if strings.HasPrefix(label, "provides:") {
-				return HandleErrorRespectJSON("'provides:' labels are reserved for cross-project capabilities. Hint: use 'bd ship %s' instead", strings.TrimPrefix(label, "provides:"))
-			}
-		}
-
-		return processBatchLabelOperation(issueIDs, labels, "added", jsonOutput,
-			func(ctx context.Context, tx storage.Transaction, issueID, lbl, act string) error {
-				return tx.AddLabel(ctx, issueID, lbl, act)
-			})
+		return runLabelAdd(rootCtx, args)
 	},
 }
 
@@ -175,23 +236,7 @@ var labelRemoveCmd = &cobra.Command{
 			}
 		}()
 
-		if usesProxiedServer() {
-			return runLabelRemoveProxiedServer(rootCtx, args)
-		}
-
-		issueIDs, labels := parseLabelArgs(args)
-		if len(labels) == 0 {
-			return HandleErrorRespectJSON("label cannot be empty")
-		}
-		ctx := rootCtx
-		issueIDs, err := resolveLabelIssueIDs(ctx, "remove", issueIDs)
-		if err != nil {
-			return HandleErrorRespectJSON("%v", err)
-		}
-		return processBatchLabelOperation(issueIDs, labels, "removed", jsonOutput,
-			func(ctx context.Context, tx storage.Transaction, issueID, lbl, act string) error {
-				return tx.RemoveLabel(ctx, issueID, lbl, act)
-			})
+		return runLabelRemove(rootCtx, args)
 	},
 }
 var labelListCmd = &cobra.Command{
@@ -208,38 +253,7 @@ var labelListCmd = &cobra.Command{
 			}
 		}()
 
-		if usesProxiedServer() {
-			return runLabelListProxiedServer(rootCtx, args)
-		}
-
-		ctx := rootCtx
-		var issueID string
-		var err error
-		issueID, err = utils.ResolvePartialID(ctx, store, args[0])
-		if err != nil {
-			return HandleErrorRespectJSON("resolving %s: %v", args[0], err)
-		}
-		var labels []string
-		labels, err = store.GetLabels(ctx, issueID)
-		if err != nil {
-			return HandleErrorRespectJSON("%v", err)
-		}
-		if jsonOutput {
-			if labels == nil {
-				labels = []string{}
-			}
-			return outputJSON(labels)
-		}
-		if len(labels) == 0 {
-			fmt.Printf("\n%s has no labels\n", issueID)
-			return nil
-		}
-		fmt.Printf("\n%s Labels for %s:\n", ui.RenderAccent("🏷"), issueID)
-		for _, label := range labels {
-			fmt.Printf("  - %s\n", label)
-		}
-		fmt.Println()
-		return nil
+		return runLabelList(rootCtx, args)
 	},
 }
 var labelListAllCmd = &cobra.Command{
@@ -411,4 +425,77 @@ func init() {
 	labelCmd.AddCommand(labelListAllCmd)
 	labelCmd.AddCommand(labelPropagateCmd)
 	rootCmd.AddCommand(labelCmd)
+}
+
+// runLabelAdd, runLabelRemove and runLabelList are ONE body each, for both
+// routes. The route fork is gone from these three commands: what used to be an
+// `if usesProxiedServer() { return run…ProxiedServer(...) }` in the middle of a
+// RunE — with a second, separately-maintained implementation on the other side
+// of it — is now a fork inside resolveLabelTarget and inside the accessor, and
+// both arms end at the same role.
+func runLabelAdd(ctx context.Context, args []string) error {
+	issueIDs, labels := parseLabelArgs(args)
+	if len(labels) == 0 {
+		return HandleErrorRespectJSON("label cannot be empty")
+	}
+	// The reserved-prefix refusal is checked BEFORE anything is resolved, so a
+	// caller that both typo'd an id and reached for a reserved label is told
+	// about the label — the one of the two this command will never accept.
+	for _, label := range labels {
+		if strings.HasPrefix(label, "provides:") {
+			return HandleErrorRespectJSON("'provides:' labels are reserved for cross-project capabilities. Hint: use 'bd ship %s' instead", strings.TrimPrefix(label, "provides:"))
+		}
+	}
+	issueIDs, err := resolveLabelIssueIDs(ctx, "add", issueIDs)
+	if err != nil {
+		return HandleErrorRespectJSON("%v", err)
+	}
+	return applyLabelEdit(ctx, issueIDs, labels, labelOperationAdded)
+}
+
+func runLabelRemove(ctx context.Context, args []string) error {
+	issueIDs, labels := parseLabelArgs(args)
+	if len(labels) == 0 {
+		return HandleErrorRespectJSON("label cannot be empty")
+	}
+	issueIDs, err := resolveLabelIssueIDs(ctx, "remove", issueIDs)
+	if err != nil {
+		return HandleErrorRespectJSON("%v", err)
+	}
+	return applyLabelEdit(ctx, issueIDs, labels, labelOperationRemoved)
+}
+
+func runLabelList(ctx context.Context, args []string) error {
+	issueID, err := resolveLabelTarget(ctx, args[0])
+	if err != nil {
+		return HandleErrorRespectJSON("resolving %s: %v", args[0], err)
+	}
+	reader, err := openIssueReader()
+	if err != nil {
+		return HandleErrorRespectJSON("%v", err)
+	}
+	// The detail read already carries the labels, sorted, for whichever
+	// plane holds the row — so there is no label-shaped read here, and no
+	// wisp branch either.
+	details, err := reader.Get(ctx, issueops.GetRequest{ID: issueID})
+	if err != nil {
+		return HandleErrorRespectJSON("%v", err)
+	}
+	labels := details.Labels
+	if jsonOutput {
+		if labels == nil {
+			labels = []string{}
+		}
+		return outputJSON(labels)
+	}
+	if len(labels) == 0 {
+		fmt.Printf("\n%s has no labels\n", issueID)
+		return nil
+	}
+	fmt.Printf("\n%s Labels for %s:\n", ui.RenderAccent("🏷"), issueID)
+	for _, label := range labels {
+		fmt.Printf("  - %s\n", label)
+	}
+	fmt.Println()
+	return nil
 }

--- a/cmd/bd/label.go
+++ b/cmd/bd/label.go
@@ -80,6 +80,16 @@ func applyLabelEdit(ctx context.Context, issueIDs []string, labels []string, ope
 	if err != nil {
 		return HandleErrorRespectJSON("%v", err)
 	}
+	// The role creates its Dolt version commit inside the storage layer, so
+	// `--dolt-auto-commit batch` cannot be honored by blanking a commit message
+	// the way transactHonoringAutoCommit did on the old direct route: it has to
+	// be said on the CONTEXT. This is the one thing a command loses by moving
+	// off the raw transaction, and issueOpsContext is where every other
+	// role-routed write says it.
+	ctx, err = issueOpsContext(ctx)
+	if err != nil {
+		return HandleErrorRespectJSON("%v", err)
+	}
 	patch := issueops.IssuePatch{}
 	if operation == labelOperationRemoved {
 		patch.Labels.Remove = labels

--- a/cmd/bd/label_proxied_server.go
+++ b/cmd/bd/label_proxied_server.go
@@ -14,139 +14,32 @@ import (
 	"github.com/steveyegge/beads/internal/workapi"
 )
 
-func runLabelAddProxiedServer(ctx context.Context, args []string) error {
-	return labelMutateProxied(ctx, args, "added")
-}
-
-func runLabelRemoveProxiedServer(ctx context.Context, args []string) error {
-	return labelMutateProxied(ctx, args, "removed")
-}
-
-func labelMutateProxied(ctx context.Context, args []string, operation string) error {
-	issueIDs, labels := parseLabelArgs(args)
-	if len(labels) == 0 {
-		return HandleErrorRespectJSON("label cannot be empty")
-	}
-	if operation == "added" {
-		for _, label := range labels {
-			if strings.HasPrefix(label, "provides:") {
-				return HandleErrorRespectJSON("'provides:' labels are reserved for cross-project capabilities. Hint: use 'bd ship %s' instead", strings.TrimPrefix(label, "provides:"))
-			}
-		}
-	}
-	if uowProvider == nil {
-		return HandleError("proxied-server UOW provider not initialized")
-	}
-
-	labelDesc := strings.Join(labels, "', '")
-	commitMsg := fmt.Sprintf("bd: label %s '%s' on %d issue(s)", operation, labelDesc, len(issueIDs))
-
-	var resolvedIDs []string
-	err := uow.RunTx(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (string, error) {
-		resolvedIDs = resolvedIDs[:0]
-		for _, inputID := range issueIDs {
-			issue, isWisp, rerr := workapi.GetIssueOrWisp(ctx, workapi.NewUOWDetailSource(uw), inputID)
-			if errors.Is(rerr, storage.ErrNotFound) {
-				return "", fmt.Errorf("resolving issue ID %q: not found", inputID)
-			}
-			if rerr != nil {
-				return "", fmt.Errorf("resolving issue ID %q: %w", inputID, rerr)
-			}
-			for _, label := range labels {
-				var e error
-				switch {
-				case operation == "added" && isWisp:
-					e = uw.LabelUseCase().AddWispLabel(ctx, issue.ID, label, actor)
-				case operation == "added":
-					e = uw.LabelUseCase().AddLabel(ctx, issue.ID, label, actor)
-				case isWisp:
-					e = uw.LabelUseCase().RemoveWispLabel(ctx, issue.ID, label, actor)
-				default:
-					e = uw.LabelUseCase().RemoveLabel(ctx, issue.ID, label, actor)
-				}
-				if e != nil {
-					return "", fmt.Errorf("%s label '%s' on %s: %w", operation, label, issue.ID, e)
-				}
-			}
-			resolvedIDs = append(resolvedIDs, issue.ID)
-		}
-		return commitMsg, nil
-	})
-	if err != nil {
-		return HandleErrorRespectJSON("label %s: %v", operation, err)
-	}
-	commandDidWrite.Store(true)
-
-	if jsonOutput {
-		results := make([]map[string]interface{}, 0, len(resolvedIDs)*len(labels))
-		for _, issueID := range resolvedIDs {
-			for _, label := range labels {
-				results = append(results, map[string]interface{}{
-					"status":   operation,
-					"issue_id": issueID,
-					"label":    label,
-				})
-			}
-		}
-		return outputJSON(results)
-	}
-
-	verb, prep := "Added", "to"
-	if operation == "removed" {
-		verb, prep = "Removed", "from"
-	}
-	noun := "label"
-	if len(labels) > 1 {
-		noun = "labels"
-	}
-	for _, issueID := range resolvedIDs {
-		fmt.Printf("%s %s %s '%s' %s %s\n", ui.RenderPass("✓"), verb, noun, labelDesc, prep, issueID)
-	}
-	return nil
-}
-
-func runLabelListProxiedServer(ctx context.Context, args []string) error {
+// resolveLabelTargetProxied is `bd label`'s exact-id lookup on the
+// proxied-server route: the same issue-then-wisp resolution
+// workapi.GetIssueOrWisp gives every other proxied front door, with not-found
+// normalized to the shape the direct route's resolver produces.
+//
+// It is what is LEFT of this route's label plumbing. The four-way
+// wisp-by-operation switch that used to live here, and the read that used to
+// ask a label use case for one issue's labels, are gone: both routes now end at
+// issueops.Lifecycle and issueops.Reader, which resolve the plane themselves
+// inside their own transaction. Only the resolution stays, because the roles
+// take an exact id by contract.
+func resolveLabelTargetProxied(ctx context.Context, id string) (string, error) {
 	uw, err := proxiedOpenReadUOW(ctx)
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer uw.Close(ctx)
 
-	issue, isWisp, err := workapi.GetIssueOrWisp(ctx, workapi.NewUOWDetailSource(uw), args[0])
-	if errors.Is(err, storage.ErrNotFound) {
-		return HandleErrorRespectJSON("resolving %s: not found", args[0])
+	issue, _, rerr := workapi.GetIssueOrWisp(ctx, workapi.NewUOWDetailSource(uw), id)
+	if errors.Is(rerr, storage.ErrNotFound) {
+		return "", errors.New("not found")
 	}
-	if err != nil {
-		return HandleErrorRespectJSON("resolving %s: %v", args[0], err)
+	if rerr != nil {
+		return "", rerr
 	}
-	issueID := issue.ID
-
-	var labels []string
-	if isWisp {
-		labels, err = uw.LabelUseCase().GetWispLabels(ctx, issueID)
-	} else {
-		labels, err = uw.LabelUseCase().GetLabels(ctx, issueID)
-	}
-	if err != nil {
-		return HandleErrorRespectJSON("%v", err)
-	}
-
-	if jsonOutput {
-		if labels == nil {
-			labels = []string{}
-		}
-		return outputJSON(labels)
-	}
-	if len(labels) == 0 {
-		fmt.Printf("\n%s has no labels\n", issueID)
-		return nil
-	}
-	fmt.Printf("\n%s Labels for %s:\n", ui.RenderAccent("🏷"), issueID)
-	for _, label := range labels {
-		fmt.Printf("  - %s\n", label)
-	}
-	fmt.Println()
-	return nil
+	return issue.ID, nil
 }
 
 func runLabelListAllProxiedServer(ctx context.Context) error {

--- a/cmd/bd/proxied_lookup_failure_test.go
+++ b/cmd/bd/proxied_lookup_failure_test.go
@@ -81,6 +81,19 @@ func withStubbedProxiedLookup(t *testing.T, hardErr error) {
 	})
 }
 
+// inProxiedRoute selects the proxied route for one call.
+//
+// The label commands no longer have a run…ProxiedServer entry point to call
+// directly: their route fork moved into resolveLabelTarget and the role
+// accessor, which is the point of the change, so the route has to be selected
+// the way a real invocation selects it.
+func inProxiedRoute(run func() error) error {
+	old := proxiedServerMode
+	proxiedServerMode = true
+	defer func() { proxiedServerMode = old }()
+	return run()
+}
+
 const (
 	stubMissingID    = "bd-missing"
 	stubRawNoRows    = "sql: no rows in result set"
@@ -161,7 +174,7 @@ var proxiedLookupCommands = []struct {
 	{
 		name: "label list",
 		run: func(ctx context.Context) error {
-			return runLabelListProxiedServer(ctx, []string{stubMissingID})
+			return inProxiedRoute(func() error { return runLabelList(ctx, []string{stubMissingID}) })
 		},
 		wantNotFound: "Error: resolving bd-missing: not found",
 		wantHardErr:  "Error: resolving bd-missing: connection reset by peer",
@@ -265,12 +278,27 @@ var proxiedLookupCommands = []struct {
 		exitsZero:    true,
 	},
 	{
+		// The two routes now share one body, so this reports the DIRECT route's
+		// resolution message. It lost the "label added: " prefix the proxied
+		// route used to add, because that prefix named a write this command
+		// never attempted: resolution now happens before the role is even
+		// asked for.
 		name: "label add",
 		run: func(ctx context.Context) error {
-			return runLabelAddProxiedServer(ctx, []string{stubMissingID, "urgent"})
+			return inProxiedRoute(func() error { return runLabelAdd(ctx, []string{stubMissingID, "urgent"}) })
 		},
-		wantNotFound: `Error: label added: resolving issue ID "bd-missing": not found`,
-		wantHardErr:  `Error: label added: resolving issue ID "bd-missing": connection reset by peer`,
+		wantNotFound: `Error: resolving issue ID "bd-missing": not found`,
+		wantHardErr:  `Error: resolving issue ID "bd-missing": connection reset by peer`,
+	},
+	{
+		// The remove half of the same body, which had no row here before
+		// because it had no separately-callable proxied entry point to name.
+		name: "label remove",
+		run: func(ctx context.Context) error {
+			return inProxiedRoute(func() error { return runLabelRemove(ctx, []string{stubMissingID, "urgent"}) })
+		},
+		wantNotFound: `Error: resolving issue ID "bd-missing": not found`,
+		wantHardErr:  `Error: resolving issue ID "bd-missing": connection reset by peer`,
 	},
 	{
 		name: "label propagate",


### PR DESCRIPTION
`cmd/bd/label_proxied_server.go` reached `uw.LabelUseCase()` and
`uw.IssueUseCase()` — the domain layer BELOW the roles — and hand-rolled, on
that side only, a four-way switch over (add|remove) × (wisp|durable) to pick
which of four use-case methods to call:

```go
case operation == "added" && isWisp:  e = uw.LabelUseCase().AddWispLabel(...)
case operation == "added":            e = uw.LabelUseCase().AddLabel(...)
case isWisp:                          e = uw.LabelUseCase().RemoveWispLabel(...)
default:                              e = uw.LabelUseCase().RemoveLabel(...)
```

That switch is the bug class the roles exist to delete: a front door deciding
which physical plane a row lives on, in a boolean it can get backwards, with a
second implementation of the same command in the other file.

## Where each route ends now

| verb | before (direct) | before (proxied) | after (both) |
|---|---|---|---|
| `label add` | `transactHonoringAutoCommit` + `tx.AddLabel` per (issue, label) | `uow.RunTx` + the 4-way `LabelUseCase` switch | `Lifecycle.Update{Patch.Labels.Add}`, one call per issue |
| `label remove` | `transactHonoringAutoCommit` + `tx.RemoveLabel` | same switch | `Lifecycle.Update{Patch.Labels.Remove}` |
| `label list` | `store.GetLabels` | `LabelUseCase().Get{Wisp,}Labels` | `Reader.Get` → `IssueDetails.Labels` |
| `label list-all` | unchanged | unchanged | **out of scope** — see below |
| `label propagate` | unchanged | unchanged | **out of scope** — see below |

**The wisp switch is gone, not moved.** `UpdateRequest.IssuePlaneOnly` stays
false, so the role resolves the plane inside its own transaction. The four
proxied-integration cases that assert at the SQL-table level — `wisp_labels`
holds the row and `labels` stays empty — pass through the role with no branch
in the command.

**`label list` needs no label-shaped read.** `Reader.Get` answers
`*IssueDetails`, whose `Labels` is already hydrated and already sorted
(`ORDER BY label`), for whichever plane holds the row. The role that would have
been written here already exists.

## The one-RunE discipline

Each RunE was an `if usesProxiedServer() { return run…ProxiedServer(...) }` in
the MIDDLE of a body, with a separately maintained twin behind it. They are now
one line each into `runLabelAdd` / `runLabelRemove` / `runLabelList`, and the
route fork survives in exactly two places:

- **the accessor** — `openIssueLifecycle()` / `openIssueReader()`, the
  `openCounter()` / `openSweeper()` shape;
- **`resolveLabelTarget()`** — resolution stays a front-door job, because
  `GetRequest.ID` and `UpdateRequest.IssueID` are exact by contract: *"an
  affordance that can resolve to a different issue than the caller named has no
  place on a contract two front doors share."* It forks on how a route REACHES
  the store, never on what it does with the answer.

`cmd/bd/label_proxied_server.go` lost 145 lines and is down to one resolver plus
the two unmigrated subcommands.

## Two guards, because one was not enough

New depguard rule `cmd-bd-domain-boundary` (modelled on `httpapi-domain-boundary`)
**plus** a scoped forbidigo `LabelUseCase` rule. They are a pair and neither is
decorative.

**depguard denies `internal/storage/uow`, not just `internal/storage/domain`.**
The retired route called `uw.LabelUseCase().AddLabel(...)` *without importing
`domain`* — a method call on an inferred type needs no import — so a
`domain`-only deny could not have seen the bypass it was written for. Reaching a
use case needs a unit of work; opening one needs `uow.RunTx`; that is an import.

**But an import guard alone is defeated in-package, and review caught it.**
`cmd/bd` is one package, so `proxiedOpenReadUOW`
(`cmd/bd/show_proxied_server.go:61`) hands any file in it a `uow.UnitOfWork`
with **zero denied imports**. Measured on this branch: a `label.go` calling
`proxiedOpenReadUOW(ctx)` then `uw.LabelUseCase().AddLabel(...)` **compiled and
passed the rule**. A guard a reader greps for, finds, and stops looking behind
is worse than no guard, so the rule's comment now says what it covers — the
import spelling and only that — and points at its other half.

The forbidigo rule names the **call**; depguard names the **package**. A third
spelling (a helper handing back a use case directly) still trips the import.
Both mutation-verified, one bypass each:

| bypass | guard that fires |
|---|---|
| `import uow` + `uow.RunTx(...)` + `uw.LabelUseCase()` | `depguard` — `import ... is not allowed from list 'cmd-bd-domain-boundary'` |
| `proxiedOpenReadUOW(ctx)` + `uw.LabelUseCase()` (**no denied import**) | `forbidigo` — ``use of `uw.LabelUseCase` forbidden`` |

**Scoping it cost two config edits the config predicted.** Its exclusions block
said forbidigo held *"exactly one rule … a second would need this widened or
replaced"* — every per-path hole there was written for the filter rule and names
only a path, so it silently opens both rules. One of those holes covers
`cmd/bd/label.go` (which still names `types.IssueFilter` for `list-all` and
`propagate`) and would have exempted the very file the new rule exists for. That
entry is now `text:`-scoped to the filter message; the other holes name no such
file and are left alone rather than churned. A second `path-except` entry keeps
the label rule off the callers this slice did not migrate.

depguard stays scoped to `cmd/bd/label.go`: thirty non-test `cmd/bd` files import
`domain` today, so a package-wide deny would be a program, not a rule.

## Behaviour parity

Every label test in the tree, before and after:

| suite | result |
|---|---|
| `TestProxiedServerLabel` (21 subtests, `BEADS_TEST_PROXIED_SERVER=1`) | 21/21 pass — including the four that read `labels` / `wisp_labels` row counts directly, and the ones pinning exact slices (`want [alpha beta]`) |
| `TestEmbeddedLabel` (20 subtests, `BEADS_TEST_EMBEDDED_DOLT=1`) | pass — including `label_add_space_separated_labels_fails_loudly`, whose `"comma-separated"` hint is preserved |
| `TestLabelCommands` (store-level) | pass |
| `TestProxiedLookupReportsMissingIssue` / `…ReportsBackendFailure` | pass, with the label rows updated (below) and a `label remove` row added |
| full `cmd/bd` (cgo) | 20 failures, **all pre-existing**: identical-or-subset of `main`'s 25 on the same host. Zero regressions |

Output shapes preserved byte for byte: the `✓ Added label 'x' to bd-1` line, the
JSON `{status, issue_id, label}` rows, `\n<id> has no labels\n`, and the
`🏷 Labels for <id>:` block.

### Four deltas

The first draft of this list said two. The two additions are both improvements,
which is exactly why they were easy to leave out.

**1. A multi-issue edit is N guarded updates, not one raw transaction.** Both
routes used to put the whole edit in one transaction; a per-issue role call
cannot. For N issues that is N history entries each naming its own issue, **and
— under `--dolt-auto-commit on`, the default — N Dolt version commits where the
old transaction made one.** Batch mode still makes zero, via `issueOpsContext`.
A failure on the third id leaves the first two written.

*Why partial application is acceptable, as an argument rather than a shrug:*
`issueops.ApplyLabelPatch` computes the target set and returns `Changed false`
without writing when it equals the existing one, so add and remove are both
**idempotent** — a retry is a no-op on the ids that landed and does the rest, so
a partial batch **converges**. That property is what makes "landed some" a
recoverable state rather than a corrupted one; it would not hold for an edit
whose replay is not the identity, which is why it is stated here and not
generalized.

*The atomic shape, named:* `issueops.BatchApplier.ApplyBatch` takes one
`ItemUpdate` per issue carrying **this same `IssuePatch`**, applies them in order
and commits them together — N calls collapse to one transaction and one history
entry with no new role and no new request type. Already in this branch's
ancestry (#5480). Blocked only on a `cmd/bd` accessor of its own, plus its end
gate running a hierarchy/cycle walk a label-only request has no use for.

**2. A duplicate add now writes nothing.** `ApplyLabelPatch` early-returns on
`sameStringSet`, so re-adding a label the issue already carries records no event
and no version commit, where `tx.AddLabel` recorded unconditionally. An
improvement, still a delta. `add_duplicate_idempotent` covers the observable
half.

**3. The `provides:` refusal now precedes id resolution** on the direct route,
which used to resolve every id first. A caller that both typo'd an id and reached
for a reserved label is told about the label — the one of the two this command
will never accept, at any id. The proxied route already checked in this order, so
this is the two routes agreeing on the earlier answer rather than a new rule.

**4. The proxied resolution failure lost its `label added: ` prefix.**
Old: `Error: label added: resolving issue ID "bd-missing": not found`.
New: `Error: resolving issue ID "bd-missing": not found`.
The prefix named a write never attempted; the direct route never had it. Per the
D7 question the CLI's documented behaviour wins, and the pinning test carries the
new line and the reason.

## Scope, and the size of what is left

`bd label list-all` and `bd label propagate` are unchanged. No role answers
*"every distinct label in this workspace"*, and `propagate` is a search plus a
fan-out that needs the same batch question delta 1 names. Both still name
`types.IssueFilter`, so **`label` stays on the forbidigo filter-exception list
and the count above it is unchanged** — this slice closes the DOMAIN door, not
the filter one, and the rule's comment says so.

**What the follow-up program is, measured rather than gestured at:** three more
files carry the *identical* wisp switch this PR deleted —
`cmd/bd/state_proxied_server.go:165`, `cmd/bd/mol_port.go:410`,
`cmd/bd/mutate_proxied_server.go:141` — across **9 use-case call sites**, inside
a `cmd/bd` where **30 non-test files** import `internal/storage/domain`. Each
command that reaches the roles drops one file off the forbidigo exemption and
adds one to the depguard list, the way `cmd-bd-role-constructors` grows one
package per shared body. This PR is the first of those, and the pattern is the
deliverable as much as the diff is.

## Gates

- `go build ./...`, `go vet ./...`: clean
- `golangci-lint run ./...` (v2.10.1, the CI binary): **0 issues**
- both guard mutations verified red, one bypass each (table above)
- `TestProxiedServerLabel` 21/21, plus `Create`/`Mutate`/`Show` proxied families
  re-run for the forbidigo re-scoping: green
- `TestEmbeddedLabel`, `TestEmbeddedDirectCommitPathsBatchAutoCommitDoesNotAdvanceHead`
  (5/5), `TestEmbeddedDepAndLinkBatchAutoCommitDoesNotAdvanceHead`,
  `TestLabelCommands`, `TestProxiedLookup*`: green
- full `cmd/bd` (cgo): 20 failures, a strict **subset** of `main`'s 25 on the
  same host — zero regressions
- rebased over `#5482`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
