### PR TITLE
fix(ui): stop using blocked ● for priority in CLI output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,9 +50,9 @@ and credit their design/tests.
 
 **NEVER use emoji-style icons** (🔴🟠🟡🔵⚪) in CLI output. They cause cognitive overload.
 
-**ALWAYS use small Unicode symbols** with semantic colors:
+**ALWAYS use small Unicode symbols** with semantic colors (status uses symbols; priority uses labels):
 - Status: `○ ◐ ● ✓ ❄`
-- Priority: `● P0` (filled circle with color)
+- Priority: `P0`–`P4` label with color (no status glyph)
 
 See [AGENT_INSTRUCTIONS.md](AGENT_INSTRUCTIONS.md) for full development guidelines.
 

--- a/AGENT_INSTRUCTIONS.md
+++ b/AGENT_INSTRUCTIONS.md
@@ -269,7 +269,7 @@ consistency.
 Use small Unicode symbols with semantic colors applied via lipgloss:
 
 - Status: `○ ◐ ● ✓ ❄`
-- Priority: `●` (filled circle with color)
+- Priority: `P0`–`P4` label with color (no status glyph)
 
 #### Status Icons
 
@@ -283,13 +283,14 @@ Use these symbols consistently across all commands:
 ❄ deferred    - Scheduled for later (blue/muted)
 ```
 
-#### Priority Icons and Colors
+#### Priority Labels and Colors
 
-Format priority as `● P0` (filled circle icon plus label, colored by priority):
+Format priority as the P-label with color only (no status glyph — `●` is blocked status):
 
-- `● P0`: Red + bold (critical)
-- `● P1`: Orange (high)
-- `● P2-P4`: Default text (normal)
+- `P0`: Red + bold (critical)
+- `P1`: Orange (high)
+- `P2`: Amber (elevated)
+- `P3`–`P4`: Default text
 
 #### Issue Type Colors
 

--- a/cmd/bd/graph.go
+++ b/cmd/bd/graph.go
@@ -1120,7 +1120,7 @@ func formatCompactNode(node *GraphNode) string {
 	// Use shared status icon with semantic color
 	statusIcon := ui.RenderStatusIcon(status)
 
-	// Priority with icon
+	// Priority with semantic color (P-label only)
 	priorityTag := ui.RenderPriority(node.Issue.Priority)
 
 	// Title - truncate if too long
@@ -1132,7 +1132,7 @@ func formatCompactNode(node *GraphNode) string {
 		return fmt.Sprintf("%s %s %s %s",
 			statusIcon,
 			style.Render(node.Issue.ID),
-			style.Render(fmt.Sprintf("● P%d", node.Issue.Priority)),
+			style.Render(fmt.Sprintf("P%d", node.Issue.Priority)),
 			style.Render(title))
 	}
 

--- a/cmd/bd/list_format.go
+++ b/cmd/bd/list_format.go
@@ -57,13 +57,12 @@ func formatPrettyIssue(issue *types.Issue) string {
 	}
 
 	// Format: STATUS_ICON ID PRIORITY [Type] Title
-	// Priority uses ● icon with color, no brackets needed
 	// Closed issues: entire line is muted
 	if issue.Status == types.StatusClosed {
 		return fmt.Sprintf("%s %s %s %s%s",
 			statusIcon,
 			ui.RenderMuted(issue.ID),
-			ui.RenderMuted(fmt.Sprintf("● P%d", issue.Priority)),
+			ui.RenderMuted(fmt.Sprintf("P%d", issue.Priority)),
 			ui.RenderMuted(string(issue.IssueType)),
 			ui.RenderMuted(" "+issue.Title))
 	}

--- a/cmd/bd/list_tree.go
+++ b/cmd/bd/list_tree.go
@@ -212,6 +212,7 @@ func displayPrettyListWithDepsMode(issues []*types.Issue, showHeader bool, allDe
 	}
 	fmt.Println()
 	fmt.Println("Status: ○ open  ◐ in_progress  ● blocked  ✓ closed  ❄ deferred")
+	fmt.Println("Priority: P0–P4 (label only; not a status icon)")
 	if dr != nil {
 		fmt.Printf("Deps:   %s = depends-on / relationship (points to target); siblings ordered so dependencies come first; ↗ = target outside current view\n", depGlyph)
 	}

--- a/cmd/bd/ready.go
+++ b/cmd/bd/ready.go
@@ -419,6 +419,7 @@ func displayReadyList(issues []*types.Issue, parentEpicMap map[string]string) {
 	fmt.Printf("Ready: %d issues with no active blockers\n", len(issues))
 	fmt.Println()
 	fmt.Println("Status: ○ open  ◐ in_progress  ● blocked  ✓ closed  ❄ deferred")
+	fmt.Println("Priority: P0–P4 (label only; not a status icon)")
 }
 
 // readyExplainFilter is the filter both --explain routes run, derived from the

--- a/cmd/bd/show_format.go
+++ b/cmd/bd/show_format.go
@@ -32,7 +32,7 @@ func formatShortIssue(issue *types.Issue) string {
 		return fmt.Sprintf("%s %s %s %s%s",
 			statusIcon,
 			ui.RenderMuted(issue.ID),
-			ui.RenderMuted(fmt.Sprintf("● P%d", issue.Priority)),
+			ui.RenderMuted(fmt.Sprintf("P%d", issue.Priority)),
 			ui.RenderMuted(string(issue.IssueType)),
 			ui.RenderMuted(" "+issue.Title))
 	}
@@ -49,7 +49,7 @@ func formatIssueHeader(issue *types.Issue) string {
 	statusStyle := ui.GetStatusStyle(string(issue.Status))
 	statusStr := statusStyle.Render(strings.ToUpper(string(issue.Status)))
 
-	// Priority with semantic color (includes ● icon)
+	// Priority with semantic color (P-label only)
 	priorityTag := ui.RenderPriority(issue.Priority)
 
 	// Type badge for notable types
@@ -179,7 +179,7 @@ func formatDependencyLine(prefix string, dep *types.IssueWithDependencyMetadata)
 			prefix, statusIcon,
 			ui.RenderMuted(dep.ID),
 			ui.RenderMuted(dep.Title),
-			ui.RenderMuted(fmt.Sprintf("● P%d", dep.Priority)))
+			ui.RenderMuted(fmt.Sprintf("P%d", dep.Priority)))
 	}
 
 	// Active items: ID with status color, priority with semantic color
@@ -209,7 +209,7 @@ func formatSimpleDependencyLine(prefix string, dep *types.Issue) string {
 			prefix, statusIcon,
 			ui.RenderMuted(dep.ID),
 			ui.RenderMuted(dep.Title),
-			ui.RenderMuted(fmt.Sprintf("● P%d", dep.Priority)))
+			ui.RenderMuted(fmt.Sprintf("P%d", dep.Priority)))
 	}
 
 	// Active items: use semantic colors

--- a/docs/workflows/todo.md
+++ b/docs/workflows/todo.md
@@ -42,8 +42,8 @@ bd todo list --json     # JSON output
 
 **Output:**
 ```
