### PR TITLE
refactor: delete the dead orphan-handling capability (bd-gwryr)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,6 +220,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `bd query` (plus the HTTP `q=` endpoint) deliberately keeps its closed-
   exclusion default with opt-in `--all`; only `bd search` changed.
 
+### Removed
+
+- **BREAKING (published `backend` package): orphan handling is gone** (bd-gwryr).
+  `BatchCreateOptions.OrphanHandling` and its four modes never did anything
+  except cost a query. Removed symbols: `backend.OrphanHandling`,
+  `backend.OrphanAllow`, `backend.OrphanResurrect`, `backend.OrphanSkip`,
+  `backend.OrphanStrict`, and the `storage` originals they aliased
+  (`storage.OrphanHandling` and the same four constants), the
+  `BatchCreateOptions.OrphanHandling` field, and `issueops.CheckOrphan`.
+
+  **Migration for out-of-tree consumers: delete the option.** Every call site
+  in bd passed `OrphanAllow` (or left the field at its zero value, which took
+  the same branch), and `OrphanAllow` is exactly what the code still does —
+  a hierarchical create whose parent is missing is accepted, and the child's
+  auxiliary counter row is skipped because it would have no owner. Only
+  `OrphanStrict` (reject the create) and `OrphanSkip` (silently drop it)
+  behaved differently, and nothing but one conformance case ever passed them;
+  a consumer that relied on either must now check for the parent itself before
+  calling. `OrphanResurrect` was never implemented — it shared a branch with
+  `OrphanAllow`, and the resurrect-a-deleted-parent behavior its doc comment
+  described left with the JSONL sync layer long ago.
+
+  Every hierarchical-ID create paid a `SELECT COUNT(*)` parent-existence probe
+  to feed a switch whose only reachable arm ignored the answer. That query is
+  now gone from the create path.
+
 ### Fixed
 
 - **Script hooks now fire on both write plumbings** (bd-opisf). bd has two write

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -124,7 +124,6 @@ type (
 	HistoryEntry            = storage.HistoryEntry
 	MergeSlotResult         = storage.MergeSlotResult
 	MergeSlotStatus         = storage.MergeSlotStatus
-	OrphanHandling          = storage.OrphanHandling
 	RemoteInfo              = storage.RemoteInfo
 	StatusEntry             = storage.StatusEntry
 	SyncResult              = storage.SyncResult
@@ -136,14 +135,6 @@ type (
 // VCStatus here — matching the root beads package — because Status is the
 // issue-status enum from the domain types.
 type VCStatus = storage.Status
-
-// OrphanHandling values for BatchCreateOptions.
-const (
-	OrphanAllow     = storage.OrphanAllow
-	OrphanResurrect = storage.OrphanResurrect
-	OrphanSkip      = storage.OrphanSkip
-	OrphanStrict    = storage.OrphanStrict
-)
 
 // Backend describes a registered storage backend: how to open its workspace
 // store. See the field docs on the aliased struct.

--- a/backend/conformance/audit_dependencies_readiness.go
+++ b/backend/conformance/audit_dependencies_readiness.go
@@ -423,7 +423,7 @@ func testAuditReadyMultiStatusFilter(t *testing.T, f Factory) {
 	must(t, s.CreateIssuesWithFullOptions(c, []*types.Issue{
 		withDefaults(&types.Issue{ID: "msf-w-block", Title: "wisp blocked", Status: types.StatusBlocked, Ephemeral: true}),
 		withDefaults(&types.Issue{ID: "msf-w-prog", Title: "wisp in progress", Status: types.StatusInProgress, Ephemeral: true}),
-	}, "a", storage.BatchCreateOptions{OrphanHandling: storage.OrphanAllow, SkipPrefixValidation: true}))
+	}, "a", storage.BatchCreateOptions{SkipPrefixValidation: true}))
 
 	// Statuses ORs across issues and wisps in a single call.
 	multi, err := s.GetReadyWork(c, types.WorkFilter{Statuses: []types.Status{types.StatusOpen, types.StatusBlocked}, IncludeEphemeral: true})

--- a/backend/conformance/audit_molecule_wisp_batch_iter.go
+++ b/backend/conformance/audit_molecule_wisp_batch_iter.go
@@ -33,7 +33,6 @@ func RunAudit_molecule_wisp_batch_iter(t *testing.T, f Factory) {
 	t.Run("CreateRejectStaleUpserts", func(t *testing.T) { testAuditCreateRejectStaleUpserts(t, f) })
 	t.Run("CreateAllWispsFastPath", func(t *testing.T) { testAuditCreateAllWispsFastPath(t, f) })
 	t.Run("CreateAllWispsInlineDependencies", func(t *testing.T) { testAuditCreateAllWispsInlineDependencies(t, f) })
-	t.Run("CreateOrphanHandling", func(t *testing.T) { testAuditCreateOrphanHandling(t, f) })
 	t.Run("CreateCrossBucketDependency", func(t *testing.T) { testAuditCreateCrossBucketDependency(t, f) })
 	t.Run("CreateInBatchCycle", func(t *testing.T) { testAuditCreateInBatchCycle(t, f) })
 	t.Run("ListWisps", func(t *testing.T) { testAuditListWisps(t, f) })
@@ -387,7 +386,7 @@ func testAuditCreateRejectStaleUpserts(t *testing.T, f Factory) {
 	y2020 := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
 	y2021 := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
 	y2022 := time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)
-	opts := storage.BatchCreateOptions{OrphanHandling: storage.OrphanAllow, SkipPrefixValidation: true, RejectStaleUpserts: true}
+	opts := storage.BatchCreateOptions{SkipPrefixValidation: true, RejectStaleUpserts: true}
 
 	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "test-r", Title: "Orig", CreatedAt: y2021, UpdatedAt: y2021}), "a"))
 
