### PR TITLE
fix: a re-close that runs on_close, a silent cycle-gate walker, and a leaf that contradicts the wire

### DIFF
--- a/backend/conformance/releaser_contract.go
+++ b/backend/conformance/releaser_contract.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -207,6 +208,19 @@ func RunReleaserRefusesAForeignClaimUntilForced(t *testing.T, ctx context.Contex
 // most likely to get backwards: a match REPLACES the ownership fence, so the
 // caller need not be the holder. An implementation that ran the fence anyway
 // would answer ErrNotOwner here and pass every other case in this file.
+//
+// THE LAST TWO LIMBS PIN WHAT "MATCH" MEANS, which nothing at this tier pinned
+// before (ga-2ltro.14) — and it is not string equality. The comparison is
+// SEPARATOR-INSENSITIVE AND NOTHING ELSE (canonicalActor, ga-5ksp5): a run of
+// ".", "_" or "-" matches any other such run, so an expectation spelled under
+// one layer's separator convention releases a claim stored under another's.
+// NOTHING ELSE IS FORGIVEN, and the padded limb is the half that says so: an
+// implementation that reached for strings.TrimSpace to make the respelled limb
+// pass would release on an expectation the caller never actually held.
+//
+// The two limbs are ONE case rather than two because they are one predicate,
+// and a reader who sees only the forgiving half draws exactly the wrong
+// conclusion about the other.
 func RunReleaserReleasesOnlyTheExpectedHolder(t *testing.T, ctx context.Context, fixture ReleaserFixture) {
 	t.Helper()
 	stale := "releaser-previous-holder"
@@ -236,6 +250,38 @@ func RunReleaserReleasesOnlyTheExpectedHolder(t *testing.T, ctx context.Context,
 		t.Errorf("Changed = false, want true for a conditional release that wrote the row")
 	}
 	releaserAssertRow(t, ctx, fixture, "issues", matched, "", types.StatusOpen)
+
+	// releaserHolder spelled with the other separator: "releaser_holder"
+	// against a row holding "releaser-holder". Both canonicalize to one
+	// identity, so the release lands.
+	respelled := strings.ReplaceAll(releaserHolder, "-", "_")
+	if respelled == releaserHolder {
+		t.Fatalf("releaserHolder %q carries no separator to respell — this limb would assert nothing", releaserHolder)
+	}
+	separatorSpelled := releaserSeedClaimed(t, ctx, fixture, "expect", "respelled", false)
+	if _, err := fixture.Releaser.Release(ctx, publicops.ReleaseRequest{
+		Actor: "releaser-supervisor", IssueID: separatorSpelled, ExpectedAssignee: &respelled,
+	}); err != nil {
+		t.Fatalf("Release() expecting %q against a claim held by %q error = %v, want the release to land — the comparison is separator-insensitive",
+			respelled, releaserHolder, err)
+	}
+	releaserAssertRow(t, ctx, fixture, "issues", separatorSpelled, "", types.StatusOpen)
+
+	// The other half of the same predicate: separators are all that is
+	// forgiven. A padded expectation is a different string and refuses, and the
+	// claim it named is still there afterwards.
+	padded := " " + releaserHolder
+	untouched := releaserSeedClaimed(t, ctx, fixture, "expect", "padded", false)
+	paddedVersion := releaserRowVersion(t, ctx, fixture, untouched)
+	if _, err := fixture.Releaser.Release(ctx, publicops.ReleaseRequest{
+		Actor: "releaser-supervisor", IssueID: untouched, ExpectedAssignee: &padded,
+	}); !errors.Is(err, publicops.ErrAssigneeMismatch) {
+		t.Fatalf("Release() expecting %q error = %v, want ErrAssigneeMismatch — the value is not trimmed", padded, err)
+	}
+	releaserAssertRow(t, ctx, fixture, "issues", untouched, releaserHolder, types.StatusInProgress)
+	if got := releaserRowVersion(t, ctx, fixture, untouched); got != paddedVersion {
+		t.Errorf("a refused padded expectation moved the row version")
+	}
 }
 
 // RunReleaserRefusesAnUnheldIssue pins the three answers an unheld row gets

--- a/internal/storage/dolt/crosstier_dep_test.go
+++ b/internal/storage/dolt/crosstier_dep_test.go
@@ -317,3 +317,60 @@ func TestRunInTransactionMixedTierCycleSameTierClosingEdgeRejected(t *testing.T)
 	// The committed C -> W edge is untouched by the rolled-back transaction.
 	assertDepEdge(ctx, t, store, regularC.ID, wispW.ID)
 }
+
+// The gate's guard arm: an edge OUTSIDE the scheduling set is waved through
+// even when it CLOSES A LOOP in the scheduling graph, because a non-scheduling
+// edge cannot deadlock ready-work computation and so is not a cycle to reject.
+//
+// THE SHAPE IS THE POINT, and it is why the edge type is the only difference
+// between this case and TestRunInTransactionCrossTierCycleRejected: a committed
+// scheduling edge R -> W already exists, and the edge under test runs W -> R.
+// Were the guard to stop excusing the type, the merged two-session probe would
+// find W -> R -> W and refuse — so this case fails the moment the arm stops
+// answering "not my edge type", which is what makes it worth its runtime.
+//
+// It is the arm worth pinning because it is the SILENT one. It refuses nothing
+// and logs nothing, so the day types.IsSchedulingEdge grows a fifth member, a
+// stale inline copy of that set here would drop the new type into this arm and
+// commit real cycles with no signal at all (ga-2ltro.10).
+func TestRunInTransactionCrossTierNonSchedulingEdgeIsNotGated(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	regular := crossTierRegularIssue("test-xtier-related-regular", "regular issue in cross-tier related loop")
+	if err := store.CreateIssue(ctx, regular, "tester"); err != nil {
+		t.Fatalf("CreateIssue regular: %v", err)
+	}
+	wisp := crossTierWispIssue("test-xtier-related-wisp", "wisp in cross-tier related loop")
+	if err := store.CreateIssue(ctx, wisp, "tester"); err != nil {
+		t.Fatalf("CreateIssue wisp: %v", err)
+	}
+
+	// Committed scheduling edge R -> W, the half that puts a path in the graph.
+	if err := store.RunInTransaction(ctx, "seed committed R blocks-on W", func(tx storage.Transaction) error {
+		return tx.AddDependency(ctx, &types.Dependency{
+			IssueID:     regular.ID,
+			DependsOnID: wisp.ID,
+			Type:        types.DepBlocks,
+		}, "tester")
+	}); err != nil {
+		t.Fatalf("seed committed R -> W edge: %v", err)
+	}
+
+	// The edge under test closes the loop W -> R, but as `related`.
+	if err := store.RunInTransaction(ctx, "test: cross-tier related edge closing a scheduling loop", func(tx storage.Transaction) error {
+		return tx.AddDependency(ctx, &types.Dependency{
+			IssueID:     wisp.ID,
+			DependsOnID: regular.ID,
+			Type:        types.DepRelated,
+		}, "tester")
+	}); err != nil {
+		t.Fatalf("RunInTransaction error = %v, want the related edge to land — `related` is outside the scheduling set", err)
+	}
+
+	assertDepEdge(ctx, t, store, wisp.ID, regular.ID)
+	assertDepEdge(ctx, t, store, regular.ID, wisp.ID)
+}

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -1114,16 +1114,17 @@ func (t *doltTransaction) readDepTargetForPrecheck(ctx context.Context, sourceID
 	return &p, nil
 }
 
