### PR TITLE
test(conformance): pin the missing-parent child-counter skip on a real backend (bd-k4bcj)

### DIFF
--- a/backend/conformance/portable.go
+++ b/backend/conformance/portable.go
@@ -46,6 +46,7 @@ func RunPortableMethods(t *testing.T, factory Factory) {
 	t.Run("DeleteIssuesBySourceRepo", func(t *testing.T) { testDeleteIssuesBySourceRepo(t, factory) })
 	t.Run("CreateIssuesWithFullOptions", func(t *testing.T) { testCreateIssuesWithFullOptions(t, factory) })
 	t.Run("ReconcileHierarchicalChildIDs", func(t *testing.T) { testReconcileHierarchicalChildIDs(t, factory) })
+	t.Run("ReconcileSkipsMissingParentCounter", func(t *testing.T) { testReconcileSkipsMissingParentCounter(t, factory) })
 	t.Run("Slots", func(t *testing.T) { testSlots(t, factory) })
 }
 
@@ -718,6 +719,61 @@ func testReconcileHierarchicalChildIDs(t *testing.T, f Factory) {
 	}
 	if next, err := s.GetNextChildID(c, "x-1.2"); err != nil || next != "x-1.2.2" {
 		t.Errorf("GetNextChildID(x-1.2) = (%q,%v), want (x-1.2.2,nil) — grandchild counter reconciled", next, err)
+	}
+}
+
+// The other half of the same upsert: a dotted id whose PARENT ROW DOES NOT EXIST is
+// accepted, and no counter is minted for the absent parent. ReconcileChildCounters
+// probes the parent table first and `continue`s on sql.ErrNoRows (issueops/create.go),
+// because orphaned dotted ids are ordinary import input — the parent was deleted
+// before the export — and both counter tables carry a parent foreign key, so minting
+// the row anyway fails the whole create rather than merely leaving a stray counter.
+//
+// The skip's only real-backend exerciser was testAuditCreateOrphanHandling, deleted
+// with the orphan-handling modes in #5497. What survived is an sqlmock unit test
+// (issueops.TestReconcileChildCountersSkipsMissingParent), which asserts against a
+// mock and so cannot see how a real engine answers the parent lookup.
+//
+// HOW THE ABSENCE IS OBSERVED. No storage method reads child_counters, and
+// GetNextChildID — the one method whose answer depends on it — SELF-HEALS from the
+// issue rows, taking max(counter, highest existing direct child). So while the orphan
+// y-1.1 is still stored, a skipped counter and a wrongly minted one BOTH answer y-1.2
+// and the bug hides; and with the parent still absent the method cannot be called at
+// all, because its own counter upsert trips the same foreign key. Each arm therefore
+// deletes the orphan (removing the self-heal signal) and then creates the parent
+// (making the upsert legal), leaving the counter row as the only thing that could
+// still advance the answer: parent.1 means nothing was minted, parent.2 means it was.
+//
+// That self-heal is also why the skip costs nothing: a later child of a
+// resurrected parent steps past the surviving orphan instead of colliding with it.
+//
+// Both create paths are covered because they reach the shared body from different
+// call sites — the batch path once over the whole slice, the singular path per issue.
+func testReconcileSkipsMissingParentCounter(t *testing.T, f Factory) {
+	s := f(t)
+	c := ctx()
+
+	// Neither y-1 nor z-1 exists at this point: these ARE the orphan creates.
+	if err := s.CreateIssuesWithFullOptions(c, []*types.Issue{
+		withDefaults(&types.Issue{ID: "y-1.1", Title: "batch orphan"}),
+	}, "a", storage.BatchCreateOptions{SkipPrefixValidation: true}); err != nil {
+		t.Fatalf("batch create of orphan y-1.1 = %v, want nil — the missing-parent skip is what keeps the counter foreign key from failing the create", err)
+	}
+	if err := s.CreateIssue(c, withDefaults(&types.Issue{ID: "z-1.1", Title: "singular orphan"}), "a"); err != nil {
+		t.Fatalf("singular create of orphan z-1.1 = %v, want nil — same skip, per-issue call site", err)
+	}
+
+	for _, parent := range []string{"y-1", "z-1"} {
+		child := parent + ".1"
+		if _, err := s.GetIssue(c, child); err != nil {
+			t.Fatalf("orphan hierarchical child %s not created: %v", child, err)
+		}
+		must(t, s.DeleteIssue(c, child))
+		must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: parent, Title: "late parent"}), "a"))
+		if next, err := s.GetNextChildID(c, parent); err != nil || next != child {
+			t.Errorf("GetNextChildID(%s) = (%q,%v), want (%s,nil) — a counter row was minted for %s while it did not exist",
+				parent, next, err, child, parent)
+		}
 	}
 }
 