@@ -424,7 +423,7 @@ func testAuditCreateAllWispsFastPath(t *testing.T, f Factory) {
 	must(t, s.CreateIssuesWithFullOptions(c, []*types.Issue{
 		withDefaults(&types.Issue{ID: "test-w1", Title: "W1", Ephemeral: true}),
 		withDefaults(&types.Issue{ID: "test-w2", Title: "W2", Ephemeral: true, Labels: []string{"x"}}),
-	}, "a", storage.BatchCreateOptions{OrphanHandling: storage.OrphanAllow, SkipPrefixValidation: true}))
+	}, "a", storage.BatchCreateOptions{SkipPrefixValidation: true}))
 
 	for _, id := range []string{"test-w1", "test-w2"} {
 		got, err := s.GetIssue(c, id)
@@ -457,7 +456,6 @@ func testAuditCreateAllWispsInlineDependencies(t *testing.T, f Factory) {
 
 	var skipped [][2]string
 	opts := storage.BatchCreateOptions{
-		OrphanHandling:                 storage.OrphanAllow,
 		SkipPrefixValidation:           true,
 		SkipDependencyValidationErrors: true,
 		OnSkippedDependency: func(issueID, dependsOnID, _ string) {
@@ -503,33 +501,6 @@ func testAuditCreateAllWispsInlineDependencies(t *testing.T, f Factory) {
 	}
 }
 
-// OrphanStrict rejects an issue whose hierarchical parent is missing
-// (create.go:490-515), inserting nothing. OrphanSkip accepts the batch but
-// inserts neither the orphan nor an ownerless child-counter row: counter
-// reconciliation now verifies that the routed parent exists before touching
-// its auxiliary counter table.
-func testAuditCreateOrphanHandling(t *testing.T, f Factory) {
-	s := f(t)
-	c := ctx()
-	if err := s.CreateIssuesWithFullOptions(c, []*types.Issue{
-		withDefaults(&types.Issue{ID: "test-p.2", Title: "Orphan2"}),
-	}, "a", storage.BatchCreateOptions{OrphanHandling: storage.OrphanStrict, SkipPrefixValidation: true}); err == nil {
-		t.Error("OrphanStrict: want error, got nil")
-	}
-	if _, err := s.GetIssue(c, "test-p.2"); !errors.Is(err, storage.ErrNotFound) {
-		t.Errorf("OrphanStrict inserted the orphan: %v", err)
-	}
-
-	if err := s.CreateIssuesWithFullOptions(c, []*types.Issue{
-		withDefaults(&types.Issue{ID: "test-p.3", Title: "Orphan3"}),
-	}, "a", storage.BatchCreateOptions{OrphanHandling: storage.OrphanSkip, SkipPrefixValidation: true}); err != nil {
-		t.Errorf("OrphanSkip: unexpected error: %v", err)
-	}
-	if _, err := s.GetIssue(c, "test-p.3"); !errors.Is(err, storage.ErrNotFound) {
-		t.Errorf("OrphanSkip inserted the orphan: %v", err)
-	}
-}
-
 // A mixed regular+wisp batch with a cross-bucket edge is rejected before insert;
 // with SkipDependencyValidationErrors the edge is dropped and both issues persist
 // (create.go:288-361).
@@ -541,7 +512,7 @@ func testAuditCreateCrossBucketDependency(t *testing.T, f Factory) {
 	err := s.CreateIssuesWithFullOptions(c, []*types.Issue{
 		withDefaults(&types.Issue{ID: "test-a", Title: "A"}),
 		withDefaults(&types.Issue{ID: "test-b", Title: "B", Ephemeral: true, Dependencies: []*types.Dependency{{IssueID: "test-b", DependsOnID: "test-a", Type: types.DepBlocks}}}),
-	}, "a", storage.BatchCreateOptions{OrphanHandling: storage.OrphanAllow, SkipPrefixValidation: true})
+	}, "a", storage.BatchCreateOptions{SkipPrefixValidation: true})
 	if err == nil {
 		t.Fatal("(a) cross-bucket batch: want error, got nil")
 	}
@@ -553,7 +524,7 @@ func testAuditCreateCrossBucketDependency(t *testing.T, f Factory) {
 	must(t, s.CreateIssuesWithFullOptions(c, []*types.Issue{
 		withDefaults(&types.Issue{ID: "test-c", Title: "C"}),
 		withDefaults(&types.Issue{ID: "test-d", Title: "D", Ephemeral: true, Dependencies: []*types.Dependency{{IssueID: "test-d", DependsOnID: "test-c", Type: types.DepBlocks}}}),
-	}, "a", storage.BatchCreateOptions{OrphanHandling: storage.OrphanAllow, SkipPrefixValidation: true, SkipDependencyValidationErrors: true}))
+	}, "a", storage.BatchCreateOptions{SkipPrefixValidation: true, SkipDependencyValidationErrors: true}))
 	if _, err := s.GetIssue(c, "test-c"); err != nil {
 		t.Errorf("(b) test-c missing: %v", err)
 	}
