### PR TITLE
Make the next serve role a compile error, and check the one role with a positional result

### DIFF
--- a/cmd/bd/serve.go
+++ b/cmd/bd/serve.go
@@ -618,6 +618,52 @@ func errServeEmbedded() error {
 		&storage.ErrUnsupported{Op: "serve", Backend: "embedded-dolt"})
 }
 
+// serveRoleSource is the surface serveIssueRoles reaches on the store, spelled
+// out rather than taken as a whole storage.DoltStorage.
+//
+// THE POINT IS THE TEST STUBS. A stub that stands in for a store has to satisfy
+// whatever this function asks for, and the only affordable way to satisfy a
+// hundred-method interface is to embed it and leave it nil — which answers every
+// accessor the stub forgot with a promoted method on a nil interface. That is a
+// segfault inside the loop below rather than a compile error, and it has landed
+// twice: once on GraphCounter in serve_source_test.go, and once on the same role
+// in serve_store_identity_test.go, where no local -run pattern named the test
+// and only a full-package CI shard found it.
+//
+// Named narrowly, a stub can DECLARE this set and assert it, so the next role
+// added to the loop below is a build failure in the file that has to grow a
+// method — with the method's name in the error.
+//
+// A whole store is one of these, which is what the assertion beneath it pins:
+// the production call site passes exactly what it always did.
+type serveRoleSource interface {
+	IssueReader() (issueops.Reader, error)
+	IssueClaimer() (issueops.Claimer, error)
+	BatchCloser() (issueops.BatchCloser, error)
+	ReadyClaimer() (issueops.ReadyClaimer, error)
+	Releaser() (issueops.Releaser, error)
+	IssueLifecycle() (issueops.Lifecycle, error)
+	WorkspaceConfig() (issueops.WorkspaceConfig, error)
+	StatsReporter() (issueops.StatsReporter, error)
+	CycleDetector() (issueops.CycleDetector, error)
+	EdgeReader() (issueops.EdgeReader, error)
+	GraphCounter() (issueops.GraphCounter, error)
+	BlockingAnnotator() (issueops.BlockingAnnotator, error)
+	TreeWalker() (issueops.TreeWalker, error)
+	ReadyCounter() (issueops.ReadyCounter, error)
+	Counter() (issueops.Counter, error)
+	Querier() (issueops.Querier, error)
+	Sweeper() (issueops.Sweeper, error)
+	Deleter() (issueops.Deleter, error)
+	BatchCreator() (issueops.BatchCreator, error)
+	DependencyEditor() (issueops.DependencyEditor, error)
+	MetadataCAS() (issueops.MetadataCAS, error)
+	BatchApplier() (issueops.BatchApplier, error)
+	Memories() (memoryops.Memories, error)
+}
+
+var _ serveRoleSource = storage.DoltStorage(nil)
+
 // serveIssueRoles takes the roles this server answers from off the store the
 // root command already opened.
 //