--- a/internal/storage/issueops/create_test.go
+++ b/internal/storage/issueops/create_test.go
@@ -495,6 +495,10 @@ func TestPersistDependenciesSkipsHierarchyValidationAcrossPrefixes(t *testing.T)
 	}
 }
 
+// The mock half of the missing-parent skip: it pins the STATEMENTS (no counter
+// read, no upsert). Its real-backend twin is the conformance case
+// ReconcileSkipsMissingParentCounter (backend/conformance/portable.go), which
+// pins what a live engine does with the same skip on both Dolt legs.
 func TestReconcileChildCountersSkipsMissingParent(t *testing.T) {
 	ctx := context.Background()
 	db, mock, tx := beginMockTx(t)


### PR DESCRIPTION
## What this pins

**A hierarchical create whose parent row does not exist is ACCEPTED, and no child-counter row is minted for the missing parent.**

That is the `if err == sql.ErrNoRows { continue }` guard on the parent-existence probe in `ReconcileChildCounters` (`internal/storage/issueops/create.go`). Orphaned dotted ids are ordinary import input — the parent was deleted before the export — and both counter tables carry a parent foreign key (`fk_counter_parent`, `fk_wisp_child_counters_parent`), so minting the counter anyway fails the whole create rather than merely leaving a stray row.

Its last real-backend exerciser was `testAuditCreateOrphanHandling`, deleted with the orphan-handling modes in #5497. What survived is `issueops.TestReconcileChildCountersSkipsMissingParent` — an **sqlmock** test that asserts against a mock and so cannot catch a divergence in how a real engine answers the parent lookup. The orphan-handling *modes* are gone for good; what needed pinning is the surviving default behavior, and that is what this adds.

New case: `ReconcileSkipsMissingParentCounter`, beside `testReconcileHierarchicalChildIDs` in `backend/conformance/portable.go` and registered in `RunPortableMethods`, so it runs wherever `RunAll` runs — both Dolt legs. It covers **both** call sites of the shared body: the batch path (`CreateIssuesWithFullOptions`, one slice-wide reconcile) and the singular path (`CreateIssue`, per-issue reconcile).

## The observation, and why this one

No conformance case reads `child_counters` directly, and the tier observes through the storage interface only — no raw-SQL escape hatch was added.

`GetNextChildID` is the one method whose answer depends on the counter, but **it does not work the way the brief assumed**: `GetNextChildIDTx` (`internal/storage/issueops/child_id.go`) SELF-HEALS, taking `max(counter, highest existing direct child)` from a scan of the issue rows. So with the orphan `y-1.1` still stored, a *skipped* counter and a *wrongly minted* one both answer `y-1.2` — the bug is invisible. Worse, with the parent still absent the method cannot be called at all: its own counter upsert trips the same foreign key (measured: `Error 1452 ... Foreign key violation on fk: fk_counter_parent`).

So each arm:

1. creates the orphan (`y-1.1` via batch, `z-1.1` via the singular path) with no `y-1` / `z-1` — this create must succeed;
2. deletes the orphan, which strips the self-heal signal;
3. creates the parent, which makes the counter upsert legal;
4. reads `GetNextChildID(parent)` — `parent.1` means nothing was minted, `parent.2` means it was.

Two consequences worth stating out loud, both in the case comment:

- **No collision.** The brief flagged that a correctly skipped counter might let a later child collide with the surviving orphan. It does not: the self-heal scan sees the orphan and steps past it, so a later child of a resurrected parent gets `y-1.2`.
- The skip is load-bearing for the create succeeding at all, not merely for counter tidiness, because of the foreign key.

## Falsifiability

Mutation: in `ReconcileChildCounters`, `if err == sql.ErrNoRows { continue }` -> `if err == sql.ErrNoRows { err = nil }`, i.e. mint the counter row for the absent parent anyway.

**Dolt server leg — RED**

```
    portable.go:760: batch create of orphan y-1.1 = failed to reconcile child counter for y-1: Error 1452 (HY000): cannot add or update a child row - Foreign key violation on fk: `fk_counter_parent`, table: `child_counters`, referenced table: `issues`, key: `[y-1]`, want nil — the missing-parent skip is what keeps the counter foreign key from failing the create
--- FAIL: TestConformance/Portable/ReconcileSkipsMissingParentCounter (0.07s)
```

**Embedded Dolt leg — RED**

```
    portable.go:760: batch create of orphan y-1.1 = failed to reconcile child counter for y-1: Error 1452: cannot add or update a child row - Foreign key violation on fk: `fk_counter_parent`, table: `child_counters`, referenced table: `issues`, key: `[y-1]`, want nil — the missing-parent skip is what keeps the counter foreign key from failing the create
--- FAIL: TestConformance/Portable/ReconcileSkipsMissingParentCounter (3.89s)
```

On the canonical schema the mutation dies at the acceptance assertion, so a second experiment was run to prove the *observation* arm is live rather than decorative: same mutation, plus the counter FK removed from the schema (0008 + the ignored-track re-add, i.e. the shape a backend without that FK would have — the suite is published for out-of-tree backends). Both legs then fail on the observation, on both create paths:

```
# server leg
    portable.go:774: GetNextChildID(y-1) = ("y-1.2",<nil>), want (y-1.1,nil) — a counter row was minted for y-1 while it did not exist
    portable.go:774: GetNextChildID(z-1) = ("z-1.2",<nil>), want (z-1.1,nil) — a counter row was minted for z-1 while it did not exist
# embedded leg
    portable.go:774: GetNextChildID(y-1) = ("y-1.2",<nil>), want (y-1.1,nil) — a counter row was minted for y-1 while it did not exist
    portable.go:774: GetNextChildID(z-1) = ("z-1.2",<nil>), want (z-1.1,nil) — a counter row was minted for z-1 while it did not exist
```

Both mutations were reverted; the diff touches no non-test file. Under the mutation the pre-existing neighbour `ReconcileHierarchicalChildIDs` stays **green** (its parents all exist, so the guard never fires) — the new case is closing a real gap, not restating one.

Restored, both legs pass:

```
--- PASS: TestConformance/Portable/ReconcileSkipsMissingParentCounter (0.35s)   # server
--- PASS: TestConformance/Portable/ReconcileSkipsMissingParentCounter (7.90s)   # embedded
```

## The uow twin: not added, and why

`uow` reaches the shared body at exactly one place, `internal/storage/uow/importer.go:87`, so the only uow-reachable route is the Importer role. The twin is **not** worth it:

- `ReconcileChildCounters(ctx, tx, issues)` **takes no options**. Nothing in `BatchCreateOptions` can steer the missing-parent guard. The only opts-mediated influence on *which* issues reach it is stale-rejection filtering (`RejectStaleUpserts` drops a row from `accepted`), which is a different behavior with its own contract case.
- The importer passes `request.Issues` through unmodified; its opts differ from the store legs' only in `RejectStaleUpserts`, `SkipDependencyValidationErrors` and the two report callbacks — all consumed upstream of the reconcile.
- The remaining divergence axis would be the `DBTX`, and there is none: `importStatementRunner` hands the engine `b.tx.Runner()`, which for the Dolt server tx is `t.conn`, a bare `*sql.Conn` (`internal/storage/uow/doltserver_tx.go`). The SQL runs verbatim, same engine.
- `backend/conformance/importer_contract.go` states the scope rule itself: "The ENGINE below it (issueops.CreateIssuesInTxWithResult) is the same one the store legs run ... What no test anywhere reaches is the mapping this role puts on top of it — the stale-rejection list, its deduplication, the Created arithmetic, and the skip list." The missing-parent skip has no mapping component in `ImportBatchResult`; it is engine behavior, and the portable case covers it.

A second observer of one shared body, with no divergence axis, would be a test added to look thorough.

## Verification

```
go build ./...                                   BUILD_EXIT=0
go vet ./...                                     VET_EXIT=0
golangci-lint run                                0 issues.
gofmt -l .                                       (no output)
go test ./internal/storage/dolt/ -run TestConformance          ok  43.529s
BEADS_TEST_EMBEDDED_DOLT=1 \
  go test ./internal/storage/embeddeddolt/ -run TestConformance ok  73.208s
go test ./internal/storage/issueops/...                        ok   0.859s
go test ./internal/storage/ -run TestEveryLegWiresEveryRoleContract   ok
go test ./backend/conformance/ -run 'TestEveryRoleMethodHasAContractCase|TestRoleContractCases'   ok
```

## Note on something the brief did not predict

Migration `0039_drop_child_counters_fk` does not leave `child_counters` FK-free: ignored-track `0002` re-adds `fk_counter_parent` (with `ON UPDATE CASCADE`), and the fresh-schema bundle bakes that final shape directly (`cli_migrations.go`, `cliMigration0008CreateChildCounters`). The FK is live on both legs — verified by `SHOW CREATE TABLE` — which is exactly why the mutation fails the create outright rather than leaving a stray counter row. The code comment in `ReconcileChildCounters` ("both counter tables enforce a parent foreign key") is accurate.

Also drive-by: a four-line pointer on the sqlmock test naming its new real-backend twin, so the next person deleting one knows about the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)