### PR TITLE
Publish the row-version guard on close, reopen and delete

### DIFF
--- a/cmd/bd/serve_close_proxied_integration_test.go
+++ b/cmd/bd/serve_close_proxied_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -22,56 +23,70 @@ import (
 // internal/storage/uow/lifecycle_close_reopen_contract_test.go. This test owns
 // the wire-to-role seam and cites that one rather than duplicating it.
 
-// closeIssue posts a close for id and returns the status and decoded body.
-func (sp *serveProcess) closeIssue(t *testing.T, id, body string) (int, map[string]any) {
+// lifecycleVerbRaw posts a custom method for id and returns the status and the
+// UNDECODED body, so a caller can choose how to read a member rather than
+// inheriting encoding/json's default for `any`.
+//
+// It exists for `revision`, and the update slice paid for the lesson: live
+// row_lock tokens run past 5e17, where a float64's ulp is already 64, so a
+// token read through `map[string]any` is a value NEAR the token and is not it.
+// The decoded helpers below stay as they were — a case comparing prose members
+// wants the ordinary decode — and the guarded cases read the raw bytes.
+func (sp *serveProcess) lifecycleVerbRaw(t *testing.T, verb, id, body string) (int, []byte) {
 	t.Helper()
-	req, err := http.NewRequest(http.MethodPost, sp.url("/v0/beads/issues/"+id+":close"), strings.NewReader(body))
+	req, err := http.NewRequest(http.MethodPost, sp.url("/v0/beads/issues/"+id+":"+verb), strings.NewReader(body))
 	if err != nil {
-		t.Fatalf("new close request: %v", err)
+		t.Fatalf("new %s request: %v", verb, err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := sp.client.Do(req)
 	if err != nil {
-		t.Fatalf("POST close %s: %v\nstderr:\n%s", id, err, sp.stderr.String())
+		t.Fatalf("POST %s %s: %v\nstderr:\n%s", verb, id, err, sp.stderr.String())
 	}
 	defer func() { _ = resp.Body.Close() }()
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
-		t.Fatalf("read close body: %v", err)
+		t.Fatalf("read %s body: %v", verb, err)
 	}
+	return resp.StatusCode, raw
+}
+
+// decodeVerbBody is the ordinary decode the unguarded cases use.
+func decodeVerbBody(t *testing.T, verb string, raw []byte) map[string]any {
+	t.Helper()
 	var m map[string]any
 	if len(raw) > 0 {
 		if err := json.Unmarshal(raw, &m); err != nil {
-			t.Fatalf("decode close body %q: %v", raw, err)
+			t.Fatalf("decode %s body %q: %v", verb, raw, err)
 		}
 	}
-	return resp.StatusCode, m
+	return m
+}
+
+// closeIssueRaw posts a close and returns the status and the undecoded body.
+func (sp *serveProcess) closeIssueRaw(t *testing.T, id, body string) (int, []byte) {
+	t.Helper()
+	return sp.lifecycleVerbRaw(t, "close", id, body)
+}
+
+// closeIssue posts a close for id and returns the status and decoded body.
+func (sp *serveProcess) closeIssue(t *testing.T, id, body string) (int, map[string]any) {
+	t.Helper()
+	status, raw := sp.closeIssueRaw(t, id, body)
+	return status, decodeVerbBody(t, "close", raw)
+}
+
+// reopenIssueRaw posts a reopen and returns the status and the undecoded body.
+func (sp *serveProcess) reopenIssueRaw(t *testing.T, id, body string) (int, []byte) {
+	t.Helper()
+	return sp.lifecycleVerbRaw(t, "reopen", id, body)
 }
 
 // reopenIssue posts a reopen for id and returns the status and decoded body.
 func (sp *serveProcess) reopenIssue(t *testing.T, id, body string) (int, map[string]any) {
 	t.Helper()
-	req, err := http.NewRequest(http.MethodPost, sp.url("/v0/beads/issues/"+id+":reopen"), strings.NewReader(body))
-	if err != nil {
-		t.Fatalf("new reopen request: %v", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := sp.client.Do(req)
-	if err != nil {
-		t.Fatalf("POST reopen %s: %v\nstderr:\n%s", id, err, sp.stderr.String())
-	}
-	defer func() { _ = resp.Body.Close() }()
-	raw, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("read reopen body: %v", err)
-	}
-	var m map[string]any
-	if len(raw) > 0 {
-		if err := json.Unmarshal(raw, &m); err != nil {
-			t.Fatalf("decode reopen body %q: %v", raw, err)
-		}
-	}
-	return resp.StatusCode, m
+	status, raw := sp.reopenIssueRaw(t, id, body)
+	return status, decodeVerbBody(t, "reopen", raw)
 }
 
 func TestProxiedServerServeClose(t *testing.T) {
@@ -329,6 +344,131 @@ func TestProxiedServerServeClose(t *testing.T) {
 		// The refusals are wire-edge refusals: nothing reached the database.
 		if shown := bdProxiedShow(t, bd, p.dir, issue.ID); string(shown.Status) != "open" {
 			t.Errorf("a refused close wrote to the row: status %q", shown.Status)
+		}
+	})
+
+	// THE GUARD, AS A REAL READ-MODIFY-WRITE LOOP. The pure tests assert the
+	// projection onto issueops.CloseRequest and the shape of the 409; what only
+	// this level can show is that the token a write ANSWERS with is the one the
+	// next request must send, that a stale one really refuses against a store,
+	// and — the claim a fake has no way to hold — that the guard is evaluated
+	// BEFORE the idempotent re-close.
+	//
+	// The stale token is made by a real concurrent writer rather than by
+	// arithmetic. The token is opaque and compared for equality alone, so
+	// `revision - 1` is not "the previous revision"; there is no way to
+	// construct a stale one except to let something move the row.
+	t.Run("a guarded close and reopen compose from the revision the write answered", func(t *testing.T) {
+		issue := bdProxiedCreate(t, bd, p.dir, "guarded lifecycle", "-p", "2")
+
+		// The first guarded write has to seed itself from an unguarded one:
+		// no READ on this surface publishes a revision yet, which is the gap
+		// the document names on every one of these members.
+		status, raw := sp.updateIssueRaw(t, issue.ID, `{"actor":"http-agent","patch":{"notes":"seeded"}}`)
+		if status != http.StatusOK {
+			t.Fatalf("the seeding write: status = %d, want 200: %s", status, raw)
+		}
+		first := revisionOf(t, raw)
+
+		status, raw = sp.updateIssueRaw(t, issue.ID, `{"actor":"other-agent","patch":{"notes":"moved"}}`)
+		if status != http.StatusOK {
+			t.Fatalf("the concurrent write: status = %d, want 200: %s", status, raw)
+		}
+		second := revisionOf(t, raw)
+		if second == first {
+			t.Fatalf("revision = %d after a second write; a write that does not move the token makes every guard vacuous", second)
+		}
+
+		// The stale close. Nothing is written, and the 409 names the member.
+		status, problem := sp.closeIssue(t, issue.ID,
+			`{"actor":"http-agent","reason":"never","expected_version":`+strconv.FormatInt(first, 10)+`}`)
+		if status != http.StatusConflict {
+			t.Fatalf("stale close: status = %d, want 409: %v", status, problem)
+		}
+		if problem["code"] != "precondition_failed" || problem["param"] != "expected_version" {
+			t.Errorf("stale close: code = %v param = %v, want precondition_failed / expected_version", problem["code"], problem["param"])
+		}
+		if shown := bdProxiedShow(t, bd, p.dir, issue.ID); string(shown.Status) != "open" || shown.CloseReason != "" {
+			t.Errorf("a refused guard closed the row anyway: status %q reason %q", shown.Status, shown.CloseReason)
+		}
+
+		// FORCE DOES NOT BYPASS IT. `force` bypasses close POLICY; the guard is
+		// about whether this is still the row the caller read, which force says
+		// nothing about.
+		status, problem = sp.closeIssue(t, issue.ID,
+			`{"actor":"http-agent","force":true,"expected_version":`+strconv.FormatInt(first, 10)+`}`)
+		if status != http.StatusConflict {
+			t.Fatalf("forced stale close: status = %d, want 409 — force bypasses policy, never a precondition: %v", status, problem)
+		}
+		if shown := bdProxiedShow(t, bd, p.dir, issue.ID); string(shown.Status) != "open" {
+			t.Errorf("a forced stale close closed the row: status %q", shown.Status)
+		}
+
+		// The fresh guard lands, and answers with the token the close minted.
+		status, raw = sp.closeIssueRaw(t, issue.ID,
+			`{"actor":"http-agent","reason":"shipped","expected_version":`+strconv.FormatInt(second, 10)+`}`)
+		if status != http.StatusOK {
+			t.Fatalf("guarded close: status = %d, want 200: %s", status, raw)
+		}
+		closed := revisionOf(t, raw)
+		if closed == second {
+			t.Errorf("revision = %d after a close that wrote; the token did not move", closed)
+		}
+		if shown := bdProxiedShow(t, bd, p.dir, issue.ID); string(shown.Status) != "closed" {
+			t.Fatalf("the guarded close did not land: status %q", shown.Status)
+		}
+
+		// THE CLAIM ONLY A REAL STORE CAN SHOW: the guard is checked BEFORE the
+		// idempotent re-close. The same body that earns a 200 with
+		// `already_closed` unguarded is a 409 when it carries a token the close
+		// itself has already invalidated — which is what lets a client read
+		// `already_closed` as "and nothing has happened here since".
+		status, problem = sp.closeIssue(t, issue.ID,
+			`{"actor":"http-agent","expected_version":`+strconv.FormatInt(second, 10)+`}`)
+		if status != http.StatusConflict {
+			t.Fatalf("guarded re-close with a pre-close token: status = %d, want 409: %v", status, problem)
+		}
+
+		// Unguarded, that same replay is the ordinary idempotent answer.
+		status, raw = sp.closeIssueRaw(t, issue.ID, `{"actor":"http-agent","reason":"REWRITTEN"}`)
+		if status != http.StatusOK {
+			t.Fatalf("unguarded re-close: status = %d, want 200: %s", status, raw)
+		}
+		replay := decodeVerbBody(t, "close", raw)
+		if replay["already_closed"] != true {
+			t.Errorf("already_closed = %v, want true", replay["already_closed"])
+		}
+		afterReplay := revisionOf(t, raw)
+		if afterReplay != closed {
+			t.Errorf("revision = %d after an idempotent re-close, want the unchanged %d: a replay that writes nothing must not move the token",
+				afterReplay, closed)
+		}
+
+		// The reopen's own guard, on the mirror. Stale first.
+		status, problem = sp.reopenIssue(t, issue.ID,
+			`{"actor":"http-agent","expected_version":`+strconv.FormatInt(second, 10)+`}`)
+		if status != http.StatusConflict {
+			t.Fatalf("stale reopen: status = %d, want 409: %v", status, problem)
+		}
+		if problem["code"] != "precondition_failed" || problem["param"] != "expected_version" {
+			t.Errorf("stale reopen: code = %v param = %v", problem["code"], problem["param"])
+		}
+		if shown := bdProxiedShow(t, bd, p.dir, issue.ID); string(shown.Status) != "closed" {
+			t.Errorf("a refused guard reopened the row: status %q", shown.Status)
+		}
+
+		// And the loop closes: the token the last successful write answered
+		// with is the one that lands.
+		status, raw = sp.reopenIssueRaw(t, issue.ID,
+			`{"actor":"http-agent","expected_version":`+strconv.FormatInt(afterReplay, 10)+`}`)
+		if status != http.StatusOK {
+			t.Fatalf("guarded reopen: status = %d, want 200: %s", status, raw)
+		}
+		if reopened := revisionOf(t, raw); reopened == afterReplay {
+			t.Errorf("revision = %d after a reopen that wrote; the token did not move", reopened)
+		}
+		if shown := bdProxiedShow(t, bd, p.dir, issue.ID); string(shown.Status) != "open" || shown.CloseReason != "" {
+			t.Errorf("the guarded reopen did not land: status %q reason %q", shown.Status, shown.CloseReason)
 		}
 	})
 

--- a/cmd/bd/serve_delete_proxied_integration_test.go
+++ b/cmd/bd/serve_delete_proxied_integration_test.go
@@ -1,0 +1,207 @@
+//go:build cgo
+
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// End-to-end for the DELETE's row-version guard, against real Dolt through a
+// real `bd serve` subprocess.
+//
+// The pure tests in internal/httpapi cover the wire edge on a fake role — the
+// arity rule, the member projection, the 409's shape. What only this level can
+// prove is the part that matters most on the one operation whose mistakes are
+// irreversible: that a stale token really refuses against a store and the rows
+// are STILL THERE afterwards, and that neither `force` nor `cascade` walks past
+// it. A fake can report a refusal; only a real row can show nothing was erased.
+//
+// The role-level guard is owned against real backends by the deleter contract
+// (backend/conformance/deleter_contract.go); this test owns the wire-to-role
+// seam and cites that one rather than duplicating it.
+
+// deleteIssues posts a delete and returns the status and the UNDECODED body.
+func (sp *serveProcess) deleteIssues(t *testing.T, body string) (int, []byte) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, sp.url("/v0/beads/issues:delete"), strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("new delete request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := sp.client.Do(req)
+	if err != nil {
+		t.Fatalf("POST issues:delete: %v\nstderr:\n%s", err, sp.stderr.String())
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read delete body: %v", err)
+	}
+	return resp.StatusCode, raw
+}
+
+// deleteProblem decodes a refusal body.
+func deleteProblem(t *testing.T, raw []byte) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("decode delete problem %q: %v", raw, err)
+	}
+	return m
+}
+
+// stillThere fails unless the bead is readable, which is the assertion every
+// refusal case here ends on. A delete that refused and erased anyway is the
+// failure this whole slice exists to make impossible.
+func stillThere(t *testing.T, bd, dir, id string) {
+	t.Helper()
+	if shown := bdProxiedShow(t, bd, dir, id); shown.ID != id {
+		t.Fatalf("bd show %s answered with %q; the refused delete erased it", id, shown.ID)
+	}
+}
+
+func TestProxiedServerServeDelete(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+	p := newSharedProxiedProject(t, bd, "srvdel")
+	sp := startServe(t, bd, p.dir, bdProxiedEnv(p.dir))
+
+	// The guard's whole loop on the operation where being wrong cannot be
+	// undone: a token minted by a write, invalidated by another actor, refused
+	// while the bead survives, and then honored.
+	t.Run("a stale guard refuses and the bead survives", func(t *testing.T) {
+		issue := bdProxiedCreate(t, bd, p.dir, "guarded delete", "-p", "2")
+
+		status, raw := sp.updateIssueRaw(t, issue.ID, `{"actor":"http-agent","patch":{"notes":"seeded"}}`)
+		if status != http.StatusOK {
+			t.Fatalf("the seeding write: status = %d, want 200: %s", status, raw)
+		}
+		first := revisionOf(t, raw)
+
+		status, raw = sp.updateIssueRaw(t, issue.ID, `{"actor":"other-agent","patch":{"notes":"moved"}}`)
+		if status != http.StatusOK {
+			t.Fatalf("the concurrent write: status = %d, want 200: %s", status, raw)
+		}
+		second := revisionOf(t, raw)
+		if second == first {
+			t.Fatalf("revision = %d after a second write; a token that does not move makes the guard vacuous", second)
+		}
+
+		status, raw = sp.deleteIssues(t, `{"ids":["`+issue.ID+`"],"actor":"http-agent","expected_version":`+strconv.FormatInt(first, 10)+`}`)
+		if status != http.StatusConflict {
+			t.Fatalf("stale delete: status = %d, want 409: %s", status, raw)
+		}
+		problem := deleteProblem(t, raw)
+		if problem["code"] != "precondition_failed" || problem["param"] != "expected_version" {
+			t.Errorf("stale delete: code = %v param = %v, want precondition_failed / expected_version",
+				problem["code"], problem["param"])
+		}
+		stillThere(t, bd, p.dir, issue.ID)
+
+		// FORCE AND CASCADE BYPASS POLICY, NEVER THE PRECONDITION. Both say what
+		// to do about OTHER beads; neither says the bead named is still the one
+		// the caller read.
+		for _, flags := range []string{`"force":true`, `"cascade":true`, `"force":true,"cascade":true`} {
+			status, raw = sp.deleteIssues(t, `{"ids":["`+issue.ID+`"],`+flags+`,"expected_version":`+strconv.FormatInt(first, 10)+`}`)
+			if status != http.StatusConflict {
+				t.Fatalf("stale delete with %s: status = %d, want 409: %s", flags, status, raw)
+			}
+			stillThere(t, bd, p.dir, issue.ID)
+		}
+
+		// A DRY RUN REFUSES WHERE THE REAL RUN WOULD, which is the whole value
+		// of previewing a guarded delete: a clean preview means the real request
+		// will not stop half-explained.
+		status, raw = sp.deleteIssues(t, `{"ids":["`+issue.ID+`"],"dry_run":true,"expected_version":`+strconv.FormatInt(first, 10)+`}`)
+		if status != http.StatusConflict {
+			t.Fatalf("stale dry run: status = %d, want 409: %s", status, raw)
+		}
+		stillThere(t, bd, p.dir, issue.ID)
+
+		// And the fresh token lands.
+		status, raw = sp.deleteIssues(t, `{"ids":["`+issue.ID+`"],"actor":"http-agent","expected_version":`+strconv.FormatInt(second, 10)+`}`)
+		if status != http.StatusOK {
+			t.Fatalf("guarded delete: status = %d, want 200: %s", status, raw)
+		}
+		var result struct {
+			Deleted int `json:"deleted"`
+		}
+		if err := json.Unmarshal(raw, &result); err != nil {
+			t.Fatalf("decode delete result %q: %v", raw, err)
+		}
+		if result.Deleted != 1 {
+			t.Errorf("deleted = %d, want 1: %s", result.Deleted, raw)
+		}
+		bdProxiedShowFail(t, bd, p.dir, issue.ID, "--json")
+	})
+
+	// The arity rule, over the wire and against a store: refused before
+	// anything is read, so BOTH beads are still there. The role refuses the
+	// same pair, but with no `param` — the member name is what this refusal
+	// adds, and it is the whole recovery.
+	t.Run("a guard beside two beads is refused and neither is erased", func(t *testing.T) {
+		a := bdProxiedCreate(t, bd, p.dir, "arity a", "-p", "2")
+		b := bdProxiedCreate(t, bd, p.dir, "arity b", "-p", "2")
+
+		status, raw := sp.deleteIssues(t, `{"ids":["`+a.ID+`","`+b.ID+`"],"expected_version":41}`)
+		if status != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400: %s", status, raw)
+		}
+		problem := deleteProblem(t, raw)
+		if problem["code"] != "invalid_argument" || problem["param"] != "expected_version" {
+			t.Errorf("code = %v param = %v, want invalid_argument / expected_version", problem["code"], problem["param"])
+		}
+		stillThere(t, bd, p.dir, a.ID)
+		stillThere(t, bd, p.dir, b.ID)
+
+		// The same two ids WITHOUT the guard are an ordinary delete, which is
+		// what makes the refusal above a statement about the guard rather than
+		// about the list.
+		status, raw = sp.deleteIssues(t, `{"ids":["`+a.ID+`","`+b.ID+`"],"actor":"http-agent"}`)
+		if status != http.StatusOK {
+			t.Fatalf("unguarded two-id delete: status = %d, want 200: %s", status, raw)
+		}
+	})
+
+	// DUPLICATES COLLAPSE FIRST, so repeating one id beside a guard names one
+	// bead and is legal — the rule the handler respells because the transport
+	// boundary keeps the library's normalizer out of it. This is the case that
+	// would go red if the wire's counting ever drifted from the library's.
+	t.Run("a repeated id beside a guard is one bead", func(t *testing.T) {
+		issue := bdProxiedCreate(t, bd, p.dir, "repeated id", "-p", "2")
+
+		status, raw := sp.updateIssueRaw(t, issue.ID, `{"actor":"http-agent","patch":{"notes":"seeded"}}`)
+		if status != http.StatusOK {
+			t.Fatalf("the seeding write: status = %d, want 200: %s", status, raw)
+		}
+		token := revisionOf(t, raw)
+
+		status, raw = sp.deleteIssues(t,
+			`{"ids":["`+issue.ID+`","`+issue.ID+`"],"actor":"http-agent","expected_version":`+strconv.FormatInt(token, 10)+`}`)
+		if status != http.StatusOK {
+			t.Fatalf("status = %d, want 200 — duplicates collapse to one bead: %s", status, raw)
+		}
+		bdProxiedShowFail(t, bd, p.dir, issue.ID, "--json")
+	})
+
+	// The 404 outranks the guard: a request that named no bead has nothing to
+	// be stale about, so the caller is told about the typo rather than about a
+	// version it cannot check.
+	t.Run("an absent id outranks the guard", func(t *testing.T) {
+		status, raw := sp.deleteIssues(t, `{"ids":["bd-nosuchbead"],"expected_version":41}`)
+		if status != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404: %s", status, raw)
+		}
+		if problem := deleteProblem(t, raw); problem["code"] != "not_found" {
+			t.Errorf("code = %v, want not_found", problem["code"])
+		}
+	})
+
+	sp.shutdown(t)
+}

