### PR TITLE
fix(cook/pour): honor declared formula step types instead of squashing them to task

### DIFF
--- a/cmd/bd/cook.go
+++ b/cmd/bd/cook.go
@@ -17,9 +17,10 @@ import (
 
 // stepTypeToIssueType converts a formula step type string to a types.IssueType.
 // Returns types.TypeTask for empty types. Non-empty types pass through
-// (trimmed and normalized) rather than being validated here: pour and
-// cook --persist register non-built-in types via ensureCustomTypesForIssues,
-// and the storage layer validates them against types.custom — the same
+// (trimmed and normalized) rather than being validated here: at pour and
+// cook --persist time, flattenUnregisteredIssueTypes degrades types that
+// are neither built-in nor registered in types.custom to task (with a
+// warning), and the storage layer validates what remains — the same
 // division of labor as bd create --type.
 func stepTypeToIssueType(stepType string) types.IssueType {
 	stepType = strings.TrimSpace(stepType)
@@ -898,12 +899,12 @@ func cookFormula(ctx context.Context, s storage.DoltStorage, f *formula.Formula,
 	// Create issues, labels, and dependencies in a single atomic transaction.
 	// This prevents orphaned issues if label/dependency creation fails.
 	err := transact(ctx, s, fmt.Sprintf("bd: cook formula %s", protoID), func(tx storage.Transaction) error {
-		// Register non-built-in step types before inserting, mirroring
-		// cloneSubgraphInto (pour). Without this, PrepareIssueForInsert
-		// rejects them with "invalid issue type" and the whole cook
-		// --persist transaction rolls back.
-		if err := ensureCustomTypesForIssues(ctx, storeMolWriter{DoltStorage: s, tx: tx}, issues); err != nil {
-			return fmt.Errorf("registering custom types: %w", err)
+		// Flatten unregistered step types to task (with a warning) before
+		// inserting, mirroring cloneSubgraphInto (pour). Without this,
+		// PrepareIssueForInsert rejects them with "invalid issue type" and
+		// the whole cook --persist transaction rolls back.
+		if err := flattenUnregisteredIssueTypes(ctx, storeMolWriter{DoltStorage: s, tx: tx}, issues, deps); err != nil {
+			return fmt.Errorf("checking custom types: %w", err)
 		}
 
 		// Create all issues

--- a/cmd/bd/cook.go
+++ b/cmd/bd/cook.go
@@ -560,8 +560,9 @@ func processStepToIssue(step *formula.Step, parentID string) *types.Issue {
 	// Determine issue type. A parent step with no declared type defaults to
 	// epic; a declared type is honored even when the step has children
 	// (GH#5443).
-	issueType := stepTypeToIssueType(step.Type)
-	if len(step.Children) > 0 && strings.TrimSpace(step.Type) == "" {
+	declaredType := strings.TrimSpace(step.Type)
+	issueType := stepTypeToIssueType(declaredType)
+	if len(step.Children) > 0 && declaredType == "" {
 		issueType = types.TypeEpic
 	}
 

--- a/cmd/bd/cook.go
+++ b/cmd/bd/cook.go
@@ -18,7 +18,7 @@ import (
 // stepTypeToIssueType converts a formula step type string to a types.IssueType.
 // Returns types.TypeTask for empty types. Non-empty types pass through
 // (trimmed and normalized) rather than being validated here: pour and
-// cook --persist register non-built-in types via ensureSubgraphCustomTypes,
+// cook --persist register non-built-in types via ensureCustomTypesForIssues,
 // and the storage layer validates them against types.custom — the same
 // division of labor as bd create --type.
 func stepTypeToIssueType(stepType string) types.IssueType {
@@ -902,7 +902,7 @@ func cookFormula(ctx context.Context, s storage.DoltStorage, f *formula.Formula,
 		// cloneSubgraphInto (pour). Without this, PrepareIssueForInsert
 		// rejects them with "invalid issue type" and the whole cook
 		// --persist transaction rolls back.
-		if err := ensureSubgraphCustomTypes(ctx, storeMolWriter{DoltStorage: s, tx: tx}, &TemplateSubgraph{Issues: issues}); err != nil {
+		if err := ensureCustomTypesForIssues(ctx, storeMolWriter{DoltStorage: s, tx: tx}, issues); err != nil {
 			return fmt.Errorf("registering custom types: %w", err)
 		}
 

--- a/cmd/bd/cook.go
+++ b/cmd/bd/cook.go
@@ -17,10 +17,12 @@ import (
 
 // stepTypeToIssueType converts a formula step type string to a types.IssueType.
 // Returns types.TypeTask for empty types. Non-empty types pass through
-// (normalized) rather than being validated here: pour registers non-built-in
-// types via ensureSubgraphCustomTypes, and the storage layer validates them
-// against types.custom — the same division of labor as bd create --type.
+// (trimmed and normalized) rather than being validated here: pour and
+// cook --persist register non-built-in types via ensureSubgraphCustomTypes,
+// and the storage layer validates them against types.custom — the same
+// division of labor as bd create --type.
 func stepTypeToIssueType(stepType string) types.IssueType {
+	stepType = strings.TrimSpace(stepType)
 	if stepType == "" {
 		return types.TypeTask
 	}
@@ -554,9 +556,11 @@ func processStepToIssue(step *formula.Step, parentID string) *types.Issue {
 	// Generate issue ID (formula-name.step-id)
 	issueID := fmt.Sprintf("%s.%s", parentID, step.ID)
 
-	// Determine issue type (children override to epic)
+	// Determine issue type. A parent step with no declared type defaults to
+	// epic; a declared type is honored even when the step has children
+	// (GH#5443).
 	issueType := stepTypeToIssueType(step.Type)
-	if len(step.Children) > 0 {
+	if len(step.Children) > 0 && strings.TrimSpace(step.Type) == "" {
 		issueType = types.TypeEpic
 	}
 
@@ -894,6 +898,14 @@ func cookFormula(ctx context.Context, s storage.DoltStorage, f *formula.Formula,
 	// Create issues, labels, and dependencies in a single atomic transaction.
 	// This prevents orphaned issues if label/dependency creation fails.
 	err := transact(ctx, s, fmt.Sprintf("bd: cook formula %s", protoID), func(tx storage.Transaction) error {
+		// Register non-built-in step types before inserting, mirroring
+		// cloneSubgraphInto (pour). Without this, PrepareIssueForInsert
+		// rejects them with "invalid issue type" and the whole cook
+		// --persist transaction rolls back.
+		if err := ensureSubgraphCustomTypes(ctx, storeMolWriter{DoltStorage: s, tx: tx}, &TemplateSubgraph{Issues: issues}); err != nil {
+			return fmt.Errorf("registering custom types: %w", err)
+		}
+
 		// Create all issues
 		if err := tx.CreateIssues(ctx, issues, actor); err != nil {
 			return fmt.Errorf("failed to create issues: %w", err)

--- a/cmd/bd/cook.go
+++ b/cmd/bd/cook.go
@@ -16,22 +16,15 @@ import (
 )
 
 // stepTypeToIssueType converts a formula step type string to a types.IssueType.
-// Returns types.TypeTask for empty or unrecognized types.
+// Returns types.TypeTask for empty types. Non-empty types pass through
+// (normalized) rather than being validated here: pour registers non-built-in
+// types via ensureSubgraphCustomTypes, and the storage layer validates them
+// against types.custom — the same division of labor as bd create --type.
 func stepTypeToIssueType(stepType string) types.IssueType {
-	switch stepType {
-	case "task":
-		return types.TypeTask
-	case "bug":
-		return types.TypeBug
-	case "feature":
-		return types.TypeFeature
-	case "epic":
-		return types.TypeEpic
-	case "chore":
-		return types.TypeChore
-	default:
+	if stepType == "" {
 		return types.TypeTask
 	}
+	return types.IssueType(stepType).Normalize()
 }
 
 // cookCmd compiles a formula JSON into a proto bead.

--- a/cmd/bd/cook_test.go
+++ b/cmd/bd/cook_test.go
@@ -1027,7 +1027,7 @@ func TestStepTypeToIssueType(t *testing.T) {
 		// Aliases normalize to their canonical form.
 		{"enhancement", types.TypeFeature},
 		// Non-built-in types pass through so pour can register them as
-		// custom types (ensureSubgraphCustomTypes) and the storage layer
+		// custom types (ensureCustomTypesForIssues) and the storage layer
 		// can validate them against types.custom — matching bd create.
 		{"duty", types.IssueType("duty")},
 	}

--- a/cmd/bd/cook_test.go
+++ b/cmd/bd/cook_test.go
@@ -1026,9 +1026,9 @@ func TestStepTypeToIssueType(t *testing.T) {
 		{"story", types.TypeStory},
 		// Aliases normalize to their canonical form.
 		{"enhancement", types.TypeFeature},
-		// Non-built-in types pass through so pour can register them as
-		// custom types (ensureCustomTypesForIssues) and the storage layer
-		// can validate them against types.custom — matching bd create.
+		// Non-built-in types pass through; at pour/cook time,
+		// flattenUnregisteredIssueTypes degrades them to task unless they
+		// are already registered in types.custom.
 		{"duty", types.IssueType("duty")},
 	}
 	for _, tt := range tests {

--- a/cmd/bd/cook_test.go
+++ b/cmd/bd/cook_test.go
@@ -974,3 +974,34 @@ func TestCookFormulaToSubgraph_StepMetadata(t *testing.T) {
 		t.Errorf("Metadata[origin] = %v, want \"repro\"", got)
 	}
 }
+
+func TestStepTypeToIssueType(t *testing.T) {
+	tests := []struct {
+		stepType string
+		want     types.IssueType
+	}{
+		// Core work types pass through.
+		{"task", types.TypeTask},
+		{"bug", types.TypeBug},
+		{"feature", types.TypeFeature},
+		{"epic", types.TypeEpic},
+		{"chore", types.TypeChore},
+		// Empty defaults to task.
+		{"", types.TypeTask},
+		// Other built-in types pass through instead of collapsing to task.
+		{"decision", types.TypeDecision},
+		{"spike", types.TypeSpike},
+		{"story", types.TypeStory},
+		// Aliases normalize to their canonical form.
+		{"enhancement", types.TypeFeature},
+		// Non-built-in types pass through so pour can register them as
+		// custom types (ensureSubgraphCustomTypes) and the storage layer
+		// can validate them against types.custom — matching bd create.
+		{"duty", types.IssueType("duty")},
+	}
+	for _, tt := range tests {
+		if got := stepTypeToIssueType(tt.stepType); got != tt.want {
+			t.Errorf("stepTypeToIssueType(%q) = %q, want %q", tt.stepType, got, tt.want)
+		}
+	}
+}

--- a/cmd/bd/cook_test.go
+++ b/cmd/bd/cook_test.go
@@ -975,6 +975,35 @@ func TestCookFormulaToSubgraph_StepMetadata(t *testing.T) {
 	}
 }
 
+// TestProcessStepToIssueParentType verifies that a parent step's declared
+// type is honored; only a step with children and no declared type defaults
+// to epic (GH#5443).
+func TestProcessStepToIssueParentType(t *testing.T) {
+	tests := []struct {
+		name     string
+		stepType string
+		want     types.IssueType
+	}{
+		{"undeclared parent defaults to epic", "", types.TypeEpic},
+		{"declared built-in type kept on parent", "decision", types.TypeDecision},
+		{"declared custom type kept on parent", "duty", types.IssueType("duty")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			step := &formula.Step{
+				ID:       "parent",
+				Title:    "parent step",
+				Type:     tt.stepType,
+				Children: []*formula.Step{{ID: "c", Title: "child step"}},
+			}
+			issue := processStepToIssue(step, "f")
+			if issue.IssueType != tt.want {
+				t.Errorf("IssueType = %q, want %q", issue.IssueType, tt.want)
+			}
+		})
+	}
+}
+
 func TestStepTypeToIssueType(t *testing.T) {
 	tests := []struct {
 		stepType string
@@ -986,8 +1015,11 @@ func TestStepTypeToIssueType(t *testing.T) {
 		{"feature", types.TypeFeature},
 		{"epic", types.TypeEpic},
 		{"chore", types.TypeChore},
-		// Empty defaults to task.
+		// Empty (or whitespace-only) defaults to task; surrounding
+		// whitespace is trimmed rather than becoming part of the type.
 		{"", types.TypeTask},
+		{"   ", types.TypeTask},
+		{" bug ", types.TypeBug},
 		// Other built-in types pass through instead of collapsing to task.
 		{"decision", types.TypeDecision},
 		{"spike", types.TypeSpike},

--- a/cmd/bd/doctor/multirepo.go
+++ b/cmd/bd/doctor/multirepo.go
@@ -131,10 +131,7 @@ func readTypesFromDB(beadsDir string) ([]string, error) {
 		return nil, err
 	}
 
-	if typesStr == "" {
-		return nil, nil
-	}
-
+	// ParseTypesConfigValue returns nil for an empty or whitespace-only value.
 	return issueops.ParseTypesConfigValue(typesStr), nil
 }
 

--- a/cmd/bd/doctor/multirepo.go
+++ b/cmd/bd/doctor/multirepo.go
@@ -2,7 +2,6 @@ package doctor
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,6 +12,7 @@ import (
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/storage/dolt"
+	"github.com/steveyegge/beads/internal/storage/issueops"
 )
 
 // multiRepoYAMLConfig represents the types section of config.yaml for YAML unmarshaling.
@@ -134,29 +134,7 @@ func readTypesFromDB(beadsDir string) ([]string, error) {
 		return nil, nil
 	}
 
-	return parseTypesConfigValue(typesStr), nil
-}
-
-// parseTypesConfigValue parses a types.custom config value, accepting both
-// the JSON-array form written by bd config set / pour (e.g. ["duty","ops"])
-// and the legacy comma-separated form (duty,ops).
-func parseTypesConfigValue(value string) []string {
-	var out []string
-	var jsonTypes []string
-	if err := json.Unmarshal([]byte(value), &jsonTypes); err == nil {
-		for _, t := range jsonTypes {
-			if t = strings.TrimSpace(t); t != "" {
-				out = append(out, t)
-			}
-		}
-		return out
-	}
-	for _, t := range strings.Split(value, ",") {
-		if t = strings.TrimSpace(t); t != "" {
-			out = append(out, t)
-		}
-	}
-	return out
+	return issueops.ParseTypesConfigValue(typesStr), nil
 }
 
 // readTypesFromYAML reads types.custom from config.yaml
@@ -212,7 +190,7 @@ func findUnknownTypesInHydratedIssues(repoPath string, multiRepo *config.MultiRe
 	// Add parent's custom types
 	parentTypes, err := store.GetConfig(ctx, "types.custom")
 	if err == nil && parentTypes != "" {
-		for _, t := range parseTypesConfigValue(parentTypes) {
+		for _, t := range issueops.ParseTypesConfigValue(parentTypes) {
 			knownTypes[t] = true
 		}
 	}

--- a/cmd/bd/doctor/multirepo.go
+++ b/cmd/bd/doctor/multirepo.go
@@ -2,6 +2,7 @@ package doctor
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -133,16 +134,29 @@ func readTypesFromDB(beadsDir string) ([]string, error) {
 		return nil, nil
 	}
 
-	// Parse comma-separated list
-	var types []string
-	for _, t := range strings.Split(typesStr, ",") {
-		t = strings.TrimSpace(t)
-		if t != "" {
-			types = append(types, t)
+	return parseTypesConfigValue(typesStr), nil
+}
+
+// parseTypesConfigValue parses a types.custom config value, accepting both
+// the JSON-array form written by bd config set / pour (e.g. ["duty","ops"])
+// and the legacy comma-separated form (duty,ops).
+func parseTypesConfigValue(value string) []string {
+	var out []string
+	var jsonTypes []string
+	if err := json.Unmarshal([]byte(value), &jsonTypes); err == nil {
+		for _, t := range jsonTypes {
+			if t = strings.TrimSpace(t); t != "" {
+				out = append(out, t)
+			}
+		}
+		return out
+	}
+	for _, t := range strings.Split(value, ",") {
+		if t = strings.TrimSpace(t); t != "" {
+			out = append(out, t)
 		}
 	}
-
-	return types, nil
+	return out
 }
 
 // readTypesFromYAML reads types.custom from config.yaml
@@ -198,11 +212,8 @@ func findUnknownTypesInHydratedIssues(repoPath string, multiRepo *config.MultiRe
 	// Add parent's custom types
 	parentTypes, err := store.GetConfig(ctx, "types.custom")
 	if err == nil && parentTypes != "" {
-		for _, t := range strings.Split(parentTypes, ",") {
-			t = strings.TrimSpace(t)
-			if t != "" {
-				knownTypes[t] = true
-			}
+		for _, t := range parseTypesConfigValue(parentTypes) {
+			knownTypes[t] = true
 		}
 	}
 

--- a/cmd/bd/doctor/multirepo.go
+++ b/cmd/bd/doctor/multirepo.go
@@ -13,6 +13,7 @@ import (
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/storage/dolt"
 	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/types"
 )
 
 // multiRepoYAMLConfig represents the types section of config.yaml for YAML unmarshaling.
@@ -181,11 +182,11 @@ func findUnknownTypesInHydratedIssues(repoPath string, multiRepo *config.MultiRe
 	}
 	defer func() { _ = store.Close() }()
 
-	// Collect all known types (core work types + parent custom + all child custom)
-	// Only core work types are built-in; orchestrator types require types.custom config.
-	knownTypes := map[string]bool{
-		"bug": true, "feature": true, "task": true, "epic": true, "chore": true, "decision": true,
-	}
+	// Collect known custom types (parent custom + all child custom).
+	// Built-in types — including orchestrator types like gate, molecule,
+	// spike, story, and milestone — are recognized via IsBuiltIn below, so
+	// this map only needs the configured custom types.
+	knownTypes := make(map[string]bool)
 
 	// Add parent's custom types
 	parentTypes, err := store.GetConfig(ctx, "types.custom")
@@ -221,7 +222,7 @@ func findUnknownTypesInHydratedIssues(repoPath string, multiRepo *config.MultiRe
 		if err := rows.Scan(&issueType); err != nil {
 			continue
 		}
-		if !knownTypes[issueType] && !seen[issueType] {
+		if !types.IssueType(issueType).IsBuiltIn() && !knownTypes[issueType] && !seen[issueType] {
 			unknownTypes = append(unknownTypes, issueType)
 			seen[issueType] = true
 		}

--- a/cmd/bd/linear.go
+++ b/cmd/bd/linear.go
@@ -1217,13 +1217,6 @@ func getLinearIDMode(ctx context.Context) string {
 	return mode
 }
 
-// linearConfigReader is the minimal slice of storage.Storage that the
-// linear-config helpers depend on. Lets tests inject a fake without
-// spinning up a Dolt server.
-type linearConfigReader interface {
-	GetConfig(ctx context.Context, key string) (string, error)
-}
-
 // applyLinearExcludeIDConfig reads linear.exclude_id_prefix and
 // linear.exclude_id_patterns from the given config reader and applies them
 // to opts. Both keys are push-direction-only filters; see the help text on
@@ -1231,7 +1224,7 @@ type linearConfigReader interface {
 //
 // Empty values are no-ops. Patterns are comma-split, trimmed, with empty
 // entries dropped. If reader is nil (no store configured), this is a no-op.
-func applyLinearExcludeIDConfig(ctx context.Context, reader linearConfigReader, opts *tracker.SyncOptions) {
+func applyLinearExcludeIDConfig(ctx context.Context, reader configReader, opts *tracker.SyncOptions) {
 	if reader == nil || opts == nil {
 		return
 	}

--- a/cmd/bd/linear_test.go
+++ b/cmd/bd/linear_test.go
@@ -1771,7 +1771,7 @@ func TestIsValidUUID(t *testing.T) {
 	}
 }
 
-// fakeLinearConfigReader is a test double for linearConfigReader that
+// fakeLinearConfigReader is a test double for configReader that
 // returns values from an in-memory map. Unset keys return "" with no error
 // (matches storage.Storage's behavior for missing config keys).
 type fakeLinearConfigReader map[string]string

--- a/cmd/bd/mol_port.go
+++ b/cmd/bd/mol_port.go
@@ -38,13 +38,6 @@ type molReader interface {
 
 var _ molReader = storage.DoltStorage(nil)
 
-type molConfigWriter interface {
-	molReader
-	SetConfig(ctx context.Context, key, value string) error
-}
-
-var _ molConfigWriter = storage.DoltStorage(nil)
-
 type molWriter interface {
 	molReader
 	CreateIssue(ctx context.Context, issue *types.Issue, actor string) error
@@ -88,6 +81,18 @@ func (w storeMolWriter) DeleteIssue(ctx context.Context, id, _ string) error {
 
 func (w storeMolWriter) SetConfig(ctx context.Context, key, value string) error {
 	return w.tx.SetConfig(ctx, key, value)
+}
+
+// GetConfig reads through the transaction when one is bound. Without this,
+// config readers (flattenUnregisteredIssueTypes) would read the last
+// committed value on a separate session — missing values written earlier
+// in the same transaction, and blocking on a second pool connection when
+// MaxOpenConns=1 while the transaction holds the only one.
+func (w storeMolWriter) GetConfig(ctx context.Context, key string) (string, error) {
+	if w.tx != nil {
+		return w.tx.GetConfig(ctx, key)
+	}
+	return w.DoltStorage.GetConfig(ctx, key)
 }
 
 func (w storeMolWriter) ClaimStepIfOpen(ctx context.Context, id, actor string) error {

--- a/cmd/bd/mol_port.go
+++ b/cmd/bd/mol_port.go
@@ -84,10 +84,11 @@ func (w storeMolWriter) SetConfig(ctx context.Context, key, value string) error 
 }
 
 // GetConfig reads through the transaction when one is bound. Without this,
-// config readers (flattenUnregisteredIssueTypes) would read the last
-// committed value on a separate session — missing values written earlier
-// in the same transaction, and blocking on a second pool connection when
-// MaxOpenConns=1 while the transaction holds the only one.
+// config readers (flattenUnregisteredIssueTypes) would go to the embedded
+// store, which opens a second pool connection — a deadlock when
+// MaxOpenConns=1 and the transaction already holds the only one. It also
+// keeps the read consistent with any config written earlier in the same
+// transaction rather than seeing the last committed value.
 func (w storeMolWriter) GetConfig(ctx context.Context, key string) (string, error) {
 	if w.tx != nil {
 		return w.tx.GetConfig(ctx, key)

--- a/cmd/bd/template.go
+++ b/cmd/bd/template.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -19,8 +18,9 @@ import (
 	"github.com/steveyegge/beads/internal/utils"
 )
 
-// configReader is the narrow read surface flattenUnregisteredIssueTypes
-// needs; transaction-bound writers (storeMolWriter) satisfy it with reads
+// configReader is the minimal slice of storage.Storage that config-reading
+// helpers depend on, letting tests inject a fake without spinning up a Dolt
+// server. Transaction-bound writers (storeMolWriter) satisfy it with reads
 // that see in-transaction config writes.
 type configReader interface {
 	GetConfig(ctx context.Context, key string) (string, error)
@@ -581,19 +581,20 @@ func getRelativeID(oldID, rootID string) string {
 // with "invalid issue type" on the first unregistered bead.
 // (GH#3213, GH#5443)
 func flattenUnregisteredIssueTypes(ctx context.Context, s configReader, issues []*types.Issue, deps []*types.Dependency) error {
-	// Collect non-built-in types used by the issues. IsBuiltIn (not
+	// Seed with every non-built-in type used by the issues, then remove the
+	// registered ones below; what survives is unknown. IsBuiltIn (not
 	// IsValid) matches the validator this check exists to satisfy:
 	// IsValidWithCustom short-circuits on IsBuiltIn, so types like "event"
 	// need no types.custom entry.
-	needed := make(map[string]bool)
+	unknown := make(map[types.IssueType]bool)
 	for _, issue := range issues {
 		t := issue.IssueType
 		if t == "" || t.IsBuiltIn() {
 			continue
 		}
-		needed[string(t)] = true
+		unknown[t] = true
 	}
-	if len(needed) == 0 {
+	if len(unknown) == 0 {
 		return nil
 	}
 
@@ -607,19 +608,11 @@ func flattenUnregisteredIssueTypes(ctx context.Context, s configReader, issues [
 		// would silently flatten types the operator did register.
 		return fmt.Errorf("reading types.custom: %w", err)
 	}
-	registered := make(map[string]bool)
 	for _, t := range issueops.ParseTypesConfigValue(existing) {
-		registered[t] = true
+		delete(unknown, types.IssueType(t))
 	}
 	for _, t := range config.GetCustomTypesFromYAML() {
-		registered[t] = true
-	}
-
-	unknown := make(map[types.IssueType]bool)
-	for t := range needed {
-		if !registered[t] {
-			unknown[types.IssueType(t)] = true
-		}
+		delete(unknown, types.IssueType(t))
 	}
 	if len(unknown) == 0 {
 		return nil
@@ -630,7 +623,7 @@ func flattenUnregisteredIssueTypes(ctx context.Context, s configReader, issues [
 		names = append(names, string(t))
 	}
 	sort.Strings(names)
-	fmt.Fprintf(os.Stderr, "Warning: flattening unregistered issue type(s) to task (epic for steps with children): %s (register with bd config set types.custom to keep them)\n", strings.Join(names, ", "))
+	WarnError("flattening unregistered issue type(s) to task (epic for steps with children): %s (register with bd config set types.custom to keep them)", strings.Join(names, ", "))
 
 	hasChildren := make(map[string]bool)
 	for _, dep := range deps {

--- a/cmd/bd/template.go
+++ b/cmd/bd/template.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/formula"
 	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/utils"
 )
@@ -558,19 +559,19 @@ func getRelativeID(oldID, rootID string) string {
 	return ""
 }
 
-// ensureSubgraphCustomTypes scans the template subgraph for issue types
-// that are not built-in and ensures they are registered as custom types
-// in the database. This is needed because formula cooking can produce
-// issues with types like "gate" (for async coordination beads) that are
-// not in the default type whitelist. Without this, cloneSubgraph fails
-// with "invalid issue type" on the first non-built-in bead. (GH#3213)
-func ensureSubgraphCustomTypes(ctx context.Context, s molConfigWriter, subgraph *TemplateSubgraph) error {
-	// Collect non-built-in types used by the subgraph. IsBuiltIn (not
+// ensureCustomTypesForIssues scans the issues for types that are not
+// built-in and ensures they are registered as custom types in the
+// database. This is needed because formula cooking can produce issues
+// with types like "gate" (for async coordination beads) that are not in
+// the default type whitelist. Without this, issue creation fails with
+// "invalid issue type" on the first non-built-in bead. (GH#3213)
+func ensureCustomTypesForIssues(ctx context.Context, s molConfigWriter, issues []*types.Issue) error {
+	// Collect non-built-in types used by the issues. IsBuiltIn (not
 	// IsValid) matches the validator this registration exists to satisfy:
 	// IsValidWithCustom short-circuits on IsBuiltIn, so types like "event"
 	// need no types.custom entry.
 	needed := make(map[string]bool)
-	for _, issue := range subgraph.Issues {
+	for _, issue := range issues {
 		t := issue.IssueType
 		if t == "" || t.IsBuiltIn() {
 			continue
@@ -586,18 +587,7 @@ func ensureSubgraphCustomTypes(ctx context.Context, s molConfigWriter, subgraph 
 	if err != nil {
 		existing = ""
 	}
-	var current []string
-	if existing != "" {
-		// parseTypesValue handles both JSON arrays and comma-separated.
-		// It's in issueops — but we don't import that package here, so
-		// do a simple comma split (good enough for the merge check).
-		for _, t := range strings.Split(strings.Trim(existing, "[] \""), ",") {
-			t = strings.Trim(t, " \"")
-			if t != "" {
-				current = append(current, t)
-			}
-		}
-	}
+	current := issueops.ParseTypesConfigValue(existing)
 	currentSet := make(map[string]bool, len(current))
 	for _, t := range current {
 		currentSet[t] = true
@@ -650,7 +640,7 @@ func cloneSubgraph(ctx context.Context, s storage.DoltStorage, subgraph *Templat
 }
 
 func cloneSubgraphInto(ctx context.Context, w molWriter, subgraph *TemplateSubgraph, opts CloneOptions) (*InstantiateResult, error) {
-	if err := ensureSubgraphCustomTypes(ctx, w, subgraph); err != nil {
+	if err := ensureCustomTypesForIssues(ctx, w, subgraph.Issues); err != nil {
 		return nil, fmt.Errorf("registering custom types for subgraph: %w", err)
 	}
 

--- a/cmd/bd/template.go
+++ b/cmd/bd/template.go
@@ -565,11 +565,14 @@ func getRelativeID(oldID, rootID string) string {
 // not in the default type whitelist. Without this, cloneSubgraph fails
 // with "invalid issue type" on the first non-built-in bead. (GH#3213)
 func ensureSubgraphCustomTypes(ctx context.Context, s molConfigWriter, subgraph *TemplateSubgraph) error {
-	// Collect non-built-in types used by the subgraph.
+	// Collect non-built-in types used by the subgraph. IsBuiltIn (not
+	// IsValid) matches the validator this registration exists to satisfy:
+	// IsValidWithCustom short-circuits on IsBuiltIn, so types like "event"
+	// need no types.custom entry.
 	needed := make(map[string]bool)
 	for _, issue := range subgraph.Issues {
 		t := issue.IssueType
-		if t == "" || t.IsValid() {
+		if t == "" || t.IsBuiltIn() {
 			continue
 		}
 		needed[string(t)] = true
@@ -615,18 +618,13 @@ func ensureSubgraphCustomTypes(ctx context.Context, s molConfigWriter, subgraph 
 	// PrepareIssueForInsert → ValidateWithCustom.
 	merged := append(current, toAdd...)
 	// Serialize as JSON array for consistency with bd config set.
-	var buf strings.Builder
-	buf.WriteString("[")
-	for i, t := range merged {
-		if i > 0 {
-			buf.WriteString(",")
-		}
-		buf.WriteString("\"")
-		buf.WriteString(t)
-		buf.WriteString("\"")
+	// json.Marshal (rather than hand-rolled string building) so a type
+	// containing a quote or backslash cannot corrupt the config value.
+	data, err := json.Marshal(merged)
+	if err != nil {
+		return fmt.Errorf("serializing types.custom: %w", err)
 	}
-	buf.WriteString("]")
-	return s.SetConfig(ctx, "types.custom", buf.String())
+	return s.SetConfig(ctx, "types.custom", string(data))
 }
 
 // cloneSubgraph creates new issues from the template with variable substitution.

--- a/cmd/bd/template.go
+++ b/cmd/bd/template.go
@@ -5,16 +5,26 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
+	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/formula"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/utils"
 )
+
+// configReader is the narrow read surface flattenUnregisteredIssueTypes
+// needs; transaction-bound writers (storeMolWriter) satisfy it with reads
+// that see in-transaction config writes.
+type configReader interface {
+	GetConfig(ctx context.Context, key string) (string, error)
+}
 
 // BeadsTemplateLabel is the label used to identify Beads-based templates
 const BeadsTemplateLabel = "template"
@@ -559,15 +569,20 @@ func getRelativeID(oldID, rootID string) string {
 	return ""
 }
 
-// ensureCustomTypesForIssues scans the issues for types that are not
-// built-in and ensures they are registered as custom types in the
-// database. This is needed because formula cooking can produce issues
-// with types like "gate" (for async coordination beads) that are not in
-// the default type whitelist. Without this, issue creation fails with
-// "invalid issue type" on the first non-built-in bead. (GH#3213)
-func ensureCustomTypesForIssues(ctx context.Context, s molConfigWriter, issues []*types.Issue) error {
+// flattenUnregisteredIssueTypes flattens issue types that are neither
+// built-in nor already registered in types.custom, printing a warning
+// naming each flattened type. Issues with children (the DependsOnID side
+// of a parent-child dep) flatten to epic — matching the default for
+// undeclared parent step types — and leaves flatten to task.
+// Materializing a formula must not silently grow the type whitelist — a
+// typo'd step type would become a permanently registered custom type — so
+// unregistered types degrade instead; operators opt in with bd config set
+// types.custom before pouring. Without the flatten, issue creation fails
+// with "invalid issue type" on the first unregistered bead.
+// (GH#3213, GH#5443)
+func flattenUnregisteredIssueTypes(ctx context.Context, s configReader, issues []*types.Issue, deps []*types.Dependency) error {
 	// Collect non-built-in types used by the issues. IsBuiltIn (not
-	// IsValid) matches the validator this registration exists to satisfy:
+	// IsValid) matches the validator this check exists to satisfy:
 	// IsValidWithCustom short-circuits on IsBuiltIn, so types like "event"
 	// need no types.custom entry.
 	needed := make(map[string]bool)
@@ -582,39 +597,57 @@ func ensureCustomTypesForIssues(ctx context.Context, s molConfigWriter, issues [
 		return nil
 	}
 
-	// Read the current custom types and check which are missing.
+	// Match insert validation's sources: the types.custom config value
+	// (kept in step with the custom_types table by SyncConfigTables)
+	// overlaid with config.yaml-declared types. Read through s so a
+	// transaction-bound caller sees in-transaction registration.
 	existing, err := s.GetConfig(ctx, "types.custom")
 	if err != nil {
-		existing = ""
+		// Don't degrade to "nothing registered": a transient read failure
+		// would silently flatten types the operator did register.
+		return fmt.Errorf("reading types.custom: %w", err)
 	}
-	current := issueops.ParseTypesConfigValue(existing)
-	currentSet := make(map[string]bool, len(current))
-	for _, t := range current {
-		currentSet[t] = true
+	registered := make(map[string]bool)
+	for _, t := range issueops.ParseTypesConfigValue(existing) {
+		registered[t] = true
+	}
+	for _, t := range config.GetCustomTypesFromYAML() {
+		registered[t] = true
 	}
 
-	var toAdd []string
+	unknown := make(map[types.IssueType]bool)
 	for t := range needed {
-		if !currentSet[t] {
-			toAdd = append(toAdd, t)
+		if !registered[t] {
+			unknown[types.IssueType(t)] = true
 		}
 	}
-	if len(toAdd) == 0 {
+	if len(unknown) == 0 {
 		return nil
 	}
 
-	// Merge and write back. SetConfig triggers SyncCustomTypesTable
-	// which populates the normalized custom_types table used by
-	// PrepareIssueForInsert → ValidateWithCustom.
-	merged := append(current, toAdd...)
-	// Serialize as JSON array for consistency with bd config set.
-	// json.Marshal (rather than hand-rolled string building) so a type
-	// containing a quote or backslash cannot corrupt the config value.
-	data, err := json.Marshal(merged)
-	if err != nil {
-		return fmt.Errorf("serializing types.custom: %w", err)
+	names := make([]string, 0, len(unknown))
+	for t := range unknown {
+		names = append(names, string(t))
 	}
-	return s.SetConfig(ctx, "types.custom", string(data))
+	sort.Strings(names)
+	fmt.Fprintf(os.Stderr, "Warning: flattening unregistered issue type(s) to task (epic for steps with children): %s (register with bd config set types.custom to keep them)\n", strings.Join(names, ", "))
+
+	hasChildren := make(map[string]bool)
+	for _, dep := range deps {
+		if dep.Type == types.DepParentChild {
+			hasChildren[dep.DependsOnID] = true
+		}
+	}
+	for _, issue := range issues {
+		if unknown[issue.IssueType] {
+			if hasChildren[issue.ID] {
+				issue.IssueType = types.TypeEpic
+			} else {
+				issue.IssueType = types.TypeTask
+			}
+		}
+	}
+	return nil
 }
 
 // cloneSubgraph creates new issues from the template with variable substitution.
@@ -640,8 +673,8 @@ func cloneSubgraph(ctx context.Context, s storage.DoltStorage, subgraph *Templat
 }
 
 func cloneSubgraphInto(ctx context.Context, w molWriter, subgraph *TemplateSubgraph, opts CloneOptions) (*InstantiateResult, error) {
-	if err := ensureCustomTypesForIssues(ctx, w, subgraph.Issues); err != nil {
-		return nil, fmt.Errorf("registering custom types for subgraph: %w", err)
+	if err := flattenUnregisteredIssueTypes(ctx, w, subgraph.Issues, subgraph.Dependencies); err != nil {
+		return nil, fmt.Errorf("checking custom types for subgraph: %w", err)
 	}
 
 	idMapping := make(map[string]string)

--- a/cmd/bd/template_test.go
+++ b/cmd/bd/template_test.go
@@ -1125,3 +1125,48 @@ func TestExtractRequiredVariables_IgnoresUndeclaredVars(t *testing.T) {
 		})
 	}
 }
+
+// stubConfigReader serves config values from a map for
+// flattenUnregisteredIssueTypes tests.
+type stubConfigReader map[string]string
+
+func (s stubConfigReader) GetConfig(_ context.Context, key string) (string, error) {
+	return s[key], nil
+}
+
+// TestFlattenUnregisteredIssueTypes verifies that pour/cook honor built-in
+// and already-registered custom types but never auto-register: an
+// unregistered type degrades (with a warning) instead of silently growing
+// types.custom — to epic when the issue has children, task otherwise.
+func TestFlattenUnregisteredIssueTypes(t *testing.T) {
+	cfg := stubConfigReader{"types.custom": `["duty"]`}
+	issues := []*types.Issue{
+		{ID: "f.a", IssueType: types.TypeBug},
+		{ID: "f.b", IssueType: types.IssueType("gate")}, // built-in orchestrator type
+		{ID: "f.c", IssueType: types.IssueType("duty")}, // registered custom type
+		{ID: "f.d", IssueType: types.IssueType("typo")}, // unregistered leaf — flattens to task
+		{ID: "f.e", IssueType: ""},
+		{ID: "f.p", IssueType: types.IssueType("typo")}, // unregistered parent — flattens to epic
+	}
+	deps := []*types.Dependency{
+		{IssueID: "f.d", DependsOnID: "f.p", Type: types.DepParentChild},
+	}
+
+	if err := flattenUnregisteredIssueTypes(context.Background(), cfg, issues, deps); err != nil {
+		t.Fatalf("flattenUnregisteredIssueTypes: %v", err)
+	}
+
+	want := []types.IssueType{
+		types.TypeBug,
+		types.IssueType("gate"),
+		types.IssueType("duty"),
+		types.TypeTask,
+		"",
+		types.TypeEpic,
+	}
+	for i, issue := range issues {
+		if issue.IssueType != want[i] {
+			t.Errorf("issues[%d] (%s) IssueType = %q, want %q", i, issue.ID, issue.IssueType, want[i])
+		}
+	}
+}

--- a/internal/formula/schema_gen.go
+++ b/internal/formula/schema_gen.go
@@ -660,7 +660,10 @@ Used for dependency references and bond points.`,
 				Name:     "Type",
 				Type:     "string",
 				JSONName: "type",
-				Doc:      `Type is the issue type: task, bug, feature, epic, chore.`,
+				Doc: `Type is the issue type: any built-in type (task by default; bug,
+feature, epic, chore, decision, spike, story, milestone, ...) or a
+custom type, which is registered in types.custom when the formula
+is cooked or poured.`,
 			},
 			{
 				Name:     "Priority",

--- a/internal/formula/schema_gen.go
+++ b/internal/formula/schema_gen.go
@@ -662,8 +662,9 @@ Used for dependency references and bond points.`,
 				JSONName: "type",
 				Doc: `Type is the issue type: any built-in type (task by default; bug,
 feature, epic, chore, decision, spike, story, milestone, ...) or a
-custom type, which is registered in types.custom when the formula
-is cooked or poured.`,
+custom type already registered in types.custom. Unregistered types
+are flattened to task, with a warning, when the formula is cooked
+or poured.`,
 			},
 			{
 				Name:     "Priority",

--- a/internal/formula/types.go
+++ b/internal/formula/types.go
@@ -208,8 +208,9 @@ type Step struct {
 
 	// Type is the issue type: any built-in type (task by default; bug,
 	// feature, epic, chore, decision, spike, story, milestone, ...) or a
-	// custom type, which is registered in types.custom when the formula
-	// is cooked or poured.
+	// custom type already registered in types.custom. Unregistered types
+	// are flattened to task, with a warning, when the formula is cooked
+	// or poured.
 	Type string `json:"type,omitempty"`
 
 	// Priority is the issue priority (0-4).

--- a/internal/formula/types.go
+++ b/internal/formula/types.go
@@ -206,7 +206,10 @@ type Step struct {
 	// Notes are additional notes for the issue (supports substitution).
 	Notes string `json:"notes,omitempty"`
 
-	// Type is the issue type: task, bug, feature, epic, chore.
+	// Type is the issue type: any built-in type (task by default; bug,
+	// feature, epic, chore, decision, spike, story, milestone, ...) or a
+	// custom type, which is registered in types.custom when the formula
+	// is cooked or poured.
 	Type string `json:"type,omitempty"`
 
 	// Priority is the issue priority (0-4).

--- a/internal/storage/dolt/config.go
+++ b/internal/storage/dolt/config.go
@@ -3,7 +3,6 @@ package dolt
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"log"
 
 	"github.com/steveyegge/beads/internal/config"
@@ -19,17 +18,8 @@ func (s *DoltStore) SetConfig(ctx context.Context, key, value string) error {
 			return err
 		}
 		// Sync normalized tables when config keys change
-		switch key {
-		case "status.custom":
-			if err := issueops.SyncCustomStatusesTable(ctx, tx, value); err != nil {
-				return fmt.Errorf("syncing custom_statuses table: %w", err)
-			}
-		case "types.custom":
-			if err := issueops.SyncCustomTypesTable(ctx, tx, value); err != nil {
-				return fmt.Errorf("syncing custom_types table: %w", err)
-			}
-		}
-		return nil
+		_, err := issueops.SyncConfigTables(ctx, tx, key, value)
+		return err
 	}); err != nil {
 		return err
 	}

--- a/internal/storage/dolt/config.go
+++ b/internal/storage/dolt/config.go
@@ -25,6 +25,19 @@ func (s *DoltStore) SetConfig(ctx context.Context, key, value string) error {
 	}
 
 	// Invalidate caches for keys that affect cached data
+	s.invalidateConfigCaches(key)
+
+	return nil
+}
+
+// invalidateConfigCaches drops the store-level caches derived from a config
+// key. Every path that writes config — store-level SetConfig and
+// doltTransaction.SetConfig alike — must call this, or a long-lived process
+// (server/daemon) keeps serving the pre-write set from GetCustomTypes /
+// GetCustomStatuses / GetInfraTypes until restart. Invalidating for a
+// transaction that later rolls back is harmless: the lazy reload just
+// re-reads the committed state.
+func (s *DoltStore) invalidateConfigCaches(key string) {
 	s.cacheMu.Lock()
 	switch key {
 	case "status.custom":
@@ -39,8 +52,6 @@ func (s *DoltStore) SetConfig(ctx context.Context, key, value string) error {
 		s.infraTypeCache = nil
 	}
 	s.cacheMu.Unlock()
-
-	return nil
 }
 
 // GetConfig retrieves a configuration value

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -428,24 +428,22 @@ func (t *doltTransaction) CreateIssue(ctx context.Context, issue *types.Issue, a
 		return fmt.Errorf("issue must not be nil")
 	}
 
-	if issueops.IsWisp(issue) {
-		// Wisp rows live on the ignored session, but the validation context
-		// (config, custom_types) lives in regular dolt-tracked tables — read
-		// it through regularTx so types registered earlier in this
-		// transaction (ensureSubgraphCustomTypes during a wisp pour) are
-		// visible. Both sessions are pinned to the same branch (GH#5443).
-		bc, err := issueops.NewBatchContext(ctx, t.regularTx, storage.BatchCreateOptions{SkipPrefixValidation: true})
-		if err != nil {
-			return err
-		}
-		_, err = issueops.CreateIssueInTxWithResult(ctx, t.ignoredTx, bc, issue, actor)
-		return err
-	}
-
+	// Build the validation context on regularTx for both tiers: wisp rows
+	// live on the ignored session, but the validation context (config,
+	// custom_types) lives in regular dolt-tracked tables — reading it
+	// through regularTx keeps types registered earlier in this transaction
+	// (ensureCustomTypesForIssues during a wisp pour) visible. Both
+	// sessions are pinned to the same branch (GH#5443).
 	bc, err := issueops.NewBatchContext(ctx, t.regularTx, storage.BatchCreateOptions{SkipPrefixValidation: true})
 	if err != nil {
 		return err
 	}
+
+	if issueops.IsWisp(issue) {
+		_, err = issueops.CreateIssueInTxWithResult(ctx, t.ignoredTx, bc, issue, actor)
+		return err
+	}
+
 	result, err := issueops.CreateIssueInTxWithResult(ctx, t.regularTx, bc, issue, actor)
 	if err != nil {
 		return err
@@ -478,10 +476,18 @@ func (t *doltTransaction) CreateIssues(ctx context.Context, issues []*types.Issu
 		}
 	}
 
+	// See CreateIssue: one validation context on regularTx serves both
+	// tiers, so in-transaction custom-type registration is visible to the
+	// wisp tier too (GH#5443).
+	bc, err := issueops.NewBatchContext(ctx, t.regularTx, storage.BatchCreateOptions{
+		SkipPrefixValidation: true,
+	})
+	if err != nil {
+		return err
+	}
+
 	if len(regularIssues) > 0 {
-		result, err := issueops.CreateIssuesInTxWithResult(ctx, t.regularTx, regularIssues, actor, storage.BatchCreateOptions{
-			SkipPrefixValidation: true,
-		})
+		result, err := issueops.CreateIssuesInTxWithContext(ctx, t.regularTx, bc, regularIssues, actor)
 		if err != nil {
 			return err
 		}
@@ -491,14 +497,6 @@ func (t *doltTransaction) CreateIssues(ctx context.Context, issues []*types.Issu
 	}
 
 	if len(wispIssues) > 0 {
-		// See CreateIssue: the validation context must come from regularTx so
-		// in-transaction custom-type registration is visible (GH#5443).
-		bc, err := issueops.NewBatchContext(ctx, t.regularTx, storage.BatchCreateOptions{
-			SkipPrefixValidation: true,
-		})
-		if err != nil {
-			return err
-		}
 		if _, err := issueops.CreateIssuesInTxWithContext(ctx, t.ignoredTx, bc, wispIssues, actor); err != nil {
 			return err
 		}
@@ -1293,23 +1291,16 @@ func (t *doltTransaction) SetConfig(ctx context.Context, key, value string) erro
 	}
 	t.dirty.MarkDirty("config")
 
-	// Sync normalized tables when config keys change, matching
-	// embeddedTransaction.SetConfig and DoltStore.SetConfig.
 	// ResolveCustomTypesInTx reads the normalized tables first, so without
-	// this a type registered in-transaction (e.g. by
-	// ensureSubgraphCustomTypes during pour) stays invisible to validation
+	// this sync a type registered in-transaction (e.g. by
+	// ensureCustomTypesForIssues during pour) stays invisible to validation
 	// whenever the table already has rows.
-	switch key {
-	case "status.custom":
-		if err := issueops.SyncCustomStatusesTable(ctx, t.regularTx, value); err != nil {
-			return fmt.Errorf("syncing custom_statuses table: %w", err)
-		}
-		t.dirty.MarkDirty("custom_statuses")
-	case "types.custom":
-		if err := issueops.SyncCustomTypesTable(ctx, t.regularTx, value); err != nil {
-			return fmt.Errorf("syncing custom_types table: %w", err)
-		}
-		t.dirty.MarkDirty("custom_types")
+	table, err := issueops.SyncConfigTables(ctx, t.regularTx, key, value)
+	if err != nil {
+		return err
+	}
+	if table != "" {
+		t.dirty.MarkDirty(table)
 	}
 	return nil
 }

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -429,7 +429,12 @@ func (t *doltTransaction) CreateIssue(ctx context.Context, issue *types.Issue, a
 	}
 
 	if issueops.IsWisp(issue) {
-		bc, err := issueops.NewBatchContext(ctx, t.ignoredTx, storage.BatchCreateOptions{SkipPrefixValidation: true})
+		// Wisp rows live on the ignored session, but the validation context
+		// (config, custom_types) lives in regular dolt-tracked tables — read
+		// it through regularTx so types registered earlier in this
+		// transaction (ensureSubgraphCustomTypes during a wisp pour) are
+		// visible. Both sessions are pinned to the same branch (GH#5443).
+		bc, err := issueops.NewBatchContext(ctx, t.regularTx, storage.BatchCreateOptions{SkipPrefixValidation: true})
 		if err != nil {
 			return err
 		}
@@ -486,9 +491,15 @@ func (t *doltTransaction) CreateIssues(ctx context.Context, issues []*types.Issu
 	}
 
 	if len(wispIssues) > 0 {
-		if _, err := issueops.CreateIssuesInTxWithResult(ctx, t.ignoredTx, wispIssues, actor, storage.BatchCreateOptions{
+		// See CreateIssue: the validation context must come from regularTx so
+		// in-transaction custom-type registration is visible (GH#5443).
+		bc, err := issueops.NewBatchContext(ctx, t.regularTx, storage.BatchCreateOptions{
 			SkipPrefixValidation: true,
-		}); err != nil {
+		})
+		if err != nil {
+			return err
+		}
+		if _, err := issueops.CreateIssuesInTxWithContext(ctx, t.ignoredTx, bc, wispIssues, actor); err != nil {
 			return err
 		}
 	}
@@ -1277,10 +1288,30 @@ func (t *doltTransaction) SetConfig(ctx context.Context, key, value string) erro
 		INSERT INTO config (`+"`key`"+`, value) VALUES (?, ?)
 		ON DUPLICATE KEY UPDATE value = VALUES(value)
 	`, key, value)
-	if err == nil {
-		t.dirty.MarkDirty("config")
+	if err != nil {
+		return wrapExecError("set config in tx", err)
 	}
-	return wrapExecError("set config in tx", err)
+	t.dirty.MarkDirty("config")
+
+	// Sync normalized tables when config keys change, matching
+	// embeddedTransaction.SetConfig and DoltStore.SetConfig.
+	// ResolveCustomTypesInTx reads the normalized tables first, so without
+	// this a type registered in-transaction (e.g. by
+	// ensureSubgraphCustomTypes during pour) stays invisible to validation
+	// whenever the table already has rows.
+	switch key {
+	case "status.custom":
+		if err := issueops.SyncCustomStatusesTable(ctx, t.regularTx, value); err != nil {
+			return fmt.Errorf("syncing custom_statuses table: %w", err)
+		}
+		t.dirty.MarkDirty("custom_statuses")
+	case "types.custom":
+		if err := issueops.SyncCustomTypesTable(ctx, t.regularTx, value); err != nil {
+			return fmt.Errorf("syncing custom_types table: %w", err)
+		}
+		t.dirty.MarkDirty("custom_types")
+	}
+	return nil
 }
 
 // GetConfig gets a config value within the transaction

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -432,8 +432,8 @@ func (t *doltTransaction) CreateIssue(ctx context.Context, issue *types.Issue, a
 	// live on the ignored session, but the validation context (config,
 	// custom_types) lives in regular dolt-tracked tables — reading it
 	// through regularTx keeps types registered earlier in this transaction
-	// (ensureCustomTypesForIssues during a wisp pour) visible. Both
-	// sessions are pinned to the same branch (GH#5443).
+	// (tx.SetConfig("types.custom", ...)) visible. Both sessions are
+	// pinned to the same branch (GH#5443).
 	bc, err := issueops.NewBatchContext(ctx, t.regularTx, storage.BatchCreateOptions{SkipPrefixValidation: true})
 	if err != nil {
 		return err
@@ -1292,15 +1292,20 @@ func (t *doltTransaction) SetConfig(ctx context.Context, key, value string) erro
 	t.dirty.MarkDirty("config")
 
 	// ResolveCustomTypesInTx reads the normalized tables first, so without
-	// this sync a type registered in-transaction (e.g. by
-	// ensureCustomTypesForIssues during pour) stays invisible to validation
-	// whenever the table already has rows.
+	// this sync a type registered in-transaction stays invisible to
+	// validation whenever the table already has rows.
 	table, err := issueops.SyncConfigTables(ctx, t.regularTx, key, value)
 	if err != nil {
 		return err
 	}
 	if table != "" {
 		t.dirty.MarkDirty(table)
+	}
+
+	// Keep store-level caches (GetCustomTypes and friends) coherent with
+	// in-transaction config writes; see invalidateConfigCaches.
+	if t.store != nil {
+		t.store.invalidateConfigCaches(key)
 	}
 	return nil
 }

--- a/internal/storage/dolt/wisp_custom_type_tx_test.go
+++ b/internal/storage/dolt/wisp_custom_type_tx_test.go
@@ -1,0 +1,169 @@
+package dolt
+
+import (
+	"database/sql"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/doltserver"
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/doltutil"
+	"github.com/steveyegge/beads/internal/testutil"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// setupAnyServerStore returns a store on the shared test server when TestMain
+// brought one up (Docker), and otherwise starts a private local dolt
+// sql-server from the dolt binary — the same recipe as
+// TestMultiProcessSchemaInit_DoltVerify — so the test still runs on machines
+// without a container runtime.
+func setupAnyServerStore(t *testing.T) (*DoltStore, func()) {
+	t.Helper()
+	if testServerPort != 0 {
+		return setupTestStore(t)
+	}
+	return setupLocalServerStore(t)
+}
+
+// setupLocalServerStore starts a dedicated dolt sql-server in a temp dir and
+// opens a DoltStore against it. Not parallel: it mutates process env via
+// t.Setenv, which is only safe here because every shared-server test skips
+// when this path is taken (no container).
+func setupLocalServerStore(t *testing.T) (*DoltStore, func()) {
+	t.Helper()
+	testutil.RequireDoltBinary(t)
+	doltPath, err := exec.LookPath("dolt")
+	if err != nil {
+		t.Skip("dolt binary not found in PATH")
+	}
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	doltDir := filepath.Join(beadsDir, "dolt")
+	if err := os.MkdirAll(doltDir, 0700); err != nil {
+		t.Fatalf("mkdir dolt: %v", err)
+	}
+
+	env := append(os.Environ(), "HOME="+tmpDir, "DOLT_ROOT_PATH="+tmpDir)
+	for _, args := range [][]string{
+		{"config", "--global", "--add", "user.name", "test"},
+		{"config", "--global", "--add", "user.email", "test@example.com"},
+		{"init"},
+	} {
+		cmd := exec.Command(doltPath, args...)
+		cmd.Dir = doltDir
+		cmd.Env = env
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("dolt %v: %v\n%s", args, err, out)
+		}
+	}
+
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "0")
+	t.Setenv("BEADS_DOLT_AUTO_START", "1")
+
+	state, err := doltserver.Start(beadsDir)
+	if err != nil {
+		t.Fatalf("doltserver.Start: %v", err)
+	}
+	stopServer := func() { _ = doltserver.Stop(beadsDir) }
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	dbName := uniqueTestDBName(t)
+	adminDSN := doltutil.ServerDSN{Host: "127.0.0.1", Port: state.Port, User: "root"}.String()
+	adminDB, err := sql.Open("mysql", adminDSN)
+	if err != nil {
+		stopServer()
+		t.Fatalf("admin connect: %v", err)
+	}
+	_, err = adminDB.ExecContext(ctx, "CREATE DATABASE `"+dbName+"`")
+	adminDB.Close()
+	if err != nil {
+		stopServer()
+		t.Fatalf("create database: %v", err)
+	}
+
+	store, err := New(ctx, &Config{
+		Path:           doltDir,
+		BeadsDir:       beadsDir,
+		CommitterName:  "test",
+		CommitterEmail: "test@example.com",
+		Database:       dbName,
+		ServerPort:     state.Port,
+		MaxOpenConns:   1, // Required: DOLT_CHECKOUT is session-level
+	})
+	if err != nil {
+		stopServer()
+		t.Fatalf("New: %v", err)
+	}
+	if _, err := initSchemaOnDB(ctx, store.db); err != nil {
+		store.Close()
+		stopServer()
+		t.Fatalf("initSchemaOnDB: %v", err)
+	}
+	if err := store.SetConfig(ctx, "issue_prefix", "test"); err != nil {
+		store.Close()
+		stopServer()
+		t.Fatalf("set issue_prefix: %v", err)
+	}
+
+	return store, func() {
+		store.Close()
+		stopServer()
+	}
+}
+
+// TestWispSeesCustomTypeRegisteredInTransaction verifies that a wisp created
+// in the same transaction that registers its custom type validates against
+// the fresh registration. Wisp rows are written on the ignored-tables
+// session, but the validation context (config, custom_types) must be read
+// from the regular session, or in-transaction registration — how
+// ensureSubgraphCustomTypes works during a wisp pour — stays invisible
+// (GH#5443).
+func TestWispSeesCustomTypeRegisteredInTransaction(t *testing.T) {
+	store, cleanup := setupAnyServerStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	wisp := &types.Issue{
+		Title:     "custom-typed wisp",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.IssueType("duty"),
+		Ephemeral: true,
+	}
+	batchWisp := &types.Issue{
+		Title:     "custom-typed wisp via batch",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.IssueType("duty"),
+		Ephemeral: true,
+	}
+	err := store.RunInTransaction(ctx, "register type then create wisps", func(tx storage.Transaction) error {
+		if err := tx.SetConfig(ctx, "types.custom", `["duty"]`); err != nil {
+			return err
+		}
+		if err := tx.CreateIssue(ctx, wisp, "test-user"); err != nil {
+			return err
+		}
+		return tx.CreateIssues(ctx, []*types.Issue{batchWisp}, "test-user")
+	})
+	if err != nil {
+		t.Fatalf("wisp create after in-tx type registration failed: %v", err)
+	}
+
+	for _, id := range []string{wisp.ID, batchWisp.ID} {
+		got, err := store.GetIssue(ctx, id)
+		if err != nil {
+			t.Fatalf("GetIssue(%s) failed for created wisp: %v", id, err)
+		}
+		if got.IssueType != types.IssueType("duty") {
+			t.Errorf("IssueType of %s = %q, want %q", id, got.IssueType, "duty")
+		}
+	}
+}

--- a/internal/storage/dolt/wisp_custom_type_tx_test.go
+++ b/internal/storage/dolt/wisp_custom_type_tx_test.go
@@ -1,24 +1,20 @@
 package dolt
 
 import (
-	"database/sql"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/doltserver"
 	"github.com/steveyegge/beads/internal/storage"
-	"github.com/steveyegge/beads/internal/storage/doltutil"
 	"github.com/steveyegge/beads/internal/testutil"
 	"github.com/steveyegge/beads/internal/types"
 )
 
 // setupAnyServerStore returns a store on the shared test server when TestMain
 // brought one up (Docker), and otherwise starts a private local dolt
-// sql-server from the dolt binary — the same recipe as
-// TestMultiProcessSchemaInit_DoltVerify — so the test still runs on machines
-// without a container runtime.
+// sql-server from the dolt binary — the same recipe as setupWispCascadeStore
+// — so the test still runs on machines without a container runtime.
 func setupAnyServerStore(t *testing.T) (*DoltStore, func()) {
 	t.Helper()
 	if testServerPort != 0 {
@@ -34,30 +30,10 @@ func setupAnyServerStore(t *testing.T) (*DoltStore, func()) {
 func setupLocalServerStore(t *testing.T) (*DoltStore, func()) {
 	t.Helper()
 	testutil.RequireDoltBinary(t)
-	doltPath, err := exec.LookPath("dolt")
-	if err != nil {
-		t.Skip("dolt binary not found in PATH")
-	}
 
-	tmpDir := t.TempDir()
-	beadsDir := filepath.Join(tmpDir, ".beads")
-	doltDir := filepath.Join(beadsDir, "dolt")
-	if err := os.MkdirAll(doltDir, 0700); err != nil {
-		t.Fatalf("mkdir dolt: %v", err)
-	}
-
-	env := append(os.Environ(), "HOME="+tmpDir, "DOLT_ROOT_PATH="+tmpDir)
-	for _, args := range [][]string{
-		{"config", "--global", "--add", "user.name", "test"},
-		{"config", "--global", "--add", "user.email", "test@example.com"},
-		{"init"},
-	} {
-		cmd := exec.Command(doltPath, args...)
-		cmd.Dir = doltDir
-		cmd.Env = env
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("dolt %v: %v\n%s", args, err, out)
-		}
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(beadsDir, 0700); err != nil {
+		t.Fatalf("mkdir beads dir: %v", err)
 	}
 
 	t.Setenv("BEADS_DOLT_SHARED_SERVER", "0")
@@ -67,53 +43,33 @@ func setupLocalServerStore(t *testing.T) (*DoltStore, func()) {
 	if err != nil {
 		t.Fatalf("doltserver.Start: %v", err)
 	}
-	stopServer := func() { _ = doltserver.Stop(beadsDir) }
+	t.Cleanup(func() { _ = doltserver.Stop(beadsDir) })
 
 	ctx, cancel := testContext(t)
 	defer cancel()
 
-	dbName := uniqueTestDBName(t)
-	adminDSN := doltutil.ServerDSN{Host: "127.0.0.1", Port: state.Port, User: "root"}.String()
-	adminDB, err := sql.Open("mysql", adminDSN)
-	if err != nil {
-		stopServer()
-		t.Fatalf("admin connect: %v", err)
-	}
-	_, err = adminDB.ExecContext(ctx, "CREATE DATABASE `"+dbName+"`")
-	adminDB.Close()
-	if err != nil {
-		stopServer()
-		t.Fatalf("create database: %v", err)
-	}
-
 	store, err := New(ctx, &Config{
-		Path:           doltDir,
-		BeadsDir:       beadsDir,
-		CommitterName:  "test",
-		CommitterEmail: "test@example.com",
-		Database:       dbName,
-		ServerPort:     state.Port,
-		MaxOpenConns:   1, // Required: DOLT_CHECKOUT is session-level
+		Path:            filepath.Join(beadsDir, "dolt"),
+		BeadsDir:        beadsDir,
+		CommitterName:   "test",
+		CommitterEmail:  "test@example.com",
+		Database:        uniqueTestDBName(t),
+		ServerHost:      "127.0.0.1",
+		ServerPort:      state.Port,
+		ServerUser:      "root",
+		CreateIfMissing: true, // creates and schema-inits the fresh database
+		MaxOpenConns:    1,    // Required: DOLT_CHECKOUT is session-level
 	})
 	if err != nil {
-		stopServer()
 		t.Fatalf("New: %v", err)
 	}
-	if _, err := initSchemaOnDB(ctx, store.db); err != nil {
-		store.Close()
-		stopServer()
-		t.Fatalf("initSchemaOnDB: %v", err)
-	}
+	t.Cleanup(func() { store.Close() })
+
 	if err := store.SetConfig(ctx, "issue_prefix", "test"); err != nil {
-		store.Close()
-		stopServer()
 		t.Fatalf("set issue_prefix: %v", err)
 	}
 
-	return store, func() {
-		store.Close()
-		stopServer()
-	}
+	return store, func() {}
 }
 
 // TestWispSeesCustomTypeRegisteredInTransaction verifies that a wisp created
@@ -121,7 +77,7 @@ func setupLocalServerStore(t *testing.T) (*DoltStore, func()) {
 // the fresh registration. Wisp rows are written on the ignored-tables
 // session, but the validation context (config, custom_types) must be read
 // from the regular session, or in-transaction registration — how
-// ensureSubgraphCustomTypes works during a wisp pour — stays invisible
+// ensureCustomTypesForIssues works during a wisp pour — stays invisible
 // (GH#5443).
 func TestWispSeesCustomTypeRegisteredInTransaction(t *testing.T) {
 	store, cleanup := setupAnyServerStore(t)

--- a/internal/storage/dolt/wisp_custom_type_tx_test.go
+++ b/internal/storage/dolt/wisp_custom_type_tx_test.go
@@ -76,8 +76,7 @@ func setupLocalServerStore(t *testing.T) (*DoltStore, func()) {
 // in the same transaction that registers its custom type validates against
 // the fresh registration. Wisp rows are written on the ignored-tables
 // session, but the validation context (config, custom_types) must be read
-// from the regular session, or in-transaction registration — how
-// ensureCustomTypesForIssues works during a wisp pour — stays invisible
+// from the regular session, or in-transaction registration stays invisible
 // (GH#5443).
 func TestWispSeesCustomTypeRegisteredInTransaction(t *testing.T) {
 	store, cleanup := setupAnyServerStore(t)

--- a/internal/storage/domain/db/config.go
+++ b/internal/storage/domain/db/config.go
@@ -3,7 +3,6 @@ package db
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -94,15 +93,8 @@ func (r *configSQLRepositoryImpl) SetConfig(ctx context.Context, key, value stri
 	//
 	// The caller supplies a transactional runner, so the row and its projection
 	// commit together or neither does.
-	switch key {
-	case "status.custom":
-		if err := issueops.SyncCustomStatusesTable(ctx, r.runner, value); err != nil {
-			return fmt.Errorf("db: SetConfig %s: syncing custom_statuses table: %w", key, err)
-		}
-	case "types.custom":
-		if err := issueops.SyncCustomTypesTable(ctx, r.runner, value); err != nil {
-			return fmt.Errorf("db: SetConfig %s: syncing custom_types table: %w", key, err)
-		}
+	if _, err := issueops.SyncConfigTables(ctx, r.runner, key, value); err != nil {
+		return fmt.Errorf("db: SetConfig %s: %w", key, err)
 	}
 	return nil
 }
@@ -182,15 +174,7 @@ func (r *configSQLRepositoryImpl) readCustomTypesConfig(ctx context.Context) ([]
 	if err != nil {
 		return nil, fmt.Errorf("db: GetCustomTypes: %w", err)
 	}
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return nil, nil
-	}
-	var jsonTypes []string
-	if err := json.Unmarshal([]byte(value), &jsonTypes); err == nil {
-		return parseCustomTypesList(jsonTypes), nil
-	}
-	return parseCustomTypesList(strings.Split(value, ",")), nil
+	return issueops.ParseTypesConfigValue(value), nil
 }
 
 func unionWithYAMLCustomTypes(dbTypes, yamlTypes []string) []string {
@@ -209,20 +193,6 @@ func unionWithYAMLCustomTypes(dbTypes, yamlTypes []string) []string {
 				continue
 			}
 			seen[t] = struct{}{}
-			out = append(out, t)
-		}
-	}
-	if len(out) == 0 {
-		return nil
-	}
-	return out
-}
-
-func parseCustomTypesList(in []string) []string {
-	out := make([]string, 0, len(in))
-	for _, t := range in {
-		t = strings.TrimSpace(t)
-		if t != "" {
 			out = append(out, t)
 		}
 	}

--- a/internal/storage/embeddeddolt/config_metadata.go
+++ b/internal/storage/embeddeddolt/config_metadata.go
@@ -5,7 +5,6 @@ package embeddeddolt
 import (
 	"context"
 	"database/sql"
-	"fmt"
 
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/storage/domain"
@@ -19,17 +18,8 @@ func (s *EmbeddedDoltStore) SetConfig(ctx context.Context, key, value string) er
 			return err
 		}
 		// Sync normalized tables when config keys change
-		switch key {
-		case "status.custom":
-			if err := issueops.SyncCustomStatusesTable(ctx, tx, value); err != nil {
-				return fmt.Errorf("syncing custom_statuses table: %w", err)
-			}
-		case "types.custom":
-			if err := issueops.SyncCustomTypesTable(ctx, tx, value); err != nil {
-				return fmt.Errorf("syncing custom_types table: %w", err)
-			}
-		}
-		return nil
+		_, err := issueops.SyncConfigTables(ctx, tx, key, value)
+		return err
 	})
 }
 

--- a/internal/storage/embeddeddolt/transaction.go
+++ b/internal/storage/embeddeddolt/transaction.go
@@ -264,17 +264,12 @@ func (t *embeddedTransaction) SetConfig(ctx context.Context, key, value string) 
 		return err
 	}
 	// Sync normalized tables when config keys change
-	switch key {
-	case "status.custom":
-		t.dirty.MarkDirty("custom_statuses")
-		if err := issueops.SyncCustomStatusesTable(ctx, t.tx, value); err != nil {
-			return fmt.Errorf("syncing custom_statuses table: %w", err)
-		}
-	case "types.custom":
-		t.dirty.MarkDirty("custom_types")
-		if err := issueops.SyncCustomTypesTable(ctx, t.tx, value); err != nil {
-			return fmt.Errorf("syncing custom_types table: %w", err)
-		}
+	table, err := issueops.SyncConfigTables(ctx, t.tx, key, value)
+	if err != nil {
+		return err
+	}
+	if table != "" {
+		t.dirty.MarkDirty(table)
 	}
 	return nil
 }

--- a/internal/storage/issueops/config_helpers.go
+++ b/internal/storage/issueops/config_helpers.go
@@ -463,29 +463,6 @@ func SyncConfigTables(ctx context.Context, tx DBTX, key, value string) (string, 
 	return "", nil
 }
 
-// EnsureCustomTypeInTx registers name as a custom type if it is not
-// already a built-in type and not already in the custom_types table.
-// This is used by bd mol pour/wisp to auto-register types that the
-// formula system creates implicitly (e.g. "gate" for async coordination
-// beads) so that operators don't have to run bd config set types.custom
-// manually before pouring a formula with gate steps. See GH#3213.
-func EnsureCustomTypeInTx(ctx context.Context, tx DBTX, name string) error {
-	if types.IssueType(name).IsValid() {
-		return nil
-	}
-	existing, err := ResolveCustomTypesInTx(ctx, tx)
-	if err != nil {
-		return err
-	}
-	for _, t := range existing {
-		if t == name {
-			return nil
-		}
-	}
-	_, err = tx.ExecContext(ctx, "INSERT INTO custom_types (name) VALUES (?)", name)
-	return err
-}
-
 // ResolveInfraTypesInTx reads infrastructure types from the database,
 // falling back to config.yaml then to hardcoded defaults.
 // Returns a map[string]bool for O(1) lookups.

--- a/internal/storage/issueops/config_helpers.go
+++ b/internal/storage/issueops/config_helpers.go
@@ -377,9 +377,10 @@ func dedupePreservingOrder(in []string) []string {
 	return out
 }
 
-// SyncCustomStatusesTable replaces all rows in custom_statuses with parsed config value.
-// Used by both DoltStore and EmbeddedDoltStore when "status.custom" config changes.
-func SyncCustomStatusesTable(ctx context.Context, tx DBTX, value string) error {
+// syncCustomStatusesTable replaces all rows in custom_statuses with parsed config value.
+// Reached only through SyncConfigTables, which is the single entry point every
+// SetConfig path uses; call that rather than this directly. Triggered when"status.custom" config changes.
+func syncCustomStatusesTable(ctx context.Context, tx DBTX, value string) error {
 	if _, err := tx.ExecContext(ctx, "DELETE FROM custom_statuses"); err != nil {
 		return err
 	}
@@ -399,9 +400,10 @@ func SyncCustomStatusesTable(ctx context.Context, tx DBTX, value string) error {
 	return nil
 }
 
-// SyncCustomTypesTable replaces all rows in custom_types with parsed config value.
-// Used by both DoltStore and EmbeddedDoltStore when "types.custom" config changes.
-func SyncCustomTypesTable(ctx context.Context, tx DBTX, value string) error {
+// syncCustomTypesTable replaces all rows in custom_types with parsed config value.
+// Reached only through SyncConfigTables, which is the single entry point every
+// SetConfig path uses; call that rather than this directly. Triggered when"types.custom" config changes.
+func syncCustomTypesTable(ctx context.Context, tx DBTX, value string) error {
 	if _, err := tx.ExecContext(ctx, "DELETE FROM custom_types"); err != nil {
 		return err
 	}
@@ -450,12 +452,12 @@ func ParseTypesConfigValue(value string) []string {
 func SyncConfigTables(ctx context.Context, tx DBTX, key, value string) (string, error) {
 	switch key {
 	case "status.custom":
-		if err := SyncCustomStatusesTable(ctx, tx, value); err != nil {
+		if err := syncCustomStatusesTable(ctx, tx, value); err != nil {
 			return "", fmt.Errorf("syncing custom_statuses table: %w", err)
 		}
 		return "custom_statuses", nil
 	case "types.custom":
-		if err := SyncCustomTypesTable(ctx, tx, value); err != nil {
+		if err := syncCustomTypesTable(ctx, tx, value); err != nil {
 			return "", fmt.Errorf("syncing custom_types table: %w", err)
 		}
 		return "custom_types", nil

--- a/internal/storage/issueops/config_helpers.go
+++ b/internal/storage/issueops/config_helpers.go
@@ -85,12 +85,7 @@ func ResolveCustomConfigInTx(ctx context.Context, tx DBTX) (statuses []types.Cus
 	}
 	if !typesFromTable {
 		if v := cfg["types.custom"]; v != "" {
-			var jsonTypes []string
-			if jsonErr := json.Unmarshal([]byte(v), &jsonTypes); jsonErr == nil {
-				customTypes = jsonTypes
-			} else {
-				customTypes = ParseCommaSeparatedList(v)
-			}
+			customTypes = ParseTypesConfigValue(v)
 		} else if yamlTypes := config.GetCustomTypesFromYAML(); len(yamlTypes) > 0 {
 			customTypes = yamlTypes
 		}
@@ -291,13 +286,7 @@ func ResolveCustomTypesInTx(ctx context.Context, tx DBTX) ([]string, error) {
 			return customTypesYAMLFallback(config.GetCustomTypesFromYAML, err)
 		}
 		if value != "" {
-			// Try JSON array first (e.g. '["gate","convoy"]'), fall back to comma-separated.
-			var jsonTypes []string
-			if err := json.Unmarshal([]byte(value), &jsonTypes); err == nil {
-				fromDB = jsonTypes
-			} else {
-				fromDB = ParseCommaSeparatedList(value)
-			}
+			fromDB = ParseTypesConfigValue(value)
 		}
 	}
 
@@ -419,7 +408,7 @@ func SyncCustomTypesTable(ctx context.Context, tx DBTX, value string) error {
 	if value == "" {
 		return nil
 	}
-	names := parseTypesValue(value)
+	names := ParseTypesConfigValue(value)
 	for _, name := range names {
 		if _, err := tx.ExecContext(ctx, "INSERT INTO custom_types (name) VALUES (?)", name); err != nil {
 			return err
@@ -428,8 +417,11 @@ func SyncCustomTypesTable(ctx context.Context, tx DBTX, value string) error {
 	return nil
 }
 
-// parseTypesValue tries JSON array first, then falls back to comma-separated.
-func parseTypesValue(value string) []string {
+// ParseTypesConfigValue parses a types.custom config value, accepting both
+// the JSON-array form written by bd config set / pour (e.g. ["duty","ops"])
+// and the legacy comma-separated form (duty,ops). Elements are trimmed and
+// empties dropped.
+func ParseTypesConfigValue(value string) []string {
 	value = strings.TrimSpace(value)
 	if value == "" {
 		return nil
@@ -437,10 +429,38 @@ func parseTypesValue(value string) []string {
 	// Try JSON array first (e.g. '["gate","convoy"]')
 	var jsonTypes []string
 	if err := json.Unmarshal([]byte(value), &jsonTypes); err == nil {
-		return jsonTypes
+		var out []string
+		for _, t := range jsonTypes {
+			if t = strings.TrimSpace(t); t != "" {
+				out = append(out, t)
+			}
+		}
+		return out
 	}
 	// Fall back to comma-separated
 	return ParseCommaSeparatedList(value)
+}
+
+// SyncConfigTables re-syncs the normalized lookup table backing a config
+// key, if any (status.custom → custom_statuses, types.custom →
+// custom_types). Reads of those sets are table-first, so every SetConfig
+// path must keep the projection in step with the string value or stale
+// table rows win forever. Returns the name of the synced table ("" when
+// the key has no projection) so transactional callers can mark it dirty.
+func SyncConfigTables(ctx context.Context, tx DBTX, key, value string) (string, error) {
+	switch key {
+	case "status.custom":
+		if err := SyncCustomStatusesTable(ctx, tx, value); err != nil {
+			return "", fmt.Errorf("syncing custom_statuses table: %w", err)
+		}
+		return "custom_statuses", nil
+	case "types.custom":
+		if err := SyncCustomTypesTable(ctx, tx, value); err != nil {
+			return "", fmt.Errorf("syncing custom_types table: %w", err)
+		}
+		return "custom_types", nil
+	}
+	return "", nil
 }
 
 // EnsureCustomTypeInTx registers name as a custom type if it is not

--- a/internal/storage/issueops/create.go
+++ b/internal/storage/issueops/create.go
@@ -273,7 +273,7 @@ func CreateIssuesInTxWithResult(ctx context.Context, tx DBTX, issues []*types.Is
 // caller-supplied BatchContext. Callers that split config reads from row
 // writes across SQL sessions (doltTransaction's wisp tier) build the context
 // on the session that sees in-transaction config writes and pass it here.
-// Mutates bc: sets SkipChildCounterReconcile.
+// The caller's bc is not modified, so one context can serve several calls.
 func CreateIssuesInTxWithContext(ctx context.Context, tx DBTX, bc *BatchContext, issues []*types.Issue, actor string) (CreateIssuesResult, error) {
 	opts := bc.Opts
 	filteredIssues, err := filterCreateIssuesMixedBucketDependencies(issues, opts)
@@ -284,7 +284,11 @@ func CreateIssuesInTxWithContext(ctx context.Context, tx DBTX, bc *BatchContext,
 
 	// This function already runs a slice-wide ReconcileChildCounters below,
 	// covering every accepted issue; skip the redundant per-issue reconcile.
-	bc.SkipChildCounterReconcile = true
+	// Set the flag on a shallow copy so the caller's context keeps its own
+	// reconcile behavior.
+	local := *bc
+	local.SkipChildCounterReconcile = true
+	bc = &local
 
 	result := CreateIssuesResult{}
 	accepted := issues[:0:0]

--- a/internal/storage/issueops/create.go
+++ b/internal/storage/issueops/create.go
@@ -262,16 +262,26 @@ func CreateIssuesInTx(ctx context.Context, tx DBTX, issues []*types.Issue, actor
 // CreateIssuesInTxWithResult creates issues and reports tables whose writes are
 // only knowable after SQL reconciliation, such as child counter advances.
 func CreateIssuesInTxWithResult(ctx context.Context, tx DBTX, issues []*types.Issue, actor string, opts storage.BatchCreateOptions) (CreateIssuesResult, error) {
+	bc, err := NewBatchContext(ctx, tx, opts)
+	if err != nil {
+		return CreateIssuesResult{}, err
+	}
+	return CreateIssuesInTxWithContext(ctx, tx, bc, issues, actor)
+}
+
+// CreateIssuesInTxWithContext is CreateIssuesInTxWithResult with a
+// caller-supplied BatchContext. Callers that split config reads from row
+// writes across SQL sessions (doltTransaction's wisp tier) build the context
+// on the session that sees in-transaction config writes and pass it here.
+// Mutates bc: sets SkipChildCounterReconcile.
+func CreateIssuesInTxWithContext(ctx context.Context, tx DBTX, bc *BatchContext, issues []*types.Issue, actor string) (CreateIssuesResult, error) {
+	opts := bc.Opts
 	filteredIssues, err := filterCreateIssuesMixedBucketDependencies(issues, opts)
 	if err != nil {
 		return CreateIssuesResult{}, err
 	}
 	issues = filteredIssues
 
-	bc, err := NewBatchContext(ctx, tx, opts)
-	if err != nil {
-		return CreateIssuesResult{}, err
-	}
 	// This function already runs a slice-wide ReconcileChildCounters below,
 	// covering every accepted issue; skip the redundant per-issue reconcile.
 	bc.SkipChildCounterReconcile = true

--- a/internal/storage/issueops/create.go
+++ b/internal/storage/issueops/create.go
@@ -286,14 +286,13 @@ func CreateIssuesInTxWithContext(ctx context.Context, tx DBTX, bc *BatchContext,
 	// covering every accepted issue; skip the redundant per-issue reconcile.
 	// Set the flag on a shallow copy so the caller's context keeps its own
 	// reconcile behavior.
-	local := *bc
-	local.SkipChildCounterReconcile = true
-	bc = &local
+	batch := *bc
+	batch.SkipChildCounterReconcile = true
 
 	result := CreateIssuesResult{}
 	accepted := issues[:0:0]
 	for _, issue := range issues {
-		issueResult, err := CreateIssueInTxWithResult(ctx, tx, bc, issue, actor)
+		issueResult, err := CreateIssueInTxWithResult(ctx, tx, &batch, issue, actor)
 		if err != nil {
 			return CreateIssuesResult{}, err
 		}

--- a/internal/storage/issueops/helpers.go
+++ b/internal/storage/issueops/helpers.go
@@ -403,28 +403,6 @@ func GetCustomStatusesTx(ctx context.Context, tx DBTX) ([]string, error) {
 	return types.CustomStatusNames(detailed), nil
 }
 
-// GetCustomTypesTx reads custom types from config within a transaction.
-func GetCustomTypesTx(ctx context.Context, tx *sql.Tx) ([]string, error) {
-	var raw string
-	err := tx.QueryRowContext(ctx, "SELECT value FROM config WHERE `key` = ?", "types.custom").Scan(&raw)
-	if err == sql.ErrNoRows || raw == "" {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("failed to read custom_types config: %w", err)
-	}
-	var customTypes []string
-	if err := json.Unmarshal([]byte(raw), &customTypes); err != nil {
-		for _, s := range strings.Split(raw, ",") {
-			s = strings.TrimSpace(s)
-			if s != "" {
-				customTypes = append(customTypes, s)
-			}
-		}
-	}
-	return customTypes, nil
-}
-
 // ValidateMetadataIfConfigured checks metadata against the schema from config.
 func ValidateMetadataIfConfigured(metadata json.RawMessage) error {
 	mode := config.MetadataValidationMode()

--- a/internal/storage/schema/backfill.go
+++ b/internal/storage/schema/backfill.go
@@ -3,11 +3,11 @@ package schema
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"fmt"
 	"log"
 	"strings"
 
+	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -52,7 +52,7 @@ func needsCustomTypesBackfill(ctx context.Context, db DBConn) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return len(parseTypesValue(value)) > 0, nil
+	return len(issueops.ParseTypesConfigValue(value)) > 0, nil
 }
 
 func needsCustomStatusesBackfill(ctx context.Context, db DBConn) (bool, error) {
@@ -105,11 +105,8 @@ func backfillCustomTypes(ctx context.Context, db DBConn) (bool, error) {
 	}
 
 	wrote := false
-	for _, name := range parseTypesValue(value) {
-		name = strings.TrimSpace(name)
-		if name == "" {
-			continue
-		}
+	// ParseTypesConfigValue already trims elements and drops empties.
+	for _, name := range issueops.ParseTypesConfigValue(value) {
 		res, err := db.ExecContext(ctx, "INSERT IGNORE INTO custom_types (name) VALUES (?)", name)
 		if err != nil {
 			return wrote, fmt.Errorf("inserting type %q: %w", name, err)
@@ -158,24 +155,4 @@ func backfillCustomStatuses(ctx context.Context, db DBConn) (bool, error) {
 		}
 	}
 	return wrote, nil
-}
-
-func parseTypesValue(value string) []string {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return nil
-	}
-	var jsonTypes []string
-	if err := json.Unmarshal([]byte(value), &jsonTypes); err == nil {
-		return jsonTypes
-	}
-	parts := strings.Split(value, ",")
-	var result []string
-	for _, p := range parts {
-		p = strings.TrimSpace(p)
-		if p != "" {
-			result = append(result, p)
-		}
-	}
-	return result
 }


### PR DESCRIPTION
Fixes #5443.

## The bug

`stepTypeToIssueType` in `cmd/bd/cook.go` was a hardcoded switch over
`task|bug|feature|epic|chore` with `default: return types.TypeTask`, so
every step type outside that set was silently rewritten to `task` before
anything downstream could see it. That hit registered custom types
(`duty`), built-in types outside the whitelist (`decision`, `spike`,
`story`, `milestone`), and aliases like `enhancement` that never reached
their `Normalize()` mapping. No warning, no error.

Non-empty types now pass through trimmed and normalized; only an empty
step type defaults to `task`. Validation stays where `bd create --type`
leaves it — in the storage layer, against `types.custom`.

Fixing that surfaced three more gaps, each with a commit:

- **A declared parent type was overridden.** `processStepToIssue` forced
  `epic` on any step with children, so `type: "duty"` on a parent was
  lost even after the pass-through fix. Now only a parent with *no*
  declared type defaults to epic.
- **Wisps couldn't see types registered in the same transaction.** Wisp
  rows are written on the ignored-tables session, but the validation
  context was built there too, so it missed `custom_types` on the
  regular session. Both tiers now share one `BatchContext` built on
  `regularTx`. Also: in-transaction `SetConfig` didn't re-sync the
  normalized table or invalidate the store caches, so a type registered
  mid-transaction stayed invisible to a table-first read.
- **The same parse/sync logic existed in five places.** Four copies of
  the `types.custom` parser collapse into
  `issueops.ParseTypesConfigValue`, and the `switch key` sync block from
  every `SetConfig` path collapses into `issueops.SyncConfigTables`. The
  two table-sync helpers are now unexported, so the "every SetConfig
  path keeps the projection in step" invariant is enforced by the
  compiler rather than by a comment.

## The one deliberate behavior change

The issue proposed keeping `ensureSubgraphCustomTypes`, which
auto-registered unknown types at pour time. This PR **removes** that
instead. Auto-registration means materializing a formula silently grows
the type whitelist — one typo'd step type becomes a permanently
registered custom type, and there is no way to tell an intentional new
type from a mistake after the fact.

`flattenUnregisteredIssueTypes` replaces it: a type that is neither
built-in nor registered degrades (epic if the issue has children, task
otherwise) with a warning naming each flattened type and pointing at
`bd config set types.custom`. Registered types and built-ins are
untouched, which is the case the issue is actually about. Operators opt
in rather than opting out.

Worth a maintainer opinion — it is the one place this diverges from the
proposed fix, and it trades silent success for a visible warning.

Note that `ensureSubgraphCustomTypes`'s sibling `EnsureCustomTypeInTx`
was dead code; it never had a caller. So no repo can be carrying types
that live in `custom_types` without also being in `types.custom`, and
reading the config string is equivalent to the table-first resolve.

## Testing

New coverage for step-type pass-through and normalization, parent-type
precedence, the flatten decision table, and an integration test that
registers a custom type and creates both a single and a batched wisp in
that same transaction.

`gofmt`, `go vet`, and the affected package tests pass locally.
`golangci-lint` isn't installed in this environment, so CI is the first
real run of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLWg73gpPfwinj1jn3UhmU
