### PR TITLE
Refuse kv.* point reads on the settings role and stop printing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   keeps the escape hatch for a wedged memory. What is gone is reading memory
   contents through `bd config get`, `bd config list` and `bd config show`.
 
+  **This is plane hygiene, not a confidentiality boundary.** `bd serve` has no
+  authentication, and it serves every memory in full through
+  `/v0/beads/memories` by design — anyone who can reach the server can still
+  read them. What this closes is the settings plane's habit of handing user
+  data to callers that asked for configuration: the routes that get republished
+  into agent transcripts and pasted into issues. Do not read it as a fix that
+  makes memories secret from someone who can already reach the port.
+
 - **`bd search` now includes closed issues by default** (bd-t5yex). The
   dominant real-world search query is "was this already found/filed/fixed?" —
   exactly the query where silently excluding closed issues produced a false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The settings plane no longer serves the KV plane by any read** (bd-rfwtv,
+  bd-klko9). `bd kv` keys and the `bd remember` memories nested under them are
+  user data stored as config rows; they ride in the settings table without being
+  settings. Listing them was already excluded, but a caller naming an exact key
+  still got the value — and since `bd remember` derives its key from the content
+  it stores, the keys are guessable, so `bd config get kv.memory.<slug>` and
+  `GET /v0/beads/config/kv.memory.<slug>` (a surface with no authentication,
+  whose redaction decides on the key NAME while a memory's secret is in the
+  VALUE) walked around the exclusion.
+
+  A point read of a `kv.` key now answers exactly as a key nothing ever stored
+  does — the echoed key, an empty value, a nil error — so a caller cannot tell a
+  refusal from an absence. `bd config show` no longer prints those rows under
+  `source=database` either; it reads the table raw and prints values in full, so
+  it had inherited neither filter.
+
+  **Nothing is deleted and nothing becomes unreachable.** The rows are
+  untouched, and the surfaces that own them — `bd kv get`, `bd kv list`,
+  `bd recall`, `bd memories` — read the store directly and are unaffected.
+  `bd config set` and `bd config unset` still take a verbatim `kv.` key, which
+  keeps the escape hatch for a wedged memory. What is gone is reading memory
+  contents through `bd config get`, `bd config list` and `bd config show`.
+
 - **`bd search` now includes closed issues by default** (bd-t5yex). The
   dominant real-world search query is "was this already found/filed/fixed?" —
   exactly the query where silently excluding closed issues produced a false

--- a/backend/conformance/role_bundle_cases.go
+++ b/backend/conformance/role_bundle_cases.go
@@ -636,6 +636,7 @@ var roleContractCases = []roleContract{
 		RunWorkspaceConfigConflatesAnUnsetKeyWithAnEmptyValue,
 		RunWorkspaceConfigListsEveryStoredSetting,
 		RunWorkspaceConfigListExcludesTheKVPlane,
+		RunWorkspaceConfigPointReadRefusesTheKVPlane,
 		RunWorkspaceConfigUnsetRemovesTheSetting,
 		RunWorkspaceConfigUnsetOfAnAbsentKeySucceeds,
 		RunWorkspaceConfigRefusesAnEmptyKey,

--- a/backend/conformance/workspaceconfig_contract.go
+++ b/backend/conformance/workspaceconfig_contract.go
@@ -245,14 +245,17 @@ func RunWorkspaceConfigListsEveryStoredSetting(t *testing.T, ctx context.Context
 }
 
 // RunWorkspaceConfigListExcludesTheKVPlane pins workspaceconfig.go's
-// ListSettings: no key under `kv.` is enumerated, and the asymmetry that stops
-// the exclusion there — GetSetting still answers each of those keys by name.
+// ListSettings: no key under `kv.` is enumerated.
 //
 // The two planes share one table, so this is the case that tells a body
 // filtering the SETTINGS plane from one that just happens to hold no memories.
 // Both probes are written THROUGH the role, because SetSetting still accepts
 // them: a write that lands and an enumeration that omits it is the whole claim,
 // and seeding out of band would leave the write half untested.
+//
+// THE OTHER HALF OF THE FIREWALL IS ITS OWN CASE.
+// RunWorkspaceConfigPointReadRefusesTheKVPlane pins what GetSetting answers for
+// these keys, which is what says the rows this case cannot see are still there.
 //
 // The generic key and the memory key are both here because the exclusion is the
 // whole prefix. A body that reached for kvkeys.MemoryConfigKeyPrefix — the
@@ -286,11 +289,89 @@ func RunWorkspaceConfigListExcludesTheKVPlane(t *testing.T, ctx context.Context,
 		}
 	}
 