--- a/internal/httpapi/apigen/types.gen.go
+++ b/internal/httpapi/apigen/types.gen.go
@@ -736,7 +736,18 @@ type CloseIssueRequest struct {
 	// Actor Who is closing the issue. `ClaimRequest.actor`'s rules exactly: the server trims it, then refuses an empty result, anything longer than 256 BYTES (the `maxLength` above counts characters — the byte limit is the binding one), and any control character including newline. The value reaches stored columns, event-stream attribution and the storage commit message, so an unvalidated newline would forge audit-trail lines.
 	Actor string `json:"actor"`
 
+	// ExpectedVersion Requires the row's revision to equal this value BEFORE the close. A miss refuses the whole request with `409 precondition_failed` and writes nothing — `UpdateIssueRequest.expected_version`'s contract, on the operation that closes one row.
+	//
+	// IT IS CHECKED BEFORE THE IDEMPOTENT RE-CLOSE, which is the one place this guard differs from the update's. A re-close of a row somebody else has moved since the caller read it is a `409` and not the 200-with-`already_closed` the same body earns without a guard: a replay whose premise has expired is a refusal the caller wants to see, and it is the only way `already_closed` can be trusted as "nothing has happened here since".
+	//
+	// The token is the `revision` this operation's own response carries. Compose the next expectation from the value a write ANSWERED with, never from a number the client incremented itself: the token is OPAQUE and compared for equality alone, so it has no predecessor a client can compute. No READ on this surface publishes one yet, so a first guarded close seeds itself from an unguarded lifecycle write or from `POST /v0/beads/issues:batchApply`'s `ApplyItemResult.revision`.
+	//
+	// DECODE IT AS A 64-BIT INTEGER, for the reason `UpdateIssueRequest.expected_version` spells out: an IEEE-754-double parser corrupts it silently, and the corruption only surfaces as a `precondition_failed` on the NEXT request.
+	ExpectedVersion *int64 `json:"expected_version,omitempty"`
+
 	// Force Bypass close policy — the open-children refusal and the live-blocker refusal — and nothing else. The refusals are the ROLE's, so this endpoint cannot skip a guard by forgetting one exists. A forced close still reports `open_children`.
+	//
+	// IT BYPASSES POLICY, NEVER A PRECONDITION. `expected_version` is still checked with it set, for the reason `issueops.CloseRequest.Force` gives: a caller saying "close it anyway" has said nothing about whether the row is still the one it read.
 	Force *bool `json:"force,omitempty"`
 
 	// Reason Why the issue is closed. Stored on the issue and read back as `close_reason`. THE FIRST CLOSE WINS: an idempotent re-close writes neither this nor `session`, so a replayed close cannot rewrite the record of why the work ended. Refused for control characters, and bounded by what the column holds rather than by the number above.
@@ -756,6 +767,13 @@ type CloseIssueResponse struct {
 
 	// OpenChildren How many open children the close observed. Reported by a FORCED close — including an idempotent re-close — because a caller that bypassed the guard is exactly the caller that wants the number. An unforced close that got this far had none, so it reports 0.
 	OpenChildren int `json:"open_children"`
+
+	// Revision The row's optimistic-concurrency token AFTER this close, spelled the way `UpdateIssueResponse.revision` spells it.
+	//
+	// It is here because `expected_version` is: a guard whose token no response carries is a guard a caller cannot fill, and a close-then-reopen or close-then-delete chain has to compose its next expectation from the value the close ANSWERED with. An idempotent re-close carries one too — the row still has a version, and a caller that guarded a replay needs the token whether or not the replay wrote.
+	//
+	// DECODE IT AS A 64-BIT INTEGER, for the reason `UpdateIssueResponse.revision` spells out.
+	Revision int64 `json:"revision"`
 }
 
 // CloseOutcome What happened to ONE requested item.
@@ -1008,6 +1026,19 @@ type DeleteIssuesRequest struct {
 
 	// DryRun Report what the deletion WOULD do and change nothing. The counts and BOTH refusals are the ones the real request would produce, computed against the same snapshot, and nothing is recorded in history either.
 	DryRun *bool `json:"dry_run,omitempty"`
+
+	// ExpectedVersion Requires the named bead's revision to equal this value before anything is erased. A miss refuses the whole request with `409 precondition_failed` and deletes NOTHING — `UpdateIssueRequest.expected_version`'s contract, on the operation where being wrong about which row you are looking at cannot be undone.
+	//
+	// IT REQUIRES A SINGLE-ID REQUEST. Sending it beside more than one DISTINCT id is a `400` naming this member, refused before anything is read. One token cannot describe two rows: the version space is per-row, so checking one number against a list would pass by coincidence for a list of never-written rows — every one of them holds 0 — and fail forever for a list whose rows have since diverged. A guard that passes by coincidence and a guard nobody can satisfy are one defect seen from two sides. Delete one bead per guarded request; the per-id shape a batch would need is a token PER id, which is a different request type.
+	//
+	// DUPLICATES COLLAPSE FIRST, so `{"ids":["be-1","be-1"], "expected_version":N}` names one bead and is legal. The refusal counts DISTINCT ids, not mentions, exactly as the library surface does.
+	//
+	// NEITHER `cascade` NOR `force` BYPASSES IT. Both bypass POLICY — the dependents guard — and never a precondition. Under `cascade` the guard still covers only the NAMED bead: the closure is resolved inside the deleting transaction, so a matching token promises the row is the one you read and promises nothing about how far the closure has grown since. A caller that needs the closure itself pinned wants `dry_run` first.
+	//
+	// IT GUARDS LIFECYCLE STATE, NOT THE GRAPH. The token is reminted by status, assignee and started-at writes and deliberately not by label, dependency or rename writes, so a match does not promise the bead's edges are the ones you saw.
+	//
+	// The token is the `revision` a lifecycle write answers with. DECODE IT AS A 64-BIT INTEGER, for the reason `UpdateIssueRequest.expected_version` spells out; no READ on this surface publishes one yet.
+	ExpectedVersion *int64 `json:"expected_version,omitempty"`
 
 	// Force Delete the named beads and leave their dependents ORPHANED, reported in `orphaned`. Without it and without `cascade`, a named bead with a dependent the request did not name is refused.
 	//
@@ -1500,6 +1531,13 @@ type ReopenIssueRequest struct {
 	// Actor Who is reopening the issue. `ClaimRequest.actor`'s rules exactly: the server trims it, then refuses an empty result, anything longer than 256 BYTES (the `maxLength` above counts characters — the byte limit is the binding one), and any control character including newline. The value reaches the `reopened` event's attribution and the storage commit message, so an unvalidated newline would forge audit-trail lines.
 	Actor string `json:"actor"`
 
+	// ExpectedVersion Requires the row's revision to equal this value BEFORE the reopen. A miss refuses the whole request with `409 precondition_failed` and writes nothing — `CloseIssueRequest.expected_version`'s contract, on the close's mirror.
+	//
+	// IT IS CHECKED BEFORE THE NON-DONE NO-OP, the mirror of the close's check-before-the-idempotent-re-close, and for the same reason: a reopen of a row somebody else has moved is a `409` rather than the 200-with-`already_open` the same body earns unguarded, which is what lets `already_open` be read as "nothing has happened here since".
+	//
+	// The token is the `revision` this operation's own response carries; compose the next expectation from a value a write ANSWERED with and never from one the client computed. DECODE IT AS A 64-BIT INTEGER, for the reason `UpdateIssueRequest.expected_version` spells out.
+	ExpectedVersion *int64 `json:"expected_version,omitempty"`
+
 	// Reason Why the issue is being reopened. Recorded on the `reopened` EVENT this move records — not on a field of the issue, and not carried in the response, so a caller that wants it back reads the issue's events. Refused for control characters, and bounded by what the column holds rather than by the number above.
 	Reason *string `json:"reason,omitempty"`
 }
@@ -1511,6 +1549,9 @@ type ReopenIssueResponse struct {
 
 	// Issue A tracked work item. Property semantics documented here apply to every schema that repeats them below.
 	Issue Issue `json:"issue"`
+
+	// Revision The row's optimistic-concurrency token AFTER this reopen, spelled the way `CloseIssueResponse.revision` spells it and here for the same reason: a recovery flow that reopens and then re-closes composes its next `expected_version` from this value. DECODE IT AS A 64-BIT INTEGER.
+	Revision int64 `json:"revision"`
 }
 
 // Setting One entry of the workspace's stored settings plane.

--- a/internal/httpapi/batch_apply.go
+++ b/internal/httpapi/batch_apply.go
@@ -713,7 +713,7 @@ func applyCloseItem(prefix string, raw map[string]json.RawMessage) (*issueops.Cl
 	if res != nil {
 		return nil, res
 	}
-	expectedVersion, res := applyInt64Member(raw, prefix, "expected_version")
+	expectedVersion, res := applyVersionGuardMember(raw, prefix)
 	if res != nil {
 		return nil, res
 	}
@@ -1180,7 +1180,7 @@ func applyRequiredText(raw map[string]json.RawMessage, prefix, member string) (s
 	return value, nil
 }
 
-// applyTextMember, applyBoolMember and applyInt64Member are the pure twins of
+// applyTextMember, applyBoolMember and applyVersionGuardMember are the pure twins of
 // Server.storedTextMember and Server.booleanMember, with their rules unchanged:
 // an absent member is the zero value the role reads as "not supplied", an
 // explicit `null` is a 400 naming the member rather than a third state, and a
@@ -1219,14 +1219,27 @@ func applyBoolMember(raw map[string]json.RawMessage, prefix, member string) (boo
 	return *value, nil
 }
 
-func applyInt64Member(raw map[string]json.RawMessage, prefix, member string) (*int64, *Result) {
-	encoded, ok := raw[member]
+// applyVersionGuardMember is the family's int64 reader, and it names the member
+// itself rather than taking one.
+//
+// Its siblings above are generic because they read many members; this one has
+// read exactly one on every operation that has ever published a 64-bit member —
+// the row-version guard — so the member name lives in the function instead of
+// at five call sites that could disagree about how to spell it. A second int64
+// member would re-generalize it, which is a two-line change and not a reason to
+// carry a parameter nothing varies.
+//
+// prefix stays, because a batch item's guard is reported qualified by the item
+// that carried it where a single operation's is spelled bare.
+func applyVersionGuardMember(raw map[string]json.RawMessage, prefix string) (*int64, *Result) {
+	encoded, ok := raw[expectedVersionMember]
 	if !ok {
 		return nil, nil
 	}
 	var value *int64
 	if err := json.Unmarshal(encoded, &value); err != nil || value == nil {
-		res := InvalidArgument(prefix+member, ReasonInvalidValue, "`"+member+"` must be an integer")
+		res := InvalidArgument(prefix+expectedVersionMember, ReasonInvalidValue,
+			"`"+expectedVersionMember+"` must be an integer")
 		return nil, &res
 	}
 	return value, nil

--- a/internal/httpapi/close.go
+++ b/internal/httpapi/close.go
@@ -217,16 +217,17 @@ func (s *Server) booleanMember(w http.ResponseWriter, r *http.Request, members m
 // failClose answers a failed close: the precondition's 409, then the shared
 // classification with the extension member the open-children 409 carries.
 //
-// THE PRECONDITION ARM IS MATCHED TYPED AND FIRST, and that placement is the
-// whole correctness of this function rather than a stylistic preference.
-// ClassifyError has no row for ErrVersionMismatch — deliberately, since it is a
-// per-operation guard rather than a shared refusal — so below this arm a
-// version mismatch falls through failErr's default into a GENERIC 500, on both
-// legs, for a condition this document names by code. Neither leg wraps it in
-// ErrValidation either: the store legs return CheckVersionInTx's error through
-// runIssueOperationTx unchanged and the unit of work returns its own, so it
-// arrives as a bare sentinel with nothing else to catch it. Verified by
-// mutation, not asserted: removing the arm turns
+// THE PRECONDITION ARM IS MATCHED TYPED AND FIRST, obeying the rule
+// ClassifyError states rather than restating it: that function cannot build
+// this 409, because the refusal echoes the value the REQUEST guarded on and it
+// is handed an error alone.
+//
+// The cost of forgetting the arm is not a worse 4xx. Neither leg wraps
+// ErrVersionMismatch in ErrValidation — the store legs return CheckVersionInTx's
+// error through runIssueOperationTx unchanged and the unit of work returns its
+// own — so it arrives as a bare sentinel, falls through failErr's default, and
+// every guard miss on this operation becomes a GENERIC 500. Verified by
+// mutation rather than asserted: removing the arm turns
 // TestCloseRefusesAStaleGuard into a 500.
 //
 // The open-children count comes from *issueops.CloseOpenChildrenError's own

--- a/internal/httpapi/close.go
+++ b/internal/httpapi/close.go
@@ -17,7 +17,7 @@ import (
 // schema is additionalProperties: false, so anything else is refused BY NAME —
 // which is why the body is decoded as raw members first, the posture claim and
 // batchCreate already take.
-var closeRequestMembers = []string{"actor", "reason", "session", "force"}
+var closeRequestMembers = []string{"actor", "reason", "session", "force", expectedVersionMember}
 
 // handleClose closes one issue: the second half of the loop this surface exists
 // to serve, and the half that still forked a subprocess.
@@ -55,21 +55,28 @@ func (s *Server) handleClose(w http.ResponseWriter, r *http.Request) {
 
 	lifecycle, err := s.lifecycle(r)
 	if err != nil {
-		s.failClose(w, r, err)
+		s.failClose(w, r, request, err)
 		return
 	}
 	result, err := lifecycle.Close(r.Context(), request)
 	if err != nil {
-		s.failClose(w, r, err)
+		s.failClose(w, r, request, err)
 		return
 	}
 	// `already_closed` is the wire's name for the idempotent re-close, which is
 	// exactly the case the role reports as an unchanged result — and the case
 	// whose `reason` and `session` were NOT rewritten.
+	//
+	// `revision` is the row's post-close concurrency token, read off the same
+	// snapshot rather than computed. It is on the wire because `expected_version`
+	// is: a guard whose token no response carries is a guard a caller cannot
+	// fill. types.Issue.RowVersion is `json:"-"`, so the Issue body cannot carry
+	// it and this member is where it lives — updateIssue's arrangement exactly.
 	writeJSON(w, apigen.CloseIssueResponse{
 		Issue:         *result.Issue,
 		AlreadyClosed: !result.Changed,
 		OpenChildren:  result.OpenChildren,
+		Revision:      result.Issue.RowVersion,
 	})
 }
 
@@ -103,16 +110,22 @@ func (s *Server) closeRequest(w http.ResponseWriter, r *http.Request, id string)
 	if !ok {
 		return issueops.CloseRequest{}, false
 	}
+	// The guard the response's `revision` exists to feed. Read through the
+	// shared int64 decoder rather than a local one so a malformed token is
+	// refused with the same sentence on every operation that takes one.
+	expectedVersion, res := applyVersionGuardMember(members, "")
+	if res != nil {
+		s.fail(w, r, *res)
+		return issueops.CloseRequest{}, false
+	}
 
-	// ExpectedVersion stays unpublished on this surface: a precondition would
-	// need a frozen conflict code for ErrVersionMismatch and a `row_version` on
-	// the issue body for clients to echo. Both are additive later.
 	return issueops.CloseRequest{
-		Actor:   actor,
-		IssueID: id,
-		Reason:  reason,
-		Session: session,
-		Force:   force,
+		Actor:           actor,
+		IssueID:         id,
+		Reason:          reason,
+		Session:         session,
+		Force:           force,
+		ExpectedVersion: expectedVersion,
 	}, true
 }
 
@@ -201,18 +214,34 @@ func (s *Server) booleanMember(w http.ResponseWriter, r *http.Request, members m
 	return *value, true
 }
 
-// failClose answers a failed close, adding the extension member the
-// open-children 409 carries.
+// failClose answers a failed close: the precondition's 409, then the shared
+// classification with the extension member the open-children 409 carries.
 //
-// The count comes from *issueops.CloseOpenChildrenError's own field, which the
-// role fills inside the transaction that refused — never from parsing the
-// sentinel's message ("%d open child issue(s)"). That substring classification
-// is what a client adopting this endpoint gets to delete, and it can only
-// delete it if the server never does it either.
+// THE PRECONDITION ARM IS MATCHED TYPED AND FIRST, and that placement is the
+// whole correctness of this function rather than a stylistic preference.
+// ClassifyError has no row for ErrVersionMismatch — deliberately, since it is a
+// per-operation guard rather than a shared refusal — so below this arm a
+// version mismatch falls through failErr's default into a GENERIC 500, on both
+// legs, for a condition this document names by code. Neither leg wraps it in
+// ErrValidation either: the store legs return CheckVersionInTx's error through
+// runIssueOperationTx unchanged and the unit of work returns its own, so it
+// arrives as a bare sentinel with nothing else to catch it. Verified by
+// mutation, not asserted: removing the arm turns
+// TestCloseRefusesAStaleGuard into a 500.
+//
+// The open-children count comes from *issueops.CloseOpenChildrenError's own
+// field, which the role fills inside the transaction that refused — never from
+// parsing the sentinel's message ("%d open child issue(s)"). That substring
+// classification is what a client adopting this endpoint gets to delete, and it
+// can only delete it if the server never does it either.
 //
 // The live-blocker refusal shares the code and carries NO member, which is what
 // makes member presence the discriminator the document promises.
-func (s *Server) failClose(w http.ResponseWriter, r *http.Request, err error) {
+func (s *Server) failClose(w http.ResponseWriter, r *http.Request, request issueops.CloseRequest, err error) {
+	if errors.Is(err, issueops.ErrVersionMismatch) {
+		s.fail(w, r, versionPreconditionResult(request.ExpectedVersion))
+		return
+	}
 	var openChildren *issueops.CloseOpenChildrenError
 	if !errors.As(err, &openChildren) {
 		s.failErr(w, r, err)
@@ -224,3 +253,32 @@ func (s *Server) failClose(w http.ResponseWriter, r *http.Request, err error) {
 	}
 	s.fail(w, r, res)
 }
+
+// versionPreconditionResult builds the 409 for the row-version guard that
+// missed, naming the member and echoing what the request asked for.
+//
+// It is shared by the close, the reopen and the delete because all three
+// publish ONE guard, where updatePreconditionResult has to choose between
+// three. The rule is updatePreconditionResult's unchanged: the expected value
+// comes from the REQUEST rather than from a read, and the observed value is
+// absent, because the refusal rolled its transaction back and a read afterwards
+// would describe a row the refusal never saw. See PreconditionFailed.
+//
+// A nil expectation cannot reach here from any of the three handlers — the
+// role raises this sentinel only when a guard was sent — but it is handled
+// rather than dereferenced, so a role that returns it unprompted is a 409
+// without the echoed member instead of a panic on a live server.
+func versionPreconditionResult(expected *int64) Result {
+	res := PreconditionFailed()
+	member := expectedVersionMember
+	res.Problem.Param = &member
+	if expected != nil {
+		res = res.WithExpectedVersion(*expected)
+	}
+	return res
+}
+
+// expectedVersionMember is the one spelling of the row-version guard, shared by
+// the three operations that publish it so the member name a client reads off
+// `param` cannot drift from the member name it sent.
+const expectedVersionMember = "expected_version"

--- a/internal/httpapi/close_test.go
+++ b/internal/httpapi/close_test.go
@@ -1,6 +1,7 @@
 package httpapi
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -528,5 +529,225 @@ func TestCloseResolvesAcrossBothPlanes(t *testing.T) {
 	}
 	if got := lifecycle.closeRequests(); len(got) != 1 || got[0].IssueID != "bd-w1" {
 		t.Fatalf("the role received %+v, want the wisp id unchanged", got)
+	}
+}
+
+// guardToken is the fixture row version every guarded case in this package
+// uses, and its SIZE is the point: it is past 2^53, where an IEEE-754 double's
+// ulp is already 2, so a response member read through `map[string]any` comes
+// back as a value NEAR the token and is not it.
+//
+// Live row_lock tokens run in this range, which is how the update slice's first
+// integration case failed — the guard it composed from a float64-decoded
+// revision was refused against a row nothing else had touched. Pinning it here
+// means a member decoded the wrong way fails in milliseconds instead of against
+// real Dolt.
+const guardToken int64 = 9007199254740993
+
+// guard spells a row-version expectation the way a request carries one: through
+// a pointer, so that nil ("do not check") stays distinct from a guard on the
+// never-written version 0.
+func guard(v int64) *int64 { return &v }
+
+// revisionOf reads `revision` as the 64-BIT INTEGER the document declares,
+// which is the whole reason it exists beside decodeBody: that helper decodes
+// into `any`, and `any` is a float64.
+//
+// NEVER ORDER IT AND NEVER COMPUTE ONE. The token is opaque and compared for
+// equality alone, so "the previous revision" is not `revision - 1`; it is the
+// value an earlier write answered with.
+func revisionOf(t *testing.T, resp *http.Response) int64 {
+	t.Helper()
+	raw := readAll(t, resp)
+	var body struct {
+		Revision *int64 `json:"revision"`
+	}
+	if err := json.Unmarshal([]byte(raw), &body); err != nil {
+		t.Fatalf("decode revision from %q: %v", raw, err)
+	}
+	if body.Revision == nil {
+		t.Fatalf("the response carries no `revision`: %s", raw)
+	}
+	return *body.Revision
+}
+
+// TestCloseForwardsTheVersionGuard: the member reaches the role as the POINTER
+// it models, and an absent member stays nil.
+//
+// The nil half is not decoration. issueops.CloseRequest.ExpectedVersion is a
+// pointer precisely so that "do not check" is distinguishable from a caller
+// guarding on the never-written version 0, so a handler that collapsed absence
+// into &0 would refuse every close of a row that has ever been written.
+func TestCloseForwardsTheVersionGuard(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+		want *int64
+	}{
+		{"a guard is forwarded", `{"actor":"alice","expected_version":9007199254740993}`, guard(guardToken)},
+		{"the never-written version is a real guard", `{"actor":"alice","expected_version":0}`, guard(0)},
+		{"an absent guard stays nil", `{"actor":"alice"}`, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lifecycle := &roleLifecycle{closeResult: issueops.CloseResult{Issue: closedIssue("bd-1"), Changed: true}}
+			ts := newCloseServer(t, lifecycle)
+
+			resp := ts.closeIssue(t, closePath, tc.body)
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+			}
+			got := lifecycle.closeRequests()
+			if len(got) != 1 {
+				t.Fatalf("%d closes, want 1", len(got))
+			}
+			switch {
+			case tc.want == nil && got[0].ExpectedVersion != nil:
+				t.Errorf("ExpectedVersion = %d, want nil: an absent member must not become a guard", *got[0].ExpectedVersion)
+			case tc.want != nil && got[0].ExpectedVersion == nil:
+				t.Errorf("ExpectedVersion = nil, want %d", *tc.want)
+			case tc.want != nil && *got[0].ExpectedVersion != *tc.want:
+				t.Errorf("ExpectedVersion = %d, want %d", *got[0].ExpectedVersion, *tc.want)
+			}
+		})
+	}
+}
+
+// TestCloseAnswersWithTheRowsRevision is the other half of the guard: the token
+// a caller's NEXT request needs comes back on this one.
+//
+// It asserts the value against the row the ROLE answered with rather than
+// against whatever the handler put there, which is the difference between this
+// case and one that cannot fail. The update slice measured that exactly: its
+// first version echoed the handler's own number and stayed green against a
+// `revision: 0`.
+//
+// The idempotent re-close carries one too. A caller that guarded a replay needs
+// the token whether or not the replay wrote, and `already_closed: true` with no
+// revision beside it would leave a chain unable to continue.
+func TestCloseAnswersWithTheRowsRevision(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		changed bool
+	}{
+		{"a close that wrote", true},
+		{"an idempotent re-close", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			issue := closedIssue("bd-1")
+			issue.RowVersion = guardToken
+			lifecycle := &roleLifecycle{closeResult: issueops.CloseResult{Issue: issue, Changed: tc.changed}}
+			ts := newCloseServer(t, lifecycle)
+
+			resp := ts.closeIssue(t, closePath, `{"actor":"alice"}`)
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+			}
+			if got := revisionOf(t, resp); got != guardToken {
+				t.Errorf("revision = %d, want the row's %d", got, guardToken)
+			}
+		})
+	}
+}
+
+// TestCloseRefusesAStaleGuard is the 409, and it is the case whose GREEN is
+// bought by the arm's placement in failClose.
+//
+// ClassifyError has no row for ErrVersionMismatch and neither leg wraps it, so
+// the arm's absence is not a worse status — it is a 500 for a refusal this
+// document names by code. Mutation-checked: deleting the arm makes this case
+// fail with 500.
+//
+// `actual_version` stays ABSENT. The refusal rolled its transaction back, so a
+// read afterwards would describe a row it never saw; PreconditionFailed says so
+// and this pins it.
+func TestCloseRefusesAStaleGuard(t *testing.T) {
+	lifecycle := &roleLifecycle{closeErr: fmt.Errorf("close bd-1: %w", issueops.ErrVersionMismatch)}
+	ts := newCloseServer(t, lifecycle)
+
+	resp := ts.closeIssue(t, closePath, `{"actor":"alice","expected_version":9007199254740993}`)
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status = %d, want 409: %s", resp.StatusCode, readAll(t, resp))
+	}
+	body := decodeBody(t, resp)
+	if body["code"] != string(CodePreconditionFailed) {
+		t.Errorf("code = %v, want %s", body["code"], CodePreconditionFailed)
+	}
+	if body["param"] != expectedVersionMember {
+		t.Errorf("param = %v, want %s", body["param"], expectedVersionMember)
+	}
+	if _, present := body["expected_version"]; !present {
+		t.Errorf("the refusal does not echo the guard the request sent: %v", body)
+	}
+	if _, present := body["actual_version"]; present {
+		t.Errorf("actual_version = %v; the refusing transaction rolled back, so there is no observed value to report",
+			body["actual_version"])
+	}
+	// It is not the close-policy refusal wearing a different code.
+	if _, present := body["open_children"]; present {
+		t.Errorf("open_children = %v on a precondition refusal; that member is not_closable's discriminator", body["open_children"])
+	}
+}
+
+// TestCloseGuardOutranksClosePolicy pins the ORDER the role documents, over the
+// wire: ExpectedVersion is checked first, so a request that is both stale and
+// policy-refused reports the stale guard.
+//
+// A caller told "close the children first" when its whole view of the row has
+// moved would be acting on information that has already changed.
+func TestCloseGuardOutranksClosePolicy(t *testing.T) {
+	lifecycle := &roleLifecycle{closeErr: fmt.Errorf("close bd-1: %w", issueops.ErrVersionMismatch)}
+	ts := newCloseServer(t, lifecycle)
+
+	resp := ts.closeIssue(t, closePath, `{"actor":"alice","expected_version":41,"force":false}`)
+	body := decodeBody(t, resp)
+	if body["code"] != string(CodePreconditionFailed) {
+		t.Errorf("code = %v, want %s: the role checks the version before policy and the wire must not reorder it",
+			body["code"], CodePreconditionFailed)
+	}
+}
+
+// TestCloseForceDoesNotBypassTheGuard pins the two members as INDEPENDENT.
+// `force` says "close it even though the graph objects"; the guard says "only
+// if this is still the row I read". A handler that dropped the guard when force
+// arrived would let the one member that cannot be undone travel unchecked.
+func TestCloseForceDoesNotBypassTheGuard(t *testing.T) {
+	lifecycle := &roleLifecycle{closeResult: issueops.CloseResult{Issue: closedIssue("bd-1"), Changed: true}}
+	ts := newCloseServer(t, lifecycle)
+
+	if resp := ts.closeIssue(t, closePath, `{"actor":"alice","force":true,"expected_version":41}`); resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	got := lifecycle.closeRequests()
+	if len(got) != 1 {
+		t.Fatalf("%d closes, want 1", len(got))
+	}
+	if !got[0].Force || got[0].ExpectedVersion == nil || *got[0].ExpectedVersion != 41 {
+		t.Errorf("request = %+v, want both Force and the guard forwarded", got[0])
+	}
+}
+
+// TestCloseRefusesAMalformedGuard: the token is an integer and nothing else,
+// refused at the edge before any database work.
+func TestCloseRefusesAMalformedGuard(t *testing.T) {
+	for _, body := range []string{
+		`{"actor":"alice","expected_version":"41"}`,
+		`{"actor":"alice","expected_version":1.5}`,
+		`{"actor":"alice","expected_version":null}`,
+		`{"actor":"alice","expected_version":true}`,
+	} {
+		lifecycle := &roleLifecycle{closeResult: issueops.CloseResult{Issue: closedIssue("bd-1")}}
+		ts := newCloseServer(t, lifecycle)
+
+		resp := ts.closeIssue(t, closePath, body)
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("body %s: status = %d, want 400: %s", body, resp.StatusCode, readAll(t, resp))
+			continue
+		}
+		if problem := decodeBody(t, resp); problem["param"] != expectedVersionMember {
+			t.Errorf("body %s: param = %v, want %s", body, problem["param"], expectedVersionMember)
+		}
+		if calls := lifecycle.closeRequests(); len(calls) != 0 {
+			t.Errorf("body %s: %d closes reached the role; a malformed guard is refused before any database work", body, len(calls))
+		}
 	}
 }

