### PR TITLE
Make the pre-commit lint gate trustworthy, and stop one main-side lint word from reddening every PR

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,9 +9,23 @@ set -euo pipefail
 # the beads section at the bottom must run for non-Go commits too.
 staged_go_files=$(git diff --cached --name-only --diff-filter=ACM -- '*.go')
 if [ -n "$staged_go_files" ]; then
-    # Use go run so golangci-lint is always built with the project's Go
-    # toolchain, avoiding version-mismatch panics from a stale global binary.
+    # Build golangci-lint from source so it is never a stale global binary, and
+    # pin the version to the one CI uses (.github/workflows/{pr,main}.yml).
     GOLANGCI_LINT="go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1"
+
+    # Build it with the repo's own Go, the way CI does. In CI, actions/setup-go
+    # installs the go.mod version and exports GOTOOLCHAIN=local. Locally
+    # GOTOOLCHAIN defaults to "auto", and for a pkg@version build that honours
+    # golangci-lint's own toolchain directive instead: it downgrades to
+    # go1.25.12, which then refuses this repo's newer go directive at config
+    # load ("the Go language version (go1.25) used to build golangci-lint is
+    # lower than the targeted Go version") and fails every Go commit. Pinning to
+    # the go directive reproduces CI's resolution on any host toolchain.
+    go_toolchain="go$(awk '$1 == "go" { print $2; exit }' go.mod)"
+    if [ "$go_toolchain" = "go" ]; then
+        echo >&2 "pre-commit: no go directive in go.mod; cannot pin the lint toolchain"
+        exit 1
+    fi
 
     # Auto-format and re-stage
     echo "$staged_go_files" | xargs gofmt -w
@@ -20,7 +34,7 @@ if [ -n "$staged_go_files" ]; then
     # Lint changed code with auto-fix; block on remaining issues.
     # CGO_ENABLED=0 avoids typecheck failures from CGO-only dependencies
     # (e.g., dolthub/go-icu-regex) that require system headers not always present.
-    CGO_ENABLED=0 $GOLANGCI_LINT run --new-from-rev=HEAD --fix || exit 1
+    CGO_ENABLED=0 GOTOOLCHAIN="$go_toolchain" $GOLANGCI_LINT run --new-from-rev=HEAD --fix || exit 1
 
     # Re-stage any auto-fixes from the linter
     echo "$staged_go_files" | xargs git add

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -444,6 +444,9 @@ jobs:
       - name: Install golangci-lint
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
 
+      # No BD_LINT_NEW_FROM_MERGE_BASE here: the push lane sweeps the whole
+      # tree, including the GOOS=windows cross-lint. pr.yml scopes the same
+      # wrapper to the PR's own diff.
       - name: Run PR lint wrapper
         run: make ci-pr-lint
 
@@ -1160,6 +1163,9 @@ jobs:
       - name: Check gofmt
         run: make fmt-check
 
+  # The whole-tree lint sweep. pr.yml's job of the same name reports only what
+  # a PR introduces, so this push lane is where a pre-existing or newly landed
+  # issue anywhere in the tree surfaces.
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -642,6 +642,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          # --new-from-merge-base below walks real history.
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -652,7 +655,13 @@ jobs:
       - name: Install golangci-lint
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
 
+      # Scope the wrapper's lint to what this PR introduces, matching the
+      # `lint` job's only-new-issues below. main.yml runs the same wrapper with
+      # this unset, so the whole tree is still swept on every push to main.
+      # Both PR triggers (pull_request, merge_group) target main.
       - name: Run PR lint wrapper
+        env:
+          BD_LINT_NEW_FROM_MERGE_BASE: origin/main
         run: make ci-pr-lint
 
   # Focused job for the hexagonal storage layer (internal/storage/domain/* and
@@ -872,11 +881,30 @@ jobs:
       - name: Check gofmt
         run: make fmt-check
 
+  # Lint lanes are split deliberately: the PR lane reports only the issues a PR
+  # introduces, and main.yml's identical job sweeps the whole tree on every
+  # push. The tradeoff is that a pre-existing issue in untouched code no longer
+  # blocks a PR — but a lint word that lands on main now reds main's own run,
+  # where it belongs, instead of reddening every open PR for a change it did
+  # not make.
+  #
+  # "New" is measured off the diff, so MOVED CODE READS AS NEW: a pre-existing
+  # violation carried into a PR by a move or a rename is reported against that
+  # PR and blocks it. Fix it or //nolint it there — that is the accepted cost of
+  # the trade above.
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # only-new-issues reads the PR patch from the API.
+      pull-requests: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          # On merge_group there is no PR patch, so the action falls back to
+          # --new-from-rev and needs real history.
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -890,6 +918,7 @@ jobs:
           GOWORK: "off"
         with:
           version: v2.10.1