-  ○ test-yxg  Fix the login bug                         ● P1  open
-  ○ test-ryl  Update documentation                      ● P3  open
+  ○ test-yxg  Fix the login bug                         P1  open
+  ○ test-ryl  Update documentation                      P3  open
 
 Total: 2 TODOs
 ```

--- a/format/format.go
+++ b/format/format.go
@@ -29,7 +29,7 @@ func PrettyIssue(issue *types.Issue) string {
 		return fmt.Sprintf("%s %s %s %s%s",
 			statusIcon,
 			ui.RenderMuted(issue.ID),
-			ui.RenderMuted(fmt.Sprintf("● P%d", issue.Priority)),
+			ui.RenderMuted(fmt.Sprintf("P%d", issue.Priority)),
 			ui.RenderMuted(string(issue.IssueType)),
 			ui.RenderMuted(" "+issue.Title))
 	}

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -283,10 +283,6 @@ const (
 	StatusIconCustom     = "◇" // custom/uncategorized status (diamond)
 )
 
-// Priority icon - small filled circle, colored by priority level
-// IMPORTANT: Use this small circle, NOT emoji blobs (🔴🟠🟡🔵⚪)
-const PriorityIcon = "●"
-
 // RenderStatusIcon returns the appropriate icon for a status with semantic coloring.
 // This is the canonical source for status icon rendering - use this everywhere.
 // For custom statuses, call RenderStatusIconWithCategory for category-aware rendering.
@@ -514,11 +510,12 @@ func RenderStatus(status string) string {
 	}
 }
 
-// RenderPriority renders a priority level with semantic styling
-// Format: ● P0 (icon + label)
-// P0/P1 get color; P2/P3/P4 use standard text
+// RenderPriority renders a priority level with semantic styling.
+// Format: P0 (label only). Status blocked uses ● (StatusIconBlocked); reusing
+// that glyph for priority made agents misread "● P3" as blocked (GH#4996).
+// P0/P1/P2 get color; P3/P4 use standard text.
 func RenderPriority(priority int) string {
-	label := fmt.Sprintf("%s P%d", PriorityIcon, priority)
+	label := fmt.Sprintf("P%d", priority)
 	switch priority {
 	case 0:
 		return PriorityP0Style.Render(label)
@@ -535,24 +532,10 @@ func RenderPriority(priority int) string {
 	}
 }
 
-// RenderPriorityCompact renders just the priority label without icon
-// Use when space is constrained or icon would be redundant
+// RenderPriorityCompact is an alias of RenderPriority (no glyph difference
+// remains after GH#4996).
 func RenderPriorityCompact(priority int) string {
-	label := fmt.Sprintf("P%d", priority)
-	switch priority {
-	case 0:
-		return PriorityP0Style.Render(label)
-	case 1:
-		return PriorityP1Style.Render(label)
-	case 2:
-		return PriorityP2Style.Render(label)
-	case 3:
-		return PriorityP3Style.Render(label)
-	case 4:
-		return PriorityP4Style.Render(label)
-	default:
-		return label
-	}
+	return RenderPriority(priority)
 }
 
 // RenderType renders an issue type with semantic styling

--- a/internal/ui/styles_test.go
+++ b/internal/ui/styles_test.go
@@ -60,17 +60,17 @@ func TestRenderStatusAndPriority(t *testing.T) {
 		}
 	}
 
-	// RenderPriority now includes the priority icon (●)
+	// RenderPriority is P-label only (no ● — that glyph is status blocked; GH#4996)
 	priorityCases := []struct {
 		priority int
 		want     string
 	}{
-		{0, PriorityP0Style.Render(PriorityIcon + " P0")},
-		{1, PriorityP1Style.Render(PriorityIcon + " P1")},
-		{2, PriorityP2Style.Render(PriorityIcon + " P2")},
-		{3, PriorityP3Style.Render(PriorityIcon + " P3")},
-		{4, PriorityP4Style.Render(PriorityIcon + " P4")},
-		{5, PriorityIcon + " P5"},
+		{0, PriorityP0Style.Render("P0")},
+		{1, PriorityP1Style.Render("P1")},
+		{2, PriorityP2Style.Render("P2")},
+		{3, PriorityP3Style.Render("P3")},
+		{4, PriorityP4Style.Render("P4")},
+		{5, "P5"},
 	}
 	for _, tc := range priorityCases {
 		if got := RenderPriority(tc.priority); got != tc.want {
@@ -78,7 +78,7 @@ func TestRenderStatusAndPriority(t *testing.T) {
 		}
 	}
 
-	// RenderPriorityCompact returns just "P0" without icon
+	// RenderPriorityCompact returns just "P0"
 	if got := RenderPriorityCompact(0); !strings.Contains(got, "P0") {
 		t.Fatalf("compact priority should contain P0, got %q", got)
 	}

--- a/tests/oracle-a/harness/scenarios/enumerated.json
+++ b/tests/oracle-a/harness/scenarios/enumerated.json
@@ -14824,7 +14824,7 @@
     "--short"
    ]
   ],
-  "pins": "--short prints single formatShortIssue line: '<icon> sh-sho ● P1 [bug] Shorty' style (one line, no full sections)",
+  "pins": "--short prints single formatShortIssue line: '<icon> sh-sho P1 [bug] Shorty' style (one line, no full sections)",
   "deterministic": true
  },
  {


### PR DESCRIPTION
Fixes #4996 — reported by @edgetools, who traced agents' repeated "blocked?" misreads to the glyph reuse in `bd ready` output.

Priority was rendered as `● Pn`, reusing the filled circle the Status legend maps to blocked. Agents scanning `bd ready` (and tree/show/graph views) misread ready work as blocked.

Render priority as the P-label + color only; `●` stays status-blocked only. Add a `Priority: P0–P4 (label only; not a status icon)` line to the ready/tree footer legends (the agent-scanned lists). Graph footers are left as-is to keep the diff minimal — happy to extend the same Priority legend there if preferred.

Agent-facing docs and instruction files (`AGENTS.md`, `AGENT_INSTRUCTIONS.md`, todo workflow samples) are updated so agents are not re-taught the old `● P0` convention. Per-level priority colors live only in `AGENT_INSTRUCTIONS.md` (P0 red+bold, P1 orange, P2 amber, P3–P4 default), matching `internal/ui/styles.go`.

`RenderPriorityCompact` is kept as a thin alias of `RenderPriority`; internal package, so happy to delete it instead if preferred.

Verification: `CGO_ENABLED=0 go test -tags gms_pure_go ./format/ ./internal/ui/ ./cmd/bd/` — format and ui pass; cmd/bd has pre-existing env-dependent failures on this host (e.g. TestInit*, TestAutoExport*, TestMultiIDUpdate*) matching base; none on rendering paths.