-// checkCrossTierSchedulingCycle rejects a scheduling edge (blocks,
-// conditional-blocks, parent-child — the same set issueops.CheckDependencyCycleInTx
-// gates) that would close a cycle, using the merged view of both sessions'
-// dependency tables. The in-tx cycle check scans both tables on the write tx
-// and so misses edges added on the other session earlier in this logical
-// transaction.
+// checkCrossTierSchedulingCycle rejects a scheduling edge that would close a
+// cycle, using the merged view of both sessions' dependency tables. The in-tx
+// cycle check scans both tables on the write tx and so misses edges added on
+// the other session earlier in this logical transaction.
+//
+// The set is types.IsSchedulingEdge's, by call and not by restatement: an
+// inline copy that missed a fifth scheduling type would fall through to
+// "not a scheduling edge" and skip this gate entirely, which is silence rather
+// than a failure — the whole reason that predicate was consolidated (ga-2ltro.10).
 func (t *doltTransaction) checkCrossTierSchedulingCycle(ctx context.Context, dep *types.Dependency) error {
-	switch dep.Type {
-	case types.DepBlocks, types.DepConditionalBlocks, types.DepParentChild:
-	default:
+	if !types.IsSchedulingEdge(dep.Type) {
 		return nil
 	}
 	cycle, err := t.CycleThroughEdges(ctx, [][2]string{{dep.IssueID, dep.DependsOnID}})

--- a/internal/storage/hook_batch_applier.go
+++ b/internal/storage/hook_batch_applier.go
@@ -30,13 +30,13 @@ type hookBatchApplier struct {
 // all when the batch refused — the request is all or nothing, so a refusal left
 // no row for a script to be told about.
 //
-// IT FIRES ON LANDED, NOT ON "no error". That is the one place this wrapper
-// deliberately differs from its closest sibling: hookBatchCloser fires for
-// every outcome whose Err is nil, including an idempotent re-close that wrote
-// nothing, so a replayed teardown runs the workspace's on_close script on every
-// pass. There are no per-item errors here to make that mistake with, and
-// ItemResult.Changed is the fact a script cares about, so a no-op update, an
-// idempotent re-close and an edge that was already there fire nothing.
+// IT FIRES ON LANDED, NOT ON "no error". There are no per-item errors here to
+// make that mistake with, and ItemResult.Changed is the fact a script cares
+// about, so a no-op update, an idempotent re-close and an edge that was already
+// there fire nothing. hookBatchCloser once tested a nil per-item Err instead
+// and announced every idempotent re-close, running the workspace's on_close
+// script on every replayed teardown (ga-2yaqp.1); it now fires on Changed too,
+// so the two siblings state one rule rather than two.
 //
 // A CREATE ALWAYS FIRES because a create always landed; the role has no
 // idempotent create.

--- a/internal/storage/hook_batch_applier_test.go
+++ b/internal/storage/hook_batch_applier_test.go
@@ -130,10 +130,10 @@ func TestHookBatchApplierFiresPerLandedItem(t *testing.T) {
 			want: []string{"create:bd-1", "update:bd-2", "close:bd-3"},
 		},
 		{
-			// The sibling bug NOT to copy: hookBatchCloser fires for every
-			// outcome whose Err is nil, so an idempotent re-close runs the
-			// workspace's on_close script on every replayed pass. Changed is
-			// the fact a script cares about.
+			// Changed is the fact a script cares about, not "no error".
+			// hookBatchCloser tested a nil per-item Err here and ran the
+			// workspace's on_close script on every replayed pass (ga-2yaqp.1);
+			// its own table pins the same rule now.
 			name: "an item that changed nothing fires nothing",
 			applier: &fakeBatchApplier{result: issueops.ApplyBatchResult{Items: []issueops.ItemResult{
 				batchApplyItemResult(issueops.ItemUpdate, "bd-1", false),

--- a/internal/storage/hook_batch_closer.go
+++ b/internal/storage/hook_batch_closer.go
@@ -30,6 +30,18 @@ type hookBatchCloser struct {
 // batch because a hook script is written against one issue: collapsing N
 // closes into one firing would silently stop reporting N-1 of them.
 //
+// CHANGED IS THE TEST for "landed", not a nil per-item Err — the rule
+// issueops.CloseOutcome.Changed states and the sibling hookBatchApplier applies
+// to its own ItemClose. An idempotent re-close is a per-item SUCCESS that
+// persisted nothing, so announcing it would run the workspace's on_close script
+// again on every replayed teardown, for a close that already happened.
+//
+// THE SINGLE-CLOSE PATHS DELIBERATELY DIFFER: HookFiringStore.CloseIssueChecked
+// and hookIssueOperations.Close both fire on any success, re-close included,
+// for the legacy parity their own comments claim. The batch verbs are where a
+// replay is cheap to produce and N times as loud, which is why they answer the
+// narrower question. uow's notifying parity table pins both halves.
+//
 // The claim, when one happened, fires the update hook the claim paths fire,
 // after the closes — the same order the transaction applied them in.
 func (o *hookBatchCloser) CloseBatch(ctx context.Context, request issueops.CloseBatchRequest) (issueops.CloseBatchResult, error) {
@@ -38,7 +50,7 @@ func (o *hookBatchCloser) CloseBatch(ctx context.Context, request issueops.Close
 		return result, err
 	}
 	for _, outcome := range result.Outcomes {
-		if outcome.Err == nil {
+		if outcome.Changed {
 			o.hooks.CompleteIssueOperationClose(outcome.Issue)
 		}
 	}

--- a/internal/storage/hook_batch_closer.go
+++ b/internal/storage/hook_batch_closer.go
@@ -36,6 +36,12 @@ type hookBatchCloser struct {
 // persisted nothing, so announcing it would run the workspace's on_close script
 // again on every replayed teardown, for a close that already happened.
 //
+// BOTH WRITE PLUMBINGS ANSWER THIS WAY. The proxied-server path composes the
+// same close through a unit of work, and its batch compositions
+// (uow.closeBatchItem, uowApplyRun.applyClose) rewind the recorded notification
+// for an item that persisted nothing — so `bd serve` and the direct store agree
+// about what a replayed teardown announces.
+//
 // THE SINGLE-CLOSE PATHS DELIBERATELY DIFFER: HookFiringStore.CloseIssueChecked
 // and hookIssueOperations.Close both fire on any success, re-close included,
 // for the legacy parity their own comments claim. The batch verbs are where a

--- a/internal/storage/hook_batch_closer_test.go
+++ b/internal/storage/hook_batch_closer_test.go
@@ -68,31 +68,75 @@ func TestHookFiringStoreBatchCloserPropagatesInnerError(t *testing.T) {
 
 // TestHookBatchCloserFiresOncePerLandedItem pins the rule that makes a batch
 // close indistinguishable from N single closes as far as a hook script can
-// tell: one firing per item that landed, in request order, and none for an
-// item that refused. Collapsing the batch into one firing would silently stop
-// reporting every close but one.
+// tell: one firing per item that LANDED, in request order, and none for an
+// item that refused or changed nothing. Collapsing the batch into one firing
+// would silently stop reporting every close but one.
+//
+// It records the ID each hook was fired for, using the sibling applier's
+// recorder, because half these rows are about WHICH item fires: a recorder
+// that only counted firings would pass a wrapper that announced the re-close
+// and dropped the real one.
 func TestHookBatchCloserFiresOncePerLandedItem(t *testing.T) {
 	issue := func(id string) *types.Issue { return &types.Issue{ID: id} }
-	inner := &fakeBatchCloser{result: issueops.CloseBatchResult{
-		Outcomes: []issueops.CloseOutcome{
-			{IssueID: "bd-1", Issue: issue("bd-1")},
-			{IssueID: "bd-2", Err: errors.New("refused")},
-			{IssueID: "bd-3", Issue: issue("bd-3")},
+	for _, test := range []struct {
+		name  string
+		inner *fakeBatchCloser
+		want  []string
+	}{
+		{
+			// The claim's update fires last, matching the order the
+			// transaction applied them in: the closes, then the claim.
+			name: "each landed item fires its own hook, in request order, and the claim's update fires last",
+			inner: &fakeBatchCloser{result: issueops.CloseBatchResult{
+				Outcomes: []issueops.CloseOutcome{
+					{IssueID: "bd-1", Issue: issue("bd-1"), Changed: true},
+					{IssueID: "bd-2", Err: errors.New("refused")},
+					{IssueID: "bd-3", Issue: issue("bd-3"), Changed: true},
+				},
+				ClaimedNext: &types.IssueWithCounts{Issue: issue("bd-4")},
+			}},
+			want: []string{"close:bd-1", "close:bd-3", "update:bd-4"},
 		},
-		ClaimedNext: &types.IssueWithCounts{Issue: issue("bd-4")},
-	}}
-	recorder := &recordingIssueOperationHooks{}
-	closer := &hookBatchCloser{inner: inner, hooks: recorder}
+		{
+			// CHANGED IS THE TEST, not a nil per-item Err: an idempotent
+			// re-close is a per-item SUCCESS that wrote nothing
+			// (issueops.CloseOutcome.Changed), so a teardown replayed against
+			// an already-closed convoy would otherwise run the workspace's
+			// on_close script on every pass. The batch also earns no claim,
+			// for the reason BatchCloseRequest.ClaimNext gives.
+			name: "an idempotent re-close fires nothing",
+			inner: &fakeBatchCloser{result: issueops.CloseBatchResult{
+				Outcomes: []issueops.CloseOutcome{
+					{IssueID: "bd-1", Issue: issue("bd-1")},
+					{IssueID: "bd-2", Issue: issue("bd-2")},
+				},
+			}},
+			want: nil,
+		},
+		{
+			// The discriminating row: a replay where one item was still open.
+			// Only that item is a script's business.
+			name: "a re-close beside a real close announces only the close that landed",
+			inner: &fakeBatchCloser{result: issueops.CloseBatchResult{
+				Outcomes: []issueops.CloseOutcome{
+					{IssueID: "bd-1", Issue: issue("bd-1")},
+					{IssueID: "bd-2", Issue: issue("bd-2"), Changed: true},
+				},
+			}},
+			want: []string{"close:bd-2"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			recorder := &recordingBatchApplyHooks{}
+			closer := &hookBatchCloser{inner: test.inner, hooks: recorder}
 
-	if _, err := closer.CloseBatch(context.Background(), issueops.CloseBatchRequest{Actor: "worker"}); err != nil {
-		t.Fatalf("CloseBatch() error = %v", err)
-	}
-
-	// The claim's update fires last, matching the order the transaction
-	// applied them in: the closes, then the claim.
-	want := []string{"close", "close", "update"}
-	if !reflect.DeepEqual(recorder.completions, want) {
-		t.Fatalf("hooks fired = %v, want %v", recorder.completions, want)
+			if _, err := closer.CloseBatch(context.Background(), issueops.CloseBatchRequest{Actor: "worker"}); err != nil {
+				t.Fatalf("CloseBatch() error = %v", err)
+			}
+			if !reflect.DeepEqual(recorder.completions, test.want) {
+				t.Fatalf("hooks fired = %v, want %v", recorder.completions, test.want)
+			}
+		})
 	}
 }
 

--- a/internal/storage/hook_batch_closer_test.go
+++ b/internal/storage/hook_batch_closer_test.go
@@ -103,7 +103,7 @@ func TestHookBatchCloserFiresOncePerLandedItem(t *testing.T) {
 			// (issueops.CloseOutcome.Changed), so a teardown replayed against
 			// an already-closed convoy would otherwise run the workspace's
 			// on_close script on every pass. The batch also earns no claim,
-			// for the reason BatchCloseRequest.ClaimNext gives.
+			// for the reason issueops.CloseBatchRequest.ClaimNext gives.
 			name: "an idempotent re-close fires nothing",
 			inner: &fakeBatchCloser{result: issueops.CloseBatchResult{
 				Outcomes: []issueops.CloseOutcome{

--- a/internal/storage/hook_decorator.go
+++ b/internal/storage/hook_decorator.go
@@ -218,6 +218,11 @@ func (h *HookFiringStore) CloseIssue(ctx context.Context, id string, reason stri
 // on_close on success — mirroring CloseIssue, this includes the idempotent
 // no-op when the issue was already closed (res.Unchanged). A guard rejection
 // (ErrCloseBlocked) or any other error returns without firing.
+//
+// THE BATCH VERBS DO NOT FOLLOW THIS RULE: hookBatchCloser and hookBatchApplier
+// fire per item on Changed, so a replayed teardown does not re-run on_close N
+// times (ga-2yaqp.1). This single close keeps the firing because one re-close
+// is one answer to one question a script asked.
 func (h *HookFiringStore) CloseIssueChecked(ctx context.Context, id string, actor string, opts CloseIssueOptions) (CloseIssueResult, error) {
 	res, err := h.inner.CloseIssueChecked(ctx, id, actor, opts)
 	if err != nil {

--- a/internal/storage/hook_issue_operations.go
+++ b/internal/storage/hook_issue_operations.go
@@ -75,7 +75,9 @@ func (o *hookIssueOperations) Close(ctx context.Context, request issueops.CloseR
 
 // Reopen suppresses the update hook on a no-op, matching the legacy reopen
 // path (hookTrackingLifecycleTransaction.ReopenIssueWithResult). Close and
-// Update stay unconditional on success, also matching their legacy paths.
+// Update stay unconditional on success, also matching their legacy paths —
+// unlike the BATCH close verbs, which fire on Changed so that a replayed
+// teardown does not re-run on_close per item (hookBatchCloser, ga-2yaqp.1).
 func (o *hookIssueOperations) Reopen(ctx context.Context, request issueops.ReopenRequest) (issueops.ReopenResult, error) {
 	result, err := o.inner.Reopen(ctx, request)
 	if err == nil && result.Changed {

--- a/internal/storage/uow/batch_applier.go
+++ b/internal/storage/uow/batch_applier.go
@@ -322,6 +322,11 @@ func (r *uowApplyRun) applyClose(ctx context.Context, index int, item *publicops
 	}
 	params := domain.CloseIssueParams{Reason: item.Reason, Session: item.Session}
 	var closed domain.CloseIssueResult
+	// Marked after the ExpectedVersion update above, so a rewind drops this
+	// item's close and not that update's notification. See closeBatchItem: the
+	// shared close verbs announce every success, and a batch item must announce
+	// only what it actually persisted (ga-2yaqp.1).
+	mark := markBatchNotifications(r.uw)
 	if useWisp {
 		closed, err = r.uw.IssueUseCase().CloseWispChecked(ctx, id, params, r.plan.Actor, item.Force)
 	} else {
@@ -338,6 +343,9 @@ func (r *uowApplyRun) applyClose(ctx context.Context, index int, item *publicops
 		return err
 	}
 	closeChanged := !semanticIssueEqual(before, hydrated)
+	if !closeChanged {
+		rewindBatchNotifications(r.uw, mark)
+	}
 	r.write.Changed = r.write.Changed || closeChanged
 	r.result.Items[index] = publicops.ItemResult{
 		Kind:       publicops.ItemClose,

--- a/internal/storage/uow/batch_closer.go
+++ b/internal/storage/uow/batch_closer.go
@@ -96,6 +96,12 @@ func closeBatchItem(ctx context.Context, uw UnitOfWork, request publicops.CloseB
 
 	params := domain.CloseIssueParams{Reason: item.Reason, Session: request.Session}
 	var closed domain.CloseIssueResult
+	// The close verbs announce every success, re-close included, because a
+	// SINGLE close must. A batch item must not: a teardown replayed against an
+	// already-closed convoy would run the workspace's on_close script once per
+	// item on every pass (ga-2yaqp.1). The mark is taken here rather than at the
+	// top of the function so it covers the close and nothing else.
+	mark := markBatchNotifications(uw)
 	if isWisp {
 		closed, err = uw.IssueUseCase().CloseWispChecked(ctx, item.IssueID, params, request.Actor, request.Force)
 	} else {
@@ -103,6 +109,9 @@ func closeBatchItem(ctx context.Context, uw UnitOfWork, request publicops.CloseB
 	}
 	if err != nil {
 		return publicops.CloseOutcome{IssueID: item.IssueID, Err: err}
+	}
+	if !closed.Closed {
+		rewindBatchNotifications(uw, mark)
 	}
 	if closed.Issue != nil {
 		current = closed.Issue

--- a/internal/storage/uow/notifying.go
+++ b/internal/storage/uow/notifying.go
@@ -518,6 +518,56 @@ func (r *recorder) record(op string, issue *types.Issue) {
 
 func (r *recorder) drain() []mutationEntry { e := r.entries; r.entries = nil; return e }
 
+// batchNotificationBuffer is this decorator seen from the BATCH COMPOSITIONS in
+// this package. They need it because the close verbs are shared: a single close
+// and a batch item reach the same recordingIssueUC method, and the two have
+// different firing rules — the single close announces an idempotent re-close,
+// the batch verbs do not (ga-2yaqp.1). Gating inside the verb would change both.
+//
+// So the composition marks the buffer before the item's close and rewinds to
+// that mark when the close turned out to have persisted nothing. Rewinding
+// rather than not-recording is what keeps the rule where it belongs: the verb
+// stays honest about what it did, and the composition decides what is worth
+// telling a script about.
+//
+// It is an interface rather than a concrete field because a UnitOfWork is only
+// sometimes this decorator — with hooks disabled NewNotifyingProvider hands back
+// the inner provider unwrapped, and then there is no buffer and nothing to do.
+type batchNotificationBuffer interface {
+	markNotifications() int
+	rewindNotifications(mark int)
+}
+
+func (u *notifyingUOW) markNotifications() int { return len(u.rec.entries) }
+
+func (u *notifyingUOW) rewindNotifications(mark int) {
+	if mark >= 0 && mark <= len(u.rec.entries) {
+		u.rec.entries = u.rec.entries[:mark]
+	}
+}
+
+// markBatchNotifications returns a rewind token for a batch item's close, or -1
+// when this unit of work buffers nothing.
+func markBatchNotifications(uw UnitOfWork) int {
+	if buf, ok := uw.(batchNotificationBuffer); ok {
+		return buf.markNotifications()
+	}
+	return -1
+}
+
+// rewindBatchNotifications drops whatever a batch item's close buffered. The
+// caller has established the item changed nothing, which is the only thing that
+// makes discarding a recorded mutation safe: nothing observes the buffer before
+// Commit drains it.
+func rewindBatchNotifications(uw UnitOfWork, mark int) {
+	if mark < 0 {
+		return
+	}
+	if buf, ok := uw.(batchNotificationBuffer); ok {
+		buf.rewindNotifications(mark)
+	}
+}
+
 // The recorder's op vocabulary. These name what happened; hookEventForOp maps
 // them to the three events internal/hooks publishes.
 const (
@@ -1038,10 +1088,17 @@ func (u *recordingIssueUC) ClaimReadyWisp(ctx context.Context, filter types.Work
 
 // CloseIssue and its three siblings record on SUCCESS, not on "something
 // changed": the DoltStorage plumbing fires on_close for an idempotent re-close
-// too — HookFiringStore.CloseIssueChecked says so in as many words, and
-// hookBatchCloser fires for every outcome that did not refuse. A close that
-// found the issue already closed still answers "it is closed", and a script
-// that reconciles on that answer must not be told only sometimes.
+// too — HookFiringStore.CloseIssueChecked says so in as many words. A close
+// that found the issue already closed still answers "it is closed", and a
+// script that reconciles on that answer must not be told only sometimes.
+//
+// THE BATCH COMPOSITIONS OVERRIDE THAT, and they do it above these verbs rather
+// than inside them, because these are the SAME methods a single close reaches.
+// closeBatchItem and uowApplyRun.applyClose rewind the recorded notification
+// when the item persisted nothing, matching hookBatchCloser and hookBatchApplier
+// on the other plumbing (ga-2yaqp.1) — otherwise a teardown replayed against an
+// already-closed convoy runs on_close once per item on every pass. Gate here
+// and the single close would lose its re-close firing with it.
 //
 // The snapshot read is PLANE-PINNED to the verb that was called, while the verb
 // itself tolerates an id from either plane. That gap is unreachable as shipped:

--- a/internal/storage/uow/notifying_test.go
+++ b/internal/storage/uow/notifying_test.go
@@ -3,11 +3,13 @@ package uow
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/hooks"
 	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/types"
+	publicops "github.com/steveyegge/beads/issueops"
 )
 
 // ── Fakes ───────────────────────────────────────────────────────────
@@ -59,10 +61,14 @@ func newNotifyIssueUC(issues ...*types.Issue) *notifyIssueUC {
 	return uc
 }
 
+// GetIssue and GetWisp answer a miss with ErrNotFound rather than a bare
+// error, because operationIssue tells "this id is not on that plane" from "that
+// plane is broken" by that sentinel alone: a bare error there aborts the
+// two-plane resolve instead of falling through to the other plane.
 func (u *notifyIssueUC) GetIssue(_ context.Context, id string) (*types.Issue, error) {
 	issue, ok := u.issues[id]
 	if !ok {
-		return nil, errors.New("no such issue")
+		return nil, fmt.Errorf("%w: issue %s", publicops.ErrNotFound, id)
 	}
 	return issue, nil
 }
@@ -70,7 +76,7 @@ func (u *notifyIssueUC) GetIssue(_ context.Context, id string) (*types.Issue, er
 func (u *notifyIssueUC) GetWisp(_ context.Context, id string) (*types.Issue, error) {
 	wisp, ok := u.wisps[id]
 	if !ok {
-		return nil, errors.New("no such wisp")
+		return nil, fmt.Errorf("%w: wisp %s", publicops.ErrNotFound, id)
 	}
 	return wisp, nil
 }
@@ -265,6 +271,23 @@ func (f *notifyFixture) newUOW(t *testing.T) UnitOfWork {
 
 func seedIssue(id string) *types.Issue {
 	return &types.Issue{ID: id, Title: id, Status: types.StatusOpen}
+}
+
+// closeThroughBatch closes ids through the REAL batch composition rather than
+// through the use case directly. That is the whole point of the rows that call
+// it: closeBatchItem and the single close reach the same recording verb, so
+// only a test that goes through the composition can tell the two firing rules
+// apart.
+func closeThroughBatch(ctx context.Context, t *testing.T, uw UnitOfWork, ids ...string) {
+	t.Helper()
+	for _, id := range ids {
+		outcome := closeBatchItem(ctx, uw,
+			publicops.CloseBatchRequest{Actor: "tester"},
+			publicops.BatchCloseItem{IssueID: id})
+		if outcome.Err != nil {
+			t.Fatalf("closeBatchItem(%s): %v", id, outcome.Err)
+		}
+	}
 }
 
 // ── The contract ────────────────────────────────────────────────────
@@ -495,11 +518,11 @@ func TestNotifyingUOWOpToHookEventMapping(t *testing.T) {
 			// answers "it is closed", and a script reconciling on that answer
 			// must not be told only sometimes.
 			//
-			// THE BATCH PATHS DISAGREE WITH THIS ONE, deliberately and as of
-			// ga-2yaqp.1: hookBatchCloser and hookBatchApplier both fire on
-			// Changed, so a replayed teardown does not re-run on_close per
-			// item. This single-close path keeps legacy parity, which is why
-			// the divergence is pinned here rather than left to be discovered.
+			// THE BATCH COMPOSITIONS DISAGREE WITH THIS ONE, deliberately and
+			// as of ga-2yaqp.1 — see the two rows below, which are the same
+			// verb reached through closeBatchItem. This SINGLE close keeps the
+			// legacy parity; the batch verbs gate on Changed. The divergence is
+			// pinned on both sides here rather than left to be discovered.
 			name:   "a re-close still reports the close",
 			parity: "HookFiringStore.CloseIssueChecked fires on_close on success, unchanged rows included",
 			run: func(ctx context.Context, t *testing.T, uw UnitOfWork) {
@@ -510,6 +533,43 @@ func TestNotifyingUOWOpToHookEventMapping(t *testing.T) {
 				}
 			},
 			want: []firedHook{{hooks.EventClose, "bd-1"}, {hooks.EventClose, "bd-1"}},
+		},
+		{
+			// The batch half of the row above, and the reason this plumbing
+			// needed its own fix: closeBatchItem reaches the SAME recording
+			// verb, so before ga-2yaqp.1 a teardown replayed against an
+			// already-closed convoy ran the workspace's on_close script once
+			// per item on every pass. Proxied mode — which is what `bd serve`
+			// runs — is this plumbing, so that was the user-visible symptom.
+			name:   "a batch re-close reports the close once",
+			parity: "hookBatchCloser fires per outcome whose Changed is set, so the second pass announces nothing",
+			run: func(ctx context.Context, t *testing.T, uw UnitOfWork) {
+				for i := 0; i < 2; i++ {
+					closeThroughBatch(ctx, t, uw, "bd-1")
+				}
+			},
+			want: []firedHook{{hooks.EventClose, "bd-1"}},
+		},
+		{
+			// The discriminating row: a replay where one item was still open.
+			// Only that item is a script's business, and a wrapper that
+			// announced the whole pass would be indistinguishable from one that
+			// announced the right item on the rows above.
+			name:   "a batch pass announces only the close that landed",
+			parity: "hookBatchCloser's mixed re-close row: the landed item fires, the idempotent one does not",
+			run: func(ctx context.Context, t *testing.T, uw UnitOfWork) {
+				if _, err := uw.IssueUseCase().CreateIssue(ctx, domain.CreateIssueParams{Issue: seedIssue("bd-2")}, "tester"); err != nil {
+					t.Fatalf("CreateIssue: %v", err)
+				}
+				closeThroughBatch(ctx, t, uw, "bd-1")
+				// The replayed pass: bd-1 is already closed, bd-2 is not.
+				closeThroughBatch(ctx, t, uw, "bd-1", "bd-2")
+			},
+			want: []firedHook{
+				{hooks.EventCreate, "bd-2"},
+				{hooks.EventClose, "bd-1"},
+				{hooks.EventClose, "bd-2"},
+			},
 		},
 		{
 			// The far end of a REVERSE edge: the create wrote an edge leaving
@@ -821,4 +881,35 @@ func assertFired(t *testing.T, got, want []firedHook) {
 			t.Fatalf("fired %v, want %v", got, want)
 		}
 	}
+}
+
+// TestNotifyingUOWBatchApplierAnnouncesOnlyLandedCloses is the BatchApplier's
+// half of the batch firing rule the parity table pins for closeBatchItem. Both
+// compositions reach the same recording close verb, so both had the same defect
+// and both need their own case: a fix applied to one of them passes the other's
+// tests untouched (ga-2yaqp.1).
+//
+// The batch mixes a row that is already closed with one that is not, which is
+// the shape a replayed teardown produces. Only the row that actually closed is
+// a script's business.
+func TestNotifyingUOWBatchApplierAnnouncesOnlyLandedCloses(t *testing.T) {
+	closedAlready := seedIssue("bd-closed")
+	closedAlready.Status = types.StatusClosed
+	f := newNotifyFixture(t, closedAlready, seedIssue("bd-open"))
+
+	applier, err := NewBatchApplier(f.provider)
+	if err != nil {
+		t.Fatalf("NewBatchApplier: %v", err)
+	}
+	if _, err := applier.ApplyBatch(context.Background(), publicops.ApplyBatchRequest{
+		Actor: "tester",
+		Items: []publicops.ApplyItem{
+			{Kind: publicops.ItemClose, Close: &publicops.CloseItem{Target: publicops.Ref{ID: "bd-closed"}}},
+			{Kind: publicops.ItemClose, Close: &publicops.CloseItem{Target: publicops.Ref{ID: "bd-open"}}},
+		},
+	}); err != nil {
+		t.Fatalf("ApplyBatch: %v", err)
+	}
+
+	assertFired(t, f.runner.events(), []firedHook{{hooks.EventClose, "bd-open"}})
 }

--- a/internal/storage/uow/notifying_test.go
+++ b/internal/storage/uow/notifying_test.go
@@ -491,10 +491,15 @@ func TestNotifyingUOWOpToHookEventMapping(t *testing.T) {
 			// The one predicate that reads backwards at first glance, and the
 			// reason it is spelled out: HookFiringStore.CloseIssueChecked fires
 			// on_close for the idempotent no-op too ("this includes the
-			// idempotent no-op when the issue was already closed"), and
-			// hookBatchCloser fires for every outcome that did not refuse. A
-			// re-close answers "it is closed", and a script reconciling on that
-			// answer must not be told only sometimes.
+			// idempotent no-op when the issue was already closed"). A re-close
+			// answers "it is closed", and a script reconciling on that answer
+			// must not be told only sometimes.
+			//
+			// THE BATCH PATHS DISAGREE WITH THIS ONE, deliberately and as of
+			// ga-2yaqp.1: hookBatchCloser and hookBatchApplier both fire on
+			// Changed, so a replayed teardown does not re-run on_close per
+			// item. This single-close path keeps legacy parity, which is why
+			// the divergence is pinned here rather than left to be discovered.
 			name:   "a re-close still reports the close",
 			parity: "HookFiringStore.CloseIssueChecked fires on_close on success, unchanged rows included",
 			run: func(ctx context.Context, t *testing.T, uw UnitOfWork) {

--- a/issueops/releaser.go
+++ b/issueops/releaser.go
@@ -21,7 +21,9 @@ type ReleaseRequest struct {
 	// is the current holder. That is not authentication — Actor is
 	// caller-asserted provenance here as it is everywhere else in this package
 	// — it is the same anti-yank guard ClaimRequest gets from refusing a
-	// foreign holder, pointed the other way.
+	// foreign holder, pointed the other way. "Is the current holder" is the
+	// same separator-insensitive comparison ExpectedAssignee documents below,
+	// not exact equality.
 	Actor string
 	// IssueID is the exact canonical id and must not be empty.
 	//
@@ -49,12 +51,17 @@ type ReleaseRequest struct {
 	// wants, and it is safer than Force for the purpose because it cannot
 	// release a claim that has since moved.
 	//
-	// HOLDERS COMPARE BYTE FOR BYTE, not trimmed and not folded: " agent-a" is
-	// not agent-a and will refuse. The validation below trims only far enough to
-	// tell a blank expectation from a real one, and never writes the trimmed
-	// form back — the no-mutation promise above makes that permanent, so a
-	// caller that pads its expectation loses every time rather than
-	// intermittently. Compose it from a holder a read gave you.
+	// THE COMPARISON IS SEPARATOR-INSENSITIVE AND NOTHING ELSE. A run of ".",
+	// "_" or "-" matches any other such run, so "agent-a", "agent_a" and
+	// "agent.a" are one holder — that is deliberate, so a caller naming the
+	// holder under a different layer's spelling is a match rather than a
+	// mismatch (ga-5ksp5). NOTHING ELSE IS FORGIVEN: the value is not trimmed
+	// and not case-folded, so " agent-a" and "Agent-a" are both refusals. The
+	// validation below trims only far enough to tell a blank expectation from a
+	// real one, and never writes the trimmed form back — the no-mutation
+	// promise above makes that permanent, so a caller that pads its expectation
+	// loses every time rather than intermittently. Compose it from a holder a
+	// read gave you.
 	//
 	// nil DISABLES THE CHECK and selects the unconditional path. It is a
 	// pointer so that "do not check" is distinct from a value — but unlike


### PR DESCRIPTION
Three small, independent defects from the ext-api-store program, bundled into
one PR because they share no files and reviewing them separately costs more
than it saves. **One commit per defect**, plus a fourth carrying the review
fixes (kept separate so the verification pass can diff exactly what changed).

| Commit | Bead | Subject |
| --- | --- | --- |
| 1 | ga-2yaqp.1 | `hookBatchCloser` fired on a nil per-item `Err`, so replayed teardowns re-ran `on_close` |
| 2 | ga-2ltro.10 | the fifth inline scheduling-set walker `#5480` missed |
| 3 | ga-2ltro.14 | the Releaser leaf and the shipped wire spec contradicted each other about a CAS predicate |
| 4 | ga-2yaqp.1 | **review fix:** the same defect in the SECOND write plumbing (proxied/uow), plus the review's doc corrections |

No wire changes. `make api-check` is clean and the generated spec/types are
untouched.

---

### 1 — `fix(storage)`: fire the batch-close hook on `Changed` (ga-2yaqp.1)

`hookBatchCloser.CloseBatch` tested `outcome.Err == nil`. An idempotent
re-close is a per-item **success that persisted nothing**, so it announced
itself exactly like a close that landed — and a teardown replayed against an
already-closed convoy ran the workspace's `on_close` script again on every
pass, once per item.

The wrapper's own header already claimed per-LANDED-item firing, and the
sibling `hookBatchApplier` fires its `ItemClose` on `Changed` and explicitly
named this predicate as the bug not to copy. The predicate now matches both,
and the two comments that described the bug as live are now history.

**Evidence.** The firing test becomes a table modelled on the applier's,
recording the id each hook fired for. Two new rows, both red against the old
predicate:

```
--- FAIL: TestHookBatchCloserFiresOncePerLandedItem/an_idempotent_re-close_fires_nothing
    hooks fired = [close:bd-1 close:bd-2], want []
--- FAIL: TestHookBatchCloserFiresOncePerLandedItem/a_re-close_beside_a_real_close_announces_only_the_close_that_landed
    hooks fired = [close:bd-1 close:bd-2], want [close:bd-2]
```

Green after the change; `internal/storage` and `internal/storage/uow` both pass.

> **Two premise corrections, both worth reading before review.**
>
> **(a) It was not the sole outlier among five wrappers.** The **single**-close
> paths deliberately fire on a re-close and say so —
> `HookFiringStore.CloseIssueChecked` ("this includes the idempotent no-op") and
> `hookIssueOperations.Close` ("Close and Update stay unconditional on success").
> So the close vocabulary has two camps. This PR moves only the **batch** verbs,
> where a replay is cheap to produce and N times as loud, and leaves the single
> close alone — that is a behaviour change with its own blast radius. Both camps
> are now pinned side by side in `uow`'s notifying parity table, and each
> single-close site carries a back-pointer to the batch camp.
>
> **(b) The bead's anchor was the wrong sentence.** It cited
> `issueops/batchcloser.go:60-66` "CHANGED IS THE TEST" — but that sentence is
> about `ClaimNext` **earning** ("at least one item closed"), not about hook
> firing. The correct anchor is `CloseOutcome.Changed` at
> `batchcloser.go:81-83`: "Changed reports whether this item persisted a
> semantic mutation. It is false for an idempotent re-close." The fix stands on
> that.

### 4 — `fix(uow)`: the same defect in the second write plumbing (ga-2yaqp.1, review fix)

Commit 1 fixed **one of the two write plumbings**. In proxied-server mode —
what `bd serve`, and therefore the whole HTTP path, runs — `CloseBatch`
composes `uow.closeBatchItem` onto `recordingIssueUC.CloseIssueChecked`, which
records `opClose` whenever `err == nil`. The user-visible symptom of
ga-2yaqp.1 survived there untouched.

**Placement.** The gate goes in the **batch compositions**, not in the verb:
`recordingIssueUC`'s close methods are shared with the single close, whose
re-close firing is deliberate and pinned. `closeBatchItem` and
`uowApplyRun.applyClose` mark the notification buffer before the item's close
and rewind when the item persisted nothing. With hooks disabled the
`UnitOfWork` is not the notifying decorator at all and both helpers are no-ops.

**Red-first**, reproducing the symptom on the uow leg:

```
a batch re-close reports the close once:
  fired [{close bd-1} {close bd-1}], want [{close bd-1}]
a batch pass announces only the close that landed:
  fired [{create bd-2} {close bd-1} {close bd-1} {close bd-2}],
  want [{create bd-2} {close bd-1} {close bd-2}]
```

The parity table's existing double-close row still asserts **two** firings for
the single close, so both camps sit in one table. The BatchApplier arm gets its
own case — both compositions reach the same verb, so a fix applied to one
passes the other's tests untouched; each gate was removed in turn and only its
own case went red.

### 2 — `refactor(dolt)`: call `types.IsSchedulingEdge` in the cross-tier cycle gate (ga-2ltro.10)

`checkCrossTierSchedulingCycle` spelled the scheduling-type set as an inline
`switch`, so it was not among the four copies #5480 folded into
`types.IsSchedulingEdge` — and it is the copy whose staleness is **silent**. A
fifth scheduling type would fall to the switch's `default`, return nil, and
skip the merged two-session cycle probe entirely: no error, no log line, a
committed cross-session cycle. The other copies refuse or mis-render; this one
just stops looking.

Behaviour is unchanged today, and #5480's "one edit for a fifth type" claim is
now true.

**Evidence.** The guard arm had no coverage, so it gets a case: a committed
scheduling edge `R -> W`, then a cross-tier `related` edge `W -> R` closing the
loop. The **only** difference from `TestRunInTransactionCrossTierCycleRejected`
is the edge type, so it fails the moment the arm stops excusing non-scheduling
edges — verified by replacing the guard with `if false`:

```
--- FAIL: TestRunInTransactionCrossTierNonSchedulingEdgeIsNotGated
    RunInTransaction error = adding dependency would create a cycle,
    want the related edge to land — `related` is outside the scheduling set
```

My first draft of this case used a `related` pair with no scheduling path and
did **not** discriminate — `AppendSchedulingGraphInTx` never puts a `related`
edge in the graph, so the mutant passed. The shape above is what makes the arm
load-bearing.

All cross-tier and mixed-tier cases pass.

### 3 — `fix(issueops)`: the Releaser leaf claimed byte-for-byte holders (ga-2ltro.14)

`ReleaseRequest.ExpectedAssignee` documented "HOLDERS COMPARE BYTE FOR BYTE,
not trimmed and not folded". False since ga-5ksp5: the comparison is
`actorMatches`/`canonicalActor`, which collapses any run of `.`, `_` or `-` to
one separator, so `agent-a`, `agent_a` and `agent.a` are one holder.

The published wire schema already says this correctly
(`ReleaseIssueRequest.expected_assignee`: "SEPARATOR-INSENSITIVE AND NOTHING
ELSE ... not trimmed and not case-folded"), so a role leaf and a shipped spec
**contradicted each other about a compare-and-set predicate**, and the leaf was
the wrong one. A client author reading the role doc coded the wrong holder
comparison. The wire text is the model and is ported here.

`Actor`'s ownership-fence paragraph gets the same cross-reference — that fence
is `actorMatches` too (`issueops/unclaim.go`), so "is the current holder" must
not be read as exact equality either.

A sweep of the leaf for other stale comparison claims found none: the remaining
byte-for-byte mentions are about project ids, error text and metadata
round-tripping, and the other `Expected*` docs say only "must match" without
asserting how.

**Evidence.** Nothing at the role tier pinned the canonicalization, so
`RunReleaserReleasesOnlyTheExpectedHolder` grows the two limbs that do:
`releaser_holder` releases a claim held by `releaser-holder`, and
`" releaser-holder"` still refuses with `ErrAssigneeMismatch`, leaving the row
and its version untouched. Both verified able to fail:

```
# actorMatches made byte-for-byte (the old doc's claim):
Release() expecting "releaser_holder" against a claim held by "releaser-holder"
  error = assignee mismatch: ..., want the release to land — the comparison is separator-insensitive

# actorMatches made TrimSpace-tolerant:
Release() expecting " releaser-holder" error = <nil>,
  want ErrAssigneeMismatch — the value is not trimmed
```

They are **arms inside the existing case**, not new `Run*` entrypoints, so the
bundle and coverage gates need no new accounting — `backend/conformance` passes
unchanged. Green on all three legs: dolt, uow, and embeddeddolt under
`BEADS_TEST_EMBEDDED_DOLT=1`.

---

### Gates

- `go build ./...`, `go vet ./...` — clean
- `golangci-lint run --new-from-rev=origin/main` — **0 issues**; `gofmt` clean
- `make api-check` — clean, no generated drift
- `internal/storage`, `internal/storage/uow`, `internal/storage/issueops`,
  `issueops`, `backend/conformance`, `internal/httpapi`, `cmd/bd -run Close` — pass
- `internal/storage/dolt` — cross-tier, mixed-tier and Releaser-contract cases pass (13s; the earlier host contention did not reproduce)

Commits used `--no-verify`: the pre-commit hook's
`go run golangci-lint@v2.10.1` resolves a **go1.25** toolchain and refuses this
repo's `go 1.26.5` target ("the Go language version used to build
golangci-lint is lower than the targeted Go version"), independent of staged
content. The correctly-built local v2.10.1 binary was run instead and reports
0 issues.

Refs: ga-2yaqp.1, ga-2ltro.10, ga-2ltro.14
