### PR TITLE
fix: repair main misspell lint regression

### DIFF
--- a/internal/httpapi/problem.go
+++ b/internal/httpapi/problem.go
@@ -82,7 +82,7 @@ const (
 	//
 	// THE TWO CONDITIONS ARE FULLY DISTINGUISHABLE HERE. ErrNotClaimed and
 	// ErrNotReleasable are two distinct typed sentinels, and failRelease holds
-	// both in one case arm — so a future split needs no archaeology and no
+	// both in one case arm — so a future split needs no archeology and no
 	// prose-scraping: it is a mapping change in that arm plus a code in this
 	// block and a line in the document. What IS unavailable typed is the
 	// OBSERVATION either refusal made — the status it saw, the emptiness of the
@@ -551,7 +551,7 @@ var operationCodes = map[string][]Code{
 	//
 	// The 404 is the path id's, on the terms updateIssue states. There is no
 	// `not_claimable` here even though the claim's status refusal is the nearest
-	// neighbour — see CodeNotReleasable for why that reuse was refused.
+	// neighbor — see CodeNotReleasable for why that reuse was refused.
 	OpReleaseIssue: {
 		CodeInvalidArgument, CodeNotFound,
 		CodeAlreadyClaimed, CodeNotReleasable, CodePreconditionFailed,


### PR DESCRIPTION
## Summary

- replace the two comment spellings introduced by #5507 that `misspell`
  rejects; and
- restore the required lint gate for pull requests based on current `main`.

## Problem

The merge of #5507 added `archaeology` and `neighbour` to
`internal/httpapi/problem.go`. The repository lint policy requires the US
spellings, so unrelated pull-request merge refs now fail both lint jobs. #5512
demonstrated the failure even though its exact candidate head passed the same
lint locally.

## Scope

This changes only those two comments to `archeology` and `neighbor`. Runtime
behavior, HTTP vocabulary, generated API files, tests, and user-visible output
are unchanged.

## Validation

```text
./scripts/ci/pr-lint.sh
==> gofmt check
All Go files are properly formatted
==> golangci-lint
0 issues.
==> golangci-lint (windows)
0 issues.
```

Fixes #5514

_codex-gpt-5-unknown-reasoning on behalf of Ewen Cuthiell_
