### PR TITLE
Fix supersedes and other dependency types displaying as blockers

### DIFF
--- a/cmd/bd/cli_fast_test.go
+++ b/cmd/bd/cli_fast_test.go
@@ -835,6 +835,46 @@ func TestCLI_DepAdd_TypeBlockedByAliasGates(t *testing.T) {
 	}
 }
 
+// TestCLI_Show_SupersedesIsNotABlocker is the regression test for bd show
+// grouping every dependency type it did not name explicitly into the blocks
+// bucket. A supersedes edge printed under "DEPENDS ON" on the replaced issue
+// and "BLOCKS" on the replacement — a blocking claim that is false, since
+// supersedes takes no part in the ready-work calculation.
+func TestCLI_Show_SupersedesIsNotABlocker(t *testing.T) {
+	// Note: Not using t.Parallel() because inProcessMutex serializes execution anyway
+	tmpDir := setupCLITestDB(t)
+
+	outOld := runBDInProcess(t, tmpDir, "create", "V1 spec", "-p", "1", "--json")
+	outNew := runBDInProcess(t, tmpDir, "create", "V2 spec", "-p", "1", "--json")
+
+	var oldIssue, newIssue map[string]interface{}
+	json.Unmarshal([]byte(outOld), &oldIssue)
+	json.Unmarshal([]byte(outNew), &newIssue)
+
+	oldID := oldIssue["id"].(string)
+	newID := newIssue["id"].(string)
+
+	runBDInProcess(t, tmpDir, "supersede", oldID, "--with", newID)
+
+	// `bd supersede old --with new` stores (old, new), so the replaced issue is
+	// the edge's source and names its replacement.
+	replaced := runBDInProcess(t, tmpDir, "show", oldID)
+	if !strings.Contains(replaced, "SUPERSEDED BY") {
+		t.Errorf("expected SUPERSEDED BY section on the replaced issue, got: %s", replaced)
+	}
+	if strings.Contains(replaced, "DEPENDS ON") {
+		t.Errorf("replaced issue must not claim it depends on its replacement, got: %s", replaced)
+	}
+
+	replacement := runBDInProcess(t, tmpDir, "show", newID)
+	if !strings.Contains(replacement, "SUPERSEDES") {
+		t.Errorf("expected SUPERSEDES section on the replacement, got: %s", replacement)
+	}
+	if strings.Contains(replacement, "BLOCKS") {
+		t.Errorf("replacement must not claim it blocks the issue it replaced, got: %s", replacement)
+	}
+}
+
 func TestCLI_DepRemove(t *testing.T) {
 	// Note: Not using t.Parallel() because inProcessMutex serializes execution anyway
 	tmpDir := setupCLITestDB(t)

--- a/cmd/bd/dep.go
+++ b/cmd/bd/dep.go
@@ -428,8 +428,8 @@ Examples:
 			})
 		}
 
-		fmt.Printf("%s Added dependency: %s depends on %s (%s)\n",
-			ui.RenderPass("✓"), formatFeedbackIDParen(fromID, lookupTitle(fromID)), formatFeedbackIDParen(toID, lookupTitle(toID)), dt)
+		fmt.Printf("%s Added dependency: %s %s %s (%s)\n",
+			ui.RenderPass("✓"), formatFeedbackIDParen(fromID, lookupTitle(fromID)), depRelationFor(dt).phrase, formatFeedbackIDParen(toID, lookupTitle(toID)), dt)
 		return nil
 	},
 }
@@ -774,7 +774,7 @@ func printDepListEdges(anchors []issueops.AnchorEdges) error {
 			fmt.Printf("\n%s has no dependencies\n", anchor.ID)
 			continue
 		}
-		fmt.Printf("\n%s %s depends on:\n\n", ui.RenderAccent("📋"), anchor.ID)
+		fmt.Printf("\n%s Dependencies of %s:\n\n", ui.RenderAccent("📋"), anchor.ID)
 		for _, dep := range anchor.Edges {
 			fmt.Printf("  %s via %s\n", dep.DependsOnID, dep.Type)
 		}
@@ -1063,7 +1063,7 @@ var depRemoveCmd = &cobra.Command{
 			})
 		}
 
-		fmt.Printf("%s Removed dependency: %s no longer depends on %s\n",
+		fmt.Printf("%s Removed dependency: %s → %s\n",
 			ui.RenderPass("✓"), formatFeedbackIDParen(fullFromID, lookupTitle(fullFromID)), formatFeedbackIDParen(fullToID, lookupTitle(fullToID)))
 		return nil
 	},

--- a/cmd/bd/dep_proxied_server.go
+++ b/cmd/bd/dep_proxied_server.go
@@ -254,9 +254,10 @@ func runDepAddProxiedServer(cmd *cobra.Command, ctx context.Context, args []stri
 		return nil
 	}
 
