### PR TITLE
docs: clarify CI topology authority

### DIFF
--- a/engdocs/CI_REQUIRED_CHECK_TOPOLOGY.md
+++ b/engdocs/CI_REQUIRED_CHECK_TOPOLOGY.md
@@ -1,8 +1,11 @@
 # Required Check Topology
 
-Status: initial aggregate gate jobs implemented on branch
-`ci/bd-am3.1-wrapper-commands`. Do not change branch protection until the new
-checks have appeared and passed on at least one recent commit.
+Status: aggregate gate jobs are implemented; branch-protection and ruleset
+adoption remain pending. The aggregate-gate policy below remains maintainer
+context, but `.github/workflows/*.yml` and their structural tests are
+authoritative for current job membership and display names. Copied workflow
+wiring and rollout steps in this note describe the initial rollout, not the
+live topology.
 
 ## Problem
 
@@ -81,7 +84,7 @@ Do not require these existing check names directly:
 
 - `Detect CI tier`
 - `Check build-tag policy`
-- `Check cmd/bd pure-Go tests compile (CGO_ENABLED=0)`
+- `Check pure-Go and js/wasm boundaries (CGO_ENABLED=0)`
 - `Check version consistency`
 - `Check doc flags freshness`
 - `Check for .beads changes`
@@ -123,7 +126,11 @@ Do not add `paths`, `paths-ignore`, or narrower branch filters to `pr.yml` or
 
 ### 2. Add Aggregate Gate Jobs
 
-`.github/workflows/pr.yml` now has one final baseline gate job:
+The block below is a historical snapshot of the initial baseline gate. It is
+intentionally not kept in lockstep with later leaf additions and renames; use
+`.github/workflows/pr.yml` and its structural tests for the current wiring.
+
+`.github/workflows/pr.yml` introduced one final baseline gate job:
 
 <!-- markdownlint-disable MD013 -->
 
@@ -323,10 +330,15 @@ Policy for `merge_group`:
   results, except PR-only hygiene checks such as `Check for .beads changes` may
   be skipped by design.
 
-## Rollout Steps
+## Initial Rollout Snapshot
+
+The following checklist records the original rollout plan. It is retained as
+decision context, not as a current deployment procedure. Workflow plumbing is
+implemented; the branch-protection and ruleset policy changes in steps 7 and 8
+remain pending maintainer decisions.
 
 1. Add `.github/scripts/ci-gate.sh` and aggregate gate jobs to the required PR
-   workflows. Initial implementation exists on branch
+   workflows. The initial implementation was developed on branch
    `ci/bd-am3.1-wrapper-commands`.
 2. Open a PR and verify the new aggregate check names appear exactly as
    expected from GitHub Actions.

--- a/engdocs/DOC_INVENTORY.md
+++ b/engdocs/DOC_INVENTORY.md
@@ -61,7 +61,7 @@ Follow-up automation should replace marker-only checks with generated or
 | `CLAUDE.md` | Revise | Kept as architecture orientation only; command/workflow duplication was reduced in favour of root `AGENTS.md` and `AGENT_INSTRUCTIONS.md`. |
 | `CLI_REFERENCE.md` | Keep/generated | Generated command reference from live help output. |
 | `CI_CLEANUP_PLAN.md` | Keep as maintainer context | Dated CI policy, measurements, and implementation roadmap; current commands live in workflows and the `Makefile`. |
-| `CI_REQUIRED_CHECK_TOPOLOGY.md` | Keep | Design note for the required-check aggregate gate topology; explicitly flags pre-rollout status and gates branch-protection changes on the new checks passing first. |
+| `CI_REQUIRED_CHECK_TOPOLOGY.md` | Keep as maintainer context | Implemented workflow design record for aggregate-gate policy; branch-protection and ruleset adoption remain pending. Live job membership and display names come from `.github/workflows/*.yml` and their structural tests; copied wiring and rollout steps are historical snapshots. |
 | `CI_TEST_SURFACE_AUDIT.md` | Keep as historical snapshot | Dated test-surface inventory; current commands live in workflows and the `Makefile`. |
 | `plugins/beads/skills/beads/resources/CLI_REFERENCE.md` | Keep pointer | Plugin skill resource intentionally points at live CLI sources to avoid duplicate generated command snapshots. |
 | `CODEX_INTEGRATION.md` | Keep | User-facing Codex integration guide. |


### PR DESCRIPTION
## What

- Mark the aggregate gate jobs as implemented while keeping
  branch-protection/ruleset adoption explicitly pending.
- Make workflow YAML plus its structural tests the authority for current job
  membership and display names.
- Update the current do-not-require list to the adopted
  `Check pure-Go and js/wasm boundaries (CGO_ENABLED=0)` name.
- Label the copied gate block and rollout checklist as historical context.
- Give `DOC_INVENTORY.md` the same disposition.

## Why

The aggregate-gate policy is still useful maintainer guidance, but the note
mixed an obsolete pre-rollout status, a copied workflow snapshot, and one stale
hosted-check name. That made it easy to mistake historical wiring for current
authority or assume the live ruleset had already adopted required checks.

This is documentation-only. It does not change workflow, branch-protection, or
runtime behavior, and it preserves the instruction to require aggregate gates
rather than individual leaves.

## Validation

- `go test -tags=gms_pure_go ./test/docsync`
- `go test ./scripts -run '^TestPRCIGateRequiresJSWasmHookExecution$' -count=1`
- Git-for-Windows Bash `./scripts/check-doc-freshness.sh`
- `markdownlint-cli2 engdocs/CI_REQUIRED_CHECK_TOPOLOGY.md` (0 issues)
- Exact literal assertions against `.github/workflows/pr.yml`
- `git diff --check`

`DOC_INVENTORY.md` retains its existing repository-wide markdownlint baseline:
82 findings before and after this one-row edit.

Fixes #5500.

Related: #5478 and #5053.

_codex-gpt-5-unknown-reasoning on behalf of Ewen Cuthiell_
