### PR TITLE
serve: optional bearer auth and a Host allowlist

### DIFF
--- a/cmd/bd/serve.go
+++ b/cmd/bd/serve.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"time"
 
@@ -30,9 +31,27 @@ const serveCmdName = "serve"
 // itself. It is not the drain budget — the server has already drained by then.
 const providerCloseTimeout = 10 * time.Second
 
+// serveTokenFileEnv is the environment fallback for --auth-token-file, which an
+// operator would otherwise have to thread through a container spec. It follows
+// the BEADS_* convention the rest of the binary uses, and applies ONLY when the
+// flag was not passed.
+//
+// It is read here and nowhere else. internal/httpapi never reads the
+// environment, so the library, its tests and an embedded caller cannot be
+// reconfigured by an exported variable in somebody's shell.
+const (
+	// #nosec G101 -- this is the NAME of an environment variable that holds a
+	// file PATH. No credential appears in this source file, and none may: a
+	// token reaches the process only by being read out of that file.
+	serveTokenFileEnv = "BEADS_SERVE_TOKEN_FILE"
+)
+
 var (
 	serveAddr             string
 	serveAllowNonLoopback bool
+	serveAuthTokenFile    string
+	serveInsecureNoAuth   bool
+	serveAllowedHosts     []string
 )
 
 var serveCmd = &cobra.Command{
@@ -64,12 +83,40 @@ PROBES
   readiness use GET /v0/beads/ready?limit=1 — a real query, where 200 means
   ready and 503 means live but not ready.
 
+AUTHENTICATION
+
+  Optional, and off by default on loopback — where the trust model is the
+  loopback boundary itself, the same one the database behind it already relies
+  on. --auth-token-file turns it on: every operation except GET /healthz then
+  requires an "Authorization: Bearer <token>" header, GET /v0/beads/context
+  included, because it reports the repo root, beads directory and database name.
+
+  The file holds ONE TOKEN PER LINE and every line is accepted. That is the
+  rotation mechanism: write the new token alongside the old, roll the clients
+  over, then delete the old line. The file is re-read while the server runs, so
+  both the addition and the removal take effect within about a second and
+  neither needs a restart. Write it atomically (a temp file plus rename; a
+  Kubernetes secret mount already does this).
+
+  There is deliberately no --auth-token flag. A credential passed as an
+  argument is readable by every local user in the process listing.
+
+  --allow-non-loopback REQUIRES a token file. Beyond loopback, reaching the
+  address would otherwise be the whole authorization: any peer could read every
+  issue and claim work as any actor. --insecure-no-auth is the explicit,
+  auditable way to say you meant that anyway.
+
+  The Host allowlist is what a service deployment usually trips over first. The
+  DNS-rebinding check answers only to loopback spellings and the bind address,
+  so a client dialing a service name gets 400 on every request; enumerate the
+  names it dials with --allowed-host (repeatable). Matching is exact — no
+  wildcards — and the startup log line prints the effective allowlist.
+
 WHAT THIS DOES NOT DO
 
-  No authentication and no TLS. The trust model is the loopback boundary, which
-  is the same one the database behind it already relies on. --allow-non-loopback
-  extends the surface to every network peer that can reach the address; nothing
-  else about the server changes.
+  No TLS. Even with a token, the credential and every issue body travel in
+  plaintext, so a deployment beyond loopback has to supply confidentiality
+  itself — a service mesh, or a network boundary you already trust.
 
   Hooks do not fire. A hook is a user-controlled subprocess per mutation: in a
   concurrent server that is an unbounded latency multiplier and an orphaned
@@ -121,13 +168,91 @@ func registerServeFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&serveAddr, "addr", "127.0.0.1:0",
 		"Address to bind as IP:PORT; the host must be a numeric IP literal, and port 0 takes an ephemeral port")
 	cmd.Flags().BoolVar(&serveAllowNonLoopback, "allow-non-loopback", false,
-		"Permit a bind beyond loopback. bd serve has no authentication: every peer that can reach the address gets full read and claim access")
+		"Permit a bind beyond loopback. Requires --auth-token-file, since reaching the address would otherwise be the whole authorization")
+	cmd.Flags().StringVar(&serveAuthTokenFile, "auth-token-file", "",
+		"Require an Authorization: Bearer token from this file, one token per line, all accepted. Re-read while running, so rewriting it rotates tokens without a restart (env "+serveTokenFileEnv+")")
+	cmd.Flags().BoolVar(&serveInsecureNoAuth, "insecure-no-auth", false,
+		"Serve a non-loopback bind with NO authentication. Every peer that can reach the address gets full read and claim access")
+	cmd.Flags().StringArrayVar(&serveAllowedHosts, "allowed-host", nil,
+		"Additional Host header value to answer to, e.g. a service DNS name. Repeatable; matched exactly, with no wildcards")
+}
+
+// serveOptions is the part of a server's configuration that depends on NEITHER
+// the workspace nor its database source: the operator's flags, and the
+// environment fallbacks behind them.
+//
+// It is deliberately not an httpapi.Config. Every Config bd builds names the
+// one database source it serves from, and that source is not known until the
+// workspace has been classified — so a Config filled in this early would be a
+// server configuration that cannot yet describe a server. The field names match
+// Config's because they become those fields verbatim, in applyTo.
+type serveOptions struct {
+	Addr             string
+	AllowNonLoopback bool
+	InsecureNoAuth   bool
+	AllowedHosts     []string
+	Auth             *httpapi.TokenFileAuth
+}
+
+// applyTo writes the operator's choices onto the configuration a database arm
+// built. It is the ONLY place they are set, so an arm can add a source but can
+// never be the one that forgot the credential or the host allowlist.
+func (o serveOptions) applyTo(cfg *httpapi.Config) {
+	cfg.Addr = o.Addr
+	cfg.AllowNonLoopback = o.AllowNonLoopback
+	cfg.InsecureNoAuth = o.InsecureNoAuth
+	cfg.AllowedHosts = o.AllowedHosts
+	cfg.Auth = o.Auth
+}
+
+// resolveServeConfig turns the flags and their environment fallbacks into the
+// parts of the server configuration that depend on NEITHER the workspace nor a
+// listener.
+//
+// It is separate from runServe, and runs first, for the reason every other
+// validation in this command does: a refusal for a posture that cannot be
+// served must not depend on which workspace the operator happened to be
+// standing in, and must not arrive after a database has been opened.
+func resolveServeConfig() (serveOptions, error) {
+	cfg := serveOptions{
+		Addr:             serveAddr,
+		AllowNonLoopback: serveAllowNonLoopback,
+		InsecureNoAuth:   serveInsecureNoAuth,
+		AllowedHosts:     serveAllowedHosts,
+	}
+	if _, err := httpapi.ValidateBindAddr(serveAddr, serveAllowNonLoopback); err != nil {
+		return cfg, err
+	}
+
+	tokenFile := serveAuthTokenFile
+	if tokenFile == "" {
+		tokenFile = os.Getenv(serveTokenFileEnv)
+	}
+	if err := httpapi.ValidateAuthPosture(serveAllowNonLoopback, tokenFile != "", serveInsecureNoAuth); err != nil {
+		return cfg, err
+	}
+	if tokenFile != "" {
+		auth, err := httpapi.NewTokenFileAuth(tokenFile)
+		if err != nil {
+			return cfg, fmt.Errorf("--auth-token-file: %w", err)
+		}
+		cfg.Auth = auth
+	}
+
+	for _, host := range serveAllowedHosts {
+		if err := httpapi.ValidateAllowedHost(host); err != nil {
+			return cfg, err
+		}
+	}
+	return cfg, nil
 }
 
 func runServe() error {
 	// Flag validation first: it depends on nothing about the workspace, so the
-	// refusal for a bad --addr is the same in every mode.
-	if _, err := httpapi.ValidateBindAddr(serveAddr, serveAllowNonLoopback); err != nil {
+	// refusal for a bad --addr or an unservable auth posture is the same in
+	// every mode, and it lands before anything opens a database.
+	opts, err := resolveServeConfig()
+	if err != nil {
 		return HandleError("%v", err)
 	}
 	if readonlyMode {
@@ -152,14 +277,6 @@ func runServe() error {
 		return HandleError("%v", err)
 	}
 
-	if serveAllowNonLoopback {
-		fmt.Fprintf(os.Stderr,
-			"bd serve: WARNING: --allow-non-loopback binds %s beyond loopback. "+
-				"This API has no authentication and no TLS: any peer that can reach it can read every issue, claim work as any actor, "+
-				"bulk-delete closed beads, and delete any bead it can name.\n",
-			serveAddr)
-	}
-
 	if db.source == serveSourceStore {
 		// Nothing to create. PersistentPreRunE already opened this workspace
 		// through the same backends.Lookup dispatch every ordinary bd command
@@ -179,9 +296,7 @@ func runServe() error {
 			return HandleError("bd serve: %v", err)
 		}
 		defer startServeEventsJournalMaintenance(info.BeadsDir, store)()
-		return serveListen(httpapi.Config{
-			Addr:              serveAddr,
-			AllowNonLoopback:  serveAllowNonLoopback,
+		return serveListen(opts, httpapi.Config{
 			Reader:            roles.reader,
 			Claimer:           roles.claimer,
 			BatchCloser:       roles.batchCloser,
@@ -268,10 +383,8 @@ func runServe() error {
 
 	defer startServeEventsJournalMaintenance(info.BeadsDir, provider)()
 
-	return serveListen(httpapi.Config{
-		Addr:             serveAddr,
-		AllowNonLoopback: serveAllowNonLoopback,
-		Provider:         provider,
+	return serveListen(opts, httpapi.Config{
+		Provider: provider,
 		// No EventsJournal field on this arm: the provider carries the journal
 		// read as one of its own capability accessors, exactly as it carries
 		// every other role Listen would otherwise need spelled out. Activation
@@ -321,6 +434,11 @@ func startServeEventsJournalMaintenance(beadsDir string, source any) func() {
 // serveListen binds and runs. It is where the two database sources converge:
 // everything past the source is the same server.
 //
+// The operator's options and the database source arrive separately because they
+// are resolved at different times — the flags before anything opens a database,
+// the source only once the workspace has been classified — and this is where
+// they meet, once, for every arm.
+//
 // Graceful shutdown rides the signal context the root command already sets up
 // (SIGINT/SIGTERM/SIGHUP). A proxied provider is closed where every proxied
 // command closes it, in PersistentPostRunE — which in proxied mode does nothing
@@ -329,12 +447,46 @@ func startServeEventsJournalMaintenance(beadsDir string, source any) func() {
 // PersistentPostRunE that opened it. None of those paths runs the auto-commit,
 // export or push maintenance: proxied mode never had it, and serve is excluded
 // from it by name (runsPostCommandMaintenance, cmd/bd/main.go).
-func serveListen(cfg httpapi.Config) error {
+func serveListen(opts serveOptions, cfg httpapi.Config) error {
+	opts.applyTo(&cfg)
+
+	// The posture warning belongs here rather than on either source arm: it
+	// reports what this bind does not protect, which is a property of the
+	// listener both arms share.
+	warnServePosture(os.Stderr, opts)
+
 	srv, err := httpapi.Listen(cfg)
 	if err != nil {
 		return HandleError("%v", err)
 	}
 	return srv.Serve(rootCtx)
+}
+
+// warnServePosture says out loud what this deployment does not protect.
+//
+// Two different warnings, because they are two different exposures. Running
+// unauthenticated beyond loopback is the one that was always here, and the
+// operator now has to have asked for it by name. Running authenticated beyond
+// loopback is the remaining gap: the token itself crosses the network in
+// plaintext on every request, so a network that can read it can replay it.
+//
+// Nothing is printed for the loopback default, which is what it has always
+// been.
+func warnServePosture(w io.Writer, opts serveOptions) {
+	if !opts.AllowNonLoopback {
+		return
+	}
+	if opts.Auth == nil {
+		fmt.Fprintf(w,
+			"bd serve: WARNING: --insecure-no-auth binds %s beyond loopback with no authentication. "+
+				"Any peer that can reach it can read every issue and claim work as any actor.\n",
+			opts.Addr)
+		return
+	}
+	fmt.Fprintf(w,
+		"bd serve: WARNING: %s is bound beyond loopback with bearer authentication but NO TLS. "+
+			"Tokens and issue data travel in plaintext; deploy it inside a trusted network boundary.\n",
+		opts.Addr)
 }
 
 // serveSource names which of httpapi.Config's two database sources a workspace

--- a/cmd/bd/serve_test.go
+++ b/cmd/bd/serve_test.go
@@ -22,18 +22,48 @@ import (
 	"github.com/steveyegge/beads/internal/storage"
 )
 
-// TestServeFlags pins the flag surface. v0 has two flags and no more: every
-// other bound in this server (in-flight limit, connection cap, wait budget,
-// deadline, pool caps) is a constant precisely so that it can become a flag
-// later, deliberately, rather than arriving as one nobody designed.
+// TestServeFlags pins the flag surface. Every bound that is NOT here — the
+// connection cap, the wait budget, the request deadline, the connection
+// lifetimes — is still a constant precisely so that it becomes a flag later,
+// deliberately, rather than arriving as one nobody designed.
+//
+// Every flag added here defaults to the behavior that existed without it, so
+// `bd serve` with no arguments is the same server it has always been.
 func TestServeFlags(t *testing.T) {
 	var got []string
 	serveCmd.Flags().VisitAll(func(f *pflag.Flag) { got = append(got, f.Name) })
 	sort.Strings(got)
 
-	want := []string{"addr", "allow-non-loopback"}
+	want := []string{
+		"addr", "allow-non-loopback", "allowed-host", "auth-token-file",
+		"insecure-no-auth",
+	}
 	if strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Errorf("bd serve flags = %v, want %v", got, want)
+	}
+
+	// The defaults ARE the compatibility promise: no token file, no extra
+	// hosts, and no waiver.
+	for _, tc := range []struct{ flag, want string }{
+		{"auth-token-file", ""},
+		{"insecure-no-auth", "false"},
+		{"allowed-host", "[]"},
+	} {
+		f := serveCmd.Flags().Lookup(tc.flag)
+		if f == nil {
+			t.Errorf("no --%s flag", tc.flag)
+			continue
+		}
+		if f.DefValue != tc.want {
+			t.Errorf("--%s default = %q, want %q: a non-neutral default would change an existing deployment", tc.flag, f.DefValue, tc.want)
+		}
+	}
+
+	// A raw --auth-token flag would put the credential in the process listing,
+	// where every local user reads it out of ps. There is no such flag and
+	// there must never be one.
+	if f := serveCmd.Flags().Lookup("auth-token"); f != nil {
+		t.Error("--auth-token takes the credential as an argument, which publishes it in ps output; the token belongs in a file")
 	}
 
 	addr := serveCmd.Flags().Lookup("addr")
@@ -459,4 +489,204 @@ func runServeUnderReadonly(t *testing.T, dir string) (string, error) {
 	var err error
 	stderr := captureBootstrapStderr(t, func() { err = runServe() })
 	return stderr, err
+}
+
+// clearServeEnv removes the BEADS_SERVE_* fallback for one test. Without it a
+// developer (or a CI runner) with it exported in their shell would silently
+// change what these tests assert — env is read only in this package, which is
+// what keeps the library and the dev binary immune to the same hazard.
+func clearServeEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{serveTokenFileEnv} {
+		t.Setenv(key, "")
+		if err := os.Unsetenv(key); err != nil {
+			t.Fatalf("unset %s: %v", key, err)
+		}
+	}
+}
+
+// withServeFlags sets the serve globals for one test and restores them, so a
+// table row cannot leak its posture into the next one.
+func withServeFlags(t *testing.T) {
+	t.Helper()
+	addr, nonLoopback := serveAddr, serveAllowNonLoopback
+	token, insecure := serveAuthTokenFile, serveInsecureNoAuth
+	hosts := serveAllowedHosts
+	t.Cleanup(func() {
+		serveAddr, serveAllowNonLoopback = addr, nonLoopback
+		serveAuthTokenFile, serveInsecureNoAuth = token, insecure
+		serveAllowedHosts = hosts
+	})
+	serveAddr, serveAllowNonLoopback = "127.0.0.1:0", false
+	serveAuthTokenFile, serveInsecureNoAuth = "", false
+	serveAllowedHosts = nil
+}
+
+func serveTokenFile(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "tokens")
+	if err := os.WriteFile(path, []byte("a-token\n"), 0o600); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+	return path
+}
+
+// TestServeConfigRefusesAnUnservablePosture drives the flag resolution alone —
+// no listener, no workspace — because the refusal must not depend on either.
+// The row that matters most is the first: reaching the address used to BE the
+// authorization, so a bind beyond loopback with no credential is now a refusal
+// rather than a warning nobody reads.
+func TestServeConfigRefusesAnUnservablePosture(t *testing.T) {
+	token := serveTokenFile(t)
+
+	for _, tc := range []struct {
+		name    string
+		apply   func(t *testing.T)
+		wantErr string
+	}{
+		{
+			name:  "loopback with no token is unchanged",
+			apply: func(*testing.T) {},
+		},
+		{
+			name:  "loopback with a token",
+			apply: func(*testing.T) { serveAuthTokenFile = token },
+		},
+		{
+			name: "non-loopback with a token",
+			apply: func(*testing.T) {
+				serveAddr, serveAllowNonLoopback = "0.0.0.0:0", true
+				serveAuthTokenFile = token
+			},
+		},
+		{
+			name: "non-loopback with no credential",
+			apply: func(*testing.T) {
+				serveAddr, serveAllowNonLoopback = "0.0.0.0:0", true
+			},
+			wantErr: "--auth-token-file",
+		},
+		{
+			name: "non-loopback waived explicitly",
+			apply: func(*testing.T) {
+				serveAddr, serveAllowNonLoopback = "0.0.0.0:0", true
+				serveInsecureNoAuth = true
+			},
+		},
+		{
+			name: "a token file that does not exist",
+			apply: func(*testing.T) {
+				serveAuthTokenFile = filepath.Join(t.TempDir(), "absent")
+			},
+			wantErr: "no such file",
+		},
+		{
+			name:    "an allowed host with a port",
+			apply:   func(*testing.T) { serveAllowedHosts = []string{"bd.beads.svc:8080"} },
+			wantErr: "--allowed-host",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clearServeEnv(t)
+			withServeFlags(t)
+			tc.apply(t)
+
+			_, err := resolveServeConfig()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("resolveServeConfig() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("resolveServeConfig() = nil, want a refusal naming %s", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("refusal %q does not name %s, so it does not say how to proceed", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestServeEnvFallbackAppliesOnlyWhenTheFlagIsUnset. The env alias exists for
+// container deployments where the flag list is awkward; a flag the operator
+// typed must still win.
+func TestServeEnvFallbackAppliesOnlyWhenTheFlagIsUnset(t *testing.T) {
+	envToken := serveTokenFile(t)
+
+	t.Run("env supplies what the flag did not", func(t *testing.T) {
+		clearServeEnv(t)
+		withServeFlags(t)
+		t.Setenv(serveTokenFileEnv, envToken)
+
+		cfg, err := resolveServeConfig()
+		if err != nil {
+			t.Fatalf("resolveServeConfig: %v", err)
+		}
+		if cfg.Auth == nil {
+			t.Errorf("%s did not enable authentication", serveTokenFileEnv)
+		}
+	})
+
+	t.Run("an explicit flag wins", func(t *testing.T) {
+		clearServeEnv(t)
+		withServeFlags(t)
+		t.Setenv(serveTokenFileEnv, filepath.Join(t.TempDir(), "absent"))
+		serveAuthTokenFile = serveTokenFile(t)
+
+		if _, err := resolveServeConfig(); err != nil {
+			t.Fatalf("the flag lost to an unreadable environment fallback: %v", err)
+		}
+	})
+}
+
+// TestServeConfigCarriesTheOperatorsChoicesThrough. resolveServeConfig is the
+// only place the flags become a Config, so this is where a field that is
+// parsed but never wired would show up.
+func TestServeConfigCarriesTheOperatorsChoicesThrough(t *testing.T) {
+	clearServeEnv(t)
+	withServeFlags(t)
+	serveAuthTokenFile = serveTokenFile(t)
+	serveAllowedHosts = []string{"bd-proj.beads.svc.cluster.local", "bd-proj.beads.svc"}
+
+	cfg, err := resolveServeConfig()
+	if err != nil {
+		t.Fatalf("resolveServeConfig: %v", err)
+	}
+	if cfg.Auth == nil {
+		t.Error("--auth-token-file did not reach the server config")
+	}
+	if strings.Join(cfg.AllowedHosts, ",") != strings.Join(serveAllowedHosts, ",") {
+		t.Errorf("AllowedHosts = %v, want %v", cfg.AllowedHosts, serveAllowedHosts)
+	}
+	if cfg.InsecureNoAuth {
+		t.Error("InsecureNoAuth is set without the flag")
+	}
+}
+
+// TestServeHelpDescribesTheAuthPosture. The help text is where an operator
+// learns what this server does and does not protect, and it used to say "No
+// authentication and no TLS" flatly. Half of that is now false; leaving it
+// would be a false security statement shipped in the binary.
+func TestServeHelpDescribesTheAuthPosture(t *testing.T) {
+	long := serveCmd.Long
+	for _, want := range []string{"--auth-token-file", "--allowed-host", "rotat", "tls"} {
+		if !strings.Contains(strings.ToLower(long), want) {
+			t.Errorf("`bd serve --help` does not mention %q", want)
+		}
+	}
+	if strings.Contains(long, "No authentication and no TLS") {
+		t.Error("the help still claims this server has no authentication; it has optional bearer authentication and it is mandatory beyond loopback")
+	}
+
+	// The two refusal messages that make the same claim must not contradict
+	// the help either.
+	if _, err := httpapi.ValidateBindAddr("10.0.0.5:8080", false); err == nil {
+		t.Fatal("a non-loopback bind without the opt-in was accepted")
+	} else if strings.Contains(err.Error(), "no authentication") {
+		t.Errorf("the bind refusal still claims the server has no authentication: %q", err)
+	}
+	if usage := serveCmd.Flags().Lookup("allow-non-loopback").Usage; strings.Contains(usage, "no authentication") {
+		t.Errorf("--allow-non-loopback still advertises that the server has no authentication: %q", usage)
+	}
 }

--- a/internal/httpapi/apigen/types.gen.go
+++ b/internal/httpapi/apigen/types.gen.go
@@ -12,6 +12,10 @@ import (
 	issueops "github.com/steveyegge/beads/issueops"
 )
 
+const (
+	BearerTokenScopes = "bearerToken.Scopes"
+)
+
 // Defines values for ApplyItemKind.
 const (
 	ApplyItemKindClose  ApplyItemKind = "close"
@@ -1309,7 +1313,7 @@ type Problem struct {
 	// BlockerIsAncestor With `dependency_cycle`, hierarchy refusal only: true when `blocker_id` is an ANCESTOR of `issue_id` (which cannot close until its descendants finish, so the gate would never clear), false when it is a DESCENDANT (blocked status cascades, so it would inherit the block and never close). Both polarities are reported; this member is never omitted to mean false. See `issue_id`.
 	BlockerIsAncestor *bool `json:"blocker_is_ancestor,omitempty"`
 
-	// Code The stable machine-readable reason, and the ONLY member a client may dispatch on. v0's vocabulary: `invalid_argument` (400, also emitted by the Host-header middleware on any route), `invalid_cursor` (400), `not_found` (404), `already_claimed` (409), `not_claimable` (409), `not_closable` (409), `not_releasable` (409), `dependency_cycle` (409), `dependency_exists` (409), `already_exists` (409), `precondition_failed` (409), `events_journal_disabled` (409), `events_journal_truncated` (410), `busy` (503), `db_unavailable` (503), `events_watch_saturated` (503), `internal` (500). Renaming or removing a status+code pair is a breaking change; ADDING one is not, so clients MUST default-branch on unknown values and fall back to the status class (unknown 4xx → client bug, fail loud; unknown 503 → retry per `Retry-After`; other unknown 5xx → server fault).
+	// Code The stable machine-readable reason, and the ONLY member a client may dispatch on. v0's vocabulary: `invalid_argument` (400, also emitted by the Host-header middleware on any route), `invalid_cursor` (400), `unauthenticated` (401, only on a server configured with a token file), `not_found` (404), `already_claimed` (409), `not_claimable` (409), `not_closable` (409), `not_releasable` (409), `dependency_cycle` (409), `dependency_exists` (409), `already_exists` (409), `precondition_failed` (409), `events_journal_disabled` (409), `events_journal_truncated` (410), `busy` (503), `db_unavailable` (503), `events_watch_saturated` (503), `internal` (500). Renaming or removing a status+code pair is a breaking change; ADDING one is not, so clients MUST default-branch on unknown values and fall back to the status class (unknown 4xx → client bug, fail loud; unknown 503 → retry per `Retry-After`; other unknown 5xx → server fault).
 	Code string `json:"code"`
 
 	// DeclaredLater With `invalid_argument` on a batch operation whose items may name each other: whether the unresolvable key IS declared by the request, at a LATER index.
@@ -1317,7 +1321,7 @@ type Problem struct {
 	// True is an ORDERING mistake — a key reaches backward only — and false is a key nothing in the request declares, which is a typo or a missing item. A client acts differently on each. Both polarities are emitted and the member is never omitted to mean false: an absent member says the refusal was not about a key at all.
 	DeclaredLater *bool `json:"declared_later,omitempty"`
 
-	// Detail Optional prose, never load-bearing. For 5xx codes it is a FIXED string per code and carries nothing about the underlying failure: driver and dial errors routinely embed the DSN, database user and host:port, and this API supports binding beyond loopback. 4xx details reflect the caller's own input back and are specific.
+	// Detail Optional prose, never load-bearing. For 5xx codes it is a FIXED string per code and carries nothing about the underlying failure: driver and dial errors routinely embed the DSN, database user and host:port, and this API supports binding beyond loopback. It is fixed for `unauthenticated` too, and for the mirror-image reason: the caller's own input there is a credential, so echoing it would write the token into every client log and proxy trace on the way back. Other 4xx details reflect the caller's own input back and are specific.
 	Detail *string `json:"detail,omitempty"`
 
 	// ExistingType With `dependency_exists`: the type of the edge the pair already carries, read inside the refusing transaction.
@@ -1753,6 +1757,9 @@ type InvalidArgument = Problem
 
 // NotFound RFC 9457 problem detail. This is the only error shape on this surface. The core declares `type`; this server never emits it, so `about:blank` is implied throughout.
 type NotFound = Problem
+
+// Unauthenticated RFC 9457 problem detail. This is the only error shape on this surface. The core declares `type`; this server never emits it, so `about:blank` is implied throughout.
+type Unauthenticated = Problem
 
 // Unavailable RFC 9457 problem detail. This is the only error shape on this surface. The core declares `type`; this server never emits it, so `about:blank` is implied throughout.
 type Unavailable = Problem

--- a/internal/httpapi/auth.go
+++ b/internal/httpapi/auth.go
@@ -1,0 +1,262 @@
+package httpapi
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Bearer authentication over a file of accepted tokens.
+//
+// The whole design is one rule: every non-empty line of the file is an accepted
+// token, and the file is re-read while the server runs. That single rule is
+// what makes rotation hitless and revocation possible without a restart —
+// write {new,old}, roll the clients, drop old — and it is why there is no
+// second mechanism here. A startup snapshot would instead make rotation a
+// process restart and leave a leaked token live for as long as the process is.
+//
+// There is no token MINTING here and no identity: a token is a shared secret
+// that grants the whole surface. Per-client identity, scopes and TLS are
+// separate concerns that this file deliberately does not pretend to have.
+
+const (
+	// authReloadInterval is the floor between two reload ATTEMPTS, and so both
+	// the cost bound and the staleness bound: one stat(2) per interval for the
+	// whole server whatever the request rate, and a token added to or removed
+	// from the file taking effect within one interval of the next request.
+	authReloadInterval = time.Second
+	// maxTokenFileBytes refuses to slurp a mis-pointed path. A token file is a
+	// handful of lines; anything at this size is a wrong argument, and reading
+	// it into memory on every reload would be the actual damage.
+	maxTokenFileBytes = 1 << 20
+)
+
+// TokenFileAuth verifies presented bearer tokens against a file of accepted
+// tokens, one per line, all accepted.
+//
+// The accepted set is held as SHA-256 digests, never as the tokens themselves,
+// so a heap profile or core dump of a running server discloses no credential.
+// Verification hashes the presented token and compares digests in constant
+// time; hashing both sides also makes the compared lengths uniform, which is
+// what subtle.ConstantTimeCompare requires to be constant-time at all.
+//
+// The zero value is not usable — build one with NewTokenFileAuth.
+type TokenFileAuth struct {
+	path string
+	// reloadGate and now are the two test seams: they let the reload behavior
+	// be exercised in milliseconds of fake time instead of real seconds. Both
+	// fall back to the constants above when unset.
+	reloadGate time.Duration
+	now        func() time.Time
+
+	// digests is the last-good accepted set, swapped as a whole. Readers take
+	// it with a single atomic load, so the hot path takes no lock and a reload
+	// never makes the server briefly accept nothing.
+	digests atomic.Pointer[[][sha256.Size]byte]
+	// lastAttempt is the unix-nanos of the last reload ATTEMPT — attempt, not
+	// success, because the point is to bound the rate at which a storm of
+	// unknown tokens can touch the filesystem.
+	lastAttempt atomic.Int64
+
+	// mu serializes stat + read + swap. modTime and size are the stat cache
+	// that lets an unchanged file cost a stat and no read.
+	mu      sync.Mutex
+	modTime time.Time
+	size    int64
+}
+
+// NewTokenFileAuth reads path and returns the verifier for it.
+//
+// It is deliberately eager and strict: an unreadable, oversized or
+// token-less file is an error here rather than a server that starts anyway.
+// Both silent alternatives are worse than not starting — failing open serves
+// the whole surface with no credential, and failing closed answers 401 to
+// every client with nothing on stderr that says why.
+func NewTokenFileAuth(path string) (*TokenFileAuth, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, errors.New("no token file path given")
+	}
+	a := &TokenFileAuth{path: path}
+	digests, modTime, size, err := readTokenFile(path)
+	if err != nil {
+		return nil, err
+	}
+	a.digests.Store(&digests)
+	a.modTime, a.size = modTime, size
+	return a, nil
+}
+
+// Verify reports whether token is currently accepted, and returns any error
+// from a reload it triggered so the caller can log it. A reload error is not a
+// verification result: the last-good set stays in force, and ok is simply the
+// answer that set gives.
+//
+// Freshness is checked BEFORE the comparison and on every call, not only on a
+// mismatch, because those two are not the same property. A mismatch-triggered
+// reload gives rotation — a client that rolled to a new token 401s once and
+// succeeds on the retry — but it cannot give REVOCATION: a token the operator
+// has just deleted from the file still matches the cached set, so it triggers
+// nothing and stays accepted until some unrelated unknown token happens to
+// arrive. Since revocation without a restart is the point, the check runs on
+// the accepting path too.
+//
+// The cost of that is bounded by the same gate, so it is one stat(2) per
+// interval for the whole server whatever the request rate — and an unchanged
+// file stops at the stat, so the steady state reads nothing. There is no
+// background goroutine and no work at all while the server is idle: the check
+// rides the requests that care about it.
+func (a *TokenFileAuth) Verify(token string) (ok bool, reloadErr error) {
+	if token == "" {
+		return false, nil
+	}
+	// A caller that loses the gate to a concurrent reload compares against the
+	// set that reload is about to replace, rather than blocking on it. That is
+	// a bounded staleness of one gate interval, which is the window this whole
+	// mechanism is specified in; blocking every request behind one stat is not
+	// a trade worth making.
+	if a.claimReloadSlot() {
+		reloadErr = a.reload()
+	}
+	return a.accepts(sha256.Sum256([]byte(token))), reloadErr
+}
+
+// accepts compares want against every cached digest with no early exit, so the
+// time taken says nothing about WHICH token was closest.
+func (a *TokenFileAuth) accepts(want [sha256.Size]byte) bool {
+	match := 0
+	for _, d := range *a.digests.Load() {
+		match |= subtle.ConstantTimeCompare(d[:], want[:])
+	}
+	return match == 1
+}
+
+// claimReloadSlot admits at most one reload attempt per gate interval across
+// all goroutines. It records the ATTEMPT, not the success, because what needs
+// bounding is how often the filesystem is touched. The compare-and-swap is
+// what makes a loser return immediately instead of queueing behind the
+// winner's stat.
+func (a *TokenFileAuth) claimReloadSlot() bool {
+	gate := a.reloadGate
+	if gate <= 0 {
+		gate = authReloadInterval
+	}
+	clock := a.now
+	if clock == nil {
+		clock = time.Now
+	}
+	now := clock().UnixNano()
+	last := a.lastAttempt.Load()
+	if now-last < int64(gate) {
+		return false
+	}
+	return a.lastAttempt.CompareAndSwap(last, now)
+}
+
+// reload re-reads the token file if it has changed, and swaps the accepted set.
+//
+// A failed read or a file that parses to zero tokens KEEPS the last-good set
+// and reports the error. A writer that truncates before writing must not lock
+// every client out of the server for the duration of its write — and because
+// the stat cache is only updated on success, the next attempt past the gate
+// re-reads and recovers by itself. (Operators should still write the file
+// atomically, temp file plus rename; a Kubernetes secret mount already does.)
+func (a *TokenFileAuth) reload() error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	fi, err := os.Stat(a.path)
+	if err != nil {
+		return fmt.Errorf("token file %s: %w", a.path, err)
+	}
+	if fi.ModTime().Equal(a.modTime) && fi.Size() == a.size {
+		return nil
+	}
+	digests, modTime, size, err := readTokenFile(a.path)
+	if err != nil {
+		return err
+	}
+	a.digests.Store(&digests)
+	a.modTime, a.size = modTime, size
+	return nil
+}
+
+// readTokenFile reads and parses the whole file, returning the stat it read it
+// under so the caller's cache describes the bytes it actually holds.
+func readTokenFile(path string) (digests [][sha256.Size]byte, modTime time.Time, size int64, err error) {
+	// #nosec G304 -- opening an operator-named path IS the feature: the path
+	// comes from --auth-token-file (or its BEADS_SERVE_* alias), which only the
+	// person starting the process supplies. No request influences it.
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, time.Time{}, 0, fmt.Errorf("token file %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	fi, err := f.Stat()
+	if err != nil {
+		return nil, time.Time{}, 0, fmt.Errorf("token file %s: %w", path, err)
+	}
+	if fi.IsDir() {
+		return nil, time.Time{}, 0, fmt.Errorf("token file %s is a directory", path)
+	}
+
+	// One byte past the cap, so an oversized file is detected rather than
+	// silently truncated into an accepted set missing its last token.
+	data, err := io.ReadAll(io.LimitReader(f, maxTokenFileBytes+1))
+	if err != nil {
+		return nil, time.Time{}, 0, fmt.Errorf("token file %s: %w", path, err)
+	}
+	if len(data) > maxTokenFileBytes {
+		return nil, time.Time{}, 0, fmt.Errorf("token file %s is larger than %d bytes; that is a mis-pointed path, not a token file",
+			path, maxTokenFileBytes)
+	}
+
+	digests = parseTokens(data)
+	if len(digests) == 0 {
+		return nil, time.Time{}, 0, fmt.Errorf("token file %s contains no tokens", path)
+	}
+	return digests, fi.ModTime(), fi.Size(), nil
+}
+
+// parseTokens turns the file into the accepted digest set: every non-empty
+// line, trimmed, is one token. Trimming handles CRLF and stray indentation; no
+// comment syntax is invented, because a "#" line would be a token an operator
+// believed was disabled.
+func parseTokens(data []byte) [][sha256.Size]byte {
+	var out [][sha256.Size]byte
+	for line := range strings.SplitSeq(string(data), "\n") {
+		tok := strings.TrimSpace(line)
+		if tok == "" {
+			continue
+		}
+		out = append(out, sha256.Sum256([]byte(tok)))
+	}
+	return out
+}
+
+// ValidateAuthPosture refuses the flag combinations that would ship a server
+// nobody meant to ship. It is called from the CLI so the refusal is immediate,
+// and again from Listen so the library cannot be misused by a second caller.
+//
+// The rule the whole slice turns on: loopback with no token file is today's
+// behavior, byte for byte. Everything else is either authenticated or refused,
+// with one explicitly-named escape hatch.
+func ValidateAuthPosture(allowNonLoopback, hasTokenFile, insecureNoAuth bool) error {
+	if insecureNoAuth && hasTokenFile {
+		return errors.New("--insecure-no-auth contradicts --auth-token-file; pass one or the other")
+	}
+	if insecureNoAuth && !allowNonLoopback {
+		return errors.New("--insecure-no-auth applies only to a bind beyond loopback; on loopback there is nothing to waive, so pass --allow-non-loopback or drop the flag")
+	}
+	if allowNonLoopback && !hasTokenFile && !insecureNoAuth {
+		return errors.New("--allow-non-loopback requires --auth-token-file (or the explicit --insecure-no-auth): every peer that can reach the address gets full read and claim access")
+	}
+	return nil
+}

--- a/internal/httpapi/auth_test.go
+++ b/internal/httpapi/auth_test.go
@@ -1,0 +1,335 @@
+package httpapi
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// These tests are pure: a token file in t.TempDir and an injected clock. The
+// rotation property they pin — a token added to the file is accepted without a
+// restart, and one removed from it stops being accepted — is the whole reason
+// the accepted set is not a startup snapshot.
+
+// fakeClock is the injected time source. Verify's reload gate is the one place
+// this package reads a wall clock, so a test that wants to cross the gate moves
+// this rather than sleeping a real second.
+type fakeClock struct{ nanos atomic.Int64 }
+
+func (c *fakeClock) now() time.Time          { return time.Unix(0, c.nanos.Load()) }
+func (c *fakeClock) advance(d time.Duration) { c.nanos.Add(int64(d)) }
+
+// writeTokenFile writes content and returns the path. Every rewrite moves the
+// modification time forward explicitly: a test that rewrites a file twice
+// inside one filesystem timestamp tick would otherwise be asserting against
+// the stat cache rather than against the reload.
+func writeTokenFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	touch(t, path, time.Now())
+}
+
+func touch(t *testing.T, path string, mod time.Time) {
+	t.Helper()
+	if err := os.Chtimes(path, mod, mod); err != nil {
+		t.Fatalf("chtimes %s: %v", path, err)
+	}
+}
+
+func newAuthForTest(t *testing.T, content string) (*TokenFileAuth, string, *fakeClock) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "tokens")
+	writeTokenFile(t, path, content)
+	auth, err := NewTokenFileAuth(path)
+	if err != nil {
+		t.Fatalf("NewTokenFileAuth: %v", err)
+	}
+	clock := &fakeClock{}
+	clock.nanos.Store(int64(time.Hour))
+	auth.now = clock.now
+	auth.reloadGate = time.Second
+	return auth, path, clock
+}
+
+func mustVerify(t *testing.T, a *TokenFileAuth, token string) bool {
+	t.Helper()
+	ok, err := a.Verify(token)
+	if err != nil {
+		t.Fatalf("Verify(%q): unexpected reload error: %v", token, err)
+	}
+	return ok
+}
+
+// TestTokenFileAcceptsEveryLine is the rotation mechanism stated as a parse
+// rule: every non-empty line is a token and all of them are accepted, which is
+// what lets an operator write {new,old}, roll clients, and drop old.
+func TestTokenFileAcceptsEveryLine(t *testing.T) {
+	auth, _, _ := newAuthForTest(t, "alpha\r\n  bravo  \n\n\ncharlie\n")
+
+	for _, tok := range []string{"alpha", "bravo", "charlie"} {
+		if !mustVerify(t, auth, tok) {
+			t.Errorf("token %q from the file was refused", tok)
+		}
+	}
+	for _, tok := range []string{"", "  ", "delta", "alpha ", "ALPHA"} {
+		if mustVerify(t, auth, tok) {
+			t.Errorf("token %q is not in the file but was accepted", tok)
+		}
+	}
+}
+
+// TestNewTokenFileAuthRefusesAnUnusableFile: a server whose token file cannot
+// be read must not start. Failing open serves the whole surface
+// unauthenticated; failing silently closed answers 401 to every client with
+// nothing on stderr saying why.
+func TestNewTokenFileAuthRefusesAnUnusableFile(t *testing.T) {
+	dir := t.TempDir()
+
+	empty := filepath.Join(dir, "empty")
+	writeTokenFile(t, empty, "")
+	blank := filepath.Join(dir, "blank")
+	writeTokenFile(t, blank, "\n  \n\r\n")
+	fat := filepath.Join(dir, "fat")
+	writeTokenFile(t, fat, strings.Repeat("a", maxTokenFileBytes+1))
+
+	for _, tc := range []struct{ name, path, want string }{
+		{"missing", filepath.Join(dir, "nope"), "no such file"},
+		{"empty", empty, "no tokens"},
+		{"blank lines only", blank, "no tokens"},
+		{"oversized", fat, "larger than"},
+		{"unnamed", "", "no token file"},
+		{"directory", dir, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewTokenFileAuth(tc.path)
+			if err == nil {
+				t.Fatalf("NewTokenFileAuth(%q) = nil error, want a startup refusal", tc.path)
+			}
+			if tc.want != "" && !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not explain the refusal (want %q in it)", err, tc.want)
+			}
+			if !strings.Contains(err.Error(), "token") && !strings.Contains(err.Error(), tc.path) {
+				t.Errorf("error %q names neither the token file nor its path", err)
+			}
+		})
+	}
+}
+
+// TestTokenRotatesWithoutARestart is the CRITICAL property. A snapshot taken at
+// startup would make rotation a pod restart and would make a leaked token
+// unrevokable for the life of the process.
+func TestTokenRotatesWithoutARestart(t *testing.T) {
+	auth, path, clock := newAuthForTest(t, "old-token\n")
+
+	if !mustVerify(t, auth, "old-token") {
+		t.Fatal("the token the server started with was refused")
+	}
+
+	// Overlap window: both tokens are live, so clients roll one at a time.
+	writeTokenFile(t, path, "new-token-value\nold-token\n")
+	clock.advance(2 * time.Second)
+	if !mustVerify(t, auth, "new-token-value") {
+		t.Error("a token added to the file was refused; rotation would need a restart")
+	}
+	if !mustVerify(t, auth, "old-token") {
+		t.Error("the overlapping old token was refused mid-rotation")
+	}
+
+	// Revocation: drop the old token and it stops being accepted, with no
+	// restart and no window longer than the reload gate.
+	writeTokenFile(t, path, "new-token-value\n")
+	clock.advance(2 * time.Second)
+	if mustVerify(t, auth, "old-token") {
+		t.Error("a token removed from the file is still accepted; a leaked token would be unrevokable")
+	}
+	if !mustVerify(t, auth, "new-token-value") {
+		t.Error("the surviving token was refused after revocation")
+	}
+}
+
+// TestReloadIsStatGated bounds what a 401 storm can cost: at most one stat per
+// gate interval, whatever the request rate.
+func TestReloadIsStatGated(t *testing.T) {
+	auth, path, clock := newAuthForTest(t, "first\n")
+
+	// First mismatch claims the reload slot and finds nothing new.
+	if mustVerify(t, auth, "second-token") {
+		t.Fatal("an unknown token was accepted")
+	}
+	// The file now carries it, but the gate has not elapsed, so the second
+	// mismatch must not even stat.
+	writeTokenFile(t, path, "first\nsecond-token\n")
+	if mustVerify(t, auth, "second-token") {
+		t.Error("a reload ran inside the gate window; a 401 storm would stat the file per request")
+	}
+
+	clock.advance(2 * time.Second)
+	if !mustVerify(t, auth, "second-token") {
+		t.Error("the reload did not run after the gate elapsed")
+	}
+}
+
+// TestUnchangedFileIsNotReread is the cheap branch a wrong-token storm actually
+// hits: the gate elapses, the server stats, nothing moved, and it stops there.
+// Rewriting the bytes while restoring mtime and size makes a re-read
+// observable — if one happened, the new token would be accepted.
+func TestUnchangedFileIsNotReread(t *testing.T) {
+	auth, path, clock := newAuthForTest(t, "aaaaa\n")
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	writeTokenFile(t, path, "bbbbb\n") // same length
+	touch(t, path, fi.ModTime())
+
+	clock.advance(2 * time.Second)
+	if mustVerify(t, auth, "bbbbb") {
+		t.Error("the file was re-read despite an unchanged mtime and size")
+	}
+	if !mustVerify(t, auth, "aaaaa") {
+		t.Error("the cached set was dropped by a reload that should not have happened")
+	}
+}
+
+// TestBadReloadKeepsTheLastGoodSet: a writer that truncates before writing must
+// not lock every client out of the server for the duration of its write. The
+// error is reported to the caller so it reaches the log, and the next mismatch
+// past the gate re-reads.
+func TestBadReloadKeepsTheLastGoodSet(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		break_ func(t *testing.T, path string)
+	}{
+		{"truncated mid-write", func(t *testing.T, path string) { writeTokenFile(t, path, "") }},
+		{"deleted", func(t *testing.T, path string) {
+			if err := os.Remove(path); err != nil {
+				t.Fatalf("remove: %v", err)
+			}
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			auth, path, clock := newAuthForTest(t, "live-token\n")
+			tc.break_(t, path)
+			clock.advance(2 * time.Second)
+
+			ok, err := auth.Verify("unknown")
+			if ok {
+				t.Error("an unknown token was accepted")
+			}
+			if err == nil {
+				t.Error("a failed reload was silent; the operator gets no log line for a broken token file")
+			}
+			if !mustVerify(t, auth, "live-token") {
+				t.Error("the last-good set was dropped, locking every client out on a writer race")
+			}
+
+			// Self-healing: the stat cache was not updated, so the next
+			// attempt past the gate re-reads.
+			writeTokenFile(t, path, "live-token\nsecond-token\n")
+			clock.advance(2 * time.Second)
+			if !mustVerify(t, auth, "second-token") {
+				t.Error("the reload did not recover after the file was restored")
+			}
+		})
+	}
+}
+
+// TestVerifyIsRaceFree hammers the accepted-token fast path and the reload path
+// together. Run under -race this is the guard on the atomic swap.
+func TestVerifyIsRaceFree(t *testing.T) {
+	auth, _, clock := newAuthForTest(t, "good\n")
+
+	var wg sync.WaitGroup
+	for i := range 8 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := range 200 {
+				if i%2 == 0 {
+					if ok, _ := auth.Verify("good"); !ok {
+						t.Errorf("the accepted token was refused under concurrency")
+						return
+					}
+					continue
+				}
+				if ok, _ := auth.Verify(fmt.Sprintf("bad-%d-%d", i, j)); ok {
+					t.Error("an unknown token was accepted under concurrency")
+					return
+				}
+				clock.advance(400 * time.Millisecond)
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+// TestValidateAuthPosture pins the default: loopback with no token file is
+// today's behavior, and every other combination either enables auth or is
+// refused at startup. --allow-non-loopback without a credential is the one that
+// mattered — reachability was full read and claim authority.
+func TestValidateAuthPosture(t *testing.T) {
+	for _, tc := range []struct {
+		name                                  string
+		nonLoopback, hasToken, insecureNoAuth bool
+		wantErr                               string
+	}{
+		{name: "loopback, no token: unchanged"},
+		{name: "loopback with a token", hasToken: true},
+		{name: "non-loopback with a token", nonLoopback: true, hasToken: true},
+		{
+			name: "non-loopback with no credential", nonLoopback: true,
+			wantErr: "--auth-token-file",
+		},
+		{
+			name: "non-loopback waived explicitly", nonLoopback: true, insecureNoAuth: true,
+		},
+		{
+			name: "waiver contradicts a token file", nonLoopback: true, hasToken: true, insecureNoAuth: true,
+			wantErr: "--insecure-no-auth",
+		},
+		{
+			name: "waiver on loopback is meaningless", insecureNoAuth: true,
+			wantErr: "--allow-non-loopback",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateAuthPosture(tc.nonLoopback, tc.hasToken, tc.insecureNoAuth)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ValidateAuthPosture = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("ValidateAuthPosture = nil, want a refusal naming %s", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("refusal %q does not name %s, so it does not say how to proceed", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestTokenFileAuthNeverHoldsRawTokens: the accepted set in memory is digests.
+// A core dump or a heap profile of a running server discloses no credential.
+func TestTokenFileAuthNeverHoldsRawTokens(t *testing.T) {
+	const secret = "s3cret-token-value"
+	auth, _, _ := newAuthForTest(t, secret+"\n")
+	if !mustVerify(t, auth, secret) {
+		t.Fatal("token refused")
+	}
+	for _, d := range *auth.digests.Load() {
+		if bytes.Contains(d[:], []byte(secret)) {
+			t.Error("the cached accepted set carries the raw token")
+		}
+	}
+}

--- a/internal/httpapi/problem.go
+++ b/internal/httpapi/problem.go
@@ -201,6 +201,13 @@ const (
 	// does not offer, namely the paged read, which holds nothing between
 	// requests and is never refused for this reason.
 	CodeEventsWatchSaturated Code = "events_watch_saturated"
+	// CodeUnauthenticated is a missing, malformed or unrecognized bearer
+	// credential on a server that was configured with one. It is a DEPLOYMENT
+	// posture, not a property of the operation: a server started with no token
+	// file never emits it. The three client mistakes are deliberately one code
+	// — telling them apart on the wire would tell an unauthenticated caller
+	// which of its guesses was closer.
+	CodeUnauthenticated Code = "unauthenticated"
 	// CodeBusy is retryable contention: the transaction retry budget was
 	// exhausted, or the in-flight request limit was saturated.
 	CodeBusy Code = "busy"
@@ -222,6 +229,7 @@ const codeClientClosed Code = "client_closed"
 var codeStatus = map[Code]int{
 	CodeInvalidArgument:  http.StatusBadRequest,
 	CodeInvalidCursor:    http.StatusBadRequest,
+	CodeUnauthenticated:  http.StatusUnauthorized,
 	CodeNotFound:         http.StatusNotFound,
 	CodeAlreadyClaimed:   http.StatusConflict,
 	CodeNotClaimable:     http.StatusConflict,
@@ -265,18 +273,28 @@ const (
 	ReasonInvalidValue Reason = "invalid_value"
 )
 
-// staticDetail is the ONLY `detail` a 5xx may carry. The underlying error goes
-// to the server log and nowhere else: driver and dial errors routinely embed
-// the DSN — go-sql-driver renders connection targets as
-// user@tcp(127.0.0.1:PORT)/db, net dial errors carry the same host:port — and
-// query errors can carry SQL fragments. The moment the server is bound with
-// --allow-non-loopback, a verbose 5xx detail is an information-disclosure
-// channel to network peers. 4xx details stay specific: they reflect the
-// caller's own input back, not server internals.
+// staticDetail is the set of codes whose `detail` is FIXED, whatever the
+// caller or the call site passed. newResult overrides the supplied detail for
+// every code listed here, which is what makes the guarantee structural rather
+// than a rule each call site has to remember.
+//
+// Every 5xx is on it. The underlying error goes to the server log and nowhere
+// else: driver and dial errors routinely embed the DSN — go-sql-driver renders
+// connection targets as user@tcp(127.0.0.1:PORT)/db, net dial errors carry the
+// same host:port — and query errors can carry SQL fragments. The moment the
+// server is bound with --allow-non-loopback, a verbose 5xx detail is an
+// information-disclosure channel to network peers.
+//
+// The 401 is on it for the mirror-image reason, and it is the one row that is
+// not a 5xx: the caller's own input here is a CREDENTIAL. Ordinary 4xx details
+// stay specific precisely because they reflect the caller's input back, which
+// is exactly what must never happen to a presented token — it would land in
+// every client log and proxy trace between here and the caller.
 var staticDetail = map[Code]string{
-	CodeBusy:          "the server is busy; retry shortly",
-	CodeDBUnavailable: "database temporarily unavailable; retry",
-	CodeInternal:      "internal server error",
+	CodeUnauthenticated: "missing or invalid bearer token",
+	CodeBusy:            "the server is busy; retry shortly",
+	CodeDBUnavailable:   "database temporarily unavailable; retry",
+	CodeInternal:        "internal server error",
 }
 
 // Retry-After values, in seconds.
@@ -480,6 +498,11 @@ const (
 	OpCompareAndSetMetadata = "compareAndSetMetadata"
 )
 
+// specBearerScheme is the name of the document's securityScheme for the bearer
+// token. It is a constant so TestSpecSecurityMatchesRouteTable compares the
+// route table's exemption column against the same string the document uses.
+const specBearerScheme = "bearerToken"
+
 // operationCodes is the per-operation problem vocabulary: exactly the codes
 // that operation's handler can produce, and therefore exactly what the spec
 // documents for it. TestSpecStatusCodesMatchHandlerTable asserts set-equality
@@ -494,65 +517,76 @@ const (
 // every operation; these rows carry what an operation produces beyond them.
 // Keep the two documents in step: a row here and the document-level prose are
 // the only two places that carve-out exists.
+//
+// The 401 is NOT one of those uniform rules and does appear in the rows below.
+// It is per-operation surface, and the policy is every operation except
+// liveness: auth is enforced in route() for every row whose authExempt column
+// is false, and OpHealth is the only row that sets it, so a probe can answer
+// with no credential. Stating it per-operation rather than once at the document
+// level is what makes TestSpecStatusCodesMatchHandlerTable require the 401s to
+// be documented in the same change as the check that emits them — including for
+// an operation added later, which inherits enforcement the moment it is routed
+// and so must carry CodeUnauthenticated here from its first commit.
 var operationCodes = map[string][]Code{
-	// Liveness answers from the process and touches nothing that can fail.
+	// Liveness answers from the process, touches nothing that can fail, and
+	// carries no credential: it is the one auth-exempt row of the route table.
 	OpHealth: nil,
 	// v0 serves a startup snapshot without touching the database, so there is
 	// no 503 here. If a later slice makes this a DB-probing readiness
 	// endpoint, db_unavailable joins this row and the spec in the same change.
-	OpGetContext:    {CodeInternal},
-	OpListReadyWork: {CodeInvalidArgument, CodeBusy, CodeDBUnavailable, CodeInternal},
-	OpListIssues:    {CodeInvalidArgument, CodeInvalidCursor, CodeBusy, CodeDBUnavailable, CodeInternal},
+	OpGetContext:    {CodeUnauthenticated, CodeInternal},
+	OpListReadyWork: {CodeInvalidArgument, CodeUnauthenticated, CodeBusy, CodeDBUnavailable, CodeInternal},
+	OpListIssues:    {CodeInvalidArgument, CodeInvalidCursor, CodeUnauthenticated, CodeBusy, CodeDBUnavailable, CodeInternal},
 	// The 400 is this operation's own, the getStats precedent: a malformed
 	// `include_comments` or `include_dependents` is a bad value on a parameter
 	// this server knows, not the document-level unknown-key rule this table
 	// omits.
-	OpGetIssue: {CodeInvalidArgument, CodeNotFound, CodeBusy, CodeDBUnavailable, CodeInternal},
+	OpGetIssue: {CodeInvalidArgument, CodeUnauthenticated, CodeNotFound, CodeBusy, CodeDBUnavailable, CodeInternal},
 	// No 400 of its own: the operation takes no parameters, so the only
 	// invalid_argument it can raise is the document-level unknown-query-key
 	// rule this table deliberately omits.
-	OpListSettings: {CodeBusy, CodeDBUnavailable, CodeInternal},
+	OpListSettings: {CodeUnauthenticated, CodeBusy, CodeDBUnavailable, CodeInternal},
 	// No 404: a key nothing stored and a key stored as the empty string are one
 	// answer on this surface, so the only refusal a key can earn is the 400
 	// that says it was not a key.
-	OpGetSetting: {CodeInvalidArgument, CodeBusy, CodeDBUnavailable, CodeInternal},
+	OpGetSetting: {CodeInvalidArgument, CodeUnauthenticated, CodeBusy, CodeDBUnavailable, CodeInternal},
 	// The 400 here is this operation's own, not the document-level
 	// unknown-parameter rule: a malformed `skip_blocked`, and the EMPTY
 	// `assignee` the document refuses rather than answering with the rows that
 	// have no assignee.
-	OpGetStats: {CodeInvalidArgument, CodeBusy, CodeDBUnavailable, CodeInternal},
+	OpGetStats: {CodeInvalidArgument, CodeUnauthenticated, CodeBusy, CodeDBUnavailable, CodeInternal},
 	// The cycle sweep takes no parameters at all, so it has no 400 of its own:
 	// the two uniform ones above are the whole of its invalid-argument story.
-	OpListDependencyCycles: {CodeBusy, CodeDBUnavailable, CodeInternal},
+	OpListDependencyCycles: {CodeUnauthenticated, CodeBusy, CodeDBUnavailable, CodeInternal},
 	// No not_found here, deliberately: an id that names nothing is reported in
 	// the response's `missing` member, so a batch keeps the answers for the ids
 	// that were found. A 404 would discard them.
-	OpListDependencies: {CodeInvalidArgument, CodeBusy, CodeDBUnavailable, CodeInternal},
+	OpListDependencies: {CodeInvalidArgument, CodeUnauthenticated, CodeBusy, CodeDBUnavailable, CodeInternal},
 	// The same vocabulary as the stored-edge read beside it, and no not_found
 	// for a stronger version of the same reason: this operation probes no id's
 	// existence at all, so there is nothing it could 404 on.
-	OpListBlockingAnnotations: {CodeInvalidArgument, CodeBusy, CodeDBUnavailable, CodeInternal},
+	OpListBlockingAnnotations: {CodeInvalidArgument, CodeUnauthenticated, CodeBusy, CodeDBUnavailable, CodeInternal},
 	// The 404 is the difference from the row above: this operation has ONE
 	// anchor, so there is no other answer to preserve by reporting the miss in
 	// the body. Its 400 is its own — an empty root, a direction outside the
 	// closed set, a non-positive max_depth — all three the ROLE's ErrValidation
 	// reaching the wire.
-	OpGetDependencyTree: {CodeInvalidArgument, CodeNotFound, CodeBusy, CodeDBUnavailable, CodeInternal},
+	OpGetDependencyTree: {CodeInvalidArgument, CodeUnauthenticated, CodeNotFound, CodeBusy, CodeDBUnavailable, CodeInternal},
 	// The same vocabulary as the listing it sizes: it takes the same filters
 	// and can refuse them the same way. limit=0's mode-dependent refusal has no
 	// analog here because there is no limit to pass.
-	OpCountReadyWork: {CodeInvalidArgument, CodeBusy, CodeDBUnavailable, CodeInternal},
+	OpCountReadyWork: {CodeInvalidArgument, CodeUnauthenticated, CodeBusy, CodeDBUnavailable, CodeInternal},
 	// The listing's vocabulary minus the cursor: this operation has none, so
 	// invalid_cursor cannot arise. An unparseable EXPRESSION is an
 	// invalid_argument on `q` rather than a code of its own — a client's
 	// recovery is the same as for any other malformed parameter value.
-	OpQueryIssues: {CodeInvalidArgument, CodeBusy, CodeDBUnavailable, CodeInternal},
+	OpQueryIssues: {CodeInvalidArgument, CodeUnauthenticated, CodeBusy, CodeDBUnavailable, CodeInternal},
 	// The 400 here is the widest on this surface, and most of it is not this
 	// handler's: the unfiltered durable sweep, the unrecognized tier and the
 	// malformed glob are all the ROLE's ErrValidation reaching the wire through
 	// failSweepErr. No 404 — this operation names no id — and no 409: a bead
 	// another sweep already took is simply not in the set.
-	OpSweepIssues: {CodeInvalidArgument, CodeBusy, CodeDBUnavailable, CodeInternal},
+	OpSweepIssues: {CodeInvalidArgument, CodeUnauthenticated, CodeBusy, CodeDBUnavailable, CodeInternal},
 	// CodeNotFound is the one this operation has and the sweep does not: a
 	// sweep describes a set that can legitimately be empty, while a delete
 	// names beads and an id that resolves to nothing is a caller mistake.
@@ -567,11 +601,11 @@ var operationCodes = map[string][]Code{
 	// The ARITY refusal is a 400 rather than a second conflict: a token beside
 	// two distinct ids is a malformed request, not a statement about state.
 	OpDeleteIssues: {
-		CodeInvalidArgument, CodeNotFound, CodePreconditionFailed,
+		CodeInvalidArgument, CodeUnauthenticated, CodeNotFound, CodePreconditionFailed,
 		CodeBusy, CodeDBUnavailable, CodeInternal,
 	},
 	OpClaimIssue: {
-		CodeInvalidArgument, CodeNotFound, CodeAlreadyClaimed, CodeNotClaimable,
+		CodeInvalidArgument, CodeUnauthenticated, CodeNotFound, CodeAlreadyClaimed, CodeNotClaimable,
 		CodeBusy, CodeDBUnavailable, CodeInternal,
 	},
 	// The NARROWEST write vocabulary on this surface, and the narrowness is the
@@ -581,7 +615,7 @@ var operationCodes = map[string][]Code{
 	// item's outcome inside a 200. A 404 here would say the operation went to
 	// the wrong place, and a 409 would say the whole batch was refused, and
 	// neither is ever true of a per-item refusal.
-	OpBatchCloseIssues: {CodeInvalidArgument, CodeBusy, CodeDBUnavailable, CodeInternal},
+	OpBatchCloseIssues: {CodeInvalidArgument, CodeUnauthenticated, CodeBusy, CodeDBUnavailable, CodeInternal},
 	// NO 409 AND NO 404, and both absences are this operation's contract rather
 	// than an omission. There is no id to have missed, and a row a racing agent
 	// took is simply not in the set this claim scanned — the role walks past it
@@ -591,7 +625,7 @@ var operationCodes = map[string][]Code{
 	// The 400 is the ready listing's filter vocabulary plus this operation's own
 	// `limit` refusal plus the body rules, and the ROLE's ErrValidation behind
 	// them, which is defensively unreachable.
-	OpClaimNextIssue: {CodeInvalidArgument, CodeBusy, CodeDBUnavailable, CodeInternal},
+	OpClaimNextIssue: {CodeInvalidArgument, CodeUnauthenticated, CodeBusy, CodeDBUnavailable, CodeInternal},
 	// THREE conflict codes, and only one of them is new. `already_claimed` is
 	// the ownership fence, inherited from updateIssue's assignee arm: the same
 	// situation — a live foreign owner refusing a write — with the same two
@@ -606,7 +640,7 @@ var operationCodes = map[string][]Code{
 	// `not_claimable` here even though the claim's status refusal is the nearest
 	// neighbor — see CodeNotReleasable for why that reuse was refused.
 	OpReleaseIssue: {
-		CodeInvalidArgument, CodeNotFound,
+		CodeInvalidArgument, CodeUnauthenticated, CodeNotFound,
 		CodeAlreadyClaimed, CodeNotReleasable, CodePreconditionFailed,
 		CodeBusy, CodeDBUnavailable, CodeInternal,
 	},
@@ -625,7 +659,7 @@ var operationCodes = map[string][]Code{
 	// (issueops.Lifecycle.Close). `force` bypasses policy and never it: the two
 	// members make unrelated claims.
 	OpCloseIssue: {
-		CodeInvalidArgument, CodeNotFound, CodeNotClosable, CodePreconditionFailed,
+		CodeInvalidArgument, CodeUnauthenticated, CodeNotFound, CodeNotClosable, CodePreconditionFailed,
 		CodeBusy, CodeDBUnavailable, CodeInternal,
 	},
 	// ONE 409, and it is a PRECONDITION rather than a policy. Close has a policy
@@ -636,7 +670,7 @@ var operationCodes = map[string][]Code{
 	// own premise, which every write can have wrong. The idempotent case is
 	// still a 200 carrying `already_open`, unless a guard came with it.
 	OpReopenIssue: {
-		CodeInvalidArgument, CodeNotFound, CodePreconditionFailed,
+		CodeInvalidArgument, CodeUnauthenticated, CodeNotFound, CodePreconditionFailed,
 		CodeBusy, CodeDBUnavailable, CodeInternal,
 	},
 	// FOUR conflict codes, and the three members that publish them are exactly
@@ -660,7 +694,7 @@ var operationCodes = map[string][]Code{
 	// could not spell, a field-length refusal that slipped the edge check —
 	// through failUpdate.
 	OpUpdateIssue: {
-		CodeInvalidArgument, CodeNotFound,
+		CodeInvalidArgument, CodeUnauthenticated, CodeNotFound,
 		CodePreconditionFailed, CodeNotClosable, CodeAlreadyClaimed,
 		CodeDependencyCycle, CodeDependencyExists,
 		CodeBusy, CodeDBUnavailable, CodeInternal,
@@ -674,7 +708,7 @@ var operationCodes = map[string][]Code{
 	// No conflict code either: this operation publishes no `id` member, so no
 	// item can collide with a stored row and the role's ErrAlreadyExists is
 	// unreachable from the wire.
-	OpBatchCreateIssues: {CodeInvalidArgument, CodeBusy, CodeDBUnavailable, CodeInternal},
+	OpBatchCreateIssues: {CodeInvalidArgument, CodeUnauthenticated, CodeBusy, CodeDBUnavailable, CodeInternal},
 	// The batch's row plus the two codes its narrower vocabulary cannot earn,
 	// and both additions are members rather than judgement calls.
 	//
@@ -698,7 +732,7 @@ var operationCodes = map[string][]Code{
 	// stored edge can name a pair whose endpoint is an id this request is
 	// minting.
 	OpCreateIssue: {
-		CodeInvalidArgument, CodeAlreadyExists, CodeDependencyCycle,
+		CodeInvalidArgument, CodeUnauthenticated, CodeAlreadyExists, CodeDependencyCycle,
 		CodeBusy, CodeDBUnavailable, CodeInternal,
 	},
 	// The widest row here, and every code on it is inherited from an operation
@@ -722,7 +756,7 @@ var operationCodes = map[string][]Code{
 	// conforming to addDependencies — nothing in that refusal is about a
 	// resource this operation was asked to address.
 	OpApplyBatch: {
-		CodeInvalidArgument, CodeNotFound,
+		CodeInvalidArgument, CodeUnauthenticated, CodeNotFound,
 		CodePreconditionFailed, CodeNotClosable, CodeAlreadyClaimed, CodeAlreadyExists,
 		CodeDependencyCycle, CodeDependencyExists,
 		CodeBusy, CodeDBUnavailable, CodeInternal,
@@ -731,7 +765,7 @@ var operationCodes = map[string][]Code{
 	// key, so there is no resource it can fail to address and no row it can
 	// collide with. Its 400 is the body vocabulary plus the ROLE's two
 	// refusals — empty content, and content no key can be derived from.
-	OpRememberMemory: {CodeInvalidArgument, CodeBusy, CodeDBUnavailable, CodeInternal},
+	OpRememberMemory: {CodeInvalidArgument, CodeUnauthenticated, CodeBusy, CodeDBUnavailable, CodeInternal},
 	// THE 404 IS THE DIVERGENCE, and it is deliberate. OpGetSetting has none
 	// because on that plane an absent key and a key stored empty are one answer
 	// the CLI itself prints identically, so a 404 would publish an invented
@@ -739,17 +773,17 @@ var operationCodes = map[string][]Code{
 	// an exit-code contract for it — and the role answers Found rather than a
 	// value, so the 404 reports a distinction that exists. The stored-empty row
 	// falls on the miss side of it, which the document states.
-	OpGetMemory: {CodeInvalidArgument, CodeNotFound, CodeBusy, CodeDBUnavailable, CodeInternal},
+	OpGetMemory: {CodeInvalidArgument, CodeUnauthenticated, CodeNotFound, CodeBusy, CodeDBUnavailable, CodeInternal},
 	// The read's vocabulary exactly, because the two operations address the same
 	// resource the same way and this one's Found false is the same answer: a key
 	// nothing stored is a 404 and nothing was removed. No 409 — a memory another
 	// caller already forgot is simply not there, which is what the 404 says.
-	OpForgetMemory: {CodeInvalidArgument, CodeNotFound, CodeBusy, CodeDBUnavailable, CodeInternal},
+	OpForgetMemory: {CodeInvalidArgument, CodeUnauthenticated, CodeNotFound, CodeBusy, CodeDBUnavailable, CodeInternal},
 	// The 400 here IS this operation's own, unlike listSettings' absent row: it
 	// has one parameter, and a repeated `q` is refused rather than resolved to
 	// one of its values. No 404 — a search matching nothing is an empty page,
 	// because a question about a set has an answer even when the set is empty.
-	OpListMemories: {CodeInvalidArgument, CodeBusy, CodeDBUnavailable, CodeInternal},
+	OpListMemories: {CodeInvalidArgument, CodeUnauthenticated, CodeBusy, CodeDBUnavailable, CodeInternal},
 	// The two journal codes are this operation's alone and neither has a
 	// precedent elsewhere on this surface, because no other operation reads a
 	// LOG. The 400 is its own too: `since` is required, and a negative or
@@ -762,7 +796,7 @@ var operationCodes = map[string][]Code{
 	// missing resource, and a poller that got a 404 for being up to date would
 	// have to treat the surface's miss vocabulary as a normal steady state.
 	OpListEvents: {
-		CodeInvalidArgument, CodeEventsJournalDisabled, CodeEventsJournalTruncated,
+		CodeInvalidArgument, CodeUnauthenticated, CodeEventsJournalDisabled, CodeEventsJournalTruncated,
 		CodeBusy, CodeDBUnavailable, CodeInternal,
 	},
 	// THE PAGED READ'S VOCABULARY PLUS ONE, and the shared part is the point:
@@ -777,7 +811,7 @@ var operationCodes = map[string][]Code{
 	// therefore documents three codes where every other operation's documents
 	// two.
 	OpWatchEvents: {
-		CodeInvalidArgument, CodeEventsJournalDisabled, CodeEventsJournalTruncated,
+		CodeInvalidArgument, CodeUnauthenticated, CodeEventsJournalDisabled, CodeEventsJournalTruncated,
 		CodeEventsWatchSaturated, CodeBusy, CodeDBUnavailable, CodeInternal,
 	},
 	// NO 404, for a stronger version of the batch create's reason: an edge that
@@ -793,10 +827,10 @@ var operationCodes = map[string][]Code{
 	// that loop needs next into a problem extension member. The 404 is here for
 	// the id, which is the one refusal a caller cannot converge on.
 	OpCompareAndSetMetadata: {
-		CodeInvalidArgument, CodeNotFound,
+		CodeInvalidArgument, CodeUnauthenticated, CodeNotFound,
 		CodeBusy, CodeDBUnavailable, CodeInternal,
 	},
-	OpRemoveDependency: {CodeInvalidArgument, CodeBusy, CodeDBUnavailable, CodeInternal},
+	OpRemoveDependency: {CodeInvalidArgument, CodeUnauthenticated, CodeBusy, CodeDBUnavailable, CodeInternal},
 	// The two conflict codes are this operation's alone, and both say the same
 	// kind of thing: the request is fine as a request and the GRAPH refuses it,
 	// which the caller cannot know without reading state it does not have. That
@@ -810,7 +844,7 @@ var operationCodes = map[string][]Code{
 	// so it joins the 400 with every other body refusal (batchCreateIssues'
 	// argument). Nothing was written in any of these cases.
 	OpAddDependencies: {
-		CodeInvalidArgument, CodeDependencyCycle, CodeDependencyExists,
+		CodeInvalidArgument, CodeUnauthenticated, CodeDependencyCycle, CodeDependencyExists,
 		CodeBusy, CodeDBUnavailable, CodeInternal,
 	},
 }
@@ -1221,6 +1255,12 @@ func Write(w http.ResponseWriter, res Result) {
 	h.Set("Content-Type", "application/problem+json; charset=utf-8")
 	if res.RetryAfterSeconds > 0 {
 		h.Set("Retry-After", strconv.Itoa(res.RetryAfterSeconds))
+	}
+	// RFC 9110 requires the challenge on a 401, and it is set here rather than
+	// at the refusal so a second 401 site could not forget it — the same reason
+	// Retry-After is set from the code above.
+	if res.Problem.Code == string(CodeUnauthenticated) {
+		h.Set("WWW-Authenticate", "Bearer")
 	}
 	w.WriteHeader(res.Problem.Status)
 	_ = json.NewEncoder(w).Encode(res.Problem)

--- a/internal/httpapi/reads_test.go
+++ b/internal/httpapi/reads_test.go
@@ -248,7 +248,10 @@ func TestUnlimitedReadsAreLoopbackOnly(t *testing.T) {
 	})
 
 	t.Run("a non-loopback bind refuses it", func(t *testing.T) {
-		ts, rec := newReadServer(t, Config{Addr: "127.0.0.1:0", AllowNonLoopback: true})
+		// InsecureNoAuth is what --allow-non-loopback now requires when no
+		// token file is configured. It is the posture under test here — the
+		// refusal being pinned is about the BIND, not about the credential.
+		ts, rec := newReadServer(t, Config{Addr: "127.0.0.1:0", AllowNonLoopback: true, InsecureNoAuth: true})
 		resp := ts.get(t, "/v0/beads/ready?limit=0")
 		if resp.StatusCode != http.StatusBadRequest {
 			t.Fatalf("status = %d, want 400", resp.StatusCode)

--- a/internal/httpapi/routes.go
+++ b/internal/httpapi/routes.go
@@ -116,6 +116,17 @@ type route struct {
 	// used to prevent, so the slot moves to the individual reads.
 	// TestStreamingRowsAreTheDocumentsStreamingOps pins the pair.
 	streaming bool
+	// authExempt serves an operation with no bearer credential on a server
+	// that was configured with one. Only legitimate for liveness: the probe
+	// must answer with no credential, and it discloses nothing but that the
+	// process is up. Identity is NOT exempt — GET /v0/beads/context reveals the
+	// repo root, the beads directory and the database name.
+	//
+	// It is a column rather than a middleware rule for the same reason
+	// bypassSemaphore is: the exemption is a property of the operation, so it
+	// belongs where TestSpecSecurityMatchesRouteTable can compare it against
+	// the document's per-operation `security` declarations.
+	authExempt bool
 	// implemented gates the capability list, so a release between slices never
 	// advertises an operation that does not work. Every v0 operation is
 	// implemented as of the read-endpoints slice; the flag stays because the
@@ -139,8 +150,11 @@ var routeTable = []route{
 		// fail, so it must not queue behind the database. That is exactly
 		// what makes it liveness-only: it stays green while Dolt is wedged.
 		bypassSemaphore: true,
-		implemented:     true,
-		handler:         (*Server).handleHealth,
+		// The one auth-exempt row. A kubelet probe presents no credential, and
+		// a liveness endpoint that 401s is a pod that restarts forever.
+		authExempt:  true,
+		implemented: true,
+		handler:     (*Server).handleHealth,
 	},
 	{
 		op:      OpGetContext,
@@ -353,6 +367,14 @@ var routeTable = []route{
 		// segment that ends in no registered suffix, so the wide pattern stays a
 		// routing detail rather than undocumented surface.
 		// TestCustomMethodsNarrowThePOSTSurface pins it.
+		//
+		// That 404 needs no credential, because the split happens before
+		// s.route: an unrouted suffix here is answered exactly as the catch-all
+		// answers any other unrouted path, while a registered one reaches its
+		// row and is refused. Paths are public spec, so the miss discloses
+		// nothing the document does not already publish;
+		// TestUnroutedPathsStayUnauthenticated pins both halves so neither gets
+		// "fixed" into the other.
 		specPath:     "/v0/beads/issues/{id}:claim",
 		customMethod: ":claim",
 		capability:   "issues.claim",

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -115,10 +115,23 @@ type Config struct {
 	// Addr is the host:port to bind. The host must be a numeric IP literal;
 	// see ValidateBindAddr.
 	Addr string
-	// AllowNonLoopback permits a bind beyond loopback. v0 has no
-	// authentication and no TLS, so this is an operator decision that is never
-	// taken by default.
+	// AllowNonLoopback permits a bind beyond loopback. There is no TLS, so
+	// this is an operator decision that is never taken by default, and it
+	// requires either Auth or InsecureNoAuth — see ValidateAuthPosture.
 	AllowNonLoopback bool
+	// Auth verifies bearer credentials. NIL MEANS NO AUTHENTICATION, which is
+	// the pre-existing behavior and stays the default on loopback: a zero
+	// Config serves exactly what it served before this field existed.
+	Auth *TokenFileAuth
+	// InsecureNoAuth is the operator's explicit waiver for serving a
+	// non-loopback bind with no credential. It only ever permits; it never
+	// disables a configured Auth (that combination is refused).
+	InsecureNoAuth bool
+	// AllowedHosts are extra Host header values to answer to, beyond the
+	// loopback spellings and the bind address. In a cluster the client dials a
+	// service DNS name, which the rebinding defense would otherwise refuse;
+	// see newHostPolicy. Empty leaves today's policy exactly as it was.
+	AllowedHosts []string
 	// Provider is where every database-touching handler opens its one unit of
 	// work per request.
 	Provider uow.UnitOfWorkProvider
@@ -329,6 +342,8 @@ type Server struct {
 	// sem bounds handlers that touch the database. Buffered channel rather
 	// than sync.Semaphore so the acquisition can select on a timer.
 	sem chan struct{}
+	// auth is nil on an unauthenticated server, which is the loopback default.
+	auth *TokenFileAuth
 	// semTimeout, semWarn, writeStall, watchPoll and watchBeat default to the
 	// constants above. They are fields rather than constants at the point of use
 	// so the queueing, stalled-write and streaming behavior can be exercised in
@@ -397,7 +412,7 @@ func ValidateBindAddr(addr string, allowNonLoopback bool) (net.IP, error) {
 		return nil, fmt.Errorf("--addr %q: host must be a numeric IP literal, not a name — use 127.0.0.1 rather than localhost", addr)
 	}
 	if !ip.IsLoopback() && !allowNonLoopback {
-		return nil, fmt.Errorf("--addr %q binds beyond loopback; bd serve has no authentication, so this requires --allow-non-loopback", addr)
+		return nil, fmt.Errorf("--addr %q binds beyond loopback, which requires --allow-non-loopback (and, with it, --auth-token-file)", addr)
 	}
 	return ip, nil
 }
@@ -419,6 +434,17 @@ func Listen(cfg Config) (*Server, error) {
 	ip, err := ValidateBindAddr(cfg.Addr, cfg.AllowNonLoopback)
 	if err != nil {
 		return nil, err
+	}
+	// The same posture and allowlist rules the CLI applies, applied again here
+	// so a second caller of this package cannot assemble a Config that serves
+	// the whole surface to a network with no credential.
+	if err := ValidateAuthPosture(cfg.AllowNonLoopback, cfg.Auth != nil, cfg.InsecureNoAuth); err != nil {
+		return nil, err
+	}
+	for _, host := range cfg.AllowedHosts {
+		if err := ValidateAllowedHost(host); err != nil {
+			return nil, err
+		}
 	}
 	if cfg.Stdout == nil {
 		cfg.Stdout = os.Stdout
@@ -468,7 +494,8 @@ func Listen(cfg Config) (*Server, error) {
 		log:      log.New(cfg.Stderr, "bd serve: ", log.LstdFlags|log.LUTC),
 		stdout:   cfg.Stdout,
 		ctxBody:  contextResponse(cfg.Workspace, cfg.SchemaVersion, Capabilities()),
-		hosts:    newHostPolicy(ip),
+		hosts:    newHostPolicy(ip, cfg.AllowedHosts),
+		auth:     cfg.Auth,
 		idPrefix: prefix,
 		maxConns: maxConns,
 	}
@@ -1391,7 +1418,14 @@ func (s *Server) closeStreams() {
 }
 
 // route wraps one operation with the limits that apply to it: the per-request
-// deadline, and — unless the operation is exempt — a database slot.
+// deadline, the bearer credential unless the operation is exempt, and — unless
+// the operation is exempt — a database slot.
+//
+// The credential check runs BEFORE the semaphore, which is the load-bearing
+// ordering: a storm of refused requests then costs one SHA-256 each and can
+// never occupy the slots, or the SQL connections pinned to them, that
+// authenticated clients are waiting for. It runs inside withRequestContext, so
+// a 401 gets a request id and a request log line like every other refusal.
 func (s *Server) route(rt route) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rec := requestInfo(r.Context())
@@ -1408,6 +1442,10 @@ func (s *Server) route(rt route) http.Handler {
 			r = r.WithContext(ctx)
 		}
 
+		if !rt.authExempt && s.auth != nil && !s.authorize(w, r, rec) {
+			return
+		}
+
 		if !rt.bypassSemaphore {
 			release, err := s.acquire(r.Context(), rec)
 			if err != nil {
@@ -1419,6 +1457,70 @@ func (s *Server) route(rt route) http.Handler {
 
 		rt.handler(s, w, r)
 	})
+}
+
+// authorize verifies the request's bearer credential, writing the 401 itself
+// and reporting whether the handler may run.
+//
+// The presented credential appears in NO log field and NO response byte. It is
+// deliberately not recorded through rec.refuse, which is defined as an echoed
+// CALLER VALUE and goes on the request line: a Host header or a parameter name
+// is attacker-controlled text worth attributing, and a token is a secret. What
+// the log gets instead is the reason — which of the three client mistakes it
+// was — and the request id that ties it to the response.
+func (s *Server) authorize(w http.ResponseWriter, r *http.Request, rec *reqInfo) bool {
+	token, reason := bearerCredential(r.Header.Get("Authorization"))
+	if reason == "" {
+		ok, reloadErr := s.auth.Verify(token)
+		if reloadErr != nil {
+			// A reload that failed leaves the last-good token set in force, so
+			// this is not a refusal on its own — but it means the file the
+			// operator is rotating is unreadable, and nothing else would say so.
+			s.event("auth_reload_error", "request_id", rec.id, "error", reloadErr.Error())
+		}
+		if ok {
+			return true
+		}
+		reason = "unknown_token"
+	}
+
+	s.event("auth_refused", "request_id", rec.id, "op", rec.op,
+		"reason", reason, "remote_addr", r.RemoteAddr)
+	s.fail(w, r, newResult(CodeUnauthenticated, ""))
+	return false
+}
+
+// bearerCredential extracts the token from an Authorization header value. It
+// returns a non-empty reason instead when there is nothing to verify, so the
+// log can separate a misconfigured client from a wrong or stale token.
+//
+// The scheme is matched case-insensitively, which RFC 9110 requires.
+func bearerCredential(header string) (token, reason string) {
+	if strings.TrimSpace(header) == "" {
+		return "", "missing"
+	}
+	rest, ok := strings.CutPrefix(header, "Bearer ")
+	if !ok {
+		scheme, tail, split := strings.Cut(header, " ")
+		if !split || !strings.EqualFold(scheme, "Bearer") {
+			return "", "malformed"
+		}
+		rest = tail
+	}
+	if token = strings.TrimSpace(rest); token == "" {
+		return "", "malformed"
+	}
+	return token, ""
+}
+
+// authLabel describes the credential posture for the startup line. It names the
+// token FILE, never a token: the path is configuration an operator already
+// knows, and the contents are the secret.
+func (s *Server) authLabel() string {
+	if s.auth == nil {
+		return "none"
+	}
+	return "bearer (" + s.auth.path + ")"
 }
 
 // fail writes a problem response and records what it was for the log line.
@@ -1524,9 +1626,10 @@ type hostPolicy struct {
 	// are the same hosts as ::1 and 127.0.0.1, and a client that spells one of
 	// them the long way is not an attacker.
 	ips []net.IP
-	// names are the allowed non-numeric Host values, lowercased. There is
-	// exactly one, "localhost", and no mechanism to add another: a DNS name in
-	// a Host header is precisely what the rebinding attack carries.
+	// names are the allowed non-numeric Host values, lowercased. "localhost"
+	// is always there; an operator may enumerate more with --allowed-host, and
+	// nothing else can add one. Matching is EXACT — no wildcard and no suffix
+	// syntax — so the allowlist is precisely what was enumerated.
 	names map[string]bool
 	// anyIP additionally allows ANY numeric Host literal. Only a wildcard bind
 	// sets it; see newHostPolicy for why that is still a rebinding defense.
@@ -1549,7 +1652,14 @@ type hostPolicy struct {
 // would instead surrender the defense on the serving host's own loopback
 // interface, which is rebinding's canonical target, and on every LAN browser
 // behind a firewall the attacker cannot otherwise reach.
-func newHostPolicy(bind net.IP) hostPolicy {
+// EXTRA is the operator's enumerated additions (--allowed-host). A deployment
+// where clients dial a service DNS name is refused by the policy above on every
+// single request, so without this the server is unreachable rather than
+// protected. Admitting a name the operator named does not weaken the defense
+// the check exists for: a rebound page still cannot make a browser send that
+// Host to 127.0.0.1, and the in-cluster clients that do send it are not
+// browsers. Numeric values land in ips, so a pod IP can be enumerated too.
+func newHostPolicy(bind net.IP, extra []string) hostPolicy {
 	p := hostPolicy{
 		ips:   []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
 		names: map[string]bool{"localhost": true},
@@ -1558,7 +1668,46 @@ func newHostPolicy(bind net.IP) hostPolicy {
 	if !p.anyIP && !containsIP(p.ips, bind) {
 		p.ips = append(p.ips, bind)
 	}
+	for _, host := range extra {
+		h := hostOnly(host)
+		if ip := net.ParseIP(h); ip != nil {
+			if !containsIP(p.ips, ip) {
+				p.ips = append(p.ips, ip)
+			}
+			continue
+		}
+		p.names[h] = true
+	}
 	return p
+}
+
+// ValidateAllowedHost refuses an allowlist entry that is not a bare host.
+//
+// The Host header's port is stripped before matching (hostOnly), so an entry
+// carrying one would silently never match — and an operator who wrote it would
+// reasonably read the startup line as proof that it does. A URL, a path or
+// embedded whitespace is the same mistake in a louder form.
+func ValidateAllowedHost(v string) error {
+	if strings.TrimSpace(v) == "" {
+		return errors.New("--allowed-host is empty; pass the Host header value clients send, such as bd-myproject.beads.svc.cluster.local")
+	}
+	if strings.ContainsAny(v, " \t\r\n") {
+		return fmt.Errorf("--allowed-host %q contains whitespace; it must be a bare host name or IP", v)
+	}
+	if strings.ContainsAny(v, "/@") {
+		return fmt.Errorf("--allowed-host %q looks like a URL; pass just the host, with no scheme and no path", v)
+	}
+	// An IPv6 address is spelled in brackets in a Host header, so an operator
+	// copying one off the wire types it that way. hostOnly strips them before
+	// matching, so the entry works; refusing it here — with a message about a
+	// port it does not have — would be the validation lying about the policy.
+	if net.ParseIP(strings.TrimSuffix(strings.TrimPrefix(v, "["), "]")) != nil {
+		return nil
+	}
+	if strings.Contains(v, ":") {
+		return fmt.Errorf("--allowed-host %q carries a port; the port is stripped from a request's Host before matching, so an entry with one could never match", v)
+	}
+	return nil
 }
 
 // allows reports whether a Host header value is one this server answers to.
@@ -1626,6 +1775,10 @@ func (s *Server) logStartup() {
 		"database", s.cfg.Workspace.Database,
 		"host_allowlist", s.hosts.label(),
 		"capabilities", strings.Join(s.ctxBody.Capabilities, ","),
+		// Whether this server requires a credential is the first thing an
+		// operator checks after a deploy, and the last thing they should have
+		// to infer from the absence of a flag in a process listing.
+		"auth", s.authLabel(),
 	)
 
 	limits := []any{

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -11,6 +11,8 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"sync"
@@ -520,7 +522,7 @@ func TestHostPolicyPerBindAddress(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			p := newHostPolicy(net.ParseIP(tc.bind))
+			p := newHostPolicy(net.ParseIP(tc.bind), nil)
 			for _, host := range tc.allow {
 				if !p.allows(host) {
 					t.Errorf("bind %s refuses Host %q, which is one of its own clients", tc.bind, host)
@@ -1289,4 +1291,449 @@ func findLogLine(t *testing.T, log, needle string) string {
 	}
 	t.Fatalf("no log line containing %q in:\n%s", needle, log)
 	return ""
+}
+
+// ---------------------------------------------------------------------------
+// Deployment hardening: bearer auth, the Host allowlist, and operator limits.
+//
+// All three land on one seam (Config), and the property that ties them
+// together is the default: a zero-valued Config is today's server, byte for
+// byte. Every test above this line is the proof of that half — none of them
+// passes a token, an allowed host or a limit, and all of them still pass.
+
+// authTokenFile writes a token file and returns a verifier over it.
+func authTokenFile(t *testing.T, tokens ...string) *TokenFileAuth {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "tokens")
+	if err := os.WriteFile(path, []byte(strings.Join(tokens, "\n")+"\n"), 0o600); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+	auth, err := NewTokenFileAuth(path)
+	if err != nil {
+		t.Fatalf("NewTokenFileAuth: %v", err)
+	}
+	return auth
+}
+
+// do issues a request with caller-chosen headers, which every auth test needs
+// and ts.get cannot express.
+func (ts *testServer) do(t *testing.T, method, path string, header http.Header) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(method, ts.base+path, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	for k, vs := range header {
+		// net/http sends Request.Host and ignores a "Host" entry in the header
+		// map, so a test that set only the map would silently exercise the
+		// default Host and pass against no policy at all.
+		if http.CanonicalHeaderKey(k) == "Host" {
+			req.Host = vs[0]
+			continue
+		}
+		req.Header[k] = vs
+	}
+	resp, err := ts.client.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	return resp
+}
+
+func bearer(token string) http.Header {
+	return http.Header{"Authorization": {"Bearer " + token}}
+}
+
+// authedOperations is every route the token guards — the whole table minus the
+// one exempt row. Derived rather than listed so a route added without a
+// decision about its exemption cannot slip past these tests.
+func authedOperations(t *testing.T) []route {
+	t.Helper()
+	var out []route
+	for _, rt := range routeTable {
+		if !rt.authExempt {
+			out = append(out, rt)
+		}
+	}
+	if len(out) == 0 {
+		t.Fatal("no authenticated routes in the table")
+	}
+	return out
+}
+
+// TestBearerAuthGuardsEveryOperationButLiveness is the security deliverable:
+// with a token configured, reachability alone is no longer read and claim
+// authority. Liveness is the single exemption — a probe must answer with no
+// credential — and GET /v0/beads/context is deliberately NOT one: it reveals
+// the repo root, the beads directory and the database name.
+func TestBearerAuthGuardsEveryOperationButLiveness(t *testing.T) {
+	ts := newTestServer(t, Config{Auth: authTokenFile(t, "primary-token", "secondary-token")})
+
+	if resp := ts.get(t, "/healthz"); resp.StatusCode != http.StatusOK {
+		t.Errorf("GET /healthz with no credential = %d, want 200: a liveness probe carries none", resp.StatusCode)
+	}
+
+	for _, rt := range authedOperations(t) {
+		// The rows sharing the custom-method wildcard each answer on their own
+		// suffix, so the substitution has to be the ROW's, not the claim's:
+		// hard-coding ":claim" would drive every one of them down the claim's
+		// path and stop testing the others the moment a third row was added.
+		path := strings.NewReplacer(
+			"{id}", "bd-1",
+			"{"+customMethodPathValue+"}", "bd-1"+rt.customMethod,
+		).Replace(rt.pattern)
+		for _, tc := range []struct {
+			name   string
+			header http.Header
+		}{
+			{"no header", nil},
+			{"wrong scheme", http.Header{"Authorization": {"Basic cHc6cHc="}}},
+			{"scheme only", http.Header{"Authorization": {"Bearer"}}},
+			{"empty token", http.Header{"Authorization": {"Bearer   "}}},
+			{"unknown token", bearer("not-the-token")},
+			{"near miss", bearer("primary-toke")},
+		} {
+			t.Run(rt.op+"/"+tc.name, func(t *testing.T) {
+				resp := ts.do(t, rt.method, path, tc.header)
+				if resp.StatusCode != http.StatusUnauthorized {
+					t.Fatalf("%s %s = %d, want 401", rt.method, path, resp.StatusCode)
+				}
+				if got := resp.Header.Get("WWW-Authenticate"); got != "Bearer" {
+					t.Errorf("WWW-Authenticate = %q, want Bearer", got)
+				}
+				if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/problem+json") {
+					t.Errorf("Content-Type = %q, want problem+json", ct)
+				}
+				body := decodeBody(t, resp)
+				if body["code"] != string(CodeUnauthenticated) {
+					t.Errorf("code = %v, want %s", body["code"], CodeUnauthenticated)
+				}
+				if id, _ := body["request_id"].(string); id == "" {
+					t.Error("a 401 carries no request_id, so it cannot be correlated to its log line")
+				}
+				if detail, _ := body["detail"].(string); detail != staticDetail[CodeUnauthenticated] {
+					t.Errorf("detail = %q, want the fixed string %q", detail, staticDetail[CodeUnauthenticated])
+				}
+			})
+		}
+	}
+
+	// Both tokens in the file are accepted: that is the rotation overlap, and
+	// it is the only mechanism this server has for it.
+	for _, tok := range []string{"primary-token", "secondary-token"} {
+		resp := ts.do(t, http.MethodGet, "/v0/beads/context", bearer(tok))
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("GET /v0/beads/context with token %q = %d, want 200", tok, resp.StatusCode)
+		}
+	}
+}
+
+// TestUnauthenticated401NeverEchoesTheCredential. A presented token is a
+// secret, and a 401 that quoted it would write it into every client log and
+// every proxy trace. The fixed `detail` is what makes that structural rather
+// than a rule to remember; the server log has the same duty.
+func TestUnauthenticated401NeverEchoesTheCredential(t *testing.T) {
+	const presented = "leaked-secret-value"
+	ts := newTestServer(t, Config{Auth: authTokenFile(t, "real-token")})
+
+	resp := ts.do(t, http.MethodGet, "/v0/beads/ready", bearer(presented))
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if strings.Contains(string(body), presented) {
+		t.Errorf("the 401 body echoes the presented credential:\n%s", body)
+	}
+	if log := ts.stderr.String(); strings.Contains(log, presented) {
+		t.Errorf("the server log records the presented credential:\n%s", log)
+	}
+
+	// The refusal is still attributable: a probe that leaves no server-side
+	// trace is a control nobody can investigate.
+	line := findLogLine(t, ts.stderr.String(), "event=auth_refused")
+	for _, field := range []string{"reason=unknown_token", "op=listReadyWork", "request_id="} {
+		if !strings.Contains(line, field) {
+			t.Errorf("auth_refused line is missing %q:\n%s", field, line)
+		}
+	}
+}
+
+// TestAuthRefusalNamesWhyItWasRefused separates the three client mistakes in
+// the log, because "no header" is a misconfigured client and "unknown token" is
+// either a rotation in progress or somebody trying tokens.
+func TestAuthRefusalNamesWhyItWasRefused(t *testing.T) {
+	for _, tc := range []struct {
+		name, wantReason string
+		header           http.Header
+	}{
+		{"missing", "missing", nil},
+		{"malformed", "malformed", http.Header{"Authorization": {"Basic cHc6cHc="}}},
+		{"unknown", "unknown_token", bearer("nope")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := newTestServer(t, Config{Auth: authTokenFile(t, "real-token")})
+			ts.do(t, http.MethodGet, "/v0/beads/ready", tc.header)
+			line := findLogLine(t, ts.stderr.String(), "event=auth_refused")
+			if !strings.Contains(line, "reason="+tc.wantReason) {
+				t.Errorf("auth_refused reason is not %q:\n%s", tc.wantReason, line)
+			}
+		})
+	}
+}
+
+// TestAuthRefusalCostsNoDatabaseSlot. The check runs before acquire, so a 401
+// storm is one SHA-256 per request and can never occupy the slots — or the SQL
+// connections pinned to them — that authenticated clients are waiting for.
+// Answering 503 busy here would mean refused traffic could starve real traffic.
+func TestAuthRefusalCostsNoDatabaseSlot(t *testing.T) {
+	stderr := &lockedBuffer{}
+	s := &Server{
+		sem:        make(chan struct{}, 1),
+		semTimeout: 5 * time.Second,
+		log:        newTestLogger(stderr),
+		auth:       authTokenFile(t, "real-token"),
+	}
+
+	held, err := s.acquire(context.Background(), &reqInfo{id: "holder"})
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	t.Cleanup(held)
+
+	reached := false
+	guarded := route{op: "guarded", handler: func(*Server, http.ResponseWriter, *http.Request) { reached = true }}
+	h := s.withRequestContext(s.route(guarded))
+
+	rr := httptest.NewRecorder()
+	start := time.Now()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/v0/beads/ready", nil))
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 — the refusal queued for a slot instead of answering", rr.Code)
+	}
+	if waited := time.Since(start); waited > time.Second {
+		t.Errorf("the refusal waited %v for a database slot", waited)
+	}
+	if reached {
+		t.Error("the handler ran for an unauthenticated request")
+	}
+	// The slot is still the holder's: the refusal neither took nor leaked one.
+	if len(s.sem) != 1 {
+		t.Errorf("semaphore holds %d slots, want the holder's 1", len(s.sem))
+	}
+}
+
+// TestUnroutedPathsStayUnauthenticated pins both halves of one rule: a path
+// this document does not define answers 404 with no credential — paths are
+// public spec, so refusing them first would disclose nothing and hide nothing —
+// while every path it DOES define is guarded.
+//
+// The custom-method wildcard is where the two meet. It matches every POST under
+// /v0/beads/issues/, and dispatchCustomMethod splits the suffix off BEFORE
+// s.route, so a segment ending in no registered suffix gets the catch-all's 404
+// and never reaches the credential check; a registered suffix reaches its row
+// and is refused. Neither half may be "fixed" into the other: 401 on the miss
+// would charge an unrouted path for a credential that cannot help it, and 404
+// on the hit would hide an operation behind a routing detail.
+func TestUnroutedPathsStayUnauthenticated(t *testing.T) {
+	ts := newTestServer(t, Config{Auth: authTokenFile(t, "real-token")})
+
+	for _, path := range []string{"/v0/nonsense", "/", "/v0/beads/issues/bd-1/extra"} {
+		if resp := ts.get(t, path); resp.StatusCode != http.StatusNotFound {
+			t.Errorf("GET %s with no credential = %d, want 404: paths are public spec", path, resp.StatusCode)
+		}
+	}
+
+	// Inside the wildcard, a segment ending in no registered suffix is just as
+	// unrouted, and answers the same way.
+	for _, path := range []string{"/v0/beads/issues/bd-1", "/v0/beads/issues/bd-1:nosuchverb"} {
+		if resp := ts.do(t, http.MethodPost, path, nil); resp.StatusCode != http.StatusNotFound {
+			t.Errorf("POST %s with no credential = %d, want 404: the suffix is registered nowhere", path, resp.StatusCode)
+		}
+	}
+
+	// A registered suffix names an operation, and an operation is guarded.
+	for _, rt := range authedOperations(t) {
+		if rt.customMethod == "" {
+			continue
+		}
+		path := "/v0/beads/issues/bd-1" + rt.customMethod
+		if resp := ts.do(t, rt.method, path, nil); resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("%s %s with no credential = %d, want 401", rt.method, path, resp.StatusCode)
+		}
+	}
+}
+
+// TestListenRefusesAnUnservablePosture: the library enforces the same posture
+// rules the CLI does, so a second caller cannot assemble a Config that serves
+// the whole surface to a network with no credential.
+func TestListenRefusesAnUnservablePosture(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		cfg     Config
+		wantErr string
+	}{
+		{
+			name:    "non-loopback with no credential",
+			cfg:     Config{Addr: "0.0.0.0:0", AllowNonLoopback: true},
+			wantErr: "--auth-token-file",
+		},
+		{
+			name:    "waiver contradicts a token",
+			cfg:     Config{Addr: "0.0.0.0:0", AllowNonLoopback: true, InsecureNoAuth: true, Auth: authTokenFile(t, "tok")},
+			wantErr: "--insecure-no-auth",
+		},
+		{
+			name:    "malformed allowed host",
+			cfg:     Config{Addr: "127.0.0.1:0", AllowedHosts: []string{"svc.beads.svc:8080"}},
+			wantErr: "--allowed-host",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := tc.cfg
+			if cfg.Provider == nil {
+				cfg.Provider = &fakeProvider{}
+			}
+			cfg.Stdout, cfg.Stderr = &bytes.Buffer{}, &lockedBuffer{}
+			srv, err := Listen(cfg)
+			if err == nil {
+				_ = srv.http.Close()
+				t.Fatalf("Listen accepted %+v, want a refusal naming %s", tc.cfg, tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("refusal %q does not name %s", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestAllowedHostsAdmitInClusterNames is the blocker this slice exists to
+// clear: in a cluster the client dials a service DNS name, and the
+// loopback-only Host policy 400s every such request. Matching stays EXACT —
+// there is no wildcard or suffix syntax — so the allowlist is exactly what the
+// operator enumerated.
+func TestAllowedHostsAdmitInClusterNames(t *testing.T) {
+	const svc = "bd-proj.beads.svc.cluster.local"
+	ts := newTestServer(t, Config{AllowedHosts: []string{svc, "10.4.2.9"}})
+
+	for _, host := range []string{svc, svc + ":8080", strings.ToUpper(svc), "10.4.2.9", "10.4.2.9:80", "localhost"} {
+		resp := ts.do(t, http.MethodGet, "/healthz", http.Header{"Host": {host}})
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("Host %q = %d, want 200", host, resp.StatusCode)
+		}
+	}
+	for _, host := range []string{"beads.svc.cluster.local", "evil." + svc, svc + ".evil.example", "10.4.2.10"} {
+		resp := ts.do(t, http.MethodGet, "/healthz", http.Header{"Host": {host}})
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("Host %q = %d, want 400: the allowlist is exact", host, resp.StatusCode)
+		}
+	}
+
+	// The startup line states the whole effective policy, so an operator can
+	// read what the server answers to rather than deducing it.
+	startup := findLogLine(t, ts.stderr.String(), "event=startup")
+	if !strings.Contains(startup, svc) || !strings.Contains(startup, "10.4.2.9") {
+		t.Errorf("host_allowlist does not name the operator's additions:\n%s", startup)
+	}
+}
+
+// TestARunningServerAcceptsARotatedToken is the rotation property proved end
+// to end, over a real listener, against a real token file, under the REAL
+// one-second reload gate — no injected clock. This is the deployment
+// requirement stated as a test: rotating a credential must not be a restart,
+// and revoking a leaked one must not wait for the pod's next deploy.
+//
+// It costs a couple of real seconds, which is the point: the gate it is
+// waiting out is the one that ships.
+func TestARunningServerAcceptsARotatedToken(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tokens")
+	writeTokenFile(t, path, "original-token\n")
+	auth, err := NewTokenFileAuth(path)
+	if err != nil {
+		t.Fatalf("NewTokenFileAuth: %v", err)
+	}
+	ts := newTestServer(t, Config{Auth: auth})
+
+	status := func(token string) int {
+		t.Helper()
+		return ts.do(t, http.MethodGet, "/v0/beads/context", bearer(token)).StatusCode
+	}
+
+	if got := status("original-token"); got != http.StatusOK {
+		t.Fatalf("the starting token = %d, want 200", got)
+	}
+
+	// The overlap the operator writes: new alongside old, clients roll over
+	// one at a time, nothing restarts.
+	writeTokenFile(t, path, "rotated-token\noriginal-token\n")
+	time.Sleep(authReloadInterval + 200*time.Millisecond)
+	if got := status("rotated-token"); got != http.StatusOK {
+		t.Errorf("the rotated-in token = %d, want 200 — rotation would need a restart", got)
+	}
+	if got := status("original-token"); got != http.StatusOK {
+		t.Errorf("the outgoing token = %d during the overlap, want 200", got)
+	}
+
+	// And the removal, which is revocation: the old token stops working while
+	// the same process keeps serving the new one.
+	writeTokenFile(t, path, "rotated-token\n")
+	time.Sleep(authReloadInterval + 200*time.Millisecond)
+	if got := status("original-token"); got != http.StatusUnauthorized {
+		t.Errorf("the revoked token = %d, want 401 — a leaked token would outlive the process", got)
+	}
+	if got := status("rotated-token"); got != http.StatusOK {
+		t.Errorf("the live token = %d after revocation, want 200", got)
+	}
+}
+
+// TestValidateAllowedHost covers the entries an operator actually types,
+// including the ones copied verbatim out of a Host header.
+func TestValidateAllowedHost(t *testing.T) {
+	for _, tc := range []struct {
+		name, value, wantErr string
+	}{
+		{name: "service dns name", value: "bd-proj.beads.svc.cluster.local"},
+		{name: "short service name", value: "bd-proj.beads.svc"},
+		{name: "single label", value: "bd-proj"},
+		{name: "ipv4 literal", value: "10.4.2.9"},
+		{name: "ipv6 literal", value: "2001:db8::1"},
+		// A Host header spells an IPv6 address in brackets, so an operator
+		// reading one off the wire types it that way. hostOnly strips them
+		// before matching, so it works — and the validation must not refuse
+		// it with a message about a port it does not have.
+		{name: "bracketed ipv6 literal", value: "[2001:db8::1]"},
+
+		{name: "empty", value: "", wantErr: "empty"},
+		{name: "whitespace", value: "bd proj.svc", wantErr: "whitespace"},
+		{name: "url", value: "http://bd-proj.beads.svc", wantErr: "URL"},
+		{name: "path", value: "bd-proj.beads.svc/v0", wantErr: "URL"},
+		{name: "name with a port", value: "bd-proj.beads.svc:8080", wantErr: "port"},
+		{name: "bracketed ipv6 with a port", value: "[2001:db8::1]:8080", wantErr: "port"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateAllowedHost(tc.value)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ValidateAllowedHost(%q) = %v, want nil", tc.value, err)
+				}
+				// Accepting it is only half the promise; it has to reach the
+				// policy in a form that matches.
+				p := newHostPolicy(net.ParseIP("127.0.0.1"), []string{tc.value})
+				if !p.allows(tc.value) {
+					t.Errorf("%q validates but the policy does not answer to it", tc.value)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("ValidateAllowedHost(%q) = nil, want a refusal about %s", tc.value, tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("refusal %q does not explain the problem (%s)", err, tc.wantErr)
+			}
+		})
+	}
 }

--- a/internal/httpapi/spec/openapi.v0.yaml
+++ b/internal/httpapi/spec/openapi.v0.yaml
@@ -100,6 +100,43 @@ info:
     are only `404`/`500`/`503`.
 
 
+    ## Authentication is a deployment posture
+
+
+    Bearer authentication is CONFIGURED PER DEPLOYMENT, not implied by this
+    document. A server started without a token file requires no credential and
+    never emits `401`; a server started with one requires
+    `Authorization: Bearer <token>` on every operation that declares the
+    `bearerToken` scheme below — which is all of them except `GET /healthz`, so
+    that a liveness probe can answer with no credential. `GET
+    /v0/beads/context` is NOT exempt: it reveals the repository root, the beads
+    directory and the database name.
+
+
+    The refusal is `401` / `code: unauthenticated`, with `WWW-Authenticate:
+    Bearer`. Its `detail` is a fixed string and NEVER echoes the presented
+    credential — a missing header, a wrong scheme and an unrecognized token are
+    one code deliberately, because distinguishing them would tell an
+    unauthenticated caller which guess was closer.
+
+
+    The `404` for a path this document does not define needs no credential:
+    paths are public spec, so refusing them first would disclose nothing and
+    hide nothing.
+
+
+    A token ROTATES by rewriting the token file, with no restart: every
+    non-empty line is an accepted token, so an operator writes the new token
+    alongside the old, rolls clients over, then removes the old one. Both the
+    addition and the removal take effect within about a second.
+
+
+    There is NO TLS on this surface. A deployment beyond loopback is expected
+    to supply confidentiality itself — a service mesh, or a trusted network
+    boundary — because otherwise both the token and the issue data travel in
+    plaintext.
+
+
     The unknown-parameter rule is deliberate and load-bearing: silently
     ignoring an unrecognized FILTER parameter widens the result set, so a
     client one version ahead of the server would receive — and act on — rows it
@@ -239,6 +276,8 @@ paths:
         configuration, and in particular never carries a sync remote URL (those
         routinely embed credentials). v0 answers from the snapshot without
         touching the database, which is why no 503 is documented here.
+      security:
+        - bearerToken: []
       responses:
         '200':
           description: Workspace and API identity.
@@ -246,6 +285,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ContextResponse'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '500':
           $ref: '#/components/responses/InternalError'
 
@@ -437,6 +478,8 @@ paths:
             type: integer
             minimum: 0
             default: 100
+      security:
+        - bearerToken: []
       responses:
         '200':
           description: A page of ready work.
@@ -446,6 +489,8 @@ paths:
                 $ref: '#/components/schemas/ReadyPage'
         '400':
           $ref: '#/components/responses/InvalidArgument'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '500':
           $ref: '#/components/responses/InternalError'
         '503':
@@ -516,6 +561,8 @@ paths:
           schema:
             type: boolean
             default: false
+      security:
+        - bearerToken: []
       responses:
         '200':
           description: The workspace summary.
@@ -525,6 +572,8 @@ paths:
                 $ref: '#/components/schemas/StatsResponse'
         '400':
           $ref: '#/components/responses/InvalidArgument'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '500':
           $ref: '#/components/responses/InternalError'
         '503':
@@ -563,6 +612,8 @@ paths:
         cycles in the workspace, which in a healthy one is zero. `has_more` is
         present so that adding a bound later is additive rather than a new
         envelope.
+      security:
+        - bearerToken: []
       responses:
         '200':
           description: Every dependency cycle, canonically ordered.
@@ -570,6 +621,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CyclesPage'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '500':
           $ref: '#/components/responses/InternalError'
         '503':
@@ -693,6 +746,8 @@ paths:
             an unrecognized status simply matches nothing.
           schema:
             type: string
+      security:
+        - bearerToken: []
       responses:
         '200':
           description: The walked tree, flat, in depth-first pre-order.
@@ -702,6 +757,8 @@ paths:
                 $ref: '#/components/schemas/DependencyTreePage'
         '400':
           $ref: '#/components/responses/InvalidArgument'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
@@ -844,6 +901,8 @@ paths:
           schema:
             type: boolean
             default: false
+      security:
+        - bearerToken: []
       responses:
         '200':
           description: The size of the ready set.
@@ -853,6 +912,8 @@ paths:
                 $ref: '#/components/schemas/ReadyCount'
         '400':
           $ref: '#/components/responses/InvalidArgument'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '500':
           $ref: '#/components/responses/InternalError'
         '503':
@@ -1098,6 +1159,8 @@ paths:
             type: integer
             minimum: 0
             default: 50
+      security:
+        - bearerToken: []
       responses:
         '200':
           description: A page of issues in `(created_at DESC, id ASC)` order.
@@ -1114,6 +1177,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '500':
           $ref: '#/components/responses/InternalError'
         '503':
@@ -1208,6 +1273,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateIssueRequest'
+      security:
+        - bearerToken: []
       responses:
         '200':
           description: >-
@@ -1246,6 +1313,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '409':
           description: >-
             The request is well-formed and the STATE refuses it, and NOTHING WAS
@@ -1388,6 +1457,8 @@ paths:
             type: integer
             minimum: 0
             default: 50
+      security:
+        - bearerToken: []
       responses:
         '200':
           description: A page of the issues the expression matched.
@@ -1404,6 +1475,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '500':
           $ref: '#/components/responses/InternalError'
         '503':
@@ -1449,6 +1522,8 @@ paths:
           schema:
             type: boolean
             default: false
+      security:
+        - bearerToken: []
       responses:
         '200':
           description: The issue.
@@ -1458,6 +1533,8 @@ paths:
                 $ref: '#/components/schemas/IssueDetails'
         '400':
           $ref: '#/components/responses/InvalidArgument'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
@@ -1587,6 +1664,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/UpdateIssueRequest'
+      security:
+        - bearerToken: []
       responses:
         '200':
           description: >-
@@ -1621,6 +1700,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '404':
           $ref: '#/components/responses/NotFound'
         '409':
@@ -1700,6 +1781,8 @@ paths:
         `issue_status`. Neither needs the client to parse prose.
       parameters:
         - $ref: '#/components/parameters/IssueID'
+      security:
+        - bearerToken: []
       requestBody:
         required: true
         content:
@@ -1724,6 +1807,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '404':
           $ref: '#/components/responses/NotFound'
         '409':
@@ -1855,6 +1940,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ReleaseIssueRequest'
+      security:
+        - bearerToken: []
       responses:
         '200':
           description: >-
@@ -1906,6 +1993,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '404':
           $ref: '#/components/responses/NotFound'
         '409':
@@ -2055,6 +2144,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CloseIssueRequest'
+      security:
+        - bearerToken: []
       responses:
         '200':
           description: The issue is closed.
@@ -2075,6 +2166,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '404':
           $ref: '#/components/responses/NotFound'
         '409':
@@ -2186,6 +2279,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ReopenIssueRequest'
+      security:
+        - bearerToken: []
       responses:
         '200':
           description: The issue is open.
@@ -2206,6 +2301,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '404':
           $ref: '#/components/responses/NotFound'
         '409':
@@ -2318,6 +2415,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CompareAndSetMetadataRequest'
+      security:
+        - bearerToken: []
       responses:
         '200':
           description: >-
@@ -2338,6 +2437,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
@@ -2402,6 +2503,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/SweepRequest'
+      security:
+        - bearerToken: []
       responses:
         '200':
           description: >-
@@ -2425,6 +2528,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '500':
           $ref: '#/components/responses/InternalError'
         '503':
@@ -2534,6 +2639,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/DeleteIssuesRequest'
+      security:
+        - bearerToken: []
       responses:
         '200':
           description: >-
@@ -2556,6 +2663,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '404':
           description: >-
             At least one id named no stored bead, and nothing was deleted.
@@ -2639,6 +2748,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/BatchCreateRequest'
+      security:
+        - bearerToken: []
       responses:
         '200':
           description: >-
@@ -2662,6 +2773,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '500':
           $ref: '#/components/responses/InternalError'
         '503':
@@ -2809,6 +2922,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ApplyBatchRequest'
+      security:
+        - bearerToken: []
       responses:
         '200':
           description: >-
@@ -2868,6 +2983,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '404':
           description: >-
             A `target` of an `update` or a `close` named no stored row, and
@@ -3056,6 +3173,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/BatchCloseRequest'
+      security:
+        - bearerToken: []
       responses:
         '200':
           description: >-
@@ -3077,6 +3196,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '500':
           $ref: '#/components/responses/InternalError'
         '503':
@@ -3320,6 +3441,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ClaimNextRequest'
+      security:
+        - bearerToken: []
       responses:
         '200':
           description: >-
@@ -3340,6 +3463,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '500':
           $ref: '#/components/responses/InternalError'
         '503':
@@ -3383,6 +3508,8 @@ paths:
         collection to scan, so the whole plane is returned in one page. The
         envelope is used anyway because entries are ordered by key, which makes
         a keyset cursor expressible later without a breaking change.
+      security:
+        - bearerToken: []
       responses:
         '200':
           description: The stored settings.
@@ -3390,6 +3517,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SettingsPage'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '500':
           $ref: '#/components/responses/InternalError'
         '503':
@@ -3412,6 +3541,8 @@ paths:
         this server would have to invent.
       parameters:
         - $ref: '#/components/parameters/SettingKey'
+      security:
+        - bearerToken: []
       responses:
         '200':
           description: The setting.
@@ -3428,6 +3559,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '500':
           $ref: '#/components/responses/InternalError'
         '503':
@@ -3524,6 +3657,8 @@ paths:
             type: array
             items:
               type: string
+      security:
+        - bearerToken: []
       responses:
         '200':
           description: The stored edges of the named issues.
@@ -3533,6 +3668,8 @@ paths:
                 $ref: '#/components/schemas/DependencyEdges'
         '400':
           $ref: '#/components/responses/InvalidArgument'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '500':
           $ref: '#/components/responses/InternalError'
         '503':
@@ -3610,6 +3747,8 @@ paths:
             maxItems: 100
             items:
               type: string
+      security:
+        - bearerToken: []
       responses:
         '200':
           description: The blocking decoration of the named issues.
@@ -3619,6 +3758,8 @@ paths:
                 $ref: '#/components/schemas/BlockingAnnotations'
         '400':
           $ref: '#/components/responses/InvalidArgument'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '500':
           $ref: '#/components/responses/InternalError'
         '503':
@@ -3682,6 +3823,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/AddDependenciesRequest'
+      security:
+        - bearerToken: []
       responses:
         '200':
           description: >-
@@ -3713,6 +3856,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '409':
           description: >-
             The graph refuses the requested edge set, and NOTHING WAS WRITTEN.
@@ -3789,6 +3934,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/RemoveDependencyRequest'
+      security:
+        - bearerToken: []
       responses:
         '200':
           description: >-
@@ -3810,6 +3957,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '500':
           $ref: '#/components/responses/InternalError'
         '503':
@@ -3881,6 +4030,8 @@ paths:
             what matching means; a client sends what its user typed.
           schema:
             type: string
+      security:
+        - bearerToken: []
       responses:
         '200':
           description: The stored memories, ordered by key.
@@ -3899,6 +4050,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '500':
           $ref: '#/components/responses/InternalError'
         '503':
@@ -3948,6 +4101,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/RememberRequest'
+      security:
+        - bearerToken: []
       responses:
         '200':
           description: >-
@@ -3969,6 +4124,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '500':
           $ref: '#/components/responses/InternalError'
         '503':
@@ -4019,6 +4176,8 @@ paths:
         not by path.
       parameters:
         - $ref: '#/components/parameters/MemoryKey'
+      security:
+        - bearerToken: []
       responses:
         '200':
           description: The stored memory.
@@ -4035,6 +4194,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '404':
           description: >-
             This workspace holds no memory under that key — or holds one stored
@@ -4095,6 +4256,8 @@ paths:
         `dry_run`: one named row is not a set to cost first.
       parameters:
         - $ref: '#/components/parameters/MemoryKey'
+      security:
+        - bearerToken: []
       responses:
         '200':
           description: >-
@@ -4115,6 +4278,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '404':
           description: >-
             This workspace holds no memory under that key — or holds one stored
@@ -4275,6 +4440,8 @@ paths:
             minimum: 1
             maximum: 10000
             default: 1000
+      security:
+        - bearerToken: []
       responses:
         '200':
           description: >-
@@ -4293,6 +4460,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '409':
           description: >-
             The durable events journal is NOT ENABLED on this workspace, so it
@@ -4480,6 +4649,8 @@ paths:
             type: integer
             format: int64
             minimum: 0
+      security:
+        - bearerToken: []
       responses:
         '200':
           description: >-
@@ -4543,6 +4714,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
         '409':
           description: >-
             The durable events journal is NOT ENABLED on this workspace, so
@@ -4601,6 +4774,15 @@ paths:
 
 components:
 
+  securitySchemes:
+    bearerToken:
+      type: http
+      scheme: bearer
+      description: >-
+        A shared bearer token from the server's token file. It carries no
+        identity and no scopes: presenting an accepted token grants every
+        operation. Which token is presented is never observable in a response.
+
   parameters:
     SettingKey:
       name: key
@@ -4636,6 +4818,23 @@ components:
         type: string
 
   responses:
+    Unauthenticated:
+      description: >-
+        The bearer credential was missing, malformed, or is not one this server
+        accepts. Emitted only by a server configured with a token file; one
+        without never emits it. `detail` is a fixed string, which is what
+        guarantees the presented credential is never echoed back to the client
+        or into any log between here and the caller.
+      x-bd-codes: [unauthenticated]
+      headers:
+        WWW-Authenticate:
+          description: The challenge, always `Bearer`.
+          schema:
+            type: string
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
     InvalidArgument:
       description: >-
         Invalid request: an unknown query parameter, or a malformed parameter
@@ -8882,9 +9081,10 @@ components:
             The stable machine-readable reason, and the ONLY member a client
             may dispatch on. v0's vocabulary: `invalid_argument` (400, also
             emitted by the Host-header middleware on any route),
-            `invalid_cursor` (400), `not_found` (404), `already_claimed` (409),
-            `not_claimable` (409), `not_closable` (409),
-            `not_releasable` (409),
+            `invalid_cursor` (400), `unauthenticated` (401, only on a server
+            configured with a token file), `not_found` (404),
+            `already_claimed` (409), `not_claimable` (409),
+            `not_closable` (409), `not_releasable` (409),
             `dependency_cycle` (409), `dependency_exists` (409),
             `already_exists` (409), `precondition_failed` (409),
             `events_journal_disabled` (409), `events_journal_truncated` (410),
@@ -8901,8 +9101,12 @@ components:
             Optional prose, never load-bearing. For 5xx codes it is a FIXED
             string per code and carries nothing about the underlying failure:
             driver and dial errors routinely embed the DSN, database user and
-            host:port, and this API supports binding beyond loopback. 4xx
-            details reflect the caller's own input back and are specific.
+            host:port, and this API supports binding beyond loopback. It is
+            fixed for `unauthenticated` too, and for the mirror-image reason:
+            the caller's own input there is a credential, so echoing it would
+            write the token into every client log and proxy trace on the way
+            back. Other 4xx details reflect the caller's own input back and are
+            specific.
         param:
           type: string
           description: >-

--- a/internal/httpapi/spec_parity_test.go
+++ b/internal/httpapi/spec_parity_test.go
@@ -1477,3 +1477,76 @@ func equalStrings(a, b []string) bool {
 	}
 	return true
 }
+
+// TestSpecSecurityMatchesRouteTable is the auth half of route/spec parity: an
+// operation declares the bearer scheme in the document exactly when its route
+// row is not auth-exempt. Without this the exemption column and the document's
+// `security` blocks are two independent statements about the same thing, and
+// the one clients read could quietly become the wrong one.
+//
+// Authentication is a DEPLOYMENT posture — a server started with no token file
+// never emits a 401 — so the spec's job here is to say which operations are
+// guarded when it is enabled, not to claim it always is. The scheme is declared
+// per operation rather than at the document level for the same reason the
+// exemption is a route-table column: healthz is exempt, and a top-level
+// `security` block with a per-operation override would state that twice.
+func TestSpecSecurityMatchesRouteTable(t *testing.T) {
+	doc := loadSpec(t)
+	ops := specOps(t, doc)
+
+	schemes := mapAt(t, mapAt(t, doc, "components"), "securitySchemes")
+	bearer := mapAt(t, schemes, specBearerScheme)
+	if got, _ := bearer["type"].(string); got != "http" {
+		t.Errorf("securityScheme %s type = %q, want http", specBearerScheme, got)
+	}
+	if got, _ := bearer["scheme"].(string); got != "bearer" {
+		t.Errorf("securityScheme %s scheme = %q, want bearer", specBearerScheme, got)
+	}
+	if _, ok := doc["security"]; ok {
+		t.Error("the document declares a top-level `security` block; the exemption is per operation, so declaring it globally states the policy twice")
+	}
+
+	for _, rt := range routeTable {
+		so, ok := ops[rt.op]
+		if !ok {
+			t.Errorf("route %q is not in the spec", rt.op)
+			continue
+		}
+		declared := specDeclaresBearer(t, so)
+		if rt.authExempt && declared {
+			t.Errorf("%s is auth-exempt in the route table but declares %s in the spec", rt.op, specBearerScheme)
+		}
+		if !rt.authExempt && !declared {
+			t.Errorf("%s is guarded by the route table but declares no security in the spec", rt.op)
+		}
+
+		// And the 401 travels with the declaration, so a generated client of a
+		// guarded operation always has the status in its response set.
+		_, has401 := mapAt(t, so.op, "responses")["401"]
+		if declared != has401 {
+			t.Errorf("%s declares security = %v but documents a 401 = %v; the two must move together", rt.op, declared, has401)
+		}
+	}
+}
+
+func specDeclaresBearer(t *testing.T, so specOp) bool {
+	t.Helper()
+	raw, ok := so.op["security"]
+	if !ok {
+		return false
+	}
+	list, ok := raw.([]any)
+	if !ok {
+		t.Fatalf("%s: security is %T, want a sequence", so.path, raw)
+	}
+	for _, item := range list {
+		req, ok := item.(map[string]any)
+		if !ok {
+			t.Fatalf("%s: security item is %T, want a mapping", so.path, item)
+		}
+		if _, ok := req[specBearerScheme]; ok {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
`bd serve`'s help currently says *"No authentication and no TLS"*. This answers the first half. Both flags default to today's behavior, so `bd serve` with no arguments is the server it has always been — the whole pre-existing test suite passes unmodified, and none of those tests passes a token or a host.

TLS is explicitly **not** in scope and not proposed. Where we run this, confidentiality comes from a TLS-terminating sidecar in front of a loopback bind, so there is no TLS mechanism here that anybody exercises, and proposing unbuilt code would be worse than proposing none.

## `--auth-token-file`

One file, one token per line, all accepted. There is deliberately no `--auth-token`: a credential passed as an argument is readable by every local user out of `ps`.

The accepted set is **not a startup snapshot**. It is re-read while the server runs, gated to at most one `stat(2)` per second for the whole process. That is what makes rotation hitless — write `{new,old}`, roll the clients, drop `old` — and what makes a leaked token revocable within a second with no restart. The freshness check runs on the **accepting** path too, not only on a mismatch: a token the operator just deleted still matches the cached set, so a mismatch-triggered reload would give you rotation and never give you revocation. A failed or empty re-read keeps the last-good set and logs, so a writer that truncates before writing cannot lock every client out.

The check sits in `route()` on a per-operation `authExempt` column beside `bypassSemaphore`, and runs **before** the semaphore — a refusal costs one SHA-256 and can never occupy the database slots authenticated clients are queued for. `/healthz` is the single exemption, because a kubelet probe carries no credential and a liveness endpoint that 401s is a pod that restarts forever. `GET /v0/beads/context` is **not** exempt: it reports the repo root, the beads directory and the database name.

Tokens are compared as SHA-256 digests in constant time, so the process holds no raw credential, and the 401's detail is a fixed string that can never echo what was presented. Missing header, wrong scheme and unknown token are one code on purpose.

## `--allowed-host` (repeatable)

Extra `Host` values the DNS-rebinding check answers to. Matching stays **exact** — no wildcards, no suffixes. Admitting a name the operator enumerated does not weaken the defense: a rebound page still cannot make a browser send that `Host` to `127.0.0.1`, and the automation clients that do send it are not browsers.

Without this, a server reached by any name other than a loopback spelling or the bind address 400s on every request, which is the first thing a non-loopback deployment trips over.

## The one deliberate behavior change

`--allow-non-loopback` now **requires** `--auth-token-file`, escapable only by naming `--insecure-no-auth`. Beyond loopback the old default was that reaching the address granted every read and every claim. The three places that advertised "no authentication" — the help text, the bind refusal, and the flag usage — are reworded, because leaving any of them would ship a false security statement.

## The wire

A `bearerToken` security scheme, a documented `401` on every guarded operation, and `TestSpecSecurityMatchesRouteTable`, which fails if the route table's exemption column and the document's `security` blocks ever disagree. `operationCodes` carries `CodeUnauthenticated` per operation rather than as a document-level rule, so an operation added later inherits enforcement the moment it is routed and cannot be merged without documenting its 401 — which is exactly what caught `releaseIssue` while preparing this branch.

## Verification

- `go test ./internal/httpapi/...` — green, including the regenerated `apigen` types and both spec-parity gates.
- `go test ./cmd/bd/` — every `TestServe*` green. The `TestInit*` / notion-config / config-validate failures in this environment reproduce identically on a clean `origin/main` checkout (a `TMPDIR` workspacegate issue), so they are not from this change.
- `gofmt` and `go vet` clean. The repo's pre-commit `golangci-lint` could not run here: `golangci-lint@v2.10.1` pins `go1.25` in its own go.mod, so `go run` downgrades the toolchain below this module's target and refuses — that reproduces on a clean checkout too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)