-	fmt.Printf("%s Added dependency: %s depends on %s (%s)\n",
+	fmt.Printf("%s Added dependency: %s %s %s (%s)\n",
 		ui.RenderPass("✓"),
 		formatFeedbackIDParen(fromID, res.fromTitle),
+		depRelationFor(dt).phrase,
 		formatFeedbackIDParen(toID, res.toTitle),
 		dt)
 	return nil
@@ -353,7 +354,7 @@ func runDepRemoveProxiedServer(_ *cobra.Command, ctx context.Context, args []str
 		return nil
 	}
 
-	fmt.Printf("%s Removed dependency: %s no longer depends on %s\n",
+	fmt.Printf("%s Removed dependency: %s → %s\n",
 		ui.RenderPass("✓"),
 		formatFeedbackIDParen(fromID, res.fromTitle),
 		formatFeedbackIDParen(toID, res.toTitle))

--- a/cmd/bd/dep_relation.go
+++ b/cmd/bd/dep_relation.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// depRelation names one dependency type from both ends of its edge. A stored
+// edge is (issue_id, depends_on_id, type): out* describes the edge as the
+// issue_id side sees it, in* as the depends_on_id side sees it.
+//
+// Each type's direction comes from the command that writes it, NOT from reading
+// the type name left to right — beads has no single convention there.
+// `bd supersede old --with new` stores (old, new, supersedes), so the edge
+// reads "issue_id is superseded by depends_on_id", while
+// `bd duplicate dup --of canonical` stores (dup, canonical, duplicates), which
+// reads the other way round. Getting this backwards prints a lie, so change an
+// entry only alongside the command that creates that edge.
+type depRelation struct {
+	outHeading string // bd show section heading for the edge's source
+	inHeading  string // bd show section heading for the edge's target
+	outGlyph   string
+	inGlyph    string
+	phrase     string // reads "<source> <phrase> <target>", for dep add feedback
+}
+
+// depRelations covers the well-known types. Missing entries fall back to the
+// type's own name (see depRelationFor), which is what custom types get.
+var depRelations = map[types.DependencyType]depRelation{
+	types.DepBlocks:            {"DEPENDS ON", "BLOCKS", "→", "←", "depends on"},
+	types.DepParentChild:       {"PARENT", "CHILDREN", "↑", "↳", "is a child of"},
+	types.DepConditionalBlocks: {"CONDITIONALLY DEPENDS ON", "CONDITIONALLY BLOCKS", "→", "←", "conditionally depends on"},
+	types.DepWaitsFor:          {"WAITS FOR", "AWAITED BY", "→", "←", "waits for"},
+	types.DepRelated:           {"RELATED", "RELATED", "↔", "↔", "is related to"},
+	types.DepRelatesTo:         {"RELATED", "RELATED", "↔", "↔", "relates to"},
+	types.DepDiscoveredFrom:    {"DISCOVERED FROM", "DISCOVERED", "◊", "◊", "was discovered from"},
+	types.DepRepliesTo:         {"IN REPLY TO", "REPLIES", "→", "←", "replies to"},
+	types.DepDuplicates:        {"DUPLICATE OF", "DUPLICATED BY", "→", "←", "duplicates"},
+	types.DepSupersedes:        {"SUPERSEDED BY", "SUPERSEDES", "→", "←", "is superseded by"},
+	types.DepAuthoredBy:        {"AUTHORED BY", "AUTHORED", "→", "←", "was authored by"},
+	types.DepAssignedTo:        {"ASSIGNED TO", "ASSIGNED", "→", "←", "is assigned to"},
+	types.DepApprovedBy:        {"APPROVED BY", "APPROVED", "→", "←", "was approved by"},
+	types.DepAttests:           {"ATTESTS", "ATTESTED BY", "→", "←", "attests"},
+	types.DepTracks:            {"TRACKS", "TRACKED BY", "→", "←", "tracks"},
+	types.DepUntil:             {"ACTIVE UNTIL", "KEEPS ACTIVE", "→", "←", "is active until"},
+	types.DepCausedBy:          {"CAUSED BY", "CAUSED", "→", "←", "was caused by"},
+	types.DepValidates:         {"VALIDATES", "VALIDATED BY", "→", "←", "validates"},
+	types.DepDelegatedFrom:     {"DELEGATED FROM", "DELEGATED TO", "→", "←", "was delegated from"},
+}
+
+// depRelationFor returns how to name an edge of this type. A custom type gets
+// its own name rather than being described as a blocker it is not.
+func depRelationFor(t types.DependencyType) depRelation {
+	if rel, ok := depRelations[t]; ok {
+		return rel
+	}
+	name := strings.ToUpper(string(t))
+	return depRelation{
+		outHeading: name,
+		inHeading:  name + " (INBOUND)",
+		outGlyph:   "→",
+		inGlyph:    "←",
+		phrase:     string(t),
+	}
+}
+
+// depSectionOrder fixes the order dependency sections print in. It leads with
+// the types bd show has always grouped, so an issue wired only with those
+// renders exactly as it did before the other types got sections of their own.
+// DepRelated stands for both symmetric spellings and sorts last, matching where
+// bd show has always printed RELATED.
+var depSectionOrder = []types.DependencyType{
+	types.DepParentChild, types.DepBlocks,
+	types.DepConditionalBlocks, types.DepWaitsFor,
+	types.DepDiscoveredFrom,
+	types.DepRepliesTo, types.DepDuplicates, types.DepSupersedes,
+	types.DepAuthoredBy, types.DepAssignedTo, types.DepApprovedBy, types.DepAttests,
+	types.DepTracks, types.DepUntil, types.DepCausedBy, types.DepValidates,
+	types.DepDelegatedFrom,
+	types.DepRelated,
+}
+
+// depSection is one printable group of dependency lines under one heading.
+type depSection struct {
+	Type    types.DependencyType
+	Heading string
+	Glyph   string
+	Deps    []*types.IssueWithDependencyMetadata
+}
+
+// groupDepSections splits one direction's edges into printable sections, in
+// display order. outgoing means issue is the edges' source (dependencies.
+// issue_id).
+//
+// A non-nil relatedSeen diverts the symmetric related edges into it, keyed by
+// issue ID, so a caller that passes the same map for both directions ends up
+// with one RELATED section instead of two halves. A caller reading a single
+// direction passes nil and gets RELATED as an ordinary trailing section; either
+// way the two spellings share one section, because they read the same.
+func groupDepSections(deps []*types.IssueWithDependencyMetadata, outgoing bool, relatedSeen map[string]*types.IssueWithDependencyMetadata) []depSection {
+	byType := make(map[types.DependencyType][]*types.IssueWithDependencyMetadata)
+	for _, dep := range deps {
+		switch dep.DependencyType {
+		case types.DepRelated, types.DepRelatesTo:
+			if relatedSeen != nil {
+				relatedSeen[dep.ID] = dep
+				continue
+			}
+			byType[types.DepRelated] = append(byType[types.DepRelated], dep)
+		default:
+			byType[dep.DependencyType] = append(byType[dep.DependencyType], dep)
+		}
+	}
+
+	sections := make([]depSection, 0, len(byType))
+	emit := func(t types.DependencyType) {
+		group, ok := byType[t]
+		if !ok {
+			return
+		}
+		delete(byType, t)
+		rel := depRelationFor(t)
+		heading, glyph := rel.outHeading, rel.outGlyph
+		if !outgoing {
+			heading, glyph = rel.inHeading, rel.inGlyph
+		}
+		sections = append(sections, depSection{Type: t, Heading: heading, Glyph: glyph, Deps: group})
+	}
+	for _, t := range depSectionOrder {
+		emit(t)
+	}
+	// Custom types trail the built-ins, sorted by name so output is stable.
+	custom := make([]types.DependencyType, 0, len(byType))
+	for t := range byType {
+		custom = append(custom, t)
+	}
+	slices.Sort(custom)
+	for _, t := range custom {
+		emit(t)
+	}
+	return sections
+}

--- a/cmd/bd/dep_relation_test.go
+++ b/cmd/bd/dep_relation_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// The bug this guards: bd show used to group every type it did not name
+// explicitly into the blocks bucket, so a supersedes edge printed under
+// "DEPENDS ON" one way and "BLOCKS" the other — a blocking claim that is false
+// for every non-blocking type.
+func TestDepRelation_OnlyBlocksClaimsBlocking(t *testing.T) {
+	for _, dt := range types.WellKnownDependencyTypes() {
+		rel := depRelationFor(dt)
+		if rel.outHeading == "" || rel.inHeading == "" || rel.phrase == "" {
+			t.Errorf("%s: incomplete relation %+v", dt, rel)
+		}
+		if dt == types.DepBlocks {
+			continue
+		}
+		if rel.outHeading == "DEPENDS ON" || rel.inHeading == "BLOCKS" {
+			t.Errorf("%s borrows blocks' verbiage: out=%q in=%q", dt, rel.outHeading, rel.inHeading)
+		}
+	}
+}
+
+func TestDepRelation_Supersedes(t *testing.T) {
+	// `bd supersede old --with new` stores (old, new, supersedes), so the
+	// source end is the replaced issue and the target end is the replacement.
+	rel := depRelationFor(types.DepSupersedes)
+	if rel.outHeading != "SUPERSEDED BY" || rel.inHeading != "SUPERSEDES" {
+		t.Errorf("supersedes reads backwards: out=%q in=%q", rel.outHeading, rel.inHeading)
+	}
+}
+
+func TestDepRelationFor_CustomTypeKeepsItsName(t *testing.T) {
+	rel := depRelationFor(types.DependencyType("bikeshed-color"))
+	if rel.outHeading != "BIKESHED-COLOR" || rel.phrase != "bikeshed-color" {
+		t.Errorf("custom type lost its name: %+v", rel)
+	}
+}
+
+func TestGroupDepSections(t *testing.T) {
+	dep := func(id string, dt types.DependencyType) *types.IssueWithDependencyMetadata {
+		return &types.IssueWithDependencyMetadata{
+			Issue:          types.Issue{ID: id},
+			DependencyType: dt,
+		}
+	}
+
+	t.Run("one section per type, legacy order first", func(t *testing.T) {
+		deps := []*types.IssueWithDependencyMetadata{
+			dep("a-sup", types.DepSupersedes),
+			dep("a-disc", types.DepDiscoveredFrom),
+			dep("a-blk", types.DepBlocks),
+			dep("a-custom", types.DependencyType("zz-custom")),
+			dep("a-parent", types.DepParentChild),
+		}
+		got := groupDepSections(deps, true, map[string]*types.IssueWithDependencyMetadata{})
+		want := []string{"PARENT", "DEPENDS ON", "DISCOVERED FROM", "SUPERSEDED BY", "ZZ-CUSTOM"}
+		if len(got) != len(want) {
+			t.Fatalf("got %d sections, want %d: %+v", len(got), len(want), got)
+		}
+		for i, sec := range got {
+			if sec.Heading != want[i] {
+				t.Errorf("section %d = %q, want %q", i, sec.Heading, want[i])
+			}
+			if len(sec.Deps) != 1 {
+				t.Errorf("section %q holds %d edges, want 1", sec.Heading, len(sec.Deps))
+			}
+		}
+	})
+
+	t.Run("incoming direction flips the heading", func(t *testing.T) {
+		got := groupDepSections([]*types.IssueWithDependencyMetadata{
+			dep("b-sup", types.DepSupersedes),
+		}, false, map[string]*types.IssueWithDependencyMetadata{})
+		if len(got) != 1 || got[0].Heading != "SUPERSEDES" {
+			t.Fatalf("got %+v, want one SUPERSEDES section", got)
+		}
+	})
+
+	// bd show --refs reads one direction only, so it takes RELATED in place
+	// rather than deduplicating it against a second pass.
+	t.Run("nil relatedSeen keeps RELATED as a trailing section", func(t *testing.T) {
+		got := groupDepSections([]*types.IssueWithDependencyMetadata{
+			dep("d-rel", types.DepRelatesTo),
+			dep("d-blk", types.DepBlocks),
+			dep("d-rel2", types.DepRelated),
+		}, false, nil)
+		want := []string{"BLOCKS", "RELATED"}
+		if len(got) != len(want) {
+			t.Fatalf("got %d sections, want %d: %+v", len(got), len(want), got)
+		}
+		for i, sec := range got {
+			if sec.Heading != want[i] {
+				t.Errorf("section %d = %q, want %q", i, sec.Heading, want[i])
+			}
+		}
+		if n := len(got[1].Deps); n != 2 {
+			t.Errorf("RELATED holds %d edges, want both spellings merged into 2", n)
+		}
+	})
+
+	t.Run("related edges collapse across both directions", func(t *testing.T) {
+		relatedSeen := map[string]*types.IssueWithDependencyMetadata{}
+		out := groupDepSections([]*types.IssueWithDependencyMetadata{
+			dep("c-rel", types.DepRelatesTo),
+		}, true, relatedSeen)
+		in := groupDepSections([]*types.IssueWithDependencyMetadata{
+			dep("c-rel", types.DepRelated),
+		}, false, relatedSeen)
+		if len(out) != 0 || len(in) != 0 {
+			t.Errorf("related edges should not form their own sections: out=%+v in=%+v", out, in)
+		}
+		if len(relatedSeen) != 1 {
+			t.Errorf("relatedSeen = %d entries, want 1 (deduplicated)", len(relatedSeen))
+		}
+	})
+}

--- a/cmd/bd/list_tree_deps.go
+++ b/cmd/bd/list_tree_deps.go
@@ -38,7 +38,7 @@ func depEdgeDisplay(t types.DependencyType) (label string, scheduling, ok bool) 
 	case types.DepBlocks:
 		return "depends-on", true, true
 	case types.DepConditionalBlocks:
-		return "conditional-blocks", true, true
+		return "conditionally-depends-on", true, true
 	case types.DepWaitsFor:
 		return "waits-for", true, true
 	case types.DepRelated, types.DepRelatesTo:
@@ -48,7 +48,9 @@ func depEdgeDisplay(t types.DependencyType) (label string, scheduling, ok bool) 
 	case types.DepDuplicates:
 		return "duplicates", false, true
 	case types.DepSupersedes:
-		return "supersedes", false, true
+		// `bd supersede old --with new` stores (old, new), so the source end of
+		// the edge is the issue being replaced.
+		return "superseded-by", false, true
 	case types.DepRepliesTo:
 		return "replies-to", false, true
 	default:

--- a/cmd/bd/list_tree_deps_test.go
+++ b/cmd/bd/list_tree_deps_test.go
@@ -93,13 +93,13 @@ func TestDepEdgeDisplay(t *testing.T) {
 	}{
 		{"parent-child", types.DepParentChild, "", false, false},
 		{"blocks", types.DepBlocks, "depends-on", true, true},
-		{"conditional-blocks", types.DepConditionalBlocks, "conditional-blocks", true, true},
+		{"conditional-blocks", types.DepConditionalBlocks, "conditionally-depends-on", true, true},
 		{"waits-for", types.DepWaitsFor, "waits-for", true, true},
 		{"related", types.DepRelated, "related", false, true},
 		{"relates-to", types.DepRelatesTo, "related", false, true},
 		{"discovered-from", types.DepDiscoveredFrom, "discovered-from", false, true},
 		{"duplicates", types.DepDuplicates, "duplicates", false, true},
-		{"supersedes", types.DepSupersedes, "supersedes", false, true},
+		{"supersedes", types.DepSupersedes, "superseded-by", false, true},
 		{"replies-to", types.DepRepliesTo, "replies-to", false, true},
 		{"custom-type", types.DependencyType("some-custom-type"), "some-custom-type", false, true},
 	}

--- a/cmd/bd/show.go
+++ b/cmd/bd/show.go
@@ -231,110 +231,20 @@ var showCmd = &cobra.Command{
 
 			// Show dependencies - grouped by dependency type for clarity
 			depsWithMeta, _ := issueStore.GetDependenciesWithMetadata(ctx, issue.ID) // Best effort: show issue even if deps unavailable
-
-			if len(depsWithMeta) > 0 {
-				// Group by dependency type
-				var blocks, parent, discovered []*types.IssueWithDependencyMetadata
-				for _, dep := range depsWithMeta {
-					switch dep.DependencyType {
-					case types.DepBlocks:
-						blocks = append(blocks, dep)
-					case types.DepParentChild:
-						parent = append(parent, dep)
-					case types.DepRelated, types.DepRelatesTo:
-						relatedSeen[dep.ID] = dep
-					case types.DepDiscoveredFrom:
-						discovered = append(discovered, dep)
-					default:
-						blocks = append(blocks, dep) // Default to blocks
-					}
-				}
-
-				if len(parent) > 0 {
-					fmt.Printf("\n%s\n", ui.RenderBold("PARENT"))
-					for _, dep := range parent {
-						fmt.Println(formatDependencyLine("↑", dep))
-					}
-				}
-				if len(blocks) > 0 {
-					fmt.Printf("\n%s\n", ui.RenderBold("DEPENDS ON"))
-					for _, dep := range blocks {
-						fmt.Println(formatDependencyLine("→", dep))
-					}
-				}
-				if len(discovered) > 0 {
-					fmt.Printf("\n%s\n", ui.RenderBold("DISCOVERED FROM"))
-					for _, dep := range discovered {
-						fmt.Println(formatDependencyLine("◊", dep))
-					}
-				}
+			for _, sec := range groupDepSections(depsWithMeta, true, relatedSeen) {
+				printDepSection(sec)
 			}
 
 			// Show dependents - grouped by dependency type for clarity
 			dependentsWithMeta, _ := issueStore.GetDependentsWithMetadata(ctx, issue.ID) // Best effort: show issue even if dependents unavailable
-			if len(dependentsWithMeta) > 0 {
-				// Group by dependency type
-				var blocks, children, discovered []*types.IssueWithDependencyMetadata
-				for _, dep := range dependentsWithMeta {
-					switch dep.DependencyType {
-					case types.DepBlocks:
-						blocks = append(blocks, dep)
-					case types.DepParentChild:
-						children = append(children, dep)
-					case types.DepRelated, types.DepRelatesTo:
-						relatedSeen[dep.ID] = dep
-					case types.DepDiscoveredFrom:
-						discovered = append(discovered, dep)
-					default:
-						blocks = append(blocks, dep) // Default to blocks
-					}
-				}
-
-				if len(children) > 0 {
-					fmt.Printf("\n%s\n", ui.RenderBold("CHILDREN"))
-					for _, dep := range children {
-						fmt.Println(formatDependencyLine("↳", dep))
-					}
-					// Epic progress summary
-					if issue.IssueType == types.TypeEpic {
-						closedCount := 0
-						for _, dep := range children {
-							if dep.Issue.Status == types.StatusClosed {
-								closedCount++
-							}
-						}
-						pct := 0
-						if len(children) > 0 {
-							pct = (closedCount * 100) / len(children)
-						}
-						if closedCount == len(children) {
-							fmt.Printf("  %s %d/%d complete (%d%%) — eligible for close\n", ui.RenderPass("✓"), closedCount, len(children), pct)
-						} else {
-							fmt.Printf("  %s %d/%d complete (%d%%)\n", ui.RenderMuted("◐"), closedCount, len(children), pct)
-						}
-					}
-				}
-				if len(blocks) > 0 {
-					fmt.Printf("\n%s\n", ui.RenderBold("BLOCKS"))
-					for _, dep := range blocks {
-						fmt.Println(formatDependencyLine("←", dep))
-					}
-				}
-				if len(discovered) > 0 {
-					fmt.Printf("\n%s\n", ui.RenderBold("DISCOVERED"))
-					for _, dep := range discovered {
-						fmt.Println(formatDependencyLine("◊", dep))
-					}
+			for _, sec := range groupDepSections(dependentsWithMeta, false, relatedSeen) {
+				printDepSection(sec)
+				if sec.Type == types.DepParentChild && issue.IssueType == types.TypeEpic {
+					printEpicChildProgress(sec.Deps)
 				}
 			}
 
-			// Print deduplicated RELATED section (bidirectional links shown once)
-			if len(relatedSeen) > 0 {
-				fmt.Printf("\n%s\n", ui.RenderBold("RELATED"))
-				for _, dep := range relatedSeen {
-					fmt.Println(formatDependencyLine("↔", dep))
-				}
-			}
+			printRelatedSection(relatedSeen)
 
 			// Show comments
 			comments, _ := issueStore.GetIssueComments(ctx, issue.ID) // Best effort: show issue even if comments unavailable

--- a/cmd/bd/show_display.go
+++ b/cmd/bd/show_display.go
@@ -124,88 +124,18 @@ func displayShowIssueReturn(ctx context.Context, issueID string) *types.Issue {
 	// Dependencies (what this issue depends on)
 	relatedSeen := make(map[string]*types.IssueWithDependencyMetadata)
 	depsWithMeta, _ := issueStore.GetDependenciesWithMetadata(ctx, issue.ID)
-
-	if len(depsWithMeta) > 0 {
-		var blocks, parent, discovered []*types.IssueWithDependencyMetadata
-		for _, dep := range depsWithMeta {
-			switch dep.DependencyType {
-			case types.DepBlocks:
-				blocks = append(blocks, dep)
-			case types.DepParentChild:
-				parent = append(parent, dep)
-			case types.DepRelated, types.DepRelatesTo:
-				relatedSeen[dep.ID] = dep
-			case types.DepDiscoveredFrom:
-				discovered = append(discovered, dep)
-			default:
-				blocks = append(blocks, dep)
-			}
-		}
-		if len(parent) > 0 {
-			fmt.Printf("\n%s\n", ui.RenderBold("PARENT"))
-			for _, dep := range parent {
-				fmt.Println(formatDependencyLine("↑", dep))
-			}
-		}
-		if len(blocks) > 0 {
-			fmt.Printf("\n%s\n", ui.RenderBold("DEPENDS ON"))
-			for _, dep := range blocks {
-				fmt.Println(formatDependencyLine("→", dep))
-			}
-		}
-		if len(discovered) > 0 {
-			fmt.Printf("\n%s\n", ui.RenderBold("DISCOVERED FROM"))
-			for _, dep := range discovered {
-				fmt.Println(formatDependencyLine("◊", dep))
-			}
-		}
+	for _, sec := range groupDepSections(depsWithMeta, true, relatedSeen) {
+		printDepSection(sec)
 	}
 
 	// Dependents (what depends on this issue)
 	dependentsWithMeta, _ := issueStore.GetDependentsWithMetadata(ctx, issue.ID)
-	if len(dependentsWithMeta) > 0 {
-		var blocks, children, discovered []*types.IssueWithDependencyMetadata
-		for _, dep := range dependentsWithMeta {
-			switch dep.DependencyType {
-			case types.DepBlocks:
-				blocks = append(blocks, dep)
-			case types.DepParentChild:
-				children = append(children, dep)
-			case types.DepRelated, types.DepRelatesTo:
-				relatedSeen[dep.ID] = dep
-			case types.DepDiscoveredFrom:
-				discovered = append(discovered, dep)
-			default:
-				blocks = append(blocks, dep)
-			}
-		}
-		if len(children) > 0 {
-			fmt.Printf("\n%s\n", ui.RenderBold("CHILDREN"))
-			for _, dep := range children {
-				fmt.Println(formatDependencyLine("↳", dep))
-			}
-		}
-		if len(blocks) > 0 {
-			fmt.Printf("\n%s\n", ui.RenderBold("BLOCKS"))
-			for _, dep := range blocks {
-				fmt.Println(formatDependencyLine("←", dep))
-			}
-		}
-		if len(discovered) > 0 {
-			fmt.Printf("\n%s\n", ui.RenderBold("DISCOVERED"))
-			for _, dep := range discovered {
-				fmt.Println(formatDependencyLine("◊", dep))
-			}
-		}
+	for _, sec := range groupDepSections(dependentsWithMeta, false, relatedSeen) {
+		printDepSection(sec)
 	}
 
 	// Related (bidirectional, deduplicated)
-	if len(relatedSeen) > 0 {
-		fmt.Printf("\n%s\n", ui.RenderBold("RELATED"))
-		for _, dep := range relatedSeen {
-			fmt.Println(formatDependencyLine("↔", dep))
-		}
-	}
+	printRelatedSection(relatedSeen)
 
 	// Comments
 	comments, _ := issueStore.GetIssueComments(ctx, issue.ID)

--- a/cmd/bd/show_format.go
+++ b/cmd/bd/show_format.go
@@ -198,6 +198,52 @@ func formatDependencyLine(prefix string, dep *types.IssueWithDependencyMetadata)
 	return fmt.Sprintf("  %s %s %s: %s%s %s", prefix, statusIcon, idStr, typeStr, dep.Title, priorityTag)
 }
 
+// printDepSection prints one dependency section: bold heading, then a line per
+// edge marked with the section's direction glyph.
+func printDepSection(sec depSection) {
+	fmt.Printf("\n%s\n", ui.RenderBold(sec.Heading))
+	for _, dep := range sec.Deps {
+		fmt.Println(formatDependencyLine(sec.Glyph, dep))
+	}
+}
+
+// printRelatedSection prints the deduplicated RELATED section that both
+// directions of the symmetric related/relates-to edges collapse into.
+func printRelatedSection(relatedSeen map[string]*types.IssueWithDependencyMetadata) {
+	if len(relatedSeen) == 0 {
+		return
+	}
+	fmt.Printf("\n%s\n", ui.RenderBold("RELATED"))
+	ids := make([]string, 0, len(relatedSeen))
+	for id := range relatedSeen {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		fmt.Println(formatDependencyLine("↔", relatedSeen[id]))
+	}
+}
+
+// printEpicChildProgress summarizes how much of an epic its children have
+// finished, printed under the CHILDREN section.
+func printEpicChildProgress(children []*types.IssueWithDependencyMetadata) {
+	if len(children) == 0 {
+		return
+	}
+	closed := 0
+	for _, dep := range children {
+		if dep.Status == types.StatusClosed {
+			closed++
+		}
+	}
+	pct := closed * 100 / len(children)
+	if closed == len(children) {
+		fmt.Printf("  %s %d/%d complete (%d%%) — eligible for close\n", ui.RenderPass("✓"), closed, len(children), pct)
+	} else {
+		fmt.Printf("  %s %d/%d complete (%d%%)\n", ui.RenderMuted("◐"), closed, len(children), pct)
+	}
+}
+
 // formatSimpleDependencyLine formats a dependency without metadata (fallback)
 // Closed items get entire row muted - the work is done, no need for attention
 func formatSimpleDependencyLine(prefix string, dep *types.Issue) string {

--- a/cmd/bd/show_proxied_integration_test.go
+++ b/cmd/bd/show_proxied_integration_test.go
@@ -551,12 +551,14 @@ func TestProxiedServerShow2(t *testing.T) {
 		bdProxiedCreate(t, bd, p.dir, "Related A",
 			"--type", "task", "--deps", "related:"+hub.ID)
 
+		// Groups are named from the hub's end, since every ref points at it:
+		// the hub BLOCKS the issue that named it as a blocker.
 		out := bdProxiedShowRaw(t, bd, p.dir, hub.ID, "--refs")
-		if !strings.Contains(out, "blocks") {
-			t.Errorf("expected 'blocks' group in --refs output: %s", out)
+		if !strings.Contains(out, "BLOCKS") {
+			t.Errorf("expected 'BLOCKS' group in --refs output: %s", out)
 		}
-		if !strings.Contains(out, "related") {
-			t.Errorf("expected 'related' group in --refs output: %s", out)
+		if !strings.Contains(out, "RELATED") {
+			t.Errorf("expected 'RELATED' group in --refs output: %s", out)
 		}
 	})
 

--- a/cmd/bd/show_proxied_server.go
+++ b/cmd/bd/show_proxied_server.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"slices"
-	"sort"
 	"strings"
 	"time"
 
@@ -227,28 +226,8 @@ func runShowProxiedRefs(ctx context.Context, uw uow.UnitOfWork, in *showProxiedI
 			continue
 		}
 		fmt.Printf("\n%s References to %s:\n", ui.RenderAccent("📎"), id)
-		refsByType := make(map[types.DependencyType][]*types.IssueWithDependencyMetadata)
-		for _, ref := range refs {
-			refsByType[ref.DependencyType] = append(refsByType[ref.DependencyType], ref)
-		}
-		typeOrder := []types.DependencyType{
-			types.DepUntil, types.DepCausedBy, types.DepValidates,
-			types.DepBlocks, types.DepParentChild, types.DepRelatesTo,
-			types.DepTracks, types.DepDiscoveredFrom, types.DepRelated,
-			types.DepSupersedes, types.DepDuplicates, types.DepRepliesTo,
-			types.DepApprovedBy, types.DepAuthoredBy, types.DepAssignedTo,
-		}
-		shown := make(map[types.DependencyType]bool)
-		for _, depType := range typeOrder {
-			if grp, ok := refsByType[depType]; ok {
-				displayRefGroup(depType, grp)
-				shown[depType] = true
-			}
-		}
-		for depType, grp := range refsByType {
-			if !shown[depType] {
-				displayRefGroup(depType, grp)
-			}
+		for _, sec := range groupDepSections(refs, false, nil) {
+			displayRefGroup(sec)
 		}
 		fmt.Println()
 	}
@@ -550,107 +529,19 @@ func proxiedRenderIssue(ctx context.Context, uw uow.UnitOfWork, issue *types.Iss
 	relatedSeen := make(map[string]*types.IssueWithDependencyMetadata)
 
 	depsWithMeta, _ := proxiedListDeps(ctx, uw, issue.ID, isWisp, domain.DepListFilter{Direction: domain.DepDirectionOut})
-	if len(depsWithMeta) > 0 {
-		var blocks, parent, discovered []*types.IssueWithDependencyMetadata
-		for _, dep := range depsWithMeta {
-			switch dep.DependencyType {
-			case types.DepBlocks:
-				blocks = append(blocks, dep)
-			case types.DepParentChild:
-				parent = append(parent, dep)
-			case types.DepRelated, types.DepRelatesTo:
-				relatedSeen[dep.ID] = dep
-			case types.DepDiscoveredFrom:
-				discovered = append(discovered, dep)
-			default:
-				blocks = append(blocks, dep)
-			}
-		}
-		if len(parent) > 0 {
-			fmt.Printf("\n%s\n", ui.RenderBold("PARENT"))
-			for _, dep := range parent {
-				fmt.Println(formatDependencyLine("↑", dep))
-			}
-		}
-		if len(blocks) > 0 {
-			fmt.Printf("\n%s\n", ui.RenderBold("DEPENDS ON"))
-			for _, dep := range blocks {
-				fmt.Println(formatDependencyLine("→", dep))
-			}
-		}
-		if len(discovered) > 0 {
-			fmt.Printf("\n%s\n", ui.RenderBold("DISCOVERED FROM"))
-			for _, dep := range discovered {
-				fmt.Println(formatDependencyLine("◊", dep))
-			}
-		}
+	for _, sec := range groupDepSections(depsWithMeta, true, relatedSeen) {
+		printDepSection(sec)
 	}
 
 	dependentsWithMeta, _ := proxiedListDeps(ctx, uw, issue.ID, isWisp, domain.DepListFilter{Direction: domain.DepDirectionIn})
-	if len(dependentsWithMeta) > 0 {
-		var blocks, children, discovered []*types.IssueWithDependencyMetadata
-		for _, dep := range dependentsWithMeta {
-			switch dep.DependencyType {
-			case types.DepBlocks:
-				blocks = append(blocks, dep)
-			case types.DepParentChild:
-				children = append(children, dep)
-			case types.DepRelated, types.DepRelatesTo:
-				relatedSeen[dep.ID] = dep
-			case types.DepDiscoveredFrom:
-				discovered = append(discovered, dep)
-			default:
-				blocks = append(blocks, dep)
-			}
-		}
-		if len(children) > 0 {
-			fmt.Printf("\n%s\n", ui.RenderBold("CHILDREN"))
-			for _, dep := range children {
-				fmt.Println(formatDependencyLine("↳", dep))
-			}
-			if issue.IssueType == types.TypeEpic {
-				closedCount := 0
-				for _, dep := range children {
-					if dep.Status == types.StatusClosed {
-						closedCount++
-					}
-				}
-				pct := 0
-				if len(children) > 0 {
-					pct = (closedCount * 100) / len(children)
-				}
-				if closedCount == len(children) {
-					fmt.Printf("  %s %d/%d complete (%d%%) — eligible for close\n", ui.RenderPass("✓"), closedCount, len(children), pct)
-				} else {
-					fmt.Printf("  %s %d/%d complete (%d%%)\n", ui.RenderMuted("◐"), closedCount, len(children), pct)
-				}
-			}
-		}
-		if len(blocks) > 0 {
-			fmt.Printf("\n%s\n", ui.RenderBold("BLOCKS"))
-			for _, dep := range blocks {
-				fmt.Println(formatDependencyLine("←", dep))
-			}
-		}
-		if len(discovered) > 0 {
-			fmt.Printf("\n%s\n", ui.RenderBold("DISCOVERED"))
-			for _, dep := range discovered {
-				fmt.Println(formatDependencyLine("◊", dep))
-			}
+	for _, sec := range groupDepSections(dependentsWithMeta, false, relatedSeen) {
+		printDepSection(sec)
+		if sec.Type == types.DepParentChild && issue.IssueType == types.TypeEpic {
+			printEpicChildProgress(sec.Deps)
 		}
 	}
 
-	if len(relatedSeen) > 0 {
-		fmt.Printf("\n%s\n", ui.RenderBold("RELATED"))
-		ids := make([]string, 0, len(relatedSeen))
-		for k := range relatedSeen {
-			ids = append(ids, k)
-		}
-		sort.Strings(ids)
-		for _, k := range ids {
-			fmt.Println(formatDependencyLine("↔", relatedSeen[k]))
-		}
-	}
+	printRelatedSection(relatedSeen)
 
 	comments, _ := proxiedGetComments(ctx, uw, issue.ID, isWisp)
 	if len(comments) > 0 {

--- a/cmd/bd/show_refs.go
+++ b/cmd/bd/show_refs.go
@@ -59,48 +59,25 @@ func showIssueRefs(ctx context.Context, args []string, jsonOut bool) error {
 
 		fmt.Printf("\n%s References to %s:\n", ui.RenderAccent("📎"), issueID)
 
-		// Group refs by type
-		refsByType := make(map[types.DependencyType][]*types.IssueWithDependencyMetadata)
-		for _, ref := range refs {
-			refsByType[ref.DependencyType] = append(refsByType[ref.DependencyType], ref)
-		}
-
-		// Display each type
-		typeOrder := []types.DependencyType{
-			types.DepUntil, types.DepCausedBy, types.DepValidates,
-			types.DepBlocks, types.DepParentChild, types.DepRelatesTo,
-			types.DepTracks, types.DepDiscoveredFrom, types.DepRelated,
-			types.DepSupersedes, types.DepDuplicates, types.DepRepliesTo,
-			types.DepApprovedBy, types.DepAuthoredBy, types.DepAssignedTo,
-		}
-
-		// First show types in order, then any others
-		shown := make(map[types.DependencyType]bool)
-		for _, depType := range typeOrder {
-			if refs, ok := refsByType[depType]; ok {
-				displayRefGroup(depType, refs)
-				shown[depType] = true
-			}
-		}
-		// Show any remaining types
-		for depType, refs := range refsByType {
-			if !shown[depType] {
-				displayRefGroup(depType, refs)
-			}
+		// Every ref is an edge pointing AT this issue, so each group is named
+		// from this issue's end. The bare type name would read from the other
+		// end for the types whose name runs source-first: a (dup, canonical)
+		// edge under a "duplicates" heading says the canonical is the copy.
+		for _, sec := range groupDepSections(refs, false, nil) {
+			displayRefGroup(sec)
 		}
 		fmt.Println()
 	}
 	return nil
 }
 
-// displayRefGroup displays a group of references with a given type
+// displayRefGroup displays one group of references under its relationship name
 // Closed items get entire row muted - the work is done, no need for attention
-func displayRefGroup(depType types.DependencyType, refs []*types.IssueWithDependencyMetadata) {
-	// Get emoji for type
-	emoji := getRefTypeEmoji(depType)
-	fmt.Printf("\n  %s %s (%d):\n", emoji, depType, len(refs))
+func displayRefGroup(sec depSection) {
+	emoji := getRefTypeEmoji(sec.Type)
+	fmt.Printf("\n  %s %s (%d):\n", emoji, sec.Heading, len(sec.Deps))
 
-	for _, ref := range refs {
+	for _, ref := range sec.Deps {
 		// Closed items: mute entire row since the work is complete
 		if ref.Status == types.StatusClosed {
 			fmt.Printf("    %s: %s %s\n",

--- a/docs/core-concepts/dependencies.md
+++ b/docs/core-concepts/dependencies.md
@@ -53,7 +53,7 @@ Dependencies have a type that determines whether they block work.
 | `discovered-from` | Found during work on another issue |
 | `caused-by` | Root cause link |
 | `validates` | Test or verification link |
-| `supersedes` | Replaces another issue |
+| `supersedes` | Replaced by a newer issue (`bd supersede old --with new`) |
 
 Specify with `--type`:
 


### PR DESCRIPTION
`bd show` printed "DEPENDS ON" on an issue that another supersedes, and "BLOCKS" on its replacement instead of the obvious "SUPERSEDED BY" and "SUPERSEDES." "BLOCKS" was doubly wrong since supersedes takes no part in ready-work calculation.

Only blocks, parent-child, related and discovered-from had verbiage of their own; duplicates, replies-to, tracks, attests and every other type fell through to a `default: blocks` fallback, while conditional-blocks and waits-for do block but lost the distinction.

One table now names each type from both ends of its edge and all three renderers share it.

Type names have no consistent left-to-right reading, so each entry takes its direction from the command that writes the edge: `bd supersede old --with new` stores (old, new), making the source the replaced issue.

Same bug elsewhere, also fixed: `bd show --refs` headed groups with the bare type name, so a canonical issue announced itself as the copy; `bd dep add` and `rm` said "depends on" whatever the type; `bd dep list`'s batch header said "X depends on:"; `bd list --deps` had supersedes and conditional-blocks backwards; and the dependencies doc described supersedes in reverse.