@@ -576,7 +547,7 @@ func testAuditCreateInBatchCycle(t *testing.T, f Factory) {
 	err := s.CreateIssuesWithFullOptions(c, []*types.Issue{
 		withDefaults(&types.Issue{ID: "test-a", Title: "A", Dependencies: []*types.Dependency{{IssueID: "test-a", DependsOnID: "test-b", Type: types.DepBlocks}}}),
 		withDefaults(&types.Issue{ID: "test-b", Title: "B", Dependencies: []*types.Dependency{{IssueID: "test-b", DependsOnID: "test-a", Type: types.DepBlocks}}}),
-	}, "a", storage.BatchCreateOptions{OrphanHandling: storage.OrphanAllow, SkipPrefixValidation: true})
+	}, "a", storage.BatchCreateOptions{SkipPrefixValidation: true})
 	if err == nil {
 		t.Fatal("(a) cyclic batch: want error, got nil")
 	}
@@ -589,7 +560,7 @@ func testAuditCreateInBatchCycle(t *testing.T, f Factory) {
 	must(t, s.CreateIssuesWithFullOptions(c, []*types.Issue{
 		withDefaults(&types.Issue{ID: "test-c", Title: "C", Dependencies: []*types.Dependency{{IssueID: "test-c", DependsOnID: "test-d", Type: types.DepBlocks}}}),
 		withDefaults(&types.Issue{ID: "test-d", Title: "D", Dependencies: []*types.Dependency{{IssueID: "test-d", DependsOnID: "test-c", Type: types.DepBlocks}}}),
-	}, "a", storage.BatchCreateOptions{OrphanHandling: storage.OrphanAllow, SkipPrefixValidation: true, SkipDependencyValidationErrors: true}))
+	}, "a", storage.BatchCreateOptions{SkipPrefixValidation: true, SkipDependencyValidationErrors: true}))
 	if _, err := s.GetIssue(c, "test-c"); err != nil {
 		t.Errorf("(b) test-c missing: %v", err)
 	}

--- a/backend/conformance/audit_search-counts-stats.go
+++ b/backend/conformance/audit_search-counts-stats.go
@@ -160,7 +160,7 @@ func testAuditReadyWorkDepCreatedAtParity(t *testing.T, f Factory) {
 				{IssueID: "dca-s", DependsOnID: "dca-t", Type: types.DepBlocks, CreatedAt: depCreatedAt},
 			},
 		}),
-	}, "a", storage.BatchCreateOptions{OrphanHandling: storage.OrphanAllow, SkipPrefixValidation: true}))
+	}, "a", storage.BatchCreateOptions{SkipPrefixValidation: true}))
 
 	// Rendered path: SearchIssuesWithCounts (bd list --with-counts) and
 	// GetReadyWorkWithCounts (bd ready) share ScanReadyWorkRowWithCounts, which parses

--- a/backend/conformance/portable.go
+++ b/backend/conformance/portable.go
@@ -649,7 +649,7 @@ func testCreateIssuesWithFullOptions(t *testing.T, f Factory) {
 	must(t, s.CreateIssuesWithFullOptions(c, []*types.Issue{
 		withDefaults(&types.Issue{ID: "test-a", Title: "A"}),
 		withDefaults(&types.Issue{ID: "test-b", Title: "B"}),
-	}, "a", storage.BatchCreateOptions{OrphanHandling: storage.OrphanAllow, SkipPrefixValidation: true}))
+	}, "a", storage.BatchCreateOptions{SkipPrefixValidation: true}))
 	if _, err := s.GetIssue(c, "test-a"); err != nil {
 		t.Fatalf("batch issue test-a missing: %v", err)
 	}
@@ -659,7 +659,7 @@ func testCreateIssuesWithFullOptions(t *testing.T, f Factory) {
 		withDefaults(&types.Issue{ID: "test-x", Title: "X"}),
 		withDefaults(&types.Issue{ID: "test-y", Title: "Y", Dependencies: []*types.Dependency{{IssueID: "test-y", DependsOnID: "test-x", Type: types.DepBlocks}}}),
 		withDefaults(&types.Issue{ID: "test-z", Title: "Z", Dependencies: []*types.Dependency{{IssueID: "test-z", DependsOnID: "test-absent", Type: types.DepBlocks}}}),
-	}, "a", storage.BatchCreateOptions{OrphanHandling: storage.OrphanAllow, SkipPrefixValidation: true}))
+	}, "a", storage.BatchCreateOptions{SkipPrefixValidation: true}))
 	recs, _ := s.GetAllDependencyRecords(c)
 	if got := depTargets(recs["test-y"]); !slices.Equal(got, []string{"test-x"}) {
 		t.Errorf("in-batch edge test-y = %v, want [test-x]", got)
@@ -671,7 +671,7 @@ func testCreateIssuesWithFullOptions(t *testing.T, f Factory) {
 	// ConflictSkip leaves an existing row untouched.
 	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "test-keep", Title: "Original"}), "a"))
 	must(t, s.CreateIssuesWithFullOptions(c, []*types.Issue{withDefaults(&types.Issue{ID: "test-keep", Title: "Replacement"})},
-		"a", storage.BatchCreateOptions{OrphanHandling: storage.OrphanAllow, SkipPrefixValidation: true, ConflictSkip: true}))
+		"a", storage.BatchCreateOptions{SkipPrefixValidation: true, ConflictSkip: true}))
 	if got, _ := s.GetIssue(c, "test-keep"); got.Title != "Original" {
 		t.Errorf("ConflictSkip overwrote title to %q, want Original", got.Title)
 	}