--- a/internal/httpapi/delete.go
+++ b/internal/httpapi/delete.go
@@ -3,6 +3,7 @@ package httpapi
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"slices"
 	"strings"
@@ -32,6 +33,7 @@ var deleteMembers = []string{
 	deleteCascadeMember,
 	deleteForceMember,
 	deleteDryRunMember,
+	expectedVersionMember,
 }
 
 // maxDeleteIDs bounds the `ids` array, matching the document's maxItems. It
@@ -73,7 +75,7 @@ func (s *Server) handleDelete(w http.ResponseWriter, r *http.Request) {
 	}
 	result, err := deleter.Delete(r.Context(), request)
 	if err != nil {
-		s.failDeleteErr(w, r, err)
+		s.failDeleteErr(w, r, request, err)
 		return
 	}
 	writeJSON(w, deleteResponse(result))
@@ -134,7 +136,48 @@ func (s *Server) deleteRequest(w http.ResponseWriter, r *http.Request) (issueops
 			"`"+deleteIDsMember+"` carries more ids than this operation accepts in one request"))
 		return issueops.DeleteRequest{}, false
 	}
+	// A blank entry. The ROLE refuses it too, and it is refused here for the
+	// empty-array refusal's reason — the client gets the member name — plus one
+	// the guard below adds: the arity rule counts DISTINCT TRIMMED ids, so a
+	// blank entry would otherwise count as an id and could earn the guard's
+	// refusal for a request whose actual fault is a broken id list.
+	// ValidateDeleteRequest puts the blank refusal ahead of the arity one; this
+	// keeps the wire's order the same as the library's.
+	for i, id := range *ids {
+		if strings.TrimSpace(id) == "" {
+			s.fail(w, r, InvalidArgument(deleteIDsMember, ReasonInvalidValue,
+				fmt.Sprintf("`%s[%d]` is blank; every id must name a bead", deleteIDsMember, i)))
+			return issueops.DeleteRequest{}, false
+		}
+	}
 	request.IDs = *ids
