### PR TITLE
test(ci): derive storage timeout nesting

### DIFF
--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -62,16 +62,32 @@ func TestPRCIGateRequiresPolicyAndLintWrappers(t *testing.T) {
 
 func TestStorageDomainUOWJobsUseNestedTimeoutBudgets(t *testing.T) {
 	const (
-		storageCommand = "go test -tags gms_pure_go -race -count=1 -timeout 15m -v ./internal/storage/domain/... ./internal/storage/uow/... ./internal/tracker/..."
-		doctorCommand  = "go test -tags gms_pure_go -race -count=1 -timeout 10m -v ./cmd/bd/doctor/fix/"
-		jobTimeout     = 30
+		storageTimeoutMinutes     = 15
+		doctorTimeoutMinutes      = 10
+		setupTeardownSlackMinutes = 5
+		jobTimeoutMinutes         = storageTimeoutMinutes + doctorTimeoutMinutes + setupTeardownSlackMinutes
 	)
+	storageCommand := fmt.Sprintf(
+		"go test -tags gms_pure_go -race -count=1 -timeout %dm -v ./internal/storage/domain/... ./internal/storage/uow/... ./internal/tracker/...",
+		storageTimeoutMinutes)
+	doctorCommand := fmt.Sprintf(
+		"go test -tags gms_pure_go -race -count=1 -timeout %dm -v ./cmd/bd/doctor/fix/",
+		doctorTimeoutMinutes)
 
 	for _, workflowName := range []string{"pr.yml", "main.yml"} {
 		t.Run(workflowName, func(t *testing.T) {
 			job := readCIWorkflow(t, workflowName).job(t, "test-domain-uow")
-			if job.TimeoutMinutes != jobTimeout {
-				t.Errorf("test-domain-uow timeout = %d minutes, want %d", job.TimeoutMinutes, jobTimeout)
+			if job.TimeoutMinutes != jobTimeoutMinutes {
+				t.Errorf("test-domain-uow timeout = %d minutes, want %d", job.TimeoutMinutes, jobTimeoutMinutes)
+			}
+			// Go's timeout applies per package test binary, so this is a
+			// maintenance tripwire for the declared sequential tier budgets,
+			// not a mathematical upper bound for the multi-package first step.
+			if job.TimeoutMinutes <= storageTimeoutMinutes+doctorTimeoutMinutes {
+				t.Errorf(
+					"test-domain-uow timeout = %d minutes, want more than %d minutes of declared tier budgets",
+					job.TimeoutMinutes,
+					storageTimeoutMinutes+doctorTimeoutMinutes)
 			}
 			assertStepRunsExactly(t, job, "Test domain + uow + tracker", storageCommand)
 			assertStepRunsExactly(t, job, "Test doctor/fix (Dolt-backed, hard-require container)", doctorCommand)


### PR DESCRIPTION
Fixes #5494

## Motivation

`TestStorageDomainUOWJobsUseNestedTimeoutBudgets` named a nesting contract but pinned the 15-minute storage tier, 10-minute doctor/fix tier, and 30-minute outer job budget independently. A future maintainer could update an inner timeout and its exact-command expectation while forgetting the outer budget, leaving the test green with an inverted relationship.

## What changed

- declare the two tier budgets and five minutes of setup/teardown slack once in the structural test;
- derive both exact workflow commands and the expected outer budget from those authorities;
- assert that the outer budget exceeds the two declared nominal tiers; and
- preserve the existing PR/main mirroring and CI Gate wiring checks.

No workflow behavior changes in this PR.

## Decision points

- The relationship belongs in the existing YAML structural test, not in duplicated workflow arithmetic.
- Five minutes of explicit slack preserves today's reviewed 30-minute backstop while making the coupling maintainable.
- Go's `-timeout` is per test binary/package. This guard protects the intended nominal sequential-tier maintenance relationship; it does not claim that 30 minutes exceeds every theoretical multi-package maximum.
- The model covers the two currently timed sequential steps. A future third timed step must be added explicitly.

## Validation

- Decisive mutation proof: changed both workflow storage commands and the maintained constant from 15m to 25m, deliberately left `timeout-minutes: 30`; exact-command checks passed while both mirrors failed only with `want 40` and `want more than 35 minutes of declared tier budgets`.
- Focused structural test: pass after restoration.
- `go test ./scripts -count=1`: pass.
- `go vet ./scripts`: pass.
- `mingw32-make ci-pr-lint`: pass with zero normal and Windows findings.
- `gofmt` and `git diff --check`: pass.

_codex-gpt-5-unknown-reasoning on behalf of Ewen Cuthiell_