@@ -696,7 +696,7 @@ func testReconcileHierarchicalChildIDs(t *testing.T, f Factory) {
 	must(t, s.CreateIssuesWithFullOptions(c, []*types.Issue{
 		withDefaults(&types.Issue{ID: "x-1.1", Title: "child one"}),
 		withDefaults(&types.Issue{ID: "x-1.2", Title: "child two"}),
-	}, "a", storage.BatchCreateOptions{OrphanHandling: storage.OrphanAllow, SkipPrefixValidation: true}))
+	}, "a", storage.BatchCreateOptions{SkipPrefixValidation: true}))
 
 	for _, id := range []string{"x-1.1", "x-1.2"} {
 		if _, err := s.GetIssue(c, id); err != nil {
@@ -708,7 +708,7 @@ func testReconcileHierarchicalChildIDs(t *testing.T, f Factory) {
 	// one level deeper — and, being a grandchild, must not advance the x-1 counter.
 	must(t, s.CreateIssuesWithFullOptions(c, []*types.Issue{
 		withDefaults(&types.Issue{ID: "x-1.2.1", Title: "grandchild"}),
-	}, "a", storage.BatchCreateOptions{OrphanHandling: storage.OrphanAllow, SkipPrefixValidation: true}))
+	}, "a", storage.BatchCreateOptions{SkipPrefixValidation: true}))
 
 	// GetNextChildID reserves-and-advances, so call it once per parent. x-1 was
 	// reconciled to its max direct child (2, grandchild excluded) → next is x-1.3;