+
+	// The guard, and the arity rule that comes with it. Both are decided here,
+	// before any database work, because both are statements about the REQUEST:
+	// the role refuses the same pair as ErrValidation, and reaching the wire
+	// through that route would cost the member name a client dispatches on.
+	//
+	// DISTINCT, TRIMMED ids — the role's own counting rule
+	// (workapi.NormalizeDeleteIDs), respelled here because the transport
+	// boundary keeps internal/workapi out of this package. That respelling is
+	// the drift risk this slice carries, and the case that pins it is the one
+	// asserting `["be-1", " be-1"]` beside a guard is ACCEPTED: an edge that
+	// counted mentions, or counted untrimmed, would refuse a request the role
+	// calls legal.
+	expectedVersion, res := applyVersionGuardMember(members, "")
+	if res != nil {
+		s.fail(w, r, *res)
+		return issueops.DeleteRequest{}, false
+	}
+	if expectedVersion != nil {
+		if distinct := distinctDeleteIDs(request.IDs); distinct > 1 {
+			s.fail(w, r, InvalidArgument(expectedVersionMember, ReasonInvalidValue,
+				fmt.Sprintf("`%s` guards ONE bead and this request names %d distinct ids; a row version describes one row. Send one guarded request per bead",
+					expectedVersionMember, distinct)))
+			return issueops.DeleteRequest{}, false
+		}
+		request.ExpectedVersion = expectedVersion
+	}
 
 	if raw, ok := members[deleteActorMember]; ok {
 		var value *string
@@ -176,6 +219,17 @@ func (s *Server) deleteRequest(w http.ResponseWriter, r *http.Request) (issueops
 	return request, true
 }
 
+// distinctDeleteIDs counts the ids a request really names, collapsing
+// duplicates after trimming so that the arity rule above agrees with the
+// library's own normalization. See the call site for why it is spelled here.
+func distinctDeleteIDs(ids []string) int {
+	seen := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		seen[strings.TrimSpace(id)] = true
+	}
+	return len(seen)
+}
+
 func deleteMemberList() string {
 	quoted := make([]string, len(deleteMembers))
 	for i, name := range deleteMembers {
@@ -186,17 +240,32 @@ func deleteMemberList() string {
 
 // failDeleteErr answers a failed delete.
 //
-// It draws the same ErrValidation-is-a-400 line the sweep draws, and adds ONE
-// more: the role's dependents refusal. That one is a 400 rather than a 409
-// because the fix is to change the REQUEST — send `cascade` or `force`.
+// It draws the same ErrValidation-is-a-400 line the sweep draws, and adds two
+// more arms: the row-version guard's 409, and the role's dependents refusal.
+// That last one is a 400 rather than a 409 because the fix is to change the
+// REQUEST — send `cascade` or `force`.
+//
+// THE PRECONDITION ARM IS FIRST, ABOVE THE ErrValidation LINE, and the order is
+// load-bearing rather than cosmetic. ErrVersionMismatch wraps neither
+// ErrValidation nor ErrNotFound and ClassifyError has no row for it, so below
+// this arm it falls straight through failErr's default into a GENERIC 500 — for
+// the one refusal on this operation that says an irreversible act was stopped
+// because the caller's view had moved. Verified by mutation: dropping the arm
+// turns TestDeleteRefusesAStaleGuard into a 500, not a 400.
 //
 // THE ABSENT-ID REFUSAL NEEDS NO BRANCH AT ALL, and does not get one: the
 // role's *NotFoundError wraps issueops.ErrNotFound, which ClassifyError already
 // maps to a 404 carrying NotFound()'s FIXED detail. The role's own message
 // names every id that did not resolve and the wire deliberately does not repeat
 // it — NotFound's doc says why. `bd delete` still names them, because it is
-// talking to the person who typed them.
-func (s *Server) failDeleteErr(w http.ResponseWriter, r *http.Request, err error) {
+// talking to the person who typed them. Its rank ABOVE the guard is the role's:
+// a request that named no row has nothing to be stale about, so no branch here
+// has to arrange it.
+func (s *Server) failDeleteErr(w http.ResponseWriter, r *http.Request, request issueops.DeleteRequest, err error) {
+	if errors.Is(err, issueops.ErrVersionMismatch) {
+		s.fail(w, r, versionPreconditionResult(request.ExpectedVersion))
+		return
+	}
 	if errors.Is(err, issueops.ErrValidation) || errors.Is(err, issueops.ErrDependentsOutsideRequest) {
 		// No `param`: neither refusal is about one member of the request. The
 		// dependents one is about the absence of a CHOICE between two of them.

--- a/internal/httpapi/delete.go
+++ b/internal/httpapi/delete.go
@@ -247,11 +247,11 @@ func deleteMemberList() string {
 //
 // THE PRECONDITION ARM IS FIRST, ABOVE THE ErrValidation LINE, and the order is
 // load-bearing rather than cosmetic. ErrVersionMismatch wraps neither
-// ErrValidation nor ErrNotFound and ClassifyError has no row for it, so below
-// this arm it falls straight through failErr's default into a GENERIC 500 — for
-// the one refusal on this operation that says an irreversible act was stopped
-// because the caller's view had moved. Verified by mutation: dropping the arm
-// turns TestDeleteRefusesAStaleGuard into a 500, not a 400.
+// ErrValidation nor ErrNotFound, so under ClassifyError's rule it falls straight
+// through failErr's default into a GENERIC 500 — for the one refusal on this
+// operation that reports an irreversible act being stopped because the caller's
+// view had moved. Verified by mutation: dropping the arm turns
+// TestDeleteRefusesAStaleGuard into a 500, not a 400.
 //
 // THE ABSENT-ID REFUSAL NEEDS NO BRANCH AT ALL, and does not get one: the
 // role's *NotFoundError wraps issueops.ErrNotFound, which ClassifyError already

--- a/internal/httpapi/delete_test.go
+++ b/internal/httpapi/delete_test.go
@@ -1,6 +1,7 @@
 package httpapi
 
 import (
+	"fmt"
 	"net/http"
 	"reflect"
 	"strings"
@@ -10,7 +11,7 @@ import (
 )
 
 // The pins for POST /v0/beads/issues:delete. As with the sweep, what is
-// asserted here is the WIRE EDGE — that the handler decodes the document's five
+// asserted here is the WIRE EDGE — that the handler decodes the document's
 // members into the role's request faithfully, refuses what the document
 // refuses, and does not re-implement anything the role owns.
 
@@ -41,7 +42,10 @@ func TestDeletePathReachesItsHandler(t *testing.T) {
 }
 
 // TestDeleteForwardsEveryDocumentedMember is the operation's central pin: each
-// of the five body members reaches the role's request unchanged.
+// of the body's five UNCONSTRAINED members reaches the role's request unchanged.
+// `expected_version` has cases of its own below rather than a column here,
+// because it constrains `ids` — a guard beside this case's two ids is refused
+// by design.
 //
 // It is asserted on the REQUEST the role received rather than on the response,
 // because a body carrying the right numbers says nothing about which beads went
@@ -294,5 +298,211 @@ func TestDeleteResponseCarriesEveryRoleField(t *testing.T) {
 	if role != wire {
 		t.Fatalf("issueops.DeleteResult has %d fields and the wire type has %d: "+
 			"a field was added to one and not projected onto the other (see deleteResponse)", role, wire)
+	}
+}
+
+// TestDeleteForwardsTheVersionGuard: the member reaches the role as the POINTER
+// it models, and an absent member stays nil.
+//
+// The nil half is what stops the handler inventing a guard. On this operation
+// that matters more than anywhere else on the surface: a delete that took &0 by
+// default would refuse every bead that has ever been written to, and one that
+// dropped a real guard would erase a row the caller no longer recognizes.
+func TestDeleteForwardsTheVersionGuard(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+		want *int64
+	}{
+		{"a guard is forwarded", `{"ids":["bd-1"],"expected_version":9007199254740993}`, guard(guardToken)},
+		{"the never-written version is a real guard", `{"ids":["bd-1"],"expected_version":0}`, guard(0)},
+		{"an absent guard stays nil", `{"ids":["bd-1"]}`, nil},
+		// Cascade and force bypass POLICY, never a precondition. Both travel
+		// beside the guard rather than instead of it.
+		{"cascade does not displace it", `{"ids":["bd-1"],"cascade":true,"expected_version":41}`, guard(41)},
+		{"force does not displace it", `{"ids":["bd-1"],"force":true,"expected_version":41}`, guard(41)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			deleter := &roleDeleter{}
+			ts := newTestServer(t, rolesConfig(Config{Deleter: deleter}))
+
+			resp := ts.delete(t, tc.body)
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+			}
+			reqs := deleter.requests()
+			if len(reqs) != 1 {
+				t.Fatalf("%d deletes, want 1", len(reqs))
+			}
+			switch {
+			case tc.want == nil && reqs[0].ExpectedVersion != nil:
+				t.Errorf("ExpectedVersion = %d, want nil: an absent member must not become a guard", *reqs[0].ExpectedVersion)
+			case tc.want != nil && reqs[0].ExpectedVersion == nil:
+				t.Errorf("ExpectedVersion = nil, want %d", *tc.want)
+			case tc.want != nil && *reqs[0].ExpectedVersion != *tc.want:
+				t.Errorf("ExpectedVersion = %d, want %d", *reqs[0].ExpectedVersion, *tc.want)
+			}
+		})
+	}
+}
+
+// TestDeleteRefusesAGuardBesideSeveralIDs is the arity rule at the edge: one
+// token describes one row, so a guard beside more than one DISTINCT id is a 400
+// naming the guard, and nothing reaches the role.
+//
+// It is refused here rather than left to the role — which refuses the same pair
+// as ErrValidation — because that route reaches the wire through failDeleteErr
+// with NO `param` at all, and the member name is the whole recovery: send one
+// guarded request per bead.
+func TestDeleteRefusesAGuardBesideSeveralIDs(t *testing.T) {
+	deleter := &roleDeleter{}
+	ts := newTestServer(t, rolesConfig(Config{Deleter: deleter}))
+
+	resp := ts.delete(t, `{"ids":["bd-1","bd-2"],"expected_version":41}`)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
+	}
+	body := decodeBody(t, resp)
+	if body["code"] != string(CodeInvalidArgument) {
+		t.Errorf("code = %v, want %s", body["code"], CodeInvalidArgument)
+	}
+	if body["param"] != expectedVersionMember {
+		t.Errorf("param = %v, want %s — the guard is the member that cannot be honored", body["param"], expectedVersionMember)
+	}
+	// A 400 and not a 409: a token beside two ids is a malformed request, not a
+	// statement about state, and a client must not retry it after a re-read.
+	if body["status"] != float64(http.StatusBadRequest) {
+		t.Errorf("status = %v, want %d", body["status"], http.StatusBadRequest)
+	}
+	if calls := deleter.requests(); len(calls) != 0 {
+		t.Errorf("%d deletes reached the role; the arity rule is refused before anything is read", len(calls))
+	}
+}
+
+// TestDeleteCountsDistinctIDsForTheGuard is the ANTI-DRIFT pin, and it is the
+// case that earns the local counting helper its place.
+//
+// The role's rule is DUPLICATES COLLAPSE FIRST — `bd delete a a` with a token
+// names one bead and is legal — and it collapses after TRIMMING
+// (workapi.NormalizeDeleteIDs). The transport boundary keeps that package out
+// of the handler, so the rule is respelled there; an edge that counted mentions
+// instead, or counted untrimmed, would refuse a request the library calls fine
+// and no other test in this file would notice.
+func TestDeleteCountsDistinctIDsForTheGuard(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ids  string
+	}{
+		{"a repeated id is one bead", `["bd-1","bd-1"]`},
+		{"a repeated id is one bead after trimming", `["bd-1"," bd-1"]`},
+		{"three mentions of one bead", `["bd-1","bd-1","bd-1"]`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			deleter := &roleDeleter{}
+			ts := newTestServer(t, rolesConfig(Config{Deleter: deleter}))
+
+			resp := ts.delete(t, `{"ids":`+tc.ids+`,"expected_version":41}`)
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+			}
+			reqs := deleter.requests()
+			if len(reqs) != 1 {
+				t.Fatalf("%d deletes, want 1", len(reqs))
+			}
+			if reqs[0].ExpectedVersion == nil {
+				t.Fatal("the guard did not reach the role")
+			}
+			// The ids reach the role AS SENT. Collapsing them is the role's own
+			// normalization, and a handler that did it here would be answering a
+			// different request than the one it was given.
+			if len(reqs[0].IDs) == 1 && strings.Count(tc.ids, "bd-1") > 1 {
+				t.Errorf("the handler collapsed the id list before the role saw it: %v", reqs[0].IDs)
+			}
+		})
+	}
+}
+
+// TestDeleteRefusesABlankID keeps the arity rule from stealing a broken id
+// list's answer.
+//
+// A blank entry is the ROLE's refusal too, and ValidateDeleteRequest puts it
+// AHEAD of the arity rule. The edge has to agree, because it counts trimmed
+// distinct ids: a request of `["", "bd-1"]` with a guard would otherwise be
+// told its guard names two beads, when what is actually wrong is that its id
+// list came out broken.
+func TestDeleteRefusesABlankID(t *testing.T) {
+	for _, body := range []string{
+		`{"ids":["   ","bd-1"],"expected_version":41}`,
+		`{"ids":["bd-1",""]}`,
+	} {
+		deleter := &roleDeleter{}
+		ts := newTestServer(t, rolesConfig(Config{Deleter: deleter}))
+
+		resp := ts.delete(t, body)
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("body %s: status = %d, want 400: %s", body, resp.StatusCode, readAll(t, resp))
+			continue
+		}
+		if problem := decodeBody(t, resp); problem["param"] != deleteIDsMember {
+			t.Errorf("body %s: param = %v, want %s — the fault is the id list, not the guard beside it",
+				body, problem["param"], deleteIDsMember)
+		}
+		if calls := deleter.requests(); len(calls) != 0 {
+			t.Errorf("body %s: %d deletes reached the role", body, len(calls))
+		}
+	}
+}
+
+// TestDeleteRefusesAStaleGuard is the 409, and the case whose GREEN is bought by
+// the arm's placement ABOVE the ErrValidation line in failDeleteErr.
+//
+// ErrVersionMismatch wraps neither ErrValidation nor ErrNotFound and
+// ClassifyError has no row for it, so below that line it is a generic 500 — for
+// the one refusal here that reports an irreversible act being stopped.
+// Mutation-checked: deleting the arm makes this case fail with 500.
+func TestDeleteRefusesAStaleGuard(t *testing.T) {
+	deleter := &roleDeleter{err: fmt.Errorf("delete bd-1: %w", issueops.ErrVersionMismatch)}
+	ts := newTestServer(t, rolesConfig(Config{Deleter: deleter}))
+
+	resp := ts.delete(t, `{"ids":["bd-1"],"expected_version":9007199254740993}`)
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status = %d, want 409: %s", resp.StatusCode, readAll(t, resp))
+	}
+	body := decodeBody(t, resp)
+	if body["code"] != string(CodePreconditionFailed) {
+		t.Errorf("code = %v, want %s", body["code"], CodePreconditionFailed)
+	}
+	if body["param"] != expectedVersionMember {
+		t.Errorf("param = %v, want %s", body["param"], expectedVersionMember)
+	}
+	if _, present := body["expected_version"]; !present {
+		t.Errorf("the refusal does not echo the guard the request sent: %v", body)
+	}
+	if _, present := body["actual_version"]; present {
+		t.Errorf("actual_version = %v; the refusing transaction rolled back", body["actual_version"])
+	}
+}
+
+// TestDeleteRefusesAMalformedGuard: the token is an integer and nothing else.
+func TestDeleteRefusesAMalformedGuard(t *testing.T) {
+	for _, body := range []string{
+		`{"ids":["bd-1"],"expected_version":"41"}`,
+		`{"ids":["bd-1"],"expected_version":null}`,
+		`{"ids":["bd-1"],"expected_version":{}}`,
+	} {
+		deleter := &roleDeleter{}
+		ts := newTestServer(t, rolesConfig(Config{Deleter: deleter}))
+
+		resp := ts.delete(t, body)
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("body %s: status = %d, want 400: %s", body, resp.StatusCode, readAll(t, resp))
+			continue
+		}
+		if problem := decodeBody(t, resp); problem["param"] != expectedVersionMember {
+			t.Errorf("body %s: param = %v, want %s", body, problem["param"], expectedVersionMember)
+		}
+		if calls := deleter.requests(); len(calls) != 0 {
+			t.Errorf("body %s: %d deletes reached the role", body, len(calls))
+		}
 	}
 }

