### PR TITLE
fix: export the native prebuilt test binary path

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -425,6 +425,10 @@ jobs:
         shell: bash
         run: go test '-tags=integration,gms_pure_go' -count=1 -run '^TestPRPreflight' ./scripts
 
+      - name: Exercise test.sh prebuilt binary path
+        shell: bash
+        run: go test '-tags=gms_pure_go' -count=1 -run '^TestTestScriptPrebuiltBinaryContract$' ./scripts
+
   # Fast check to catch accidental .beads/issues.jsonl changes from contributors
   check-no-beads-changes:
     name: Check for .beads changes

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -251,6 +251,42 @@ func TestMacOSTestJobsReuseWorkspaceBDBinary(t *testing.T) {
 	}
 }
 
+func TestPRPreflightPlatformsRunsTestScriptPrebuiltBinaryContract(t *testing.T) {
+	workflow := readCIWorkflow(t, "pr.yml")
+	job := workflow.job(t, "pr-preflight-platforms")
+	if job.RunsOn != "${{ matrix.os }}" {
+		t.Errorf("pr-preflight-platforms runs-on = %q, want matrix.os", job.RunsOn)
+	}
+	if job.If != "" || job.TimeoutMinutes != 10 {
+		t.Errorf("pr-preflight-platforms condition/timeout = %q/%d, want unconditional/10",
+			job.If, job.TimeoutMinutes)
+	}
+	if got := job.Strategy.Matrix.OS; !equalStrings(got, []string{"ubuntu-latest", "macos-latest", "windows-latest"}) {
+		t.Errorf("pr-preflight-platforms matrix os = %v, want all three hosted platforms", got)
+	}
+
+	const stepName = "Exercise test.sh prebuilt binary path"
+	assertStepRunsExactly(t, job, stepName,
+		"go test '-tags=gms_pure_go' -count=1 -run '^TestTestScriptPrebuiltBinaryContract$' ./scripts")
+	step := job.step(t, stepName)
+	if step.Shell != "bash" || step.If != "" || (step.ContinueOnError != nil && step.ContinueOnError != false) {
+		t.Errorf("%s shell/condition/continue-on-error = %q/%q/%v, want unconditional required bash",
+			stepName, step.Shell, step.If, step.ContinueOnError)
+	}
+
+	gate := workflow.job(t, "ci-gate")
+	gateEnv := gate.step(t, "Evaluate CI gate").Env
+	if !contains(gate.Needs, "pr-preflight-platforms") {
+		t.Errorf("ci-gate does not need pr-preflight-platforms: %v", gate.Needs)
+	}
+	if got, want := gateEnv["PR_PREFLIGHT_PLATFORMS"], "${{ needs.pr-preflight-platforms.result }}"; got != want {
+		t.Errorf("ci-gate PR_PREFLIGHT_PLATFORMS = %q, want %q", got, want)
+	}
+	if !contains(strings.Fields(gateEnv["CI_GATE_REQUIRED"]), "PR_PREFLIGHT_PLATFORMS") {
+		t.Errorf("ci-gate required set omits PR_PREFLIGHT_PLATFORMS")
+	}
+}
+
 func TestGoCacheOwnershipTopology(t *testing.T) {
 	workflows := map[string]ciWorkflow{
 		"main.yml":    readCIWorkflow(t, "main.yml"),
@@ -350,7 +386,7 @@ func TestGoCacheOwnershipTopology(t *testing.T) {
 	assertStepsBefore(t, workflows["pr.yml"].job(t, "check-doc-freshness-platforms"),
 		[]string{"Restore Go module cache"}, []string{"Exercise native date and Bash process boundary"})
 	assertStepsBefore(t, workflows["pr.yml"].job(t, "pr-preflight-platforms"),
-		[]string{"Restore Go module cache"}, []string{"Exercise the real Bash process boundary"})
+		[]string{"Restore Go module cache"}, []string{"Exercise the real Bash process boundary", "Exercise test.sh prebuilt binary path"})
 
 	prRiskEmbedded := workflows["pr-risk.yml"].job(t, "build-embedded")
 	prRiskNonRaceBuilds := []string{"Build proxied bd subprocess binary", "Build server Dolt conformance test binary"}
@@ -756,14 +792,15 @@ type ciWorkflowMatrixInclude struct {
 }
 
 type ciWorkflowStep struct {
-	Name  string            `yaml:"name"`
-	ID    string            `yaml:"id"`
-	If    string            `yaml:"if"`
-	Uses  string            `yaml:"uses"`
-	Run   string            `yaml:"run"`
-	Shell string            `yaml:"shell"`
-	Env   map[string]string `yaml:"env"`
-	With  map[string]string `yaml:"with"`
+	Name            string            `yaml:"name"`
+	ID              string            `yaml:"id"`
+	If              string            `yaml:"if"`
+	Uses            string            `yaml:"uses"`
+	Run             string            `yaml:"run"`
+	Shell           string            `yaml:"shell"`
+	ContinueOnError any               `yaml:"continue-on-error"`
+	Env             map[string]string `yaml:"env"`
+	With            map[string]string `yaml:"with"`
 }
 
 type ciWorkflowStringList []string

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -108,8 +108,9 @@ if [[ -z "${BEADS_TEST_BD_BINARY:-}" ]]; then
             fi
             mkdir -p "$PREBUILT_BD_DIR"
             echo "Prebuilding bd for subprocess tests..." >&2
-            if go build -o "$PREBUILT_BD_DIR/bd" "$REPO_ROOT/cmd/bd"; then
-                export BEADS_TEST_BD_BINARY="$PREBUILT_BD_DIR/bd"
+            PREBUILT_BD_BIN="$PREBUILT_BD_DIR/bd$(go env GOEXE)"
+            if go build -o "$PREBUILT_BD_BIN" "$REPO_ROOT/cmd/bd"; then
+                export BEADS_TEST_BD_BINARY="$PREBUILT_BD_BIN"
                 echo "Prebuilt bd: $BEADS_TEST_BD_BINARY" >&2
             else
                 echo "WARN: bd prebuild failed; tests will build their own binaries" >&2

--- a/scripts/test_script_test.go
+++ b/scripts/test_script_test.go
@@ -1,0 +1,270 @@
+package scripts_test
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+const (
+	testScriptFakeGoLogEnv      = "BEADS_TEST_SCRIPT_FAKE_GO_LOG"
+	testScriptExpectedBinaryEnv = "BEADS_TEST_SCRIPT_EXPECTED_BINARY"
+	testScriptExpectedBaseEnv   = "BEADS_TEST_SCRIPT_EXPECTED_BASENAME"
+	testScriptDriverEnv         = "BEADS_TEST_SCRIPT_DRIVER"
+	testScriptNativeSuffixEnv   = "BEADS_TEST_SCRIPT_NATIVE_SUFFIX"
+	testScriptLaunchProbeEnv    = "BEADS_TEST_SCRIPT_LAUNCH_PROBE"
+)
+
+const testScriptFakeGo = `#!/usr/bin/env bash
+set -euo pipefail
+
+record() {
+    printf '%s\n' "$1" >>"$BEADS_TEST_SCRIPT_FAKE_GO_LOG"
+}
+
+case "${1:-}" in
+    env)
+        record env
+        if [[ $# -ne 2 || "$2" != "GOEXE" ]]; then
+            printf 'fake go: unsupported env arguments: %s\n' "$*" >&2
+            exit 90
+        fi
+        printf '%s\n' "$BEADS_TEST_SCRIPT_NATIVE_SUFFIX"
+        ;;
+    build)
+        record build
+        shift
+        output=""
+        while [[ $# -gt 0 ]]; do
+            if [[ "$1" == "-o" ]]; then
+                if [[ $# -lt 2 ]]; then
+                    printf 'fake go: -o is missing its output\n' >&2
+                    exit 90
+                fi
+                output="$2"
+                shift 2
+            else
+                shift
+            fi
+        done
+        if [[ -z "$output" || "$output" != "$BEADS_TEST_SCRIPT_EXPECTED_BINARY" ]]; then
+            printf 'fake go: build output %q, want %q\n' "$output" "$BEADS_TEST_SCRIPT_EXPECTED_BINARY" >&2
+            exit 90
+        fi
+        cp -f -- "$BEADS_TEST_SCRIPT_DRIVER" "$output"
+        chmod +x "$output"
+        ;;
+    test)
+        record test
+        "$BEADS_TEST_SCRIPT_DRIVER" \
+            -test.run '^TestTestScriptPrebuiltBinaryLaunchProbe$' \
+            -test.count=1
+        ;;
+    *)
+        printf 'fake go: unsupported command: %s\n' "$*" >&2
+        exit 90
+        ;;
+esac
+`
+
+func TestTestScriptPrebuiltBinaryContract(t *testing.T) {
+	t.Run("generated path uses the native executable suffix and launches", func(t *testing.T) {
+		commands := runTestScriptWithFakeGo(t, "")
+		assertFakeGoCommands(t, commands, "env", "build", "test")
+	})
+
+	t.Run("caller supplied binary wins without a build", func(t *testing.T) {
+		fixtureRoot := filepath.Join(t.TempDir(), "caller override with spaces")
+		if err := os.MkdirAll(fixtureRoot, 0o755); err != nil {
+			t.Fatalf("create caller fixture root: %v", err)
+		}
+		callerBinary := filepath.Join(fixtureRoot, "caller supplied bd"+nativeExecutableSuffix())
+		copyCurrentTestExecutable(t, callerBinary)
+
+		commands := runTestScriptWithFakeGo(t, callerBinary)
+		assertFakeGoCommands(t, commands, "test")
+	})
+}
+
+// TestTestScriptPrebuiltBinaryLaunchProbe is selected only by the fake go test
+// process above. Keeping the os/exec probe in a normal test avoids claiming the
+// package-wide TestMain authority needed by other script-selection contracts.
+func TestTestScriptPrebuiltBinaryLaunchProbe(t *testing.T) {
+	if os.Getenv(testScriptLaunchProbeEnv) != "1" {
+		return
+	}
+
+	prebuilt := os.Getenv("BEADS_TEST_BD_BINARY")
+	expected := os.Getenv(testScriptExpectedBinaryEnv)
+	if prebuilt == "" || expected == "" || !sameTestScriptFile(prebuilt, expected) {
+		t.Fatalf("exported prebuilt binary %q is not expected file %q", prebuilt, expected)
+	}
+	if want := os.Getenv(testScriptExpectedBaseEnv); filepath.Base(prebuilt) != want {
+		t.Fatalf("exported prebuilt basename = %q, want %q", filepath.Base(prebuilt), want)
+	}
+
+	command := exec.Command(prebuilt, "-test.run=^$")
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("launch exported prebuilt binary through os/exec: %v\n%s", err, output)
+	}
+}
+
+func runTestScriptWithFakeGo(t *testing.T, callerBinary string) []string {
+	t.Helper()
+
+	root := filepath.Join(t.TempDir(), "test script root with spaces")
+	fakeBin := filepath.Join(root, "fake go bin")
+	testEnvRoot := filepath.Join(root, "isolated test environment")
+	tempRoot := filepath.Join(root, "temporary files")
+	for _, path := range []string{fakeBin, testEnvRoot, tempRoot} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("create fixture directory %s: %v", path, err)
+		}
+	}
+
+	fakeGo := filepath.Join(fakeBin, "go")
+	if err := os.WriteFile(fakeGo, []byte(testScriptFakeGo), 0o755); err != nil {
+		t.Fatalf("write fake go: %v", err)
+	}
+	callLog := filepath.Join(root, "fake go calls")
+	if err := os.WriteFile(callLog, nil, 0o600); err != nil {
+		t.Fatalf("initialize fake-go call log: %v", err)
+	}
+
+	expected := callerBinary
+	if expected == "" {
+		expected = filepath.Join(testEnvRoot, "prebuilt-bd", "bd"+nativeExecutableSuffix())
+	}
+
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Fatalf("bash is required to exercise scripts/test.sh: %v", err)
+	}
+	repoRoot := sourceRepoRoot(t)
+	env := testScriptEnvironment(testEnvRoot, tempRoot, expected, callerBinary)
+	fakeBinShellPath := shellPathUnderEnv(t, bash, fakeBin, env)
+	fakeGoShellPath := shellPathUnderEnv(t, bash, fakeGo, env)
+	driverShellPath := shellPathUnderEnv(t, bash, currentTestExecutable(t), env)
+	callLogShellPath := shellPathUnderEnv(t, bash, callLog, env)
+	env = append(env,
+		"BEADS_TEST_COMMAND_PATH="+fakeBinShellPath+":/usr/bin:/bin",
+		testScriptDriverEnv+"="+driverShellPath,
+		testScriptFakeGoLogEnv+"="+callLogShellPath,
+	)
+
+	cmd := exec.Command(
+		bash,
+		"--noprofile",
+		"--norc",
+		"-c",
+		`PATH="$BEADS_TEST_COMMAND_PATH"; export PATH; exec "$BASH" --noprofile --norc "$1" "$2"`,
+		"test-script",
+		shellPathUnderEnv(t, bash, filepath.Join(repoRoot, "scripts", "test.sh"), env),
+		"./cmd/bd",
+	)
+	cmd.Dir = repoRoot
+	cmd.Env = env
+	requireShellCommandPath(t, bash, repoRoot, env, "go", fakeGoShellPath)
+	output, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Fatalf("scripts/test.sh failed: %v\n%s", runErr, output)
+	}
+
+	content, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatalf("read fake-go call log: %v", err)
+	}
+	return strings.Fields(string(content))
+}
+
+func testScriptEnvironment(testEnvRoot string, tempRoot string, expected string, callerBinary string) []string {
+	home := filepath.Join(testEnvRoot, "home")
+	env := []string{
+		"PATH=/usr/bin:/bin",
+		"HOME=" + portableTestScriptPath(home),
+		"USERPROFILE=" + portableTestScriptPath(home),
+		"TMPDIR=" + portableTestScriptPath(tempRoot),
+		"TEMP=" + portableTestScriptPath(tempRoot),
+		"TMP=" + portableTestScriptPath(tempRoot),
+		"LC_ALL=C",
+		"LANG=C",
+		"BASH_ENV=",
+		"ENV=",
+		"CGO_ENABLED=1",
+		"GOFLAGS=",
+		"BEADS_TEST_ENV_ACTIVE=1",
+		"BEADS_TEST_ENV_ROOT=" + portableTestScriptPath(testEnvRoot),
+		testScriptExpectedBinaryEnv + "=" + portableTestScriptPath(expected),
+		testScriptExpectedBaseEnv + "=" + filepath.Base(expected),
+		testScriptNativeSuffixEnv + "=" + nativeExecutableSuffix(),
+		testScriptLaunchProbeEnv + "=1",
+	}
+	if callerBinary != "" {
+		env = append(env, "BEADS_TEST_BD_BINARY="+portableTestScriptPath(callerBinary))
+	}
+	for _, key := range []string{"SYSTEMROOT", "WINDIR", "COMSPEC", "PATHEXT"} {
+		if value, ok := os.LookupEnv(key); ok {
+			env = append(env, key+"="+value)
+		}
+	}
+	return env
+}
+
+func assertFakeGoCommands(t *testing.T, commands []string, want ...string) {
+	t.Helper()
+	if strings.Join(commands, " ") != strings.Join(want, " ") {
+		t.Fatalf("fake-go commands = %q, want %q", commands, want)
+	}
+}
+
+func copyCurrentTestExecutable(t *testing.T, destination string) {
+	t.Helper()
+	input, err := os.Open(currentTestExecutable(t))
+	if err != nil {
+		t.Fatalf("open current test executable: %v", err)
+	}
+	defer input.Close()
+
+	output, err := os.OpenFile(destination, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o755)
+	if err != nil {
+		t.Fatalf("create native test executable: %v", err)
+	}
+	if _, err := io.Copy(output, input); err != nil {
+		_ = output.Close()
+		t.Fatalf("copy native test executable: %v", err)
+	}
+	if err := output.Close(); err != nil {
+		t.Fatalf("close native test executable: %v", err)
+	}
+}
+
+func currentTestExecutable(t *testing.T) string {
+	t.Helper()
+	path, err := os.Executable()
+	if err != nil {
+		t.Fatalf("resolve current test executable: %v", err)
+	}
+	return path
+}
+
+func sameTestScriptFile(first string, second string) bool {
+	firstInfo, firstErr := os.Stat(first)
+	secondInfo, secondErr := os.Stat(second)
+	return firstErr == nil && secondErr == nil && os.SameFile(firstInfo, secondInfo)
+}
+
+func nativeExecutableSuffix() string {
+	if runtime.GOOS == "windows" {
+		return ".exe"
+	}
+	return ""
+}
+
+func portableTestScriptPath(path string) string {
+	return filepath.ToSlash(filepath.Clean(path))
+}