+          only-new-issues: true
           args: --config=.golangci.yml --modules-download-mode=readonly --timeout=5m --build-tags=gms_pure_go
 
   windows-make-shell:

--- a/engdocs/CI_CLEANUP_PLAN.md
+++ b/engdocs/CI_CLEANUP_PLAN.md
@@ -1,6 +1,6 @@
 # CI Cleanup Plan
 
-Last reviewed: 2026-08-02
+Last reviewed: 2026-08-10
 
 Freshness source: `engdocs/CI_TEST_SURFACE_AUDIT.md`, `.github/workflows/*.yml`,
 `.buildflags`, `.golangci.yml`, `scripts/ci/pr-lint.sh`, `Makefile`, package test
@@ -167,6 +167,13 @@ easy to identify and rerun. It includes:
   downloads, a five-minute timeout, and the `gms_pure_go` build tag.
 - A second non-CGO Windows cross-lint pass when the native target does not
   already cover that build tuple.
+
+Both passes are SCOPED BY LANE. On a PR the wrapper takes
+`BD_LINT_NEW_FROM_MERGE_BASE` and reports only the findings that PR introduces,
+matching the `only-new-issues` setting on the sibling `lint` job; on a push to
+`main`, and for anyone running `make ci-pr-lint` by hand, it is unset and the
+whole tree is swept. The local run is therefore stricter than the PR gate, which
+is deliberate — see `engdocs/LINTING.md`.
 
 Known false positives must be handled in `.golangci.yml` or with targeted
 `//nolint` comments. CI should not use a tolerated failing lint baseline.

--- a/engdocs/LINTING.md
+++ b/engdocs/LINTING.md
@@ -1,6 +1,6 @@
 # Linting Policy
 
-Last reviewed: 2026-08-02
+Last reviewed: 2026-08-10
 
 Freshness source: `.golangci.yml`, `scripts/ci/pr-lint.sh`, `Makefile`,
 `.github/workflows/pr.yml`, and `.github/workflows/main.yml`.
@@ -9,23 +9,40 @@ This document explains the required Go lint gate for this codebase.
 
 ## Current Status
 
-Lint is a required CI gate. The PR and main workflows install the pinned
-golangci-lint v2.10.1 release and invoke the repository-owned `ci-pr-lint`
-wrapper, which must pass with zero issues.
+Lint is a required CI gate, and it runs in TWO LANES over the same pinned
+golangci-lint v2.10.1 release and the same `.golangci.yml`. Each must pass with
+zero issues in its own scope.
 
-Run the same required contract locally with:
+- **The PR lane reports only what the PR introduces.** Both of its jobs are
+  scoped to the diff against the merge base with `main`: the `lint` job passes
+  `only-new-issues`, and `pr-lint-wrapper` runs the repository-owned
+  `ci-pr-lint` wrapper with `BD_LINT_NEW_FROM_MERGE_BASE`. A finding in code the
+  PR did not touch does not block it.
+- **The main lane sweeps the whole tree.** Both jobs run unscoped on every push
+  to `main`, so a finding that lands there reds main's own run rather than every
+  open PR.
+
+Run the wrapper locally with:
 
 ```bash
 make ci-pr-lint
 ```
 
+That is the MAIN lane's contract, not the PR lane's: with
+`BD_LINT_NEW_FROM_MERGE_BASE` unset it sweeps the whole tree, so it is
+deliberately STRICTER than the gate your PR has to clear and may report findings
+you are not required to fix. Fix the ones that are yours; the PR gate is the
+authority on what blocks a merge, and main's own run is where the rest is
+answered.
+
 The wrapper runs:
 
 - `make fmt-check`;
 - golangci-lint with `.golangci.yml`, readonly module downloads, a five-minute
-  timeout, and the `gms_pure_go` build tag; and
-- a second non-CGO Windows cross-lint pass when the native host does not already
-  cover that target.
+  timeout, the `gms_pure_go` build tag, and `--new-from-merge-base` when
+  `BD_LINT_NEW_FROM_MERGE_BASE` names a ref; and
+- a second non-CGO Windows cross-lint pass, on the same scope, when the native
+  host does not already cover that target.
 
 ## Policy
 