--- a/internal/httpapi/problem.go
+++ b/internal/httpapi/problem.go
@@ -1103,6 +1103,27 @@ func MemoryNotFound() Result {
 // ClassifyError maps an error from the storage seam onto the wire. The caller
 // is responsible for logging err: everything mapped to a 5xx deliberately
 // drops the error text on the floor (see staticDetail).
+//
+// ErrVersionMismatch — AND EVERY OTHER COMPARE-AND-SET SENTINEL — IS
+// DELIBERATELY ABSENT FROM THIS FUNCTION, because the 409 it earns cannot be
+// built from the error alone: `precondition_failed` echoes the value the
+// REQUEST guarded on, and this function is handed an error and nothing else.
+// So an operation that publishes `expected_version` (or `expected_status`, or
+// `expected_assignee`) MUST match the sentinel TYPED in its own failure path,
+// before anything reaches failErr — updateIssue, closeIssue, reopenIssue,
+// deleteIssues, releaseIssue and applyBatch each do. A handler that forgets is
+// not answering a worse 4xx: neither storage leg wraps these in ErrValidation,
+// so the miss falls through the default arm below and every guard failure on
+// that operation is a GENERIC 500. Mutation-verified on the single-issue
+// handlers.
+//
+// THE RULE IS WRITTEN HERE BECAUSE SIX HANDLERS FOUND IT SEPARATELY. failUpdate
+// worked it out, failRelease worked it out again and called it "failUpdate's
+// hazard, in a sharper form", and the guard slice worked it out three more
+// times. Six independent discoveries of one fact are a fact nobody recorded
+// where the seventh author would look — which is here, since a handler author
+// asking "does the shared mapping cover my sentinel?" reads this function and
+// finds no row.
 func ClassifyError(err error) Result {
 	// The one row that carries data out of the error rather than only a code.
 	// It lives HERE, in the shared mapping, rather than in the events handler:

--- a/internal/httpapi/problem.go
+++ b/internal/httpapi/problem.go
@@ -352,8 +352,11 @@ const (
 	// normalization, and the close policy vocabulary.
 	OpCloseIssue = "closeIssue"
 	// OpReopenIssue is the close's mirror, and it completes the lifecycle pair
-	// so a recovery flow works end to end over this surface. It is the one
-	// write here with no conflict code: reopen has no policy guard.
+	// so a recovery flow works end to end over this surface. It is the one write
+	// here with no POLICY conflict code: reopen takes an issue OUT of the done
+	// category, so there is no state of the graph that can refuse it. Its one
+	// 409 is the caller's own compare-and-set, which is a fact about the
+	// request's premise rather than about the graph.
 	OpReopenIssue = "reopenIssue"
 	// OpUpdateIssue edits the FIELDS of one issue, including the three that
 	// carry policy: `status`, `assignee` and `parent_id`.
@@ -553,7 +556,20 @@ var operationCodes = map[string][]Code{
 	// CodeNotFound is the one this operation has and the sweep does not: a
 	// sweep describes a set that can legitimately be empty, while a delete
 	// names beads and an id that resolves to nothing is a caller mistake.
-	OpDeleteIssues: {CodeInvalidArgument, CodeNotFound, CodeBusy, CodeDBUnavailable, CodeInternal},
+	//
+	// precondition_failed is `expected_version`'s, and it is the 409 form for
+	// the reason that code documents: a miss refuses the whole request and
+	// leaves nothing to report but the refusal. It ranks BELOW the 404 — a
+	// request that named no row has nothing to be stale about — and ABOVE the
+	// dependents refusal, which is the role's own order and is what makes the
+	// wire's answer the same one `bd delete` gives.
+	//
+	// The ARITY refusal is a 400 rather than a second conflict: a token beside
+	// two distinct ids is a malformed request, not a statement about state.
+	OpDeleteIssues: {
+		CodeInvalidArgument, CodeNotFound, CodePreconditionFailed,
+		CodeBusy, CodeDBUnavailable, CodeInternal,
+	},
 	OpClaimIssue: {
 		CodeInvalidArgument, CodeNotFound, CodeAlreadyClaimed, CodeNotClaimable,
 		CodeBusy, CodeDBUnavailable, CodeInternal,
@@ -594,22 +610,33 @@ var operationCodes = map[string][]Code{
 		CodeAlreadyClaimed, CodeNotReleasable, CodePreconditionFailed,
 		CodeBusy, CodeDBUnavailable, CodeInternal,
 	},
-	// The 409 is close POLICY, and it is the only conflict this operation has:
-	// an unforced close refused for open children or for a live blocker. There
-	// is no already_claimed here — closing work somebody else holds is not a
-	// refusal on this surface — and the idempotent re-close is a 200 carrying
-	// `already_closed`, the claim's answer to the same question.
+	// TWO 409s, and they answer different questions with `code` as the only
+	// discriminator a client needs.
+	//
+	// not_closable is close POLICY: an unforced close refused for open children
+	// or for a live blocker. There is no already_claimed here — closing work
+	// somebody else holds is not a refusal on this surface — and the idempotent
+	// re-close is a 200 carrying `already_closed`, the claim's answer to the
+	// same question.
+	//
+	// precondition_failed is `expected_version`'s, in the 409 form for the
+	// reason that code documents, and it is CHECKED FIRST — before policy and
+	// before the idempotent re-close, which is the role's own order
+	// (issueops.Lifecycle.Close). `force` bypasses policy and never it: the two
+	// members make unrelated claims.
 	OpCloseIssue: {
-		CodeInvalidArgument, CodeNotFound, CodeNotClosable,
+		CodeInvalidArgument, CodeNotFound, CodeNotClosable, CodePreconditionFailed,
 		CodeBusy, CodeDBUnavailable, CodeInternal,
 	},
-	// NO 409, and the absence is the point. Close has a policy guard — open
-	// children, a live blocker — and reopen is the direction that takes an issue
-	// OUT of the done category rather than putting it in, so there is no state
-	// of the graph that can refuse it and nothing to name. The idempotent case
-	// is a 200 carrying `already_open`, not a conflict.
+	// ONE 409, and it is a PRECONDITION rather than a policy. Close has a policy
+	// guard — open children, a live blocker — and reopen is the direction that
+	// takes an issue OUT of the done category rather than putting it in, so
+	// there is no state of the graph that can refuse it: not_closable is absent
+	// here and always will be. What `expected_version` refuses is the request's
+	// own premise, which every write can have wrong. The idempotent case is
+	// still a 200 carrying `already_open`, unless a guard came with it.
 	OpReopenIssue: {
-		CodeInvalidArgument, CodeNotFound,
+		CodeInvalidArgument, CodeNotFound, CodePreconditionFailed,
 		CodeBusy, CodeDBUnavailable, CodeInternal,
 	},
 	// FOUR conflict codes, and the three members that publish them are exactly

--- a/internal/httpapi/problem.go
+++ b/internal/httpapi/problem.go
@@ -82,7 +82,7 @@ const (
 	//
 	// THE TWO CONDITIONS ARE FULLY DISTINGUISHABLE HERE. ErrNotClaimed and
 	// ErrNotReleasable are two distinct typed sentinels, and failRelease holds
-	// both in one case arm — so a future split needs no excavation and no
+	// both in one case arm — so a future split needs no archeology and no
 	// prose-scraping: it is a mapping change in that arm plus a code in this
 	// block and a line in the document. What IS unavailable typed is the
 	// OBSERVATION either refusal made — the status it saw, the emptiness of the

--- a/internal/httpapi/reopen.go
+++ b/internal/httpapi/reopen.go
@@ -1,6 +1,7 @@
 package httpapi
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/steveyegge/beads/internal/httpapi/apigen"
@@ -9,7 +10,7 @@ import (
 
 // reopenRequestMembers is the document's member list for ReopenIssueRequest,
 // read as raw members for the reason closeRequestMembers is.
-var reopenRequestMembers = []string{"actor", "reason"}
+var reopenRequestMembers = []string{"actor", "reason", expectedVersionMember}
 
 // reopenProvenance labels the version-control history entry a reopen records,
 // naming the surface it came from.
@@ -58,25 +59,45 @@ func (s *Server) handleReopen(w http.ResponseWriter, r *http.Request) {
 
 	lifecycle, err := s.lifecycle(r)
 	if err != nil {
-		s.failErr(w, r, err)
+		s.failReopen(w, r, request, err)
 		return
 	}
 	result, err := lifecycle.Reopen(r.Context(), request)
 	if err != nil {
-		// No failReopen sibling, deliberately: this operation has no conflict
-		// code and therefore no typed refusal to read extension members out of.
-		// The shared mapping is the whole of its error vocabulary, and adding a
-		// pass-through wrapper would suggest otherwise.
-		s.failErr(w, r, err)
+		s.failReopen(w, r, request, err)
 		return
 	}
 	// `already_open` is the wire's name for the role's unchanged result: a
 	// reopen of an issue that was never done. Idempotent, like the re-claim and
 	// the re-close, and for the same reason.
+	//
+	// `revision` is the row's post-reopen concurrency token, on the wire for the
+	// close's reason: `expected_version` is a guard a caller cannot fill without
+	// it, and a reopen-then-re-close recovery composes its next expectation from
+	// this value.
 	writeJSON(w, apigen.ReopenIssueResponse{
 		Issue:       *result.Issue,
 		AlreadyOpen: !result.Changed,
+		Revision:    result.Issue.RowVersion,
 	})
+}
+
+// failReopen answers a failed reopen.
+//
+// It exists now, where a pass-through wrapper would once have been a lie about
+// the vocabulary: this operation has exactly one typed refusal to read an
+// extension member out of, and it is the row-version guard rather than a
+// policy. Everything else is still the shared mapping.
+//
+// THE ARM IS FIRST, and it must be: ClassifyError has no row for
+// ErrVersionMismatch and neither leg wraps it, so without this the guard's miss
+// is a generic 500 — failClose's finding, on the mirror operation.
+func (s *Server) failReopen(w http.ResponseWriter, r *http.Request, request issueops.ReopenRequest, err error) {
+	if errors.Is(err, issueops.ErrVersionMismatch) {
+		s.fail(w, r, versionPreconditionResult(request.ExpectedVersion))
+		return
+	}
+	s.failErr(w, r, err)
 }
 
 // reopenRequest decodes and validates the body, and reports whether the request
@@ -103,12 +124,18 @@ func (s *Server) reopenRequest(w http.ResponseWriter, r *http.Request, id string
 	if !ok {
 		return issueops.ReopenRequest{}, false
 	}
+	// The close's guard, read the same way: one decoder, one refusal sentence.
+	expectedVersion, res := applyVersionGuardMember(members, "")
+	if res != nil {
+		s.fail(w, r, *res)
+		return issueops.ReopenRequest{}, false
+	}
 
-	// ExpectedVersion stays unpublished on this surface, as for the close.
 	return issueops.ReopenRequest{
-		Actor:      actor,
-		IssueID:    id,
-		Reason:     reason,
-		Provenance: reopenProvenance,
+		Actor:           actor,
+		IssueID:         id,
+		Reason:          reason,
+		ExpectedVersion: expectedVersion,
+		Provenance:      reopenProvenance,
 	}, true
 }

--- a/internal/httpapi/reopen.go
+++ b/internal/httpapi/reopen.go
@@ -89,9 +89,9 @@ func (s *Server) handleReopen(w http.ResponseWriter, r *http.Request) {
 // extension member out of, and it is the row-version guard rather than a
 // policy. Everything else is still the shared mapping.
 //
-// THE ARM IS FIRST, and it must be: ClassifyError has no row for
-// ErrVersionMismatch and neither leg wraps it, so without this the guard's miss
-// is a generic 500 — failClose's finding, on the mirror operation.
+// THE ARM IS FIRST, under the rule ClassifyError states, and the cost of
+// forgetting it is a generic 500 for every guard miss here rather than a worse
+// 4xx — failClose's finding, on the mirror operation.
 func (s *Server) failReopen(w http.ResponseWriter, r *http.Request, request issueops.ReopenRequest, err error) {
 	if errors.Is(err, issueops.ErrVersionMismatch) {
 		s.fail(w, r, versionPreconditionResult(request.ExpectedVersion))

--- a/internal/httpapi/reopen_test.go
+++ b/internal/httpapi/reopen_test.go
@@ -114,19 +114,34 @@ func TestReopenIsIdempotentForAnIssueThatWasNeverDone(t *testing.T) {
 	}
 }
 
-// TestReopenPublishesNoConflictCode is the absence, asserted. The operation's
-// row says it has no 409 and the spec documents none; this is the third leg —
-// nothing in the frozen set for this operation is a conflict, so a future
-// change that gave reopen a policy guard has to land its code deliberately.
-func TestReopenPublishesNoConflictCode(t *testing.T) {
+// TestReopenPublishesNoPolicyConflictCode is the absence, asserted, and it is
+// narrower than it used to be for a reason worth stating rather than quietly
+// relaxing.
+//
+// It once said reopen publishes NO 409 at all. That claim died the moment this
+// operation took `expected_version`: a compare-and-set refusal is a statement
+// about the request's own premise, which every write can have wrong, and it has
+// nothing to do with whether the graph can refuse a reopen. What survives — and
+// what the operation's whole posture rests on — is that no POLICY conflict is
+// reachable here: reopen takes an issue OUT of the done category, so there is
+// no state of the graph to refuse it and `not_closable` must never appear.
+//
+// Written as an exact set rather than "no conflicts", so a future policy code
+// added to this row fails here and has to be landed deliberately.
+func TestReopenPublishesNoPolicyConflictCode(t *testing.T) {
 	codes, ok := operationCodes[OpReopenIssue]
 	if !ok {
 		t.Fatalf("no %s row in the handler table", OpReopenIssue)
 	}
+	var conflicts []Code
 	for _, c := range codes {
 		if c.Status() == http.StatusConflict {
-			t.Errorf("reopen publishes the conflict code %q; it has no policy guard, so there is nothing to refuse", c)
+			conflicts = append(conflicts, c)
 		}
+	}
+	if len(conflicts) != 1 || conflicts[0] != CodePreconditionFailed {
+		t.Errorf("reopen's conflict codes are %v, want exactly [%s]: the caller's own guard is the only thing that can refuse a reopen, and a POLICY conflict here would mean the graph had been given a say it does not have",
+			conflicts, CodePreconditionFailed)
 	}
 }
 
@@ -319,5 +334,135 @@ func TestReopenResolvesAcrossBothPlanes(t *testing.T) {
 	}
 	if got := lifecycle.reopenRequests(); len(got) != 1 || got[0].IssueID != "bd-w1" {
 		t.Fatalf("the role received %+v, want the wisp id unchanged", got)
+	}
+}
+
+// TestReopenForwardsTheVersionGuard is the close's case on the mirror: the
+// member reaches the role as the POINTER it models, and an absent member stays
+// nil so "do not check" never collapses into a guard on the never-written
+// version 0.
+func TestReopenForwardsTheVersionGuard(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+		want *int64
+	}{
+		{"a guard is forwarded", `{"actor":"alice","expected_version":9007199254740993}`, guard(guardToken)},
+		{"the never-written version is a real guard", `{"actor":"alice","expected_version":0}`, guard(0)},
+		{"an absent guard stays nil", `{"actor":"alice"}`, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lifecycle := &roleLifecycle{reopenResult: issueops.ReopenResult{Issue: reopenedIssue("bd-1"), Changed: true}}
+			ts := newReopenServer(t, lifecycle)
+
+			resp := ts.reopenIssue(t, reopenPath, tc.body)
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+			}
+			got := lifecycle.reopenRequests()
+			if len(got) != 1 {
+				t.Fatalf("%d reopens, want 1", len(got))
+			}
+			switch {
+			case tc.want == nil && got[0].ExpectedVersion != nil:
+				t.Errorf("ExpectedVersion = %d, want nil", *got[0].ExpectedVersion)
+			case tc.want != nil && got[0].ExpectedVersion == nil:
+				t.Errorf("ExpectedVersion = nil, want %d", *tc.want)
+			case tc.want != nil && *got[0].ExpectedVersion != *tc.want:
+				t.Errorf("ExpectedVersion = %d, want %d", *got[0].ExpectedVersion, *tc.want)
+			}
+			// The history label is still spelled here; a new member must not
+			// have displaced it.
+			if got[0].Provenance != reopenProvenance {
+				t.Errorf("Provenance = %q, want %q", got[0].Provenance, reopenProvenance)
+			}
+		})
+	}
+}
+
+// TestReopenAnswersWithTheRowsRevision is the close's case on the mirror, and
+// the value is asserted against the ROW the role answered with rather than
+// against whatever the handler put there — the assertion that stops this from
+// being a case that cannot fail.
+//
+// The `already_open` no-op carries a revision too: a recovery flow that guards
+// its replay needs the token whether or not the replay wrote.
+func TestReopenAnswersWithTheRowsRevision(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		changed bool
+	}{
+		{"a reopen that wrote", true},
+		{"an issue that was never done", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			issue := reopenedIssue("bd-1")
+			issue.RowVersion = guardToken
+			lifecycle := &roleLifecycle{reopenResult: issueops.ReopenResult{Issue: issue, Changed: tc.changed}}
+			ts := newReopenServer(t, lifecycle)
+
+			resp := ts.reopenIssue(t, reopenPath, `{"actor":"alice"}`)
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+			}
+			if got := revisionOf(t, resp); got != guardToken {
+				t.Errorf("revision = %d, want the row's %d", got, guardToken)
+			}
+		})
+	}
+}
+
+// TestReopenRefusesAStaleGuard is this operation's ONLY 409, and it is the case
+// failReopen exists for.
+//
+// Before this slice the handler answered every reopen failure through failErr,
+// and ClassifyError has no row for ErrVersionMismatch — so the arm's absence is
+// a 500 rather than a worse 409. Mutation-checked: deleting the arm makes this
+// case fail with 500.
+func TestReopenRefusesAStaleGuard(t *testing.T) {
+	lifecycle := &roleLifecycle{reopenErr: fmt.Errorf("reopen bd-1: %w", issueops.ErrVersionMismatch)}
+	ts := newReopenServer(t, lifecycle)
+
+	resp := ts.reopenIssue(t, reopenPath, `{"actor":"alice","expected_version":9007199254740993}`)
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status = %d, want 409: %s", resp.StatusCode, readAll(t, resp))
+	}
+	body := decodeBody(t, resp)
+	if body["code"] != string(CodePreconditionFailed) {
+		t.Errorf("code = %v, want %s", body["code"], CodePreconditionFailed)
+	}
+	if body["param"] != expectedVersionMember {
+		t.Errorf("param = %v, want %s", body["param"], expectedVersionMember)
+	}
+	if _, present := body["expected_version"]; !present {
+		t.Errorf("the refusal does not echo the guard the request sent: %v", body)
+	}
+	if _, present := body["actual_version"]; present {
+		t.Errorf("actual_version = %v; the refusing transaction rolled back", body["actual_version"])
+	}
+}
+
+// TestReopenRefusesAMalformedGuard: the token is an integer and nothing else,
+// refused at the edge before any database work.
+func TestReopenRefusesAMalformedGuard(t *testing.T) {
+	for _, body := range []string{
+		`{"actor":"alice","expected_version":"41"}`,
+		`{"actor":"alice","expected_version":null}`,
+		`{"actor":"alice","expected_version":[]}`,
+	} {
+		lifecycle := &roleLifecycle{reopenResult: issueops.ReopenResult{Issue: reopenedIssue("bd-1")}}
+		ts := newReopenServer(t, lifecycle)
+
+		resp := ts.reopenIssue(t, reopenPath, body)
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("body %s: status = %d, want 400: %s", body, resp.StatusCode, readAll(t, resp))
+			continue
+		}
+		if problem := decodeBody(t, resp); problem["param"] != expectedVersionMember {
+			t.Errorf("body %s: param = %v, want %s", body, problem["param"], expectedVersionMember)
+		}
+		if calls := lifecycle.reopenRequests(); len(calls) != 0 {
+			t.Errorf("body %s: %d reopens reached the role", body, len(calls))
+		}
 	}
 }

--- a/internal/httpapi/spec/openapi.v0.yaml
+++ b/internal/httpapi/spec/openapi.v0.yaml
@@ -2011,6 +2011,27 @@ paths:
         by forgetting one exists.
 
 
+        ## The guard
+
+
+        `expected_version` is a compare-and-set precondition on the row's
+        revision, checked FIRST — before close policy and before the idempotent
+        re-close. A miss refuses the whole request with
+        `409 precondition_failed` and writes nothing.
+
+
+        POLICY AND PRECONDITION ARE DIFFERENT THINGS, and `force` is the bypass
+        for exactly one of them. A forced close still answers to the guard: the
+        two members say "close it even though the graph objects" and "only if
+        this is still the row I read", which are unrelated claims.
+
+
+        The token travels back on `revision`, so a read-modify-write chain that
+        ends in a close composes its expectation from the value the previous
+        write answered with. No READ on this surface publishes a revision yet;
+        when one does, this member is what it will agree with.
+
+
         ## Planes
 
 
@@ -2046,8 +2067,9 @@ paths:
             Invalid request: an unknown query parameter, an unparseable or
             oversized body, an unknown body member, an `actor` that is empty
             after trimming, longer than 256 bytes, or carrying control
-            characters — or a `reason` or `session` longer than the column
-            holds or carrying control characters.
+            characters, a `reason` or `session` longer than the column holds or
+            carrying control characters — or an `expected_version` that is not
+            an integer.
           x-bd-codes: [invalid_argument]
           content:
             application/problem+json:
@@ -2057,11 +2079,25 @@ paths:
           $ref: '#/components/responses/NotFound'
         '409':
           description: >-
-            Close policy refused an unforced close (`not_closable`): the issue
-            has open children — carrying the `open_children` extension member —
-            or a live blocker, which carries none. Resend with `force: true` to
-            bypass both. Nothing was written.
-          x-bd-codes: [not_closable]
+            Two refusals share this status and are told apart by `code`.
+
+
+            `precondition_failed`: `expected_version` did not match the row's
+            current revision. `param` is `expected_version` and the refusal
+            echoes the value the REQUEST guarded on; there is no `actual_version`
+            beside it, because the transaction that saw the mismatch rolled back
+            and a read afterwards would describe a row the refusal never saw.
+            Re-read and recompose rather than retrying the same body.
+
+
+            `not_closable`: close policy refused an unforced close — the issue
+            has open children, carrying the `open_children` extension member, or
+            a live blocker, which carries none. Resend with `force: true` to
+            bypass both. `force` does NOT bypass the guard above.
+
+
+            Nothing was written in either case.
+          x-bd-codes: [not_closable, precondition_failed]
           content:
             application/problem+json:
               schema:
@@ -2104,14 +2140,27 @@ paths:
         simply carries none.
 
 
-        ## No conflict to name
+        ## No POLICY conflict to name
 
 
-        This operation documents no `409`, and the absence is deliberate:
-        reopen has no policy guard. Close has one — open children, a live
-        blocker — and reopen is the direction that removes an issue from the
-        done category rather than adding it, so there is nothing for a policy
-        to refuse.
+        There is still no policy refusal here, and the absence is deliberate:
+        close has one — open children, a live blocker — and reopen is the
+        direction that removes an issue from the done category rather than
+        adding it, so there is nothing for a policy to refuse. `not_closable`
+        is not in this operation's vocabulary and never will be.
+
+
+        The one `409` it does document is a PRECONDITION rather than a policy.
+        `expected_version` is a compare-and-set on the row's revision, checked
+        FIRST — before the non-done no-op — and a miss refuses the whole request
+        with `precondition_failed` and writes nothing. It is the caller's own
+        guard rather than a rule of the graph, which is why the operation can
+        carry it while carrying no policy conflict at all.
+
+
+        The token travels back on `revision`, so a reopen-then-re-close recovery
+        composes its next expectation from the value this operation answered
+        with. No READ on this surface publishes a revision yet.
 
 
         ## Planes
@@ -2149,8 +2198,9 @@ paths:
             Invalid request: an unknown query parameter, an unparseable or
             oversized body, an unknown body member, an `actor` that is empty
             after trimming, longer than 256 bytes, or carrying control
-            characters — or a `reason` longer than the column holds or carrying
-            control characters.
+            characters, a `reason` longer than the column holds or carrying
+            control characters — or an `expected_version` that is not an
+            integer.
           x-bd-codes: [invalid_argument]
           content:
             application/problem+json:
@@ -2158,6 +2208,22 @@ paths:
                 $ref: '#/components/schemas/Problem'
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          description: >-
+            `expected_version` did not match the row's current revision
+            (`precondition_failed`). `param` is `expected_version` and the
+            refusal echoes the value the REQUEST guarded on, with no
+            `actual_version` beside it for the reason
+            `POST /v0/beads/issues/{id}:close` gives. Nothing was written.
+
+
+            This operation's ONLY conflict, and it is a precondition rather than
+            a policy: `not_closable` is not in its vocabulary.
+          x-bd-codes: [precondition_failed]
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
         '500':
           $ref: '#/components/responses/InternalError'
         '503':
@@ -2417,6 +2483,37 @@ paths:
         deleting it is the one place that convenience is not one.
 
 
+        ## The guard, and why it takes one id
+
+
+        `expected_version` is a compare-and-set precondition on the row this
+        request NAMES: the deletion proceeds only if that bead's revision still
+        equals it, and otherwise the request is `409 precondition_failed` and
+        nothing is deleted. It is the guard that matters most on this operation,
+        because being wrong about which bead you are looking at is the one
+        mistake here that cannot be undone.
+
+
+        IT REQUIRES A SINGLE-ID REQUEST, and that is a `400` naming
+        `expected_version` rather than a fudge: one token cannot describe two
+        rows. Duplicates collapse first, so repeating one id is still one bead.
+
+
+        THE ORDER THE REFUSALS HAPPEN IN IS PART OF THE ANSWER. Request shape
+        first, then the existence probe (`404`), then this guard (`409`), then
+        the dependents refusal (`400`). A request that is both a typo and a
+        graph problem reports the typo, which is the one a caller can fix
+        without deciding anything; and a stale guard outranks the dependents
+        refusal because a caller whose view has moved should not be asked to
+        choose `cascade` or `force` over information that has already changed.
+
+
+        NEITHER `cascade` NOR `force` BYPASSES IT. They bypass POLICY. Under
+        `cascade` the guard covers the named bead alone — the closure is
+        resolved inside the deleting transaction, so it may have grown since the
+        caller's read.
+
+
         ## One transaction
 
 
@@ -2449,7 +2546,8 @@ paths:
           description: >-
             Invalid request: an unparseable or oversized body, an unknown body
             member, an empty or over-long `ids`, a blank id, an `actor` that is
-            empty after trimming or carries control characters — or a named
+            empty after trimming or carries control characters, an
+            `expected_version` beside more than one distinct id — or a named
             bead with a dependent the request did not name and neither
             `cascade` nor `force` to say what to do about it, which the library
             surface refuses as a safety invariant.
@@ -2466,6 +2564,22 @@ paths:
             from a malformed id would be probing the id space. `bd delete`
             names them, because it is answering the person who typed them.
           x-bd-codes: [not_found]
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '409':
+          description: >-
+            `expected_version` did not match the named bead's current revision
+            (`precondition_failed`), and NOTHING was deleted. `param` is
+            `expected_version` and the refusal echoes the value the REQUEST
+            guarded on, with no `actual_version` beside it for the reason
+            `POST /v0/beads/issues/{id}:close` gives.
+
+
+            It outranks the dependents refusal and is outranked by the `404`:
+            see the operation description.
+          x-bd-codes: [precondition_failed]
           content:
             application/problem+json:
               schema:
@@ -5650,6 +5764,55 @@ components:
             and BOTH refusals are the ones the real request would produce,
             computed against the same snapshot, and nothing is recorded in
             history either.
+        expected_version:
+          type: integer
+          format: int64
+          description: >-
+            Requires the named bead's revision to equal this value before
+            anything is erased. A miss refuses the whole request with
+            `409 precondition_failed` and deletes NOTHING —
+            `UpdateIssueRequest.expected_version`'s contract, on the operation
+            where being wrong about which row you are looking at cannot be
+            undone.
+
+
+            IT REQUIRES A SINGLE-ID REQUEST. Sending it beside more than one
+            DISTINCT id is a `400` naming this member, refused before anything
+            is read. One token cannot describe two rows: the version space is
+            per-row, so checking one number against a list would pass by
+            coincidence for a list of never-written rows — every one of them
+            holds 0 — and fail forever for a list whose rows have since
+            diverged. A guard that passes by coincidence and a guard nobody can
+            satisfy are one defect seen from two sides. Delete one bead per
+            guarded request; the per-id shape a batch would need is a token PER
+            id, which is a different request type.
+
+
+            DUPLICATES COLLAPSE FIRST, so `{"ids":["be-1","be-1"],
+            "expected_version":N}` names one bead and is legal. The refusal
+            counts DISTINCT ids, not mentions, exactly as the library surface
+            does.
+
+
+            NEITHER `cascade` NOR `force` BYPASSES IT. Both bypass POLICY — the
+            dependents guard — and never a precondition. Under `cascade` the
+            guard still covers only the NAMED bead: the closure is resolved
+            inside the deleting transaction, so a matching token promises the
+            row is the one you read and promises nothing about how far the
+            closure has grown since. A caller that needs the closure itself
+            pinned wants `dry_run` first.
+
+
+            IT GUARDS LIFECYCLE STATE, NOT THE GRAPH. The token is reminted by
+            status, assignee and started-at writes and deliberately not by
+            label, dependency or rename writes, so a match does not promise the
+            bead's edges are the ones you saw.
+
+
+            The token is the `revision` a lifecycle write answers with. DECODE
+            IT AS A 64-BIT INTEGER, for the reason
+            `UpdateIssueRequest.expected_version` spells out; no READ on this
+            surface publishes one yet.
 
     DeleteIssuesResult:
       type: object
@@ -7852,9 +8015,49 @@ components:
             ROLE's, so this endpoint cannot skip a guard by forgetting one
             exists. A forced close still reports `open_children`.
 
+
+            IT BYPASSES POLICY, NEVER A PRECONDITION. `expected_version` is
+            still checked with it set, for the reason
+            `issueops.CloseRequest.Force` gives: a caller saying "close it
+            anyway" has said nothing about whether the row is still the one it
+            read.
+        expected_version:
+          type: integer
+          format: int64
+          description: >-
+            Requires the row's revision to equal this value BEFORE the close. A
+            miss refuses the whole request with `409 precondition_failed` and
+            writes nothing — `UpdateIssueRequest.expected_version`'s contract,
+            on the operation that closes one row.
+
+
+            IT IS CHECKED BEFORE THE IDEMPOTENT RE-CLOSE, which is the one place
+            this guard differs from the update's. A re-close of a row somebody
+            else has moved since the caller read it is a `409` and not the
+            200-with-`already_closed` the same body earns without a guard: a
+            replay whose premise has expired is a refusal the caller wants to
+            see, and it is the only way `already_closed` can be trusted as
+            "nothing has happened here since".
+
+
+            The token is the `revision` this operation's own response carries.
+            Compose the next expectation from the value a write ANSWERED with,
+            never from a number the client incremented itself: the token is
+            OPAQUE and compared for equality alone, so it has no predecessor a
+            client can compute. No READ on this surface publishes one yet, so a
+            first guarded close seeds itself from an unguarded lifecycle write
+            or from `POST /v0/beads/issues:batchApply`'s
+            `ApplyItemResult.revision`.
+
+
+            DECODE IT AS A 64-BIT INTEGER, for the reason
+            `UpdateIssueRequest.expected_version` spells out: an IEEE-754-double
+            parser corrupts it silently, and the corruption only surfaces as a
+            `precondition_failed` on the NEXT request.
+
     CloseIssueResponse:
       type: object
-      required: [issue, already_closed, open_children]
+      required: [issue, already_closed, open_children, revision]
       properties:
         issue:
           $ref: '#/components/schemas/Issue'
@@ -7872,6 +8075,25 @@ components:
             close — including an idempotent re-close — because a caller that
             bypassed the guard is exactly the caller that wants the number. An
             unforced close that got this far had none, so it reports 0.
+        revision:
+          type: integer
+          format: int64
+          description: >-
+            The row's optimistic-concurrency token AFTER this close, spelled the
+            way `UpdateIssueResponse.revision` spells it.
+
+
+            It is here because `expected_version` is: a guard whose token no
+            response carries is a guard a caller cannot fill, and a
+            close-then-reopen or close-then-delete chain has to compose its next
+            expectation from the value the close ANSWERED with. An idempotent
+            re-close carries one too — the row still has a version, and a caller
+            that guarded a replay needs the token whether or not the replay
+            wrote.
+
+
+            DECODE IT AS A 64-BIT INTEGER, for the reason
+            `UpdateIssueResponse.revision` spells out.
 
     ReopenIssueRequest:
       type: object
@@ -7900,10 +8122,31 @@ components:
             the response, so a caller that wants it back reads the issue's
             events. Refused for control characters, and bounded by what the
             column holds rather than by the number above.
+        expected_version:
+          type: integer
+          format: int64
+          description: >-
+            Requires the row's revision to equal this value BEFORE the reopen. A
+            miss refuses the whole request with `409 precondition_failed` and
+            writes nothing — `CloseIssueRequest.expected_version`'s contract, on
+            the close's mirror.
+
+
+            IT IS CHECKED BEFORE THE NON-DONE NO-OP, the mirror of the close's
+            check-before-the-idempotent-re-close, and for the same reason: a
+            reopen of a row somebody else has moved is a `409` rather than the
+            200-with-`already_open` the same body earns unguarded, which is what
+            lets `already_open` be read as "nothing has happened here since".
+
+
+            The token is the `revision` this operation's own response carries;
+            compose the next expectation from a value a write ANSWERED with and
+            never from one the client computed. DECODE IT AS A 64-BIT INTEGER,
+            for the reason `UpdateIssueRequest.expected_version` spells out.
 
     ReopenIssueResponse:
       type: object
-      required: [issue, already_open]
+      required: [issue, already_open, revision]
       properties:
         issue:
           $ref: '#/components/schemas/Issue'
@@ -7914,6 +8157,15 @@ components:
             nothing — idempotent, mirroring `CloseIssueResponse.already_closed`
             and `ClaimResponse.already_claimed`. The response still carries the
             row.
+        revision:
+          type: integer
+          format: int64
+          description: >-
+            The row's optimistic-concurrency token AFTER this reopen, spelled
+            the way `CloseIssueResponse.revision` spells it and here for the same
+            reason: a recovery flow that reopens and then re-closes composes its
+            next `expected_version` from this value. DECODE IT AS A 64-BIT
+            INTEGER.
 
     MetadataValue:
       # No x-go-type-import: the generator already imports encoding/json

--- a/internal/httpapi/spec_parity_test.go
+++ b/internal/httpapi/spec_parity_test.go
@@ -1105,6 +1105,43 @@ func TestReopenRequestMembersMatchTheHandler(t *testing.T) {
 	}
 }
 