### PR DESCRIPTION
## Summary

- derive the complete prebuilt `bd` path with `go env GOEXE`;
- use that one path for both `go build -o` and `BEADS_TEST_BD_BINARY`;
- preserve the caller-supplied binary fast path; and
- maintain the contract in the existing Ubuntu/macOS/Windows preflight matrix.

## Problem

On native Windows, `scripts/test.sh` successfully built an extensionless PE
file at `.../prebuilt-bd/bd` and exported that exact spelling. Test helpers
accepted it because the file existed, but `os/exec` could not launch it:

```text
exec: "...\\prebuilt-bd\\bd": executable file not found in %PATH%
```

This disabled the prebuild optimization for representative subprocess tests
and could turn the local all-package run into a long sequence of launcher
failures.

## Implementation decisions

The script now chooses the output identity before building:

```bash
PREBUILT_BD_BIN="$PREBUILT_BD_DIR/bd$(go env GOEXE)"
```

POSIX keeps `bd`; Windows gets `bd.exe`. Consumers, package selection, timeout
policy, and caller precedence are unchanged.

The regression fakes only the expensive outer `go build`/`go test`
orchestration. It copies a real native Go test executable to the selected
output and launches that exported file through real Go `os/exec`. It also
covers paths containing spaces and proves a caller-supplied binary causes no
`go env` or build call. The test deliberately avoids claiming package-wide
`TestMain` authority.

## Validation

```text
go test -tags=gms_pure_go -count=1 \
  -run '^(TestTestScriptPrebuiltBinaryContract|TestPRPreflightPlatformsRunsTestScriptPrebuiltBinaryContract)$' \
  ./scripts
go test -tags=gms_pure_go -count=1 ./scripts
go vet -tags=gms_pure_go ./scripts
actionlint .github/workflows/pr.yml
```

The `scripts` test binary also compiled for Linux/amd64 with CGO disabled.

The real native-Windows path also passed:

```text
./scripts/test.sh -run '^TestCommandStartupRejectsRemovedBackendsBeforeLocalWrites$' ./cmd/bd
Prebuilt bd: /tmp/.../prebuilt-bd/bd.exe
ok github.com/steveyegge/beads/cmd/bd
```

Fixes #5502

_codex-gpt-5-unknown-reasoning on behalf of Ewen Cuthiell_