-	// And the stated asymmetry: the exclusion is on the ENUMERATION only, so a
-	// caller naming an exact key still gets it. Removing this half would not
-	// fail any other case — it is pinned here or nowhere.
-	assertWorkspaceConfigValue(t, ctx, fixture, generic, "kv row")
-	assertWorkspaceConfigValue(t, ctx, fixture, memory, "the deploy token is sk-live-000")
+	// The rows the enumeration did not carry are still THERE. Without this the
+	// case passes against a SetSetting that dropped the writes on the floor,
+	// which is an exclusion of nothing.
+	assertWorkspaceConfigRowCount(t, ctx, fixture, generic, 1)
+	assertWorkspaceConfigRowCount(t, ctx, fixture, memory, 1)
+}
+
+// RunWorkspaceConfigPointReadRefusesTheKVPlane pins the half of the read
+// firewall a caller reaches by NAMING a key: GetSetting answers a `kv.` key
+// exactly as it answers a key nothing ever stored, whether or not the row is
+// there.
+//
+// This half is the one that matters. The enumeration exclusion assumed a caller
+// who knew the exact key was a different class of caller, and `bd remember`
+// derives its key from the content it stores, so the keys are guessable and
+// GET /v0/beads/config/kv.memory.<slug> walked around the wall — on a surface
+// with no authentication, whose redaction decides on the key NAME while a
+// memory's secret is in the VALUE.
+//
+// WHAT IT ASSERTS IS AN INDISTINGUISHABILITY, and it takes four probes to say
+// so:
+//
+//   - A stored kv row and a stored memory both answer "" with a NIL ERROR. An
+//     error of any kind — including one wrapping ErrValidation, which this role
+//     already uses for an empty key — would confirm to the caller who guessed
+//     the key that it named something.
+//   - A `kv.` key nothing ever wrote answers the SAME THING, asserted through
+//     the same helper, so the refusal and the absence are one answer rather
+//     than two that happen to render alike.
+//   - The ROWS SURVIVE, read out of band. A body that satisfied the read by
+//     deleting the row would pass every assertion above and destroy the user's
+//     memories; and the rows are what the write half of this plane still owns.
+//   - A SETTINGS key still reads back its value. A GetSetting that answered ""
+//     for everything is the other way to pass this case for the wrong reason,
+//     and it would take out `bd config get` entirely.
+//
+// AND THE WRITES ARE UNTOUCHED, asserted last: UnsetSetting still removes a
+// `kv.` row. That is the escape hatch for a wedged memory, it is the only thing
+// left on this role that can reach the plane, and it leaves the workspace as
+// this case found it.
+func RunWorkspaceConfigPointReadRefusesTheKVPlane(t *testing.T, ctx context.Context, fixture WorkspaceConfigFixture) {
+	t.Helper()
+	setting := workspaceConfigKey(fixture, "point-read-neighbor")
+	generic := kvkeys.Prefix + fixture.IssuePrefix + "-point-read"
+	memory := kvkeys.MemoryConfigKeyPrefix + fixture.IssuePrefix + "-point-read-slug"
+	absent := kvkeys.MemoryConfigKeyPrefix + fixture.IssuePrefix + "-never-remembered"
+
+	setWorkspaceConfigSetting(t, ctx, fixture, setting, "settings row")
+	setWorkspaceConfigSetting(t, ctx, fixture, generic, "kv row")
+	setWorkspaceConfigSetting(t, ctx, fixture, memory, "the deploy token is sk-live-000")
+	// The writes landed, so the empty answers below are a refusal rather than a
+	// pair of keys that were never stored.
+	assertWorkspaceConfigRowCount(t, ctx, fixture, generic, 1)
+	assertWorkspaceConfigRowCount(t, ctx, fixture, memory, 1)
+
+	// The settings plane FIRST: a role answering "" to everything would satisfy
+	// the refusals and mean nothing.
+	assertWorkspaceConfigValue(t, ctx, fixture, setting, "settings row")
+
+	for _, key := range []string{generic, memory, absent} {
+		result, err := fixture.WorkspaceConfig.GetSetting(ctx, publicops.GetSettingRequest{Key: key})
+		if err != nil {
+			t.Fatalf("GetSetting(%q) = %v, want the absent-key answer: an error tells the caller who guessed the key that it named something", key, err)
+		}
+		if result.Key != key {
+			t.Fatalf("GetSetting(%q) echoed key %q; the refusal is the absent-key answer, which echoes the request", key, result.Key)
+		}
+		if result.Value != "" {
+			t.Fatalf("GetSetting(%q) = %q, want \"\": the kv plane is user data riding in the settings table and this role does not serve it", key, result.Value)
+		}
+	}
+
+	// The refusal did not eat the rows. Out of band, because the role has just
+	// promised it will not show them.
+	assertWorkspaceConfigRowCount(t, ctx, fixture, generic, 1)
+	assertWorkspaceConfigRowCount(t, ctx, fixture, memory, 1)
+
+	// The write half still reaches the plane, which is the escape hatch for a
+	// memory whose value has wedged something.
+	unsetWorkspaceConfigSetting(t, ctx, fixture, generic)
+	unsetWorkspaceConfigSetting(t, ctx, fixture, memory)
+	assertWorkspaceConfigRowCount(t, ctx, fixture, generic, 0)
+	assertWorkspaceConfigRowCount(t, ctx, fixture, memory, 0)
 }
 
 // RunWorkspaceConfigUnsetRemovesTheSetting pins that a removed key is gone from