+// TestDeleteRequestMembersMatchTheHandler is the reopen's gate for the delete
+// body, and it is new in the slice that gave that body a sixth member.
+//
+// The gap it closes is the same one every gate in this file closes, on the
+// operation where it costs the most. `deleteMembers` is a hand-rolled copy of
+// the schema — the handler reads raw members so a refusal can name the
+// offending one, which on THIS operation is the difference between orphaning a
+// dependent and deleting it — and nothing tied that copy to the document.
+// A member documented and not honored is refused as `unknown_parameter` with
+// every other gate green; a member honored and not documented is undisclosed
+// input on an irreversible write.
+func TestDeleteRequestMembersMatchTheHandler(t *testing.T) {
+	accepted := map[string]bool{}
+	for _, name := range deleteMembers {
+		accepted[name] = true
+	}
+
+	goFields := jsonTagNames(t, reflect.TypeOf(apigen.DeleteIssuesRequest{}))
+	if extra := diff(goFields, accepted); len(extra) > 0 {
+		t.Errorf("generated DeleteIssuesRequest declares members the delete handler refuses as unknown: %v\n"+
+			"teach deleteRequest to honor them, or the document promises a member the server turns down", extra)
+	}
+	if missing := diff(accepted, goFields); len(missing) > 0 {
+		t.Errorf("the delete handler accepts members DeleteIssuesRequest does not declare: %v", missing)
+	}
+
+	doc := loadSpec(t)
+	schema := mapAt(t, mapAt(t, mapAt(t, doc, "components"), "schemas"), "DeleteIssuesRequest")
+	specProps := schemaProperties(t, doc, schema)
+	if extra := diff(specProps, accepted); len(extra) > 0 {
+		t.Errorf("the DeleteIssuesRequest schema documents members the delete handler refuses: %v", extra)
+	}
+	if missing := diff(accepted, specProps); len(missing) > 0 {
+		t.Errorf("the delete handler accepts members the DeleteIssuesRequest schema does not document: %v", missing)
+	}
+}
+
 // TestCompareAndSetMetadataRequestMembersMatchTheHandler is the reopen's gate
 // for the compare-and-set body, and it earns its place twice over: this handler
 // reads raw members not only to name an offending one but because the OMISSION