--- a/scripts/ci/pr-lint.sh
+++ b/scripts/ci/pr-lint.sh
@@ -13,10 +13,19 @@ source "$REPO_ROOT/scripts/ci/lib/timing.sh"
 
 cd "$REPO_ROOT"
 
+# The PR lane sets this to the branch it merges into so only the issues the PR
+# introduces are reported; main's push lane leaves it unset and sweeps the
+# whole tree. See the lint comment in .github/workflows/pr.yml.
+lint_scope=()
+if [[ -n "${BD_LINT_NEW_FROM_MERGE_BASE:-}" ]]; then
+    lint_scope=(--new-from-merge-base="$BD_LINT_NEW_FROM_MERGE_BASE")
+fi
+
 ci_time "gofmt check" -- make fmt-check
 ci_time "golangci-lint" -- \
     golangci-lint run --config=.golangci.yml --modules-download-mode=readonly \
-        --timeout=5m --build-tags=gms_pure_go ./...
+        --timeout=5m --build-tags=gms_pure_go \
+        ${lint_scope[@]+"${lint_scope[@]}"} ./...
 
 # Other target tuples may not load files guarded by //go:build windows && !cgo.
 # Cross-lint that non-CGO Windows build too, unless the native target above
@@ -27,5 +36,6 @@ if [[ "$native_goos" != "windows" || "$native_cgo_enabled" != "0" ]]; then
     ci_time "golangci-lint (windows)" -- \
         env GOOS=windows GOARCH=amd64 CGO_ENABLED=0 GOWORK=off \
             golangci-lint run --config=.golangci.yml --modules-download-mode=readonly \
-                --timeout=5m --build-tags=gms_pure_go ./...
+                --timeout=5m --build-tags=gms_pure_go \
+                ${lint_scope[@]+"${lint_scope[@]}"} ./...
 fi


### PR DESCRIPTION
Two small CI/hooks fixes. One commit each; both are infrastructure only, no Go
code changes.

## `fix(githooks)`: build golangci-lint with the repo's Go — ga-2ltro.13

The hook ran `go run golangci-lint@v2.10.1`. For a `pkg@version` build the go
command honours the TARGET module's toolchain directive, so `GOTOOLCHAIN=auto`
downgraded to go1.25.12 — and golangci-lint built by go1.25 refuses this repo's
`go 1.26.5` at config load:

```
go: github.com/golangci/golangci-lint/v2@v2.10.1 requires go >= 1.25.0; switching to go1.25.12
Error: can't load config: the Go language version (go1.25) used to build golangci-lint is lower than the targeted Go version (1.26.5)
```

Every Go commit failed there. Six or more contributors independently worked
around it with `--no-verify` — the one habit a lint gate must never train.

CI never hit it because `actions/setup-go` installs the go.mod version and
exports `GOTOOLCHAIN=local`, so its `go install ...@v2.10.1` compiles the linter
with go1.26.5. The hook now pins `GOTOOLCHAIN` to the go directive, which
reproduces that resolution on any host — including one whose base toolchain is
older than the repo's target, where a bare `GOTOOLCHAIN=local` would pin the
linter to that older toolchain instead.

Verified on a real staged Go change: the message above before, `0 issues.`
after, and still exit 1 on a planted errcheck violation.

## `ci`: lint PRs for what they introduce — ga-uwix0.2

Both PR lint gates linted the whole tree: the `lint` job left `only-new-issues`
at its `false` default, and `pr-lint-wrapper` ran `make ci-pr-lint` over `./...`.
So a single lint word landing on main — twice this wave, once a prose misspell —
turned every open PR red for a change it did not make.

The tradeoff is recorded beside the job: a pre-existing issue in untouched code
no longer blocks a PR. What it buys is that a main-side word reds main's own run,
where it belongs. `main.yml` already runs both jobs unscoped on every push, so
whole-tree coverage — including the `GOOS=windows` cross-lint — is unchanged;
only its blast radius moves. The wrapper takes its scope from
`BD_LINT_NEW_FROM_MERGE_BASE`, set only by `pr.yml`, so `make ci-pr-lint` run by
hand still sweeps the tree the way CONTRIBUTING.md describes.