@@ -790,6 +871,24 @@ func listWorkspaceConfigSettings(t *testing.T, ctx context.Context, fixture Work
 		t.Fatalf("ListSettings: %v", err)
 	}
 	return result.Settings
+}
+
+// assertWorkspaceConfigRowCount reads the config table directly to say whether
+// one key has a row.
+//
+// It is the only way to observe a key the role has stopped answering for: the
+// two kv-plane cases need "the row is there and the read refuses it" to be a
+// different fact from "there is no row", and every verb on this role conflates
+// them by design.
+func assertWorkspaceConfigRowCount(t *testing.T, ctx context.Context, fixture WorkspaceConfigFixture, key string, want int) {
+	t.Helper()
+	var got int
+	if err := fixture.QueryScalar(ctx, "SELECT COUNT(*) FROM config WHERE `key` = ?", []any{key}, &got); err != nil {
+		t.Fatalf("count the config rows keyed %q: %v", key, err)
+	}
+	if got != want {
+		t.Fatalf("the config table holds %d rows keyed %q, want %d", got, key, want)
+	}
 }
 
 // assertWorkspaceConfigTableCount reads a normalized projection table directly.

--- a/cmd/bd/config_show.go
+++ b/cmd/bd/config_show.go
@@ -12,6 +12,7 @@ import (
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/metrics"
+	"github.com/steveyegge/beads/internal/workapi"
 )
 
 // configEntry represents a single configuration key with its effective value and source.
@@ -294,8 +295,33 @@ func collectDatabaseEntries() []configEntry {
 		return nil
 	}
 
+	return databaseConfigEntries(dbConfig)
+}
+
+// databaseConfigEntries turns the config table into the entries `config show`
+// prints under source=database, MINUS the KV plane.
+//
+// The store's GetAllConfig hands back one table holding two planes, and this
+// command prints values in FULL — it is the operator's provenance view, so
+// redaction would defeat it. Every `bd remember` memory therefore went into
+// every terminal, transcript and pasted bug report that ran `bd config show`,
+// which is the same disclosure the settings enumeration was closed for
+// (issueops/workspaceconfig.go, "KEYS THIS PLANE DOES NOT OWN"). This route
+// reads the store raw rather than through issueops.WorkspaceConfig, so it
+// inherited neither filter and had to be told.
+//
+// The rule is workapi's, not a second `kv.` prefix check: a local one would be
+// the fourth copy of the plane boundary and the first to drift.
+//
+// NOTHING REPLACES THE VIEW. An operator who wants those rows asks the surfaces
+// that own them — `bd kv list`, `bd memories` — which is where they were always
+// meant to be read.
+func databaseConfigEntries(dbConfig map[string]string) []configEntry {
 	var entries []configEntry
 	for key, value := range dbConfig {
+		if workapi.KeyIsOnTheKVPlane(key) {
+			continue
+		}
 		entries = append(entries, configEntry{Key: key, Value: value, Source: "database"})
 	}
 

--- a/cmd/bd/config_show_kv_exclusion_test.go
+++ b/cmd/bd/config_show_kv_exclusion_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/kvkeys"
+)
+
+// TestConfigShowExcludesTheKVPlane pins that `bd config show` does not print
+// memories under source=database.
+//
+// It asserts the pure half of collectDatabaseEntries rather than shelling out,
+// for the reason TestInfoConfigExcludesTheKVPlane does: the rest of that
+// function is store acquisition, and what can regress is the filter.
+//
+// Why this route needed telling separately: it reads the store's GetAllConfig
+// RAW rather than through issueops.WorkspaceConfig, so it inherited neither the
+// enumeration exclusion nor the point-read refusal, and it prints values in
+// FULL because it is the operator's provenance view. Every `bd remember` memory
+// went into every terminal and pasted bug report that ran the command.
+func TestConfigShowExcludesTheKVPlane(t *testing.T) {
+	stored := map[string]string{
+		"issue_prefix":    "bd",
+		"custom.statuses": "awaiting_review",
+		kvkeys.MemoryConfigKeyPrefix + "deploy-notes": "the staging deploy token is sk-live-000",
+		kvkeys.Prefix + "release.channel":             "beta",
+		// Near misses that must SURVIVE: the rule is an anchored prefix.
+		"kvetch":                    "not under the kv prefix",
+		"custom.mentions.kv.inside": "kept",
+	}
+
+	got := databaseConfigEntries(stored)
+
+	seen := make(map[string]string, len(got))
+	for _, entry := range got {
+		if strings.HasPrefix(entry.Key, kvkeys.Prefix) {
+			t.Errorf("bd config show would print %q = %q under source=database: the kv plane is user data "+
+				"riding in the settings table, and this view prints values in full", entry.Key, entry.Value)
+		}
+		if entry.Source != "database" {
+			t.Errorf("entry %q carries source %q, want %q", entry.Key, entry.Source, "database")
+		}
+		seen[entry.Key] = entry.Value
+	}
+	for key, want := range map[string]string{
+		"issue_prefix":              "bd",
+		"custom.statuses":           "awaiting_review",
+		"kvetch":                    "not under the kv prefix",
+		"custom.mentions.kv.inside": "kept",
+	} {
+		if got, ok := seen[key]; !ok || got != want {
+			t.Errorf("config show dropped or altered %q: got %q (present=%v), want %q; only keys under %q may go",
+				key, got, ok, want, kvkeys.Prefix)
+		}
+	}
+}