--- a/internal/httpapi/update.go
+++ b/internal/httpapi/update.go
@@ -146,7 +146,7 @@ func (s *Server) updateRequest(w http.ResponseWriter, r *http.Request, id string
 		return issueops.UpdateRequest{}, false
 	}
 
-	expectedVersion, res := applyInt64Member(members, "", "expected_version")
+	expectedVersion, res := applyVersionGuardMember(members, "")
 	if res != nil {
 		s.fail(w, r, *res)
 		return issueops.UpdateRequest{}, false


### PR DESCRIPTION
## What this is

Three operations publish a compare-and-set guard their roles have carried all along.

`internal/httpapi/close.go` said why it did not, in a comment:

> `ExpectedVersion` stays unpublished on this surface: a precondition would need a frozen conflict code for `ErrVersionMismatch` and a `row_version` on the issue body for clients to echo. Both are additive later.

Both landed in #5484. `precondition_failed` is frozen, `PreconditionFailed()` exists, and `UpdateIssueResponse.revision` is the token a client echoes. **This PR retires that comment by making it false**, on the three operations `ga-ufssu` still owned after #5484 took `updateIssue`'s three guards with the members that gave them meaning.

Spec first, then `make api-gen`, then the handlers.

## Member decisions

| Member | Decision | Evidence |
|---|---|---|
| `CloseIssueRequest.expected_version` | ADD | `issueops.CloseRequest.ExpectedVersion` — "requires the current row version to match and is **checked before an idempotent close**." That ordering is the one thing this guard has that `updateIssue`'s does not, and it is what lets `already_closed` be read as "and nothing has happened here since": unguarded, a replay over a row somebody else moved is a 200; guarded, it is a 409. Pinned end to end against real Dolt. |
| `ReopenIssueRequest.expected_version` | ADD | `issueops.ReopenRequest.ExpectedVersion`, "checked before a non-done no-op" — the mirror claim, and the mirror answer. |
| `DeleteIssuesRequest.expected_version` | ADD, single-id only | `issueops.DeleteRequest.ExpectedVersion` (#5481). The role's own words: "a non-nil `ExpectedVersion` beside more than one DISTINCT id is `ErrValidation`, refused before anything is read", because "a guard that passes by coincidence and a guard a caller can never satisfy are the same defect seen from two sides". **The wire refuses it at the edge** rather than letting it arrive through `failDeleteErr`, which answers the role's `ErrValidation` with **no `param` at all** — and the member name IS the recovery (send one guarded request per bead). |
| `CloseIssueResponse.revision`, `ReopenIssueResponse.revision` | ADD (required) | #5484's argument, verbatim: `types.Issue.RowVersion` is `json:"-"`, so a guard whose token no response carries is a guard a caller cannot fill. Both are REQUIRED, including on the idempotent answers: a caller that guarded a replay needs the token whether or not the replay wrote, and `already_closed: true` with no revision beside it leaves a chain unable to continue. Pinned: an idempotent re-close does **not** move the token (integration-verified against real Dolt). |
| `deleteIssues` arity `param` | `expected_version`, not `ids` | updateIssue's `force_assignee_transfer`-beside-`expected_assignee` rule: name the member that cannot be honored as sent. Removing the guard, or splitting the request, are the two recoveries; the guard is the member that says which. |
| `deleteIssues` blank-id refusal | ADD at the edge | Not a rider — a consequence. The arity rule counts DISTINCT TRIMMED ids, so `["", "be-1"]` with a guard would otherwise be told its guard names two beads, when the real fault is a broken id list. `ValidateDeleteRequest` puts the blank refusal ahead of the arity one; this keeps the wire's order the library's. It also upgrades a refusal that previously reached the wire with no `param`. |
| `revision` on `deleteIssues` | WITHHELD, necessarily | A deleted row has no version. The token a guarded delete needs comes from a lifecycle write, and the schema says so. |
| `actual_version` on any of the three 409s | WITHHELD | `PreconditionFailed`'s rule unchanged: the refusing transaction rolled back, so a read afterwards describes a row the refusal never saw. Asserted absent on all three. |
| `not_closable` on `reopenIssue` | STILL WITHHELD | Reopen takes an issue OUT of the done category, so no state of the graph can refuse it. The operation now has a 409 and still has no POLICY conflict, and the test says exactly that (below). |

## The read-side gap, again

Every one of these members has the same hole under it and every one of them names it: **no READ on this surface publishes a revision**. `getIssue` and `listIssues` do not carry one, so a first guarded write still has to seed itself from an unguarded lifecycle write or from `applyBatch`'s `ApplyItemResult.revision`. The integration loops in this PR do exactly that, visibly, because there is no other way to start one.

That is `ga-2ltro.11`'s work and is out of scope here. It is cited in every new member's description so the next slice inherits the gap rather than rediscovering it. (The gap is stated in the spec in prose; the bead id lives here, not in the OSS document.)

## The ordering that makes it correct

Every precondition arm is matched **typed and FIRST**, and on this stack the hazard is not "a worse status" — it is a **500**.

`ClassifyError` has no row for `ErrVersionMismatch`, deliberately: it is a per-operation guard, not a shared refusal. And neither leg wraps it — `CheckVersionInTx` returns the bare sentinel through `runIssueOperationTx` on the store legs (`internal/storage/issueops/version.go`) and the unit of work returns its own (`internal/storage/uow/deleter.go`). So below the arm all three fall into `failErr`'s default and answer a generic internal error for the one refusal that says an irreversible act was stopped because the caller's view had moved.

`failDeleteErr` is the sharpest case: its first arm was `errors.Is(err, ErrValidation)`, and `ErrVersionMismatch` wraps neither `ErrValidation` nor `ErrNotFound`, so the new arm had to go **above** that line.

Verified by mutation, not asserted — see the table below.

## `applyInt64Member` → `applyVersionGuardMember`

One refactor, and `unparam` asked for it: five call sites, every one passing `"expected_version"`. The function now names the member itself. Its `applyTextMember`/`applyBoolMember` siblings stay generic because they genuinely read many members; this one has read exactly one on every operation that ever published a 64-bit member. `prefix` stays — a batch item's guard is reported qualified, a single operation's bare.

The alternative was a `.golangci.yml` exclusion. Five call sites agreeing on one spelling by construction is better than a config entry saying they must.

## Tests

Pure, in `internal/httpapi/{close,reopen,delete}_test.go`, on the fake role.

- `TestCloseForwardsTheVersionGuard` / `TestReopenForwardsTheVersionGuard` / `TestDeleteForwardsTheVersionGuard` — the member reaches the role as the POINTER it models, **including a guard on the never-written version 0**, and an absent member stays nil. The nil half is not decoration: collapsing absence into `&0` would refuse every write to a row that has ever been written.
- `TestCloseAnswersWithTheRowsRevision` / `TestReopenAnswersWithTheRowsRevision` — asserted against the row the ROLE answered with, not against whatever the handler put there. #5484 measured that difference: its first version echoed the handler's own number and stayed green against `revision: 0`.
- `TestCloseRefusesAStaleGuard` / `TestReopenRefusesAStaleGuard` / `TestDeleteRefusesAStaleGuard` — 409, `param`, the echoed `expected_version`, and `actual_version` asserted ABSENT.
- `TestCloseGuardOutranksClosePolicy`, `TestCloseForceDoesNotBypassTheGuard` — the two members make unrelated claims.
- `TestDeleteRefusesAGuardBesideSeveralIDs` — 400, `param: expected_version`, nothing reaches the role.
- `TestDeleteCountsDistinctIDsForTheGuard` — **the anti-drift pin**, and the case that earns the local counting helper its place. The transport boundary keeps `internal/workapi` out of this package, so `NormalizeDeleteIDs`' rule is respelled in the handler; an edge that counted mentions, or counted untrimmed, would refuse a request the library calls legal and nothing else here would notice.
- `TestDeleteRefusesABlankID`, plus a malformed-token case on each of the three.
- `TestDeleteRequestMembersMatchTheHandler` — **new**. `deleteMembers` is hand-rolled and had nothing tying it to the document; on this operation a member documented-and-refused or honored-and-undocumented is the difference between orphaning a dependent and deleting it.
- `guardToken` is `9007199254740993` — past 2^53 on purpose, and `revisionOf` decodes into a typed `*int64` rather than `map[string]any`. Reading it the wrong way fails here in milliseconds instead of against real Dolt, which is where #5484 found it.

**One test changed rather than being added to.** `TestReopenPublishesNoConflictCode` claimed reopen publishes no 409 at all. That claim died with this member, so it is now `TestReopenPublishesNoPolicyConflictCode`, written as an EXACT SET (`{precondition_failed}`) rather than as "no conflicts" — so a future policy code on this row has to be landed deliberately. The comment says what was relaxed and why, because a silently weakened assertion is the thing a reviewer cannot see.

### Mutation checks

| Mutation | Result |
|---|---|
| remove the precondition arm from `failClose` | `TestCloseRefusesAStaleGuard` RED — **500, not 409** |
| remove the precondition arm from `failReopen` | `TestReopenRefusesAStaleGuard` RED — 500 |
| remove the precondition arm from `failDeleteErr` | `TestDeleteRefusesAStaleGuard` RED — 500 |
| answer `revision: 0` instead of the row's, on close | `TestCloseAnswersWithTheRowsRevision` RED (both arms) |
| answer `revision: 0` instead of the row's, on reopen | `TestReopenAnswersWithTheRowsRevision` RED (both arms) |
| never forward the parsed guard to the role | 3 close cases RED, including the 409's echoed member |
| count MENTIONS instead of distinct ids | `TestDeleteCountsDistinctIDsForTheGuard` RED, all three arms |
| drop the trim from the distinct count | RED on the ` be-1` arm only — the arm that exists for it |
| drop the arity rule entirely | `TestDeleteRefusesAGuardBesideSeveralIDs` RED |
| drop the blank-id check | `TestDeleteRefusesABlankID` RED |
| drop `expected_version` from `deleteMembers` | `TestDeleteRequestMembersMatchTheHandler` RED, both directions |

## Integration coverage

`cmd/bd/serve_close_proxied_integration_test.go` gains one subtest and `cmd/bd/serve_delete_proxied_integration_test.go` is new. All green against real Dolt.

**The stale token is made by a real concurrent writer, never by arithmetic.** The token is opaque and compared for equality alone, so `revision - 1` is not "the previous revision" — there is no way to construct a stale one except to let something move the row. The close loop is: seed with an unguarded write, move the row as another actor (asserting the token CHANGED, or every guard is vacuous), stale close refused with the row still open, **forced** stale close refused too, fresh guard lands, then the same for the reopen.

Two claims only a real store can hold, and both passed:

- **The guard is evaluated BEFORE the idempotent re-close.** The same body that earns `200 already_closed` unguarded is a `409` when it carries a token the close itself invalidated.
- **An idempotent re-close does not move the token.** A replay that writes nothing leaves `row_lock` where it was, so a chain can keep composing from it. Asserted rather than assumed — it is the property that makes the previous bullet useful.

The delete file covers: a stale guard refusing **with the bead still readable afterwards** (the assertion this whole slice exists for), `force`/`cascade`/both refusing identically because they bypass POLICY and never a precondition, `dry_run` refusing where the real run would, the fresh guard landing and the bead gone, the arity refusal leaving BOTH beads intact (and the same two ids without a guard succeeding, which is what makes it a statement about the guard rather than about the list), a repeated id beside a guard being one bead, and the 404 outranking the guard.

The `closeIssue`/`reopenIssue` helpers gained raw-body twins for `revision`; the decoded helpers are untouched, so the existing CLI/HTTP parity oracle is unchanged — #5484's arrangement, for its reason.

## Gates

`make api-check`, `go build ./...`, `go vet ./...`, `gofmt -l` clean, `golangci-lint run ./internal/httpapi/... ./cmd/bd/...` and `--new-from-rev=origin/main ./...` (0 issues each), and `BEADS_TEST_PROXIED_SERVER=1 CGO_ENABLED=1 go test ./cmd/bd/ -run 'TestProxiedServerServeClose|TestProxiedServerServeDelete' -count=1` green against real Dolt.

The pre-commit hook's `go run golangci-lint@v2.10.1` fails on this host with a toolchain mismatch unrelated to this change (`the Go language version (go1.25) used to build golangci-lint is lower than the targeted Go version (1.26.5)`), so the hook's contents were run by hand with the pinned v2.10.1 binary before committing with `--no-verify`.

## Stacking

**First of a two-PR stack.** `ga-9zbwu` (`issues:count`) is based on this branch: the two share spec and handler territory — `problem.go`'s operation table and the operation-vocabulary prose. Merge this one first; the counts branch then rebases onto main and its own diff is what to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