--- a/cmd/bd/doctor/fix/migrate.go
+++ b/cmd/bd/doctor/fix/migrate.go
@@ -233,7 +233,6 @@ func importJSONLIntoStore(ctx context.Context, store storage.DoltStorage, jsonlP
 	actor := detectActor()
 
 	err = store.CreateIssuesWithFullOptions(ctx, issues, actor, storage.BatchCreateOptions{
-		OrphanHandling:       storage.OrphanAllow,
 		SkipPrefixValidation: true,
 	})
 	if err != nil {

--- a/cmd/bd/import_shared.go
+++ b/cmd/bd/import_shared.go
@@ -148,7 +148,6 @@ func importIssuesCore(ctx context.Context, _ string, store storage.DoltStorage, 
 	staleRejectedSet := make(map[string]struct{})
 	actor := getActorWithGit()
 	batchOpts := storage.BatchCreateOptions{
-		OrphanHandling:                 storage.OrphanAllow,
 		SkipPrefixValidation:           opts.SkipPrefixValidation,
 		ConflictSkip:                   opts.ConflictSkip,
 		RejectStaleUpserts:             !opts.AllowStale,

--- a/cmd/bd/repo.go
+++ b/cmd/bd/repo.go
@@ -315,7 +315,6 @@ Also triggers Dolt push/pull if a remote is configured.`,
 				}
 				if len(issues) > 0 {
 					if importErr := store.CreateIssuesWithFullOptions(ctx, issues, "repo-sync", storage.BatchCreateOptions{
-						OrphanHandling:       storage.OrphanAllow,
 						SkipPrefixValidation: true,
 					}); importErr != nil {
 						fmt.Fprintf(os.Stderr, "Warning: failed to import from %s: %v\n", repoPath, importErr)
@@ -386,7 +385,6 @@ Also triggers Dolt push/pull if a remote is configured.`,
 
 			// Import with prefix validation skipped (cross-prefix hydration)
 			if err := store.CreateIssuesWithFullOptions(ctx, issues, "repo-sync", storage.BatchCreateOptions{
-				OrphanHandling:       storage.OrphanAllow,
 				SkipPrefixValidation: true,
 			}); err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: failed to import from %s: %v\n", repoPath, err)

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -202,16 +202,16 @@ rm -rf .beads/dolt           # server mode
 bd init --from-jsonl
 ```
 
-### Import fails with missing parent errors
+### Imported children whose parent is gone
 
-Errors like `parent issue bd-abc does not exist` when bootstrapping from JSONL
-or pulling hierarchical issues (e.g., `bd-abc.1`) mean the parent issue was
-deleted but children still reference it — typically after `bd delete` on a
-parent, a branch merge where one side deleted it, or an incomplete import.
+Bootstrapping from JSONL or pulling hierarchical issues (e.g., `bd-abc.1`) can
+land children whose parent `bd-abc` no longer exists — typically after
+`bd delete` on a parent, a branch merge where one side deleted it, or an
+incomplete import.
 
-Imports accept orphans without validation by default, so the children still
-arrive; the error indicates the parent itself is gone. Recreate the parent
-(or close out the orphaned children) after the import.
+Import accepts these orphans rather than failing, so the children still arrive
+and stay usable. Recreate the parent (or close out the orphaned children) once
+the import finishes.
 
 **Prevention:** use `bd delete --cascade` to also delete children, and review
 children first with `bd children <parent-id>`.

--- a/internal/config/yaml_config_test.go
+++ b/internal/config/yaml_config_test.go
@@ -42,10 +42,11 @@ func TestIsYamlOnlyKey(t *testing.T) {
 		{"backup.git-repo", true},
 		{"backup.future-key", true}, // prefix match
 
-		// Import settings
+		// Import settings. import.* is exact-match, not a prefix namespace:
+		// an unlisted import.* key must not be treated as yaml-only.
 		{"import.auto", true},
 		{"import.path", true},
-		{"import.orphan_handling", false},
+		{"import.unlisted-key", false},
 
 		// Secret keys (stored in yaml to avoid leaking via Dolt push)
 		{"github.token", true},

--- a/internal/molecules/molecules.go
+++ b/internal/molecules/molecules.go
@@ -150,7 +150,6 @@ func (l *Loader) loadMolecules(ctx context.Context, molecules []*types.Issue) (i
 	// Molecules have their own ID namespace (mol-*) independent of project prefix.
 	opts := storage.BatchCreateOptions{
 		SkipPrefixValidation: true, // Molecules use their own prefix
-		OrphanHandling:       storage.OrphanAllow,
 	}
 	if err := l.store.CreateIssuesWithFullOptions(ctx, newMolecules, "molecules-loader", opts); err != nil {
 		return 0, fmt.Errorf("batch create molecules: %w", err)

--- a/internal/molecules/molecules_test.go
+++ b/internal/molecules/molecules_test.go
@@ -163,7 +163,7 @@ func TestLoader_SkipExistingMolecules(t *testing.T) {
 		Status:     types.StatusOpen,
 		IsTemplate: true,
 	}
-	opts := storage.BatchCreateOptions{SkipPrefixValidation: true, OrphanHandling: storage.OrphanAllow}
+	opts := storage.BatchCreateOptions{SkipPrefixValidation: true}
 	if err := store.CreateIssuesWithFullOptions(ctx, []*types.Issue{existingMol}, "test", opts); err != nil {
 		t.Fatalf("Failed to create existing molecule: %v", err)
 	}

--- a/internal/storage/batch.go
+++ b/internal/storage/batch.go
@@ -1,28 +1,12 @@
 // Package storage defines the interface for issue storage backends.
 package storage
 
-// OrphanHandling specifies how to handle issues with missing parent references.
-type OrphanHandling string
-
-const (
-	// OrphanStrict fails import on missing parent (safest)
-	OrphanStrict OrphanHandling = "strict"
-	// OrphanResurrect auto-resurrects missing parents from database history
-	OrphanResurrect OrphanHandling = "resurrect"
-	// OrphanSkip skips orphaned issues with warning
-	OrphanSkip OrphanHandling = "skip"
-	// OrphanAllow imports orphans without validation (default, works around bugs)
-	OrphanAllow OrphanHandling = "allow"
-)
-
 // BatchCreateOptions contains options for batch issue creation.
 // This is a backend-agnostic type that can be used by any storage implementation.
 type BatchCreateOptions struct {
 	// CreateOnly uses strict insert semantics after the caller has reserved the
 	// issue ID. It is for guarded public creates; import behavior is unchanged.
 	CreateOnly bool
-	// OrphanHandling specifies how to handle issues with missing parent references
-	OrphanHandling OrphanHandling
 	// SkipPrefixValidation skips prefix validation for existing IDs (used during import)
 	SkipPrefixValidation bool
 	// ConflictSkip makes batch creation insert-if-new instead of UPSERT: an

--- a/internal/storage/dolt/is_blocked_test.go
+++ b/internal/storage/dolt/is_blocked_test.go
@@ -221,7 +221,6 @@ func TestIsBlocked_BatchedCreateWithDepsInOneTxn(t *testing.T) {
 	}
 	if err := store.CreateIssuesWithFullOptions(ctx, []*types.Issue{parent, child}, "tester",
 		storage.BatchCreateOptions{
-			OrphanHandling:       storage.OrphanAllow,
 			SkipPrefixValidation: true,
 		}); err != nil {
 		t.Fatalf("CreateIssuesWithFullOptions: %v", err)

--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -86,7 +86,6 @@ func sortedDirtyTables(dirty map[string]bool) []string {
 // CreateIssues creates multiple issues in a single transaction
 func (s *DoltStore) CreateIssues(ctx context.Context, issues []*types.Issue, actor string) error {
 	return s.CreateIssuesWithFullOptions(ctx, issues, actor, storage.BatchCreateOptions{
-		OrphanHandling:       storage.OrphanAllow,
 		SkipPrefixValidation: false,
 	})
 }

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -475,7 +475,6 @@ func (t *doltTransaction) CreateIssues(ctx context.Context, issues []*types.Issu
 
 	if len(regularIssues) > 0 {
 		result, err := issueops.CreateIssuesInTxWithResult(ctx, t.regularTx, regularIssues, actor, storage.BatchCreateOptions{
-			OrphanHandling:       storage.OrphanAllow,
 			SkipPrefixValidation: true,
 		})
 		if err != nil {
@@ -488,7 +487,6 @@ func (t *doltTransaction) CreateIssues(ctx context.Context, issues []*types.Issu
 
 	if len(wispIssues) > 0 {
 		if _, err := issueops.CreateIssuesInTxWithResult(ctx, t.ignoredTx, wispIssues, actor, storage.BatchCreateOptions{
-			OrphanHandling:       storage.OrphanAllow,
 			SkipPrefixValidation: true,
 		}); err != nil {
 			return err

--- a/internal/storage/embeddeddolt/create_issue.go
+++ b/internal/storage/embeddeddolt/create_issue.go
@@ -36,7 +36,6 @@ func (s *EmbeddedDoltStore) CreateIssue(ctx context.Context, issue *types.Issue,
 
 func (s *EmbeddedDoltStore) CreateIssues(ctx context.Context, issues []*types.Issue, actor string) error {
 	return s.CreateIssuesWithFullOptions(ctx, issues, actor, storage.BatchCreateOptions{
-		OrphanHandling:       storage.OrphanAllow,
 		SkipPrefixValidation: false,
 	})
 }

--- a/internal/storage/embeddeddolt/create_issue_test.go
+++ b/internal/storage/embeddeddolt/create_issue_test.go
@@ -1008,7 +1008,6 @@ func TestCreateIssues(t *testing.T) {
 		var skipped []string
 
 		err := te.store.CreateIssuesWithFullOptions(ctx, []*types.Issue{regular, wisp}, "tester", storage.BatchCreateOptions{
-			OrphanHandling:                 storage.OrphanAllow,
 			SkipPrefixValidation:           true,
 			SkipDependencyValidationErrors: true,
 			OnSkippedDependency: func(issueID, dependsOnID, reason string) {

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -767,7 +767,6 @@ func (s *EmbeddedDoltStore) ImportJSONLData(
 
 		// Create all issues in the same transaction
 		if err := issueops.CreateIssuesInTx(ctx, tx, issues, actor, storage.BatchCreateOptions{
-			OrphanHandling:       storage.OrphanAllow,
 			SkipPrefixValidation: true,
 			// Defense-in-depth (GH#3955): the embedded fast-path is the primary
 			// auto-import route for 1.0+ users and is gated by the in-transaction

--- a/internal/storage/embeddeddolt/transaction.go
+++ b/internal/storage/embeddeddolt/transaction.go
@@ -88,7 +88,6 @@ func (t *embeddedTransaction) CreateIssue(ctx context.Context, issue *types.Issu
 
 func (t *embeddedTransaction) CreateIssues(ctx context.Context, issues []*types.Issue, actor string) error {
 	result, err := issueops.CreateIssuesInTxWithResult(ctx, t.tx, issues, actor, storage.BatchCreateOptions{
-		OrphanHandling:       storage.OrphanAllow,
 		SkipPrefixValidation: true,
 	})
 	if err != nil {

--- a/internal/storage/issueops/create.go
+++ b/internal/storage/issueops/create.go
@@ -128,12 +128,6 @@ func CreateIssueInTxWithResult(ctx context.Context, tx DBTX, bc *BatchContext, i
 		return result, nil
 	}
 
-	if skip, err := CheckOrphan(ctx, tx, issue, issueTable, bc.Opts.OrphanHandling); err != nil {
-		return result, err
-	} else if skip {
-		return result, nil
-	}
-
 	isNew, staleRejected, err := InsertIssueIfNew(ctx, tx, issueTable, issue, bc.Opts)
 	if err != nil {
 		return result, err
@@ -195,8 +189,7 @@ func CreateIssueInTxWithResult(ctx context.Context, tx DBTX, bc *BatchContext, i
 	}
 	// Journal the create once, after labels and comments are in the row's
 	// transaction, so the snapshot is the complete bead. The early returns above
-	// (collision skip, orphan skip, stale reject) wrote nothing and journal
-	// nothing.
+	// (collision skip, stale reject) wrote nothing and journal nothing.
 	if err := RecordEventInTx(ctx, tx, EventCreate, issue.ID); err != nil {
 		return result, err
 	}
@@ -599,37 +592,6 @@ func AllWisps(issues []*types.Issue) bool {
 		}
 	}
 	return true
-}
-
-// CheckOrphan handles orphan detection for hierarchical IDs.
-// Returns (skip=true, nil) if the issue should be skipped.
-//
-//nolint:gosec // G201: table is a hardcoded constant
-func CheckOrphan(ctx context.Context, tx DBTX, issue *types.Issue, issueTable string, handling storage.OrphanHandling) (skip bool, err error) {
-	if issue.ID == "" {
-		return false, nil
-	}
-	parentID, _, ok := ParseHierarchicalID(issue.ID)
-	if !ok {
-		return false, nil
-	}
-
-	var parentCount int
-	if err := tx.QueryRowContext(ctx, fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE id = ?`, issueTable), parentID).Scan(&parentCount); err != nil {
-		return false, fmt.Errorf("failed to check parent existence: %w", err)
-	}
-	if parentCount > 0 {
-		return false, nil
-	}
-
-	switch handling {
-	case storage.OrphanStrict:
-		return false, fmt.Errorf("parent issue %s does not exist (strict mode)", parentID)
-	case storage.OrphanSkip:
-		return true, nil
-	default: // OrphanAllow, OrphanResurrect
-		return false, nil
-	}
 }
 
 // checkCrossTableIDCollision rejects a create whose ID already lives in the

--- a/internal/storage/issueops/create_batch.go
+++ b/internal/storage/issueops/create_batch.go
@@ -119,7 +119,6 @@ func ExecuteCreateBatch(ctx context.Context, tx *sql.Tx, request publicops.Creat
 	}
 	options := storage.BatchCreateOptions{
 		CreateOnly:           true,
-		OrphanHandling:       storage.OrphanAllow,
 		SkipPrefixValidation: attempt.ForceIDPrefix,
 	}
 	batch, err := NewBatchContext(ctx, tx, options)

--- a/internal/storage/issueops/execution.go
+++ b/internal/storage/issueops/execution.go
@@ -39,7 +39,7 @@ func ExecuteCreate(ctx context.Context, tx *sql.Tx, request publicops.CreateRequ
 	if err := ValidatePublicCreateRequest(attempt); err != nil {
 		return publicops.CreateResult{}, nil, err
 	}
-	batch, err := NewBatchContext(ctx, tx, storage.BatchCreateOptions{CreateOnly: true, OrphanHandling: storage.OrphanAllow, SkipPrefixValidation: attempt.ForceIDPrefix})
+	batch, err := NewBatchContext(ctx, tx, storage.BatchCreateOptions{CreateOnly: true, SkipPrefixValidation: attempt.ForceIDPrefix})
 	if err != nil {
 		return publicops.CreateResult{}, nil, err
 	}
@@ -81,7 +81,7 @@ func ExecuteCreate(ctx context.Context, tx *sql.Tx, request publicops.CreateRequ
 	issue.Dependencies = storage.CreatePublicCreateDependencies(issue.ID, attempt)
 	var skipped []skippedDependency
 	created, err := CreateIssuesInTxWithResult(ctx, tx, []*types.Issue{issue}, attempt.Actor, storage.BatchCreateOptions{
-		CreateOnly: true, OrphanHandling: storage.OrphanAllow, SkipPrefixValidation: attempt.ForceIDPrefix,
+		CreateOnly: true, SkipPrefixValidation: attempt.ForceIDPrefix,
 		OnSkippedDependency: func(issueID, dependsOnID, reason string) {
 			skipped = append(skipped, skippedDependency{issueID: issueID, dependsOnID: dependsOnID, reason: reason})
 		},

--- a/internal/storage/uow/importer.go
+++ b/internal/storage/uow/importer.go
@@ -61,7 +61,6 @@ func (o *importer) ImportBatch(ctx context.Context, request publicops.ImportBatc
 			staleRejected := make(map[string]struct{})
 			skippedSeen := make(map[string]struct{})
 			opts := storage.BatchCreateOptions{
-				OrphanHandling:                 storage.OrphanAllow,
 				SkipPrefixValidation:           request.SkipPrefixValidation,
 				RejectStaleUpserts:             !request.AllowStale,
 				SkipDependencyValidationErrors: true,


### PR DESCRIPTION
`BatchCreateOptions.OrphanHandling` had four modes and one behavior. This deletes
the whole capability, including its published surface on the `backend` package.

## Why it is dead

`CheckOrphan` (`internal/storage/issueops/create.go`) was called from exactly one
place, `CreateIssueInTxWithResult`, with `bc.Opts.OrphanHandling`:

```go
switch handling {
case storage.OrphanStrict:  // error
case storage.OrphanSkip:    // skip = true
default:                    // OrphanAllow, OrphanResurrect -> false, nil
}
```

- **Every production construction of `BatchCreateOptions` passed `OrphanAllow`**
  (13 sites) **or omitted the field** (zero value `""`, which lands in the same
  `default` arm). No CLI flag, no config key, no RPC or HTTP path parsed an orphan
  mode. So `CheckOrphan` returned `(false, nil)` on every path it could reach in
  production — a provable no-op.
- **It was not a free no-op.** Before the switch it paid a `SELECT COUNT(*)`
  parent-existence probe on every hierarchical-ID create, then, in the only
  reachable arm, ignored the answer. Every hierarchical create and import row paid
  a wasted query.
- **`OrphanStrict` and `OrphanSkip` were reachable only from
  `testAuditCreateOrphanHandling`** — one audit-tier conformance case that existed
  to execute them.
- **`OrphanResurrect` was not a distinct branch at all.** It shared the `default`
  arm with `OrphanAllow`. Its doc comment ("auto-resurrects missing parents from
  database history") was false; the implementation left with the JSONL sync layer.
  Nothing at HEAD writes a `[RESURRECTED]` marker.

The behavior that remains is exactly what `OrphanAllow` always did: a hierarchical
create whose parent is missing is accepted, and the child's auxiliary counter row
is skipped because it would have no owner. That skip lives in
`ReconcileChildCounters`, not in the deleted code, and is pinned by
`TestReconcileChildCountersSkipsMissingParent`.

## BREAKING CHANGE to the published `backend` package

Removed from `backend`: the `OrphanHandling` type alias and the re-exported
`OrphanAllow`, `OrphanResurrect`, `OrphanSkip`, `OrphanStrict`.

**Migration for an out-of-tree consumer: delete the option.** `OrphanAllow` was and
remains the only behavior, so a call site that passed it (or omitted the field) is
unaffected beyond dropping the field from its literal. Only `OrphanStrict` (reject
the create) and `OrphanSkip` (silently drop it) behaved differently; a consumer that
relied on either must now check for the parent itself before calling.

## What was removed

| Location | Symbol |
|---|---|
| `internal/storage/batch.go` | `type OrphanHandling`, `OrphanStrict`, `OrphanResurrect`, `OrphanSkip`, `OrphanAllow`, field `BatchCreateOptions.OrphanHandling` |
| `internal/storage/issueops/create.go` | `CheckOrphan` and its call site (+ a stale comment naming the "orphan skip" early return) |
| `backend/backend.go` | `OrphanHandling` alias, the four re-exported constants |
| `backend/conformance/audit_molecule_wisp_batch_iter.go` | `testAuditCreateOrphanHandling` and its `t.Run("CreateOrphanHandling", ...)` registration |
| 32 option literals | `OrphanHandling: storage.OrphanAllow` dropped across production and test/conformance files (incl. `backend/conformance/portable.go`, `audit_*.go`) — those tests all stay |
| `internal/config/yaml_config_test.go` | the `import.orphan_handling` row |
| `docs/reference/troubleshooting.md` | the "Import fails with missing parent errors" section |

`ParseHierarchicalID` stays — `issueops/child_id.go` and three other call sites in
`create.go` still use it.

### Two judgement calls worth flagging

**`internal/config/yaml_config_test.go`.** The `{"import.orphan_handling", false}`
row is a *negative* assertion, and it turned out to carry real coverage:
`import.auto` and `import.path` are exact entries in `YamlOnlyKeys` and `import.` is
**not** in `IsYamlOnlyKey`'s prefix list, so this was the only row asserting that
`import.*` is exact-match rather than a prefix namespace. Rather than delete it I
renamed the key to `import.unlisted-key` and said so in a comment — the regression
guard survives, the dead capability's name does not.

**`docs/reference/troubleshooting.md`.** That section quoted the error
`parent issue bd-abc does not exist`, whose only producer in the whole repo was the
`OrphanStrict` arm — an error no user could actually reach even before this PR (the
section then contradicted itself two paragraphs later: "Imports accept orphans
without validation by default, so the children still arrive"). Rewritten to describe
what actually happens and keep the useful remediation.

`cmd/bd/import_shared.go`'s `ImportOptions.OrphanHandling` and
`internal/beads`'s `TestImportWithDeletedParent` were both removed by #5492, which
landed while this was in flight; only the `OrphanAllow` literal in `importIssuesCore`
remained for this PR.

## Nothing contradicted the brief

Swept for stragglers by direct reference, string literal (`orphan`, `Orphan`,
`orphan_handling`, `RESURRECTED`), struct literal, re-export, YAML/JSON key, test
fixture, docs under `docs/` and `engdocs/`, and the CI shard manifests at
`.github/scripts/*-test-shards.txt` — all file types, not just `*.go`. After this
change the only surviving matches repo-wide are the CHANGELOG (this entry plus a
historical v0.x release note). The shard manifests never listed
`CreateOrphanHandling`; their `Orphan` hits are the unrelated `bd orphans` command.
Neither role-coverage gate (`uncoveredRoleMethods`,
`unwiredContractEntrypoints`) has an orphan row.

No live consumer or route was found that makes any of this reachable.

## Verification

Rebased onto `origin/main` (`a72a15220`) immediately before opening; all of the
below is from the post-rebase tree.

```
go build ./...                          BUILD_EXIT=0
go build -tags=integration ./...        BUILD_INTEGRATION_EXIT=0
go vet ./...                            VET_EXIT=0
gofmt -l .                              (empty)
golangci-lint run                       0 issues.
go test ./internal/storage/ -run TestEveryLegWiresEveryRoleContract      ok
go test ./backend/conformance/ -run 'TestEveryRoleMethodHasAContractCase|TestRoleContractCases'   ok
go test ./internal/config/... ./backend/... ./internal/storage/issueops/... ./scripts/... ./test/docsync   ok
BEADS_TEST_EMBEDDED_DOLT=1 go test ./internal/storage/embeddeddolt/ -run '^TestConformance$/^Audit$'   ok (30.1s)
go test ./internal/storage/dolt/       -run '^TestConformance$/^Audit$'   ok (25.4s)
```

`go vet` was also run clean under `regression`, `e2e`, `scripttests`, `ci_tools`,
`embeddeddolt`, and `regression,discovery`. The `chaos` tag fails to vet
(`runBDWithEnv redeclared`) — reproduced identically on a clean `origin/main`
worktree, unrelated.

Two red areas checked against a clean `origin/main` baseline worktree and found
pre-existing / environmental:

- **`./cmd/bd/...`** — 29 failing top-level tests on this branch vs 34 on the
  baseline, with failures unique to *each* side (baseline-only:
  `TestChildParentDependencies_*`, `TestVerifyFixTargetIdentity`, …). The three
  branch-only names (`TestIssueIDCompletion`,
  `TestIssueIDCompletion_UsesWorktreeFallbackWhenStoreNil`,
  `TestDepListCrossRigRouting`) were re-run in isolation on both trees and behave
  identically (the `_UsesWorktreeFallbackWhenStoreNil` one fails on `origin/main`
  too). Causes are a stale repo-root `bd`, `.beads` 0755 warnings, and
  `dial tcp 127.0.0.1:36829: connection refused`.
- **`internal/storage/dolt` `TestCrossProject_*`** — timed out at their hard 45s/60s
  deadlines in the full-package run on a loaded box (six other agents' Dolt
  containers up). Pass on this branch in isolation (`ok`, 204s), same as baseline
  (`ok`, 206s).

## Wasted query confirmed gone

Traced one hierarchical create end to end. `CreateIssueInTxWithResult` now goes
`PrepareIssueForInsert` -> `TableRouting` -> `assignCreateIssueIDInTx` ->
(`CreateOnly`? `EnsureIssueIDAvailableInTx`) -> `checkCrossTableIDCollision` ->
`InsertIssueIfNew`, with no parent-existence probe between the collision check and
the insert. The `SELECT COUNT(*)` calls left in `create.go` are the sibling-table
collision check, `InsertIssueIfNew`'s own existence check, the `RejectStaleUpserts`
guard, and the child-counter reconciliation — all live, none of them the parent
probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