--- a/cmd/bd/memory_proxied_integration_test.go
+++ b/cmd/bd/memory_proxied_integration_test.go
@@ -50,10 +50,17 @@ func TestProxiedServerMemory(t *testing.T) {
 		}
 
 		// Memories land under kv.memory.<key> in the config table — the
-		// namespace `bd export --all` sweeps — visible via bd config get.
+		// namespace `bd export --all` sweeps — but the settings plane does not
+		// serve them. A point read answers exactly as an unset key does, so a
+		// caller cannot tell a refusal from an absence. This is the proxied
+		// leg of the same firewall the role contract pins; recall below is the
+		// route that still reads the content.
 		out = bdProxiedMem(t, bd, p.dir, "config", "get", "kv.memory.dolt-phantoms")
-		if strings.TrimSpace(out) != content {
-			t.Errorf("expected memory at kv.memory.dolt-phantoms, got: %q", out)
+		if !strings.Contains(out, "(not set)") {
+			t.Errorf("expected kv.memory.dolt-phantoms to read as unset through config get, got: %q", out)
+		}
+		if strings.Contains(out, content) {
+			t.Errorf("config get leaked memory content: %q", out)
 		}
 
 		// List all.

--- a/internal/storage/dolt/workspace_config_contract_test.go
+++ b/internal/storage/dolt/workspace_config_contract_test.go
@@ -36,6 +36,9 @@ func TestWorkspaceConfigContract(t *testing.T) {
 	t.Run("ListExcludesTheKVPlane", func(t *testing.T) {
 		conformance.RunWorkspaceConfigListExcludesTheKVPlane(t, ctx, fixture)
 	})
+	t.Run("PointReadRefusesTheKVPlane", func(t *testing.T) {
+		conformance.RunWorkspaceConfigPointReadRefusesTheKVPlane(t, ctx, fixture)
+	})
 	t.Run("UnsetRemovesTheSetting", func(t *testing.T) {
 		conformance.RunWorkspaceConfigUnsetRemovesTheSetting(t, ctx, fixture)
 	})

--- a/internal/storage/embeddeddolt/workspace_config_contract_test.go
+++ b/internal/storage/embeddeddolt/workspace_config_contract_test.go
@@ -39,6 +39,9 @@ func TestWorkspaceConfigContract(t *testing.T) {
 	t.Run("ListExcludesTheKVPlane", func(t *testing.T) {
 		conformance.RunWorkspaceConfigListExcludesTheKVPlane(t, ctx, fixture)
 	})
+	t.Run("PointReadRefusesTheKVPlane", func(t *testing.T) {
+		conformance.RunWorkspaceConfigPointReadRefusesTheKVPlane(t, ctx, fixture)
+	})
 	t.Run("UnsetRemovesTheSetting", func(t *testing.T) {
 		conformance.RunWorkspaceConfigUnsetRemovesTheSetting(t, ctx, fixture)
 	})

--- a/internal/storage/uow/workspace_config.go
+++ b/internal/storage/uow/workspace_config.go
@@ -42,6 +42,16 @@ func (c *workspaceConfig) GetSetting(ctx context.Context, req publicops.GetSetti
 	if err != nil {
 		return publicops.SettingResult{}, err
 	}
+	// Same refusal as the store-backed body, from the same place, for the same
+	// reason the enumeration filter is shared: the config table holds the KV
+	// plane too, and what a settings read may carry is one decision.
+	//
+	// It is decided BEFORE the unit of work is opened, like the validation
+	// above: a refusal is not a read that found nothing, and there is nothing
+	// for it to read.
+	if refused, ok := workapi.FilterSettingsPointRead(key); ok {
+		return refused, nil
+	}
 	return RunTxRead(ctx, c.provider, func(ctx context.Context, uw UnitOfWork) (publicops.SettingResult, error) {
 		value, err := uw.ConfigUseCase().GetConfig(ctx, key)
 		if err != nil {

--- a/internal/storage/uow/workspace_config_contract_test.go
+++ b/internal/storage/uow/workspace_config_contract_test.go
@@ -40,6 +40,9 @@ func TestWorkspaceConfigContract(t *testing.T) {
 	t.Run("ListExcludesTheKVPlane", func(t *testing.T) {
 		conformance.RunWorkspaceConfigListExcludesTheKVPlane(t, ctx, fixture)
 	})
+	t.Run("PointReadRefusesTheKVPlane", func(t *testing.T) {
+		conformance.RunWorkspaceConfigPointReadRefusesTheKVPlane(t, ctx, fixture)
+	})
 	t.Run("UnsetRemovesTheSetting", func(t *testing.T) {
 		conformance.RunWorkspaceConfigUnsetRemovesTheSetting(t, ctx, fixture)
 	})

--- a/internal/workapi/storeworkspaceconfig/workspaceconfig.go
+++ b/internal/workapi/storeworkspaceconfig/workspaceconfig.go
@@ -36,6 +36,13 @@ func (c *storeWorkspaceConfig) GetSetting(ctx context.Context, req issueops.GetS
 	if err != nil {
 		return issueops.SettingResult{}, err
 	}
+	// The KV plane rides in the same table and is not settings. Both the
+	// refusal and the answer it gives are workapi's, shared with the
+	// unit-of-work body and with the enumeration filter, so where the plane
+	// boundary runs is one decision rather than one per door.
+	if refused, ok := workapi.FilterSettingsPointRead(key); ok {
+		return refused, nil
+	}
 	value, err := c.store.GetConfig(ctx, key)
 	if err != nil {
 		return issueops.SettingResult{}, err

--- a/internal/workapi/workspaceconfig.go
+++ b/internal/workapi/workspaceconfig.go
@@ -10,8 +10,8 @@ import (
 )
 
 // The single definition of what a write to the workspace's durable settings
-// plane is allowed to be and of what an enumeration of it may carry, beside
-// BuildListFilter and BuildCountFilter.
+// plane is allowed to be and of what a READ of it may carry — either by
+// enumeration or by name — beside BuildListFilter and BuildCountFilter.
 //
 // It lives here for the reason those do: three implementations of
 // issueops.WorkspaceConfig have to agree about it, and it is checkable without
@@ -88,12 +88,12 @@ func ValidateSettingWrite(key, value string) (string, error) {
 // into every terminal and transcript while the HTTP door claimed they were not
 // settings.
 //
-// AND IT IS AN ENUMERATION EXCLUSION, NOT A FIREWALL. GetSetting still answers
-// a verbatim kv.* key and SetSetting/UnsetSetting still write one; see
-// issueops/workspaceconfig.go for why that asymmetry is deliberate. A caller
-// who already knows the exact key is in a different class from one who
-// discovers it by listing. Making it a wall is one more refusal in this
-// function and nothing else changes.
+// IT IS ONE HALF OF THE READ FIREWALL. The other half is
+// FilterSettingsPointRead, which answers the caller who names an exact key, and
+// both decide with KeyIsOnTheKVPlane so the boundary is stated once. An
+// exclusion that stopped at the enumeration left the disclosure standing for
+// anyone who could guess a key — and the guess is cheap, since `bd memories`
+// derives its keys from the content it stores.
 //
 // The result is always a fresh map, empty rather than nil, because
 // ListSettingsResult.Settings promises a caller can range over the answer
@@ -102,10 +102,54 @@ func ValidateSettingWrite(key, value string) (string, error) {
 func FilterSettingsEnumeration(stored map[string]string) map[string]string {
 	settings := make(map[string]string, len(stored))
 	for key, value := range stored {
-		if strings.HasPrefix(key, kvkeys.Prefix) {
+		if KeyIsOnTheKVPlane(key) {
 			continue
 		}
 		settings[key] = value
 	}
 	return settings
+}
+
+// FilterSettingsPointRead answers a GetSetting that names a key on the KV
+// plane, and reports whether it answered. A caller gets (result, false) for
+// every key the settings role owns, and reads on.
+//
+// THE ANSWER IS THE ABSENT-KEY ANSWER, EXACTLY: the echoed key, an empty value
+// and a nil error, which is what SettingResult.Value documents for a key
+// nothing ever stored. Returning it rather than an error is what makes the
+// refusal indistinguishable from absence — there is no ErrNotFound on this role
+// to reach for, and a bespoke error would tell the caller that the key it
+// guessed exists, which is most of what it wanted to know.
+//
+// IT IS DECIDED BEFORE THE STORE IS ASKED. Both bodies call it between the key
+// validator and their read, so a refused key costs no query and, on the
+// unit-of-work leg, opens no transaction.
+//
+// THE ANSWER IS THE ROLE'S, NOT THE PLANE'S. `bd kv get`, `bd remember` and
+// `bd memories` read those rows through their own front doors, which do not
+// come through here, so nothing a user stored becomes unreachable — it stops
+// being reachable through the door marked "settings". The WRITES are untouched:
+// SetSetting and UnsetSetting still take a verbatim `kv.` key, which is the
+// escape hatch for a wedged memory.
+func FilterSettingsPointRead(key string) (issueops.SettingResult, bool) {
+	if !KeyIsOnTheKVPlane(key) {
+		return issueops.SettingResult{}, false
+	}
+	return issueops.SettingResult{Key: key}, true
+}
+
+// KeyIsOnTheKVPlane reports whether a config-table key names user data rather
+// than a setting.
+//
+// It is the single statement of where the plane boundary runs. Both filters
+// above decide with it, and so does `bd config show`, whose database section
+// reads the table raw and would otherwise print the plane back into every
+// terminal the two filters were added to keep it out of.
+//
+// THE WHOLE PREFIX, ANCHORED. Not kvkeys.MemoryConfigKeyPrefix, which is the
+// narrower constant and the tempting one; not an unanchored match, which would
+// take `custom.mentions.kv.somewhere` with it; and "kv." carries the dot, so
+// `kvetch` is a setting.
+func KeyIsOnTheKVPlane(key string) bool {
+	return strings.HasPrefix(key, kvkeys.Prefix)
 }

--- a/internal/workapi/workspaceconfig_test.go
+++ b/internal/workapi/workspaceconfig_test.go
@@ -163,3 +163,67 @@ func TestFilterSettingsEnumerationIsEmptyNeverNil(t *testing.T) {
 		}
 	}
 }
+
+// TestBothSettingsFiltersDrawTheSameBoundary is the guard against the failure
+// mode a second predicate would introduce: an enumeration that hides a key a
+// point read still hands over. The two filters are the two halves of one
+// firewall, so they are asserted against ONE key list rather than against each
+// other's expectations.
+func TestBothSettingsFiltersDrawTheSameBoundary(t *testing.T) {
+	for key, onThePlane := range map[string]bool{
+		"kv.deploy-token":              true,
+		"kv.memory.architecture":       true,
+		"kv.":                          true,
+		"issue_prefix":                 false,
+		"status.custom":                false,
+		"kvetch":                       false,
+		"memory.not-under-kv":          false,
+		"custom.mentions.kv.somewhere": false,
+		"":                             false,
+	} {
+		if got := KeyIsOnTheKVPlane(key); got != onThePlane {
+			t.Errorf("KeyIsOnTheKVPlane(%q) = %v, want %v", key, got, onThePlane)
+		}
+		_, enumerated := FilterSettingsEnumeration(map[string]string{key: "v"})[key]
+		if enumerated == onThePlane {
+			t.Errorf("FilterSettingsEnumeration kept %q = %v, want kept = %v", key, enumerated, !onThePlane)
+		}
+		_, refused := FilterSettingsPointRead(key)
+		if refused != onThePlane {
+			t.Errorf("FilterSettingsPointRead(%q) refused = %v, want %v — the two filters must draw the same boundary",
+				key, refused, onThePlane)
+		}
+	}
+}
+
+// TestFilterSettingsPointReadAnswersExactlyLikeAnAbsentKey pins what makes the
+// refusal a refusal a caller cannot detect: the absent-key answer, which
+// SettingResult.Value documents as the echoed key, "" and a nil error. There is
+// no ErrNotFound on this role to return instead, and an error of any kind would
+// confirm the guessed key to the caller.
+func TestFilterSettingsPointReadAnswersExactlyLikeAnAbsentKey(t *testing.T) {
+	const key = "kv.memory.deploy-notes"
+
+	result, refused := FilterSettingsPointRead(key)
+	if !refused {
+		t.Fatalf("FilterSettingsPointRead(%q) let the key through", key)
+	}
+	if want := (issueops.SettingResult{Key: key}); result != want {
+		t.Errorf("FilterSettingsPointRead(%q) = %+v, want %+v — the same result a key nothing stored produces", key, result, want)
+	}
+}
+
+// TestFilterSettingsPointReadLeavesASettingToTheStore pins the other direction:
+// the filter must not answer for a key it does not own, or every settings read
+// would return "" without ever reaching the database.
+func TestFilterSettingsPointReadLeavesASettingToTheStore(t *testing.T) {
+	for _, key := range []string{"issue_prefix", "status.custom", "custom.thing"} {
+		result, refused := FilterSettingsPointRead(key)
+		if refused {
+			t.Errorf("FilterSettingsPointRead(%q) refused a settings key", key)
+		}
+		if result != (issueops.SettingResult{}) {
+			t.Errorf("FilterSettingsPointRead(%q) = %+v alongside refused=false, want the zero result the caller ignores", key, result)
+		}
+	}
+}

--- a/issueops/workspaceconfig.go
+++ b/issueops/workspaceconfig.go
@@ -166,18 +166,24 @@ type UnsetSettingResult struct {
 // their own merge semantics (a config conflict auto-resolves --theirs only when
 // every conflicted key is a memory) and their own front doors. They are stored
 // as config rows because there is one table, not because they are settings.
-// `bd kv` and the memory surface are their views; this role is not. So
-// ListSettings OMITS them — see its own doc — while GetSetting, SetSetting and
-// UnsetSetting still answer and write a verbatim `kv.` key.
+// `bd kv` and the memory surface are their views; this role is not. So NEITHER
+// READ ANSWERS THEM: ListSettings omits them and GetSetting answers a `kv.` key
+// exactly as it answers a key nothing ever stored — see each one's own doc.
 //
-// THAT ASYMMETRY IS DELIBERATE. It is the same shape as the protected key's
-// (Set refuses issue_prefix, Unset does not): an exclusion from the ENUMERATION,
-// not a firewall. The enumeration was the disclosure — it handed every stored
-// memory, key and value, to `bd config list` and to an unauthenticated
-// GET /v0/beads/config, whose redaction decides on the key name while a
-// memory's content is in the value. A caller naming one exact key is a
-// different question, and refusing it would break `bd config get kv.foo` and
-// the escape hatch of deleting a wedged memory with `bd config unset`.
+// THE READS ARE A FIREWALL; THE WRITES ARE NOT. SetSetting and UnsetSetting
+// still take a verbatim `kv.` key, which is the escape hatch for deleting a
+// wedged memory, and a write discloses nothing.
+//
+// THE READ HALF USED TO STOP AT THE ENUMERATION, and stopping there was the
+// bug. The disclosure is a stored memory's CONTENT — `bd config list` and an
+// unauthenticated GET /v0/beads/config both handed it over, and the latter's
+// redaction decides on the key NAME while a memory's secret is in the value.
+// The exclusion was argued as "a caller naming one exact key is a different
+// question", which holds only while the key is hard to name: `bd remember`
+// derives its key from the content it stores, so the names are guessable and a
+// point read walked around the wall. What a caller loses is `bd config get
+// kv.foo`, which was never the door for those rows — `bd kv get` and
+// `bd recall` are, and they read the store directly.
 //
 // Deterministic request-validation failures match ErrValidation; result values
 // are unspecified when error is non-nil. Implementations never mutate
@@ -193,15 +199,22 @@ type WorkspaceConfig interface {
 	// An empty Key is ErrValidation. There is no row a caller could mean by
 	// it, so answering "" would report "not set" for a question that was never
 	// asked.
+	//
+	// A KEY UNDER `kv.` IS ANSWERED AS IF IT WERE ABSENT: the echoed key, ""
+	// and a nil error, whether or not a row is there. It is deliberately
+	// indistinguishable from the unset answer — an error, of any kind, would
+	// confirm the key to the caller who guessed it, and this role has no
+	// ErrNotFound to give. The row is NOT touched; see "KEYS THIS PLANE DOES
+	// NOT OWN" above for what that plane is and which doors do read it.
 	GetSetting(ctx context.Context, req GetSettingRequest) (SettingResult, error)
 
 	// ListSettings returns every stored setting.
 	//
 	// EXCEPT THE KV PLANE. No key under `kv.` appears here — not the generic
-	// `bd kv` keys and not the `bd remember` memories nested under them — even
-	// though those rows live in the same table and GetSetting still answers
-	// each one by name. See "KEYS THIS PLANE DOES NOT OWN" above for what that
-	// plane is and why the exclusion stops at the enumeration.
+	// `bd kv` keys and not the `bd remember` memories nested under them —
+	// though those rows live in the same table. Naming one exactly does not get
+	// it either: GetSetting answers a `kv.` key as absent. See "KEYS THIS PLANE
+	// DOES NOT OWN" above for what that plane is and which doors do read it.
 	//
 	// A read, on the same terms as GetSetting, and one whose answer is a MAP rather
 	// than a page: settings are a keyed namespace a workspace holds tens of,


### PR DESCRIPTION
The settings role's KV filter was an enumeration exclusion only. This makes it total, and closes the same hole on `bd config show`.

## What the point read now answers

A `GetSetting` naming any key under `kv.` returns **the echoed key, an empty value, and a nil error** — the exact answer `SettingResult.Value` documents for a key nothing ever stored. No error, of any kind:

- **It is indistinguishable from an absent key.** Same struct, same nil error, same `bd config get kv.foo` output (`kv.foo (not set)`, exit 0) as a key that was never written. There is no `ErrNotFound` on this role to reach for, and inventing an error would confirm the guessed key to the caller who guessed it — which is most of what they wanted to know.
- **The row is not touched.** No read reaches the store at all; the refusal is decided between the key validator and the query, so on the unit-of-work leg it does not even open a transaction.

Why the enumeration exclusion was not enough: `bd remember` derives its key from the content it stores, so the keys are guessable, and `GET /v0/beads/config/kv.memory.<slug>` walked around the wall — on a surface with no authentication, whose redaction decides on the key NAME while a memory's secret is in the VALUE.

## Where it lives

In `internal/workapi`, beside `FilterSettingsEnumeration`, as `FilterSettingsPointRead`. Both `WorkspaceConfig` bodies (`internal/workapi/storeworkspaceconfig` for the two store legs, `internal/storage/uow` for the third) call it, so the three legs inherit one decision rather than three per-leg refusals. Both filters — and `bd config show` — now decide with `workapi.KeyIsOnTheKVPlane`, which is the single statement of where the plane boundary runs.

The **writes are deliberately untouched**: `SetSetting` and `UnsetSetting` still take a verbatim `kv.` key, which keeps the escape hatch for a wedged memory. A write discloses nothing.

## `bd config show` no longer prints the kv plane

`collectDatabaseEntries` called `GetAllConfig` raw rather than going through the role, so it inherited neither filter, and it prints values in **full** because it is the operator's provenance view. Every stored memory went into every terminal, transcript and pasted bug report that ran the command. The map-to-entries step is now `databaseConfigEntries`, which drops kv-plane keys using the shared predicate.

Verified end to end on a scratch workspace: a memory and a `bd kv` row are absent from `bd config show` and `bd config list`, while `bd recall`, `bd memories` and `bd kv get` still return them. The database section is otherwise unchanged.

**Accepted cost:** an operator loses the one CLI view of memory contents under `source=database`. No replacement command is built here — `bd kv list` and `bd memories` are the surfaces that own those rows.

## Falsifiability proof

`RunWorkspaceConfigPointReadRefusesTheKVPlane` was added to `backend/conformance/workspaceconfig_contract.go`, entered in the `role_bundle_cases.go` dispatch table in source-declaration order, and wired on all three legs (`internal/storage/dolt`, `internal/storage/embeddeddolt`, `internal/storage/uow`).

The production refusal was then **removed from both bodies** and the case re-run per leg:

| Leg | With the refusal reverted |
|---|---|
| `internal/storage/dolt` | `FAIL ... GetSetting("kv.wcfg-point-read") = "kv row", want ""` |
| `internal/storage/embeddeddolt` | `FAIL ... GetSetting("kv.wcfg-point-read") = "kv row", want ""` |
| `internal/storage/uow` | `FAIL ... GetSetting("kv.wcfg-point-read") = "kv row", want ""` |

Restored, and all three legs green again. The `bd config show` filter was falsified the same way: removing the `continue` makes `TestConfigShowExcludesTheKVPlane` name both leaked rows.

The case reads the config table **out of band** around the refusal, because "the row is there and the read refuses it" has to be a different fact from "there is no row" — a body that satisfied the read by deleting the row would otherwise pass while destroying the user's memories. It also asserts a settings key still reads back its value, so a `GetSetting` that answered `""` for everything cannot pass either.

`RunWorkspaceConfigListExcludesTheKVPlane` previously pinned the opposite claim ("the exclusion is on the ENUMERATION only, so a caller naming an exact key still gets it"). That half is replaced by an out-of-band row-count assertion, so the enumeration case still cannot pass against a `SetSetting` that dropped the writes on the floor.

## `bd list` is not at risk

The change can only ever return a **value**, never an error, so it cannot brick a vocabulary read by construction. Checked anyway: `workapi.LoadListConfig` reads through `ConfigSource` (`GetCustomStatuses` / `GetCustomTypes` / `GetInfraTypes`, backed by the store methods or the `ConfigUseCase`), never through `GetSetting`, and none of those keys is under `kv.`. The only `GetSetting` callers outside the role are `bd config get` and the HTTP `GET /v0/beads/config/{key}` handler. `FilterSettingsEnumeration`'s behavior is byte-identical — only its prefix check moved into the shared predicate.

## Verification

```
go build ./...                                                    exit 0
go vet ./...                                                      exit 0
golangci-lint run                                                 0 issues
go test ./internal/storage/dolt/ -run TestWorkspaceConfigContract          ok (21/21)
go test ./internal/storage/embeddeddolt/ -run TestWorkspaceConfigContract  ok (21/21, BEADS_TEST_EMBEDDED_DOLT=1)
go test ./internal/storage/uow/ -run TestWorkspaceConfigContract           ok (21/21)
go test ./internal/storage/ -run TestEveryLegWiresEveryRoleContract        ok (dolt, embeddeddolt, uow)
go test ./backend/conformance/ -run 'TestEveryRoleMethodHasAContractCase|TestRoleContractCases'  ok
go test ./internal/workapi/...                                    ok
go test ./internal/httpapi/... ./internal/telemetry/... ./issueops/...     ok
```

`go test ./cmd/bd/ -run '(?i)config'` fails on `TestGetNotionConfigReadsDBPathWhenStoreUnset` and `TestConfigValidateReadOnlyIsHermetic`. Both were confirmed **already failing on `origin/main`** in a clean baseline worktree, with identical output; neither touches this code.

bd-rfwtv, bd-klko9