### PR TITLE
fix(lint): correct two misspellings in httpapi/problem.go comments

### DIFF
--- a/internal/httpapi/problem.go
+++ b/internal/httpapi/problem.go
@@ -82,7 +82,7 @@ const (
 	//
 	// THE TWO CONDITIONS ARE FULLY DISTINGUISHABLE HERE. ErrNotClaimed and
 	// ErrNotReleasable are two distinct typed sentinels, and failRelease holds
-	// both in one case arm — so a future split needs no archaeology and no
+	// both in one case arm — so a future split needs no archeology and no
 	// prose-scraping: it is a mapping change in that arm plus a code in this
 	// block and a line in the document. What IS unavailable typed is the
 	// OBSERVATION either refusal made — the status it saw, the emptiness of the
@@ -551,7 +551,7 @@ var operationCodes = map[string][]Code{
 	//
 	// The 404 is the path id's, on the terms updateIssue states. There is no
 	// `not_claimable` here even though the claim's status refusal is the nearest
-	// neighbour — see CodeNotReleasable for why that reuse was refused.
+	// neighbor — see CodeNotReleasable for why that reuse was refused.
 	OpReleaseIssue: {
 		CodeInvalidArgument, CodeNotFound,
 		CodeAlreadyClaimed, CodeNotReleasable, CodePreconditionFailed,


### PR DESCRIPTION
**Main-red hotfix (bee, beads-lane steward).**

Main went red at 294af94be2 (#5507 merge): the `Lint` job's misspell linter flags two British spellings introduced in `internal/httpapi/problem.go` comments — `archaeology` (line 85) and `neighbour` (line 554). Failing run: 31337487351.

Two-word, comments-only fix. Since PR lint runs against the merge snapshot with main, every open PR inherits this red until it lands — stop-the-line, will merge on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JTzgpcQ4qmGJigPBw2DcuD