@@ -637,7 +683,7 @@ func errServeEmbedded() error {
 // It returns the WHOLE set httpapi.Config requires; Listen refuses a partial
 // set (see checkDatabaseSource), so a role missing here is a startup failure
 // rather than a nil dereference on the first request that reaches it.
-func serveIssueRoles(src storage.DoltStorage, journalEnabled bool) (serveRoles, error) {
+func serveIssueRoles(src serveRoleSource, journalEnabled bool) (serveRoles, error) {
 	var roles serveRoles
 	if src == nil {
 		// A set of nil roles would reach Listen as "no database source" —
@@ -686,7 +732,7 @@ func serveIssueRoles(src storage.DoltStorage, journalEnabled bool) (serveRoles, 
 			// assertion has to reach the concrete store or it finds nothing at
 			// all. Nothing is skipped by going the whole way: there is no
 			// journal decorator to peel past.
-			cursor, ok := storage.UnwrapStore(src).(storage.EventsJournalCursor)
+			cursor, ok := serveJournalCursor(src)
 			if ok {
 				roles.eventsJournal = cursor
 				return nil
@@ -708,6 +754,19 @@ func serveIssueRoles(src storage.DoltStorage, journalEnabled bool) (serveRoles, 
 		}
 	}
 	return roles, nil
+}
+
+// serveJournalCursor is storage.UnwrapStore reached from serveRoleSource, which
+// is narrower than the whole store UnwrapStore takes. A source that is not a
+// store has no decorator to peel — the test stubs are exactly that — so it is
+// asked for the seam as it stands.
+func serveJournalCursor(src serveRoleSource) (storage.EventsJournalCursor, bool) {
+	raw := any(src)
+	if store, ok := src.(storage.DoltStorage); ok {
+		raw = storage.UnwrapStore(store)
+	}
+	cursor, ok := raw.(storage.EventsJournalCursor)
+	return cursor, ok
 }
 
 // serveRoles is the store-shaped database source, assembled once before Listen.

--- a/cmd/bd/serve_registered_backend_test.go
+++ b/cmd/bd/serve_registered_backend_test.go
@@ -404,10 +404,10 @@ func TestServeRefusesStrictReadonlyOnARegisteredBackend(t *testing.T) {
 		// is what sends the root command down OpenReadOnly, and that is the
 		// posture under test.
 		Open: func(context.Context, string) (storage.DoltStorage, error) {
-			return &serveIdentityStore{id: "read-write"}, nil
+			return &serveIdentityDoltStore{serveIdentityStore: &serveIdentityStore{id: "read-write"}}, nil
 		},
 		OpenReadOnly: func(context.Context, string) (storage.DoltStorage, error) {
-			return &serveIdentityStore{id: "read-only"}, nil
+			return &serveIdentityDoltStore{serveIdentityStore: &serveIdentityStore{id: "read-only"}}, nil
 		},
 		WorkspaceIsBeadsDir: true,
 	})

--- a/cmd/bd/serve_source_test.go
+++ b/cmd/bd/serve_source_test.go
@@ -92,8 +92,8 @@ func TestServeIssueRolesComeFromBeneathTheHookDecorator(t *testing.T) {
 	// peeling all of them (storage.UnwrapStore) is the mistake that looks
 	// identical on a single-layer chain. The middle store stands in for the
 	// telemetry layer bd wires there, which is an Unwrapper too.
-	stubs := func(inner storage.DoltStorage) *serveRolesStore {
-		return &serveRolesStore{
+	stubs := func(inner storage.DoltStorage) *serveRolesDoltStore {
+		return &serveRolesDoltStore{serveRolesStore: &serveRolesStore{
 			reader:       &serveStubReader{},
 			claimer:      &serveStubClaimer{},
 			batchCloser:  &serveStubBatchCloser{},
@@ -106,7 +106,7 @@ func TestServeIssueRolesComeFromBeneathTheHookDecorator(t *testing.T) {
 			counter:      &serveStubCounter{},
 			edgeCounter:  &serveStubGraphCounter{},
 			inner:        inner,
-		}
+		}}
 	}
 	inner := stubs(nil)
 	middle := stubs(inner)
@@ -326,11 +326,16 @@ func writeBrokenBeadsConfig(t *testing.T, beadsDir string) {
 	}
 }
 
-// serveRolesStore is the smallest DoltStorage the role extraction can be
-// pointed at: it publishes its own roles and unwraps to an inner store with
-// different ones, so a peel of the wrong depth lands on identifiably wrong
-// values. The embedded DoltStorage is nil, so an accessor serveIssueRoles
-// starts calling without a stub here panics rather than passing quietly.
+// serveRolesStore is the smallest source the role extraction can be pointed at:
+// it publishes its own roles and unwraps to an inner store with different ones,
+// so a peel of the wrong depth lands on identifiably wrong values.
+//
+// IT EMBEDS NOTHING, and the assertion below is why. A stub that embedded a nil
+// storage.DoltStorage would answer every accessor it forgot with a promoted
+// method on a nil interface — a segfault inside serveIssueRoles rather than a
+// compile error, which is how GraphCounter reached this file. Declaring the
+// whole of serveRoleSource means the next role added there stops the build here,
+// naming the method.
 //
 // Only the reader and the claimer carry identifiable values. That is enough to
 // pin the peel DEPTH, which is the whole property under test: serveIssueRoles
@@ -338,7 +343,6 @@ func writeBrokenBeadsConfig(t *testing.T, beadsDir string) {
 // can come from a different layer than these two did. The rest return nil
 // because the extraction does not inspect them.
 type serveRolesStore struct {
-	storage.DoltStorage
 	reader       *serveStubReader
 	claimer      *serveStubClaimer
 	batchCloser  *serveStubBatchCloser
@@ -352,6 +356,28 @@ type serveRolesStore struct {
 	edgeCounter  *serveStubGraphCounter
 	inner        storage.DoltStorage
 }
+
+var _ serveRoleSource = (*serveRolesStore)(nil)
+
+// serveRolesDoltStore is serveRolesStore where a WHOLE store is required:
+// wireStorageDecorators builds the chain this test peels, and it takes a
+// storage.DoltStorage.
+//
+// The roles above sit one embed shallower than the nil store beneath them, so
+// they shadow it: every accessor serveIssueRoles reaches is declared, and only
+// the rest of the interface — none of which this test calls — falls through to
+// the nil embed. A new role therefore fails the assertion above rather than
+// being quietly promoted here.
+type serveRolesDoltStore struct {
+	*serveRolesStore
+	serveStubRest
+}
+
+// serveStubRest carries the remainder of storage.DoltStorage for a stub that
+// declares its own roles, one embed deeper than those roles. It is the shared
+// half of the shadowing described above; serve_store_identity_test.go's stub
+// uses it for the same reason.
+type serveStubRest struct{ storage.DoltStorage }
 
 func (s *serveRolesStore) IssueReader() (issueops.Reader, error)   { return s.reader, nil }
 func (s *serveRolesStore) IssueClaimer() (issueops.Claimer, error) { return s.claimer, nil }

--- a/cmd/bd/serve_store_identity_test.go
+++ b/cmd/bd/serve_store_identity_test.go
@@ -44,7 +44,9 @@ func TestServeAnswersFromTheStoreTheRootCommandOpened(t *testing.T) {
 
 	var opens atomic.Int64
 	open := func(context.Context, string) (storage.DoltStorage, error) {
-		return &serveIdentityStore{id: fmt.Sprintf("store-%d", opens.Add(1))}, nil
+		return &serveIdentityDoltStore{
+			serveIdentityStore: &serveIdentityStore{id: fmt.Sprintf("store-%d", opens.Add(1))},
+		}, nil
 	}
 	backends.Register(name, backends.Backend{
 		Open:                open,
@@ -115,7 +117,7 @@ func TestServeAnswersFromTheStoreTheRootCommandOpened(t *testing.T) {
 
 // openRegisteredStoreForTest opens the workspace the way PersistentPreRunE
 // does: through the registry, by name, with no knowledge of what is behind it.
-func openRegisteredStoreForTest(t *testing.T, name, beadsDir string) (*serveIdentityStore, error) {
+func openRegisteredStoreForTest(t *testing.T, name, beadsDir string) (*serveIdentityDoltStore, error) {
 	t.Helper()
 	backend, ok := backends.Lookup(name)
 	if !ok {
@@ -125,7 +127,7 @@ func openRegisteredStoreForTest(t *testing.T, name, beadsDir string) (*serveIden
 	if err != nil {
 		return nil, err
 	}
-	identified, ok := opened.(*serveIdentityStore)
+	identified, ok := opened.(*serveIdentityDoltStore)
 	if !ok {
 		t.Fatalf("the registry returned %T, not the identified store this test reads by name", opened)
 	}
@@ -155,12 +157,26 @@ func getBody(t *testing.T, url string) string {
 // identity of the value the server was wired to is a substring of the response
 // rather than something a test has to reach inside the server to inspect.
 //
-// The embedded DoltStorage is nil: nothing on this path calls anything else, and
-// a nil-panic naming the method would be a truer failure than a stub that
-// answered.
+// IT EMBEDS NOTHING, and the assertion below is why. This stub used to embed a
+// nil storage.DoltStorage, so a role it had not declared arrived as a promoted
+// method on a nil interface — GraphCounter did, and it surfaced as a segfault on
+// a full-package CI shard rather than as a compile error, because no -run
+// pattern anyone reached for names this test. Declaring the whole of
+// serveRoleSource makes the next role a build failure here.
 type serveIdentityStore struct {
-	storage.DoltStorage
 	id string
+}
+
+var _ serveRoleSource = (*serveIdentityStore)(nil)
+
+// serveIdentityDoltStore is what the registry hands back, because
+// backends.Backend.Open returns a whole storage.DoltStorage. The roles above sit
+// one embed shallower than the nil store in serveStubRest and so shadow it:
+// nothing on this path calls anything else, and a nil panic naming the method
+// would be a truer failure than a stub that answered.
+type serveIdentityDoltStore struct {
+	*serveIdentityStore
+	serveStubRest
 }
 
 func (s *serveIdentityStore) IssueReader() (issueops.Reader, error) {

--- a/engdocs/ADDING_AN_ISSUEOPS_ROLE.md
+++ b/engdocs/ADDING_AN_ISSUEOPS_ROLE.md
@@ -568,8 +568,15 @@ refuse a hook-firing one — missing it is a `bd serve` that runs a user
 subprocess per call); `uow`'s notifying wrapper, in BOTH halves — the recording
 use case, which silently records nothing for an inherited method, and the
 notifying provider, whose missing accessor makes a caller's type assertion stop
-matching; and two `cmd/bd` stub stores that embed `storage.DoltStorage`. Grep
-for the embed, not for the interface. And note that `internal/storage/uow`'s own
+matching; and two `cmd/bd` stub stores that embedded `storage.DoltStorage`. Grep
+for the embed, not for the interface.
+
+Those two `cmd/bd` stubs are the one place this step is now taken FOR you.
+`serveIssueRoles` asks for `serveRoleSource` — the accessor subset it actually
+reaches — and both stubs declare that subset and assert it, so a role added to
+the loop is a compile error naming the missing method instead of a segfault
+inside role extraction. Every other surface above is still yours to grep for.
+And note that `internal/storage/uow`'s own
 package run is nine minutes — the parity guards live there, so a role slice that
 runs only its contract on the three legs has not run them.
 

--- a/internal/httpapi/batch_close_test.go
+++ b/internal/httpapi/batch_close_test.go
@@ -295,6 +295,137 @@ func TestBatchCloseCapsTheItemCount(t *testing.T) {
 	}
 }
 
+// TestBatchCloseRefusesACloserThatMiscountsItsOutcomes pins checkedBatchCloser's
+// whole-batch half, and it is the one refusal on this operation that is NOT a
+// per-item outcome.
+//
+// The array is positional: a client walks it against its own argument list, so
+// an outcome count that does not match the request cannot be attributed to any
+// item at all. Projecting it anyway would report item N's answer under item
+// N+1's id for the rest of the array — silently, inside a 200. So it is
+// checkedBatchCreator's whole-batch refusal exactly: the generic 500, and never
+// a partial projection.
+func TestBatchCloseRefusesACloserThatMiscountsItsOutcomes(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		outcomes []issueops.CloseOutcome
+	}{
+		{"fewer outcomes than items", []issueops.CloseOutcome{
+			{IssueID: "bd-1", Issue: closedIssue("bd-1"), Changed: true},
+		}},
+		{"more outcomes than items", []issueops.CloseOutcome{
+			{IssueID: "bd-1", Issue: closedIssue("bd-1"), Changed: true},
+			{IssueID: "bd-2", Issue: closedIssue("bd-2"), Changed: true},
+			{IssueID: "bd-3", Issue: closedIssue("bd-3"), Changed: true},
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ts := newBatchCloseServer(t, &roleBatchCloser{
+				result: issueops.CloseBatchResult{Outcomes: test.outcomes},
+			})
+
+			resp := ts.batchClose(t, `{"actor":"alice","items":[{"id":"bd-1"},{"id":"bd-2"}]}`)
+			if resp.StatusCode != http.StatusInternalServerError {
+				t.Fatalf("status = %d, want 500: %s", resp.StatusCode, readAll(t, resp))
+			}
+			body := decodeBody(t, resp)
+			if body["code"] != string(CodeInternal) {
+				t.Errorf("code = %v, want %s", body["code"], CodeInternal)
+			}
+			// The body is a problem document rather than a short or long array:
+			// a client that read `outcomes` positionally would misattribute
+			// every entry after the first mismatch.
+			if _, present := body["outcomes"]; present {
+				t.Errorf("a miscounted result was projected onto the wire anyway: %v", body)
+			}
+			// The fault has to arrive as an ERROR NAMING ITSELF, which is what
+			// makes this different from the same status reached by a recovered
+			// panic — checkedReleaser's rule, and the counts say which way the
+			// role was wrong.
+			line := findLogLine(t, ts.stderr.String(), "the closer reported")
+			if !strings.Contains(line, "for 2 items") {
+				t.Errorf("the logged fault does not name the request it answered:\n%s", line)
+			}
+		})
+	}
+}
+
+// TestBatchCloseFoldsAnOutcomeThatIsNeitherAnIssueNorARefusal pins
+// checkedBatchCloser's per-item half.
+//
+// The document says `code`'s absence means the item succeeded AND that `issue`
+// is present, so an outcome carrying neither a row nor a refusal has no honest
+// wire shape: projected as it stands it is a success with no row, which is the
+// exact shape closeOutcome's `default` branch already refuses to produce for an
+// unrecognized item error.
+//
+// It is folded into THAT ITEM rather than failing the request, and the batch's
+// own contract is why: the survivors have already committed, so a whole-batch
+// 500 would hide durable closes from a caller that cannot re-read them. The
+// count above has no such reading — a miscounted array says nothing trustworthy
+// about any item — which is what puts the two halves at different scopes.
+func TestBatchCloseFoldsAnOutcomeThatIsNeitherAnIssueNorARefusal(t *testing.T) {
+	ts := newBatchCloseServer(t, &roleBatchCloser{result: issueops.CloseBatchResult{
+		Outcomes: []issueops.CloseOutcome{
+			{IssueID: "bd-1", Issue: closedIssue("bd-1"), Changed: true},
+			{IssueID: "bd-2", Changed: true},
+		},
+	}})
+
+	resp := ts.batchClose(t, `{"actor":"alice","items":[{"id":"bd-1"},{"id":"bd-2"}]}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: a post-commit fault on one item must not hide the others: %s",
+			resp.StatusCode, readAll(t, resp))
+	}
+	outcomes := outcomesOf(t, resp)
+	if len(outcomes) != 2 {
+		t.Fatalf("outcomes = %v, want one per requested item", outcomes)
+	}
+	// The item that landed is untouched, which is the whole reason the fold is
+	// per-item.
+	if _, present := outcomes[0]["code"]; present {
+		t.Errorf("the item that landed was reported as a refusal: %v", outcomes[0])
+	}
+	if _, present := outcomes[0]["issue"]; !present {
+		t.Errorf("the item that landed lost its row: %v", outcomes[0])
+	}
+	if outcomes[1]["code"] != string(CodeInternal) {
+		t.Errorf("code = %v, want %s for an outcome with neither an issue nor a refusal",
+			outcomes[1]["code"], CodeInternal)
+	}
+	if _, present := outcomes[1]["already_closed"]; present {
+		t.Errorf("an outcome with no row was reported as a success: %v", outcomes[1])
+	}
+}
+
+// TestBatchCloseLeavesTheRolesOwnResultAlone is the fold's other half. The
+// outcomes slice belongs to the role, so correcting it in place would carry
+// this server's correction into whatever the role hands back next — which a
+// role that answers from one prepared result does on its very next request.
+func TestBatchCloseLeavesTheRolesOwnResultAlone(t *testing.T) {
+	closer := &roleBatchCloser{result: issueops.CloseBatchResult{
+		Outcomes: []issueops.CloseOutcome{{IssueID: "bd-1", Changed: true}},
+	}}
+	ts := newBatchCloseServer(t, closer)
+
+	const body = `{"actor":"alice","items":[{"id":"bd-1"}]}`
+	if resp := ts.batchClose(t, body); resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if err := closer.result.Outcomes[0].Err; err != nil {
+		t.Fatalf("the wrapper wrote its correction into the role's own result: %v", err)
+	}
+	// The second request is the one that would read a poisoned fixture, and it
+	// must reach the same answer as the first.
+	resp := ts.batchClose(t, body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("second request: status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if outcome := outcomesOf(t, resp)[0]; outcome["code"] != string(CodeInternal) {
+		t.Errorf("second request: code = %v, want %s", outcome["code"], CodeInternal)
+	}
+}
+
 // TestBatchCloseAdmitsADuplicateID: `bd close a b a` is a plausible typo, not a
 // failure. The role closes in order and reports the second occurrence as an
 // idempotent re-close at its OWN index, so the handler's job is to forward the

--- a/internal/httpapi/roles.go
+++ b/internal/httpapi/roles.go
@@ -91,6 +91,67 @@ func (c checkedBatchCreator) CreateBatch(ctx context.Context, req issueops.Creat
 	return result, nil
 }
 
+// checkedBatchCloser is the closer the batch-close handler is handed.
+//
+// It is the one role here whose result is POSITIONAL: the document promises one
+// outcome per requested item in request order, and a client walks the array
+// against its own argument list rather than matching ids back up. So the two
+// broken shapes it folds are at different scopes, and the scope is the whole
+// reasoning.
+//
+//   - AN OUTCOME COUNT THAT DOES NOT MATCH THE REQUEST is the whole batch's
+//     fault: it cannot be walked against the caller's items at all, and
+//     projecting it anyway would report one item's answer under another item's
+//     id for the rest of the array — silently, inside a 200. It is
+//     checkedBatchCreator's whole-batch refusal exactly, and it is the generic
+//     500 with the fault in the log, never a partial projection.
+//
+//   - AN OUTCOME CARRYING NEITHER A ROW NOR A REFUSAL has no honest wire shape:
+//     `code`'s absence promises `issue`, so projected as it stands it is a
+//     success with no row — the shape closeOutcome's `default` branch already
+//     refuses to produce. It is folded into THAT ITEM's Err instead, because
+//     this batch is not all-or-nothing: its survivors have already committed,
+//     and a whole-batch 500 would hide durable closes from a caller with no way
+//     to re-read them. The handler maps it through the branch it wrote for
+//     exactly this, and the rest of the outcomes are untouched.
+//
+// batchCloser() used to hand this role out unwrapped on the reasoning that
+// CloseBatchResult is a value and its issue pointer is forwarded rather than
+// dereferenced. That is true, and it is why there is no panic here to prevent —
+// but it left the two shapes above reaching a client as answers rather than as
+// faults.
+type checkedBatchCloser struct{ inner issueops.BatchCloser }
+
+// CloseBatch refuses a miscounted result and folds a neither-row-nor-refusal
+// outcome into its own item.
+func (c checkedBatchCloser) CloseBatch(ctx context.Context, req issueops.CloseBatchRequest) (issueops.CloseBatchResult, error) {
+	result, err := c.inner.CloseBatch(ctx, req)
+	if err != nil {
+		return result, err
+	}
+	if len(result.Outcomes) != len(req.Items) {
+		return issueops.CloseBatchResult{}, fmt.Errorf(
+			"close batch: the closer reported %d outcomes for %d items", len(result.Outcomes), len(req.Items))
+	}
+	corrected := false
+	for i := range result.Outcomes {
+		if result.Outcomes[i].Err != nil || result.Outcomes[i].Issue != nil {
+			continue
+		}
+		if !corrected {
+			// Correct a COPY. The slice is the role's own, and a role that
+			// answers from one prepared result would carry this server's
+			// correction into everything it hands back afterwards.
+			result.Outcomes = append([]issueops.CloseOutcome(nil), result.Outcomes...)
+			corrected = true
+		}
+		result.Outcomes[i].Err = fmt.Errorf(
+			"close batch: the closer reported outcome %d (%q) with neither an issue nor a refusal",
+			i, result.Outcomes[i].IssueID)
+	}
+	return result, nil
+}
+
 // checkedLifecycle is the lifecycle role every mutation handler is handed.
 //
 // All four methods are why it exists: every handler over this role writes

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -805,17 +805,21 @@ func (s *Server) claimer(r *http.Request) (issueops.Claimer, error) {
 // terms as every role above and held by INTERFACE so uow.BatchCloserSource is
 // load-bearing rather than decorative.
 //
-// It goes out UNWRAPPED, like the dependency editor: CloseBatchResult is a
-// VALUE, and the pointer its outcomes carry is forwarded rather than
-// dereferenced — a nil issue on a successful outcome is omitted from that
-// item's body, which is the same absence a refused item produces and is the
-// honest answer either way.
+// Wrapped in checkedBatchCloser from either source, and the hazard it folds is
+// not the one the other wrappers exist for. Nothing here dereferences the issue
+// pointer an outcome carries; what this role owns instead is a POSITIONAL array
+// the client reads against its own argument list, and checkedBatchCloser says
+// what a miscounted or contentless entry in it costs.
 func (s *Server) batchCloser(r *http.Request) (issueops.BatchCloser, error) {
 	if s.provider == nil {
-		return s.issueBatchCloser, nil
+		return checkedBatchCloser{inner: s.issueBatchCloser}, nil
 	}
 	var src uow.BatchCloserSource = timedProvider{inner: s.provider, rec: requestInfo(r.Context())}
-	return src.BatchCloser()
+	closer, err := src.BatchCloser()
+	if err != nil {
+		return nil, err
+	}
+	return checkedBatchCloser{inner: closer}, nil
 }
 
 // readyClaimer returns the take-ready-work surface for one request.


### PR DESCRIPTION
Two independent fixes, one commit each. Both are structural: they turn a class
of fault that reaches runtime into one the compiler or the wrapper family
catches.

## `refactor(serve)`: the next role is a compile error — ga-c3g45

`serveIssueRoles` took a whole `storage.DoltStorage`, so the test stubs that
stand in for a store satisfied it the only affordable way: embed the interface
and leave it nil. Every accessor a stub had not declared then arrived as a
promoted method on a nil interface — a segfault inside role extraction, not a
compile error.

It landed twice in one PR cycle, both on `GraphCounter`. First in
`serve_source_test.go`, then in `serve_store_identity_test.go`, where no local
`-run` pattern names the test and only a full `cmd/bd` shard found it.

The function now asks for `serveRoleSource`: the accessor subset it actually
reaches, which a whole store still satisfies (asserted). Both stubs declare that
subset and assert it, and the store they must still BE — the decorator chain
takes one, `backends.Backend.Open` returns one — comes from an embed one level
deeper that their own accessors shadow.

Property proof, commenting out one accessor on each stub:

```
cannot use (*serveRolesStore)(nil) ... does not implement serveRoleSource (missing method GraphCounter)
cannot use (*serveIdentityStore)(nil) ... does not implement serveRoleSource (missing method Counter)
```

Before this change the same deletion compiled clean under `go vet` and produced
`SIGSEGV` at `(*serveRolesStore).GraphCounter` `<autogenerated>:1`.

`ADDING_AN_ISSUEOPS_ROLE.md`'s "step with no number" listed these two stubs among
the surfaces to grep by hand; it now says this pair is taken care of and the rest
still are not. Swept `cmd/bd` for a third embed reaching this path: none.

## `fix(httpapi)`: check the batch closer — ga-39tl5

`internal/httpapi` has checked wrappers for `Reader`, `BatchCreator`,
`Lifecycle`, `Claimer` and `Releaser`, but the batch closer went out unwrapped —
on the reasoning that `CloseBatchResult` is a value and its issue pointer is
forwarded rather than dereferenced. True, and it is why there is no panic here to
prevent. What it left unguarded is what this role owns and none of the others do:
an array the client reads POSITIONALLY.

Two shapes reached the wire as answers rather than faults, and they fold at
different scopes:

- **An outcome count that does not match the request** cannot be walked against
  the caller's items at all. Projected anyway it reports one item's answer under
  another item's id for the rest of the array, silently, inside a 200.
  Whole-batch 500, never a partial projection — `checkedBatchCreator`'s refusal
  exactly.
- **An outcome carrying neither a row nor a refusal** has no honest wire shape:
  `code`'s absence promises `issue`, so it projects as a success with no row —
  the shape `closeOutcome`'s `default` branch already refuses to produce. Folded
  into THAT item, because this batch is not all-or-nothing: the survivors have
  committed, and failing the request would hide durable closes.

The fold corrects a copy — the outcomes slice is the role's, and one that answers
from a prepared result would otherwise carry this server's correction into
everything it hands back afterwards. That is its own test.

Red-first: all three new tests fail on the parent commit (a 200 carrying a
misattributed array, and a success outcome with no `issue`).

No wire shape changes and no spec changes; `make api-check` is a no-op and the
error classification order in `failBatchClose` is untouched.