### PR TITLE
feat(workapi): opt-in BriefDeps projection for the issue detail view

### DIFF
--- a/internal/storage/uow/issue_reader.go
+++ b/internal/storage/uow/issue_reader.go
@@ -145,6 +145,7 @@ func (r *issueReader) Get(ctx context.Context, req publicops.GetRequest) (*publi
 		return workapi.BuildIssueDetails(ctx, src, issue, isWisp, workapi.DetailOptions{
 			IncludeDependents: req.IncludeDependents,
 			IncludeComments:   req.IncludeComments,
+			BriefDeps:         req.BriefDeps,
 		})
 	})
 }

--- a/internal/workapi/detail.go
+++ b/internal/workapi/detail.go
@@ -14,9 +14,13 @@ import (
 // DetailOptions selects the two expensive halves of the detail view. Both
 // default to off: the detail response carries counts only (be-ijck6q), and a
 // caller that wants the rows asks for them.
+//
+// BriefDeps is opt-in for the opposite reason: dependencies are populated by
+// default and stay that way, so no existing caller loses a field it reads.
 type DetailOptions struct {
 	IncludeDependents bool
 	IncludeComments   bool
+	BriefDeps         bool
 }
 
 // DetailSource is the read seam issue-detail assembly runs on. It is the
@@ -153,7 +157,36 @@ func BuildIssueDetails(ctx context.Context, src DetailSource, issue *types.Issue
 			break
 		}
 	}
+
+	// After the Parent scan, which reads DependencyType and ID off the full rows.
+	// Builds a new slice: the source owns the one it returned and may cache it.
+	if opts.BriefDeps && details.Dependencies != nil {
+		brief := make([]*types.IssueWithDependencyMetadata, 0, len(details.Dependencies))
+		for _, dep := range details.Dependencies {
+			if dep == nil {
+				brief = append(brief, nil)
+				continue
+			}
+			brief = append(brief, shallowDep(dep))
+		}
+		details.Dependencies = brief
+	}
 	return details, nil
+}
+
+// shallowDep keeps the identity-and-shape fields callers consume and drops the
+// free-form text, which is the shape collectDependents settled on in be-4d36f2.
+func shallowDep(item *types.IssueWithDependencyMetadata) *types.IssueWithDependencyMetadata {
+	return &types.IssueWithDependencyMetadata{
+		Issue: types.Issue{
+			ID:        item.Issue.ID,
+			Status:    item.Issue.Status,
+			IssueType: item.Issue.IssueType,
+			Priority:  item.Issue.Priority,
+			Title:     item.Issue.Title,
+		},
+		DependencyType: item.DependencyType,
+	}
 }
 
 // collectDependents streams the dependents and keeps only the
@@ -177,16 +210,7 @@ func collectDependents(ctx context.Context, src DetailSource, id string, isWisp 
 		if item == nil {
 			continue
 		}
-		out = append(out, &types.IssueWithDependencyMetadata{
-			Issue: types.Issue{
-				ID:        item.Issue.ID,
-				Status:    item.Issue.Status,
-				IssueType: item.Issue.IssueType,
-				Priority:  item.Issue.Priority,
-				Title:     item.Issue.Title,
-			},
-			DependencyType: item.DependencyType,
-		})
+		out = append(out, shallowDep(item))
 	}
 	if err := iter.Err(); err != nil {
 		return nil, fmt.Errorf("iter dependents %s: %w", id, err)

--- a/internal/workapi/detail_test.go
+++ b/internal/workapi/detail_test.go
@@ -565,6 +565,96 @@ func TestBuildIssueDetailsShallowDependents(t *testing.T) {
 	}
 }
 
+// TestBuildIssueDetailsBriefDeps covers the dependency side of be-4d36f2. The
+// shared fixture gives dependency rows no free-form text, so no existing case
+// could observe them carrying it; this one plants the heavy fields first.
+func TestBuildIssueDetailsBriefDeps(t *testing.T) {
+	ctx := context.Background()
+	heavy := strings.Repeat("x", 1024)
+
+	newFixture := func() *detailFixture {
+		fx := newDetailFixture()
+		fx.deps["bd-1"] = []*types.IssueWithDependencyMetadata{{
+			Issue: types.Issue{
+				ID: "bd-blocker", Title: "Blocker", Status: types.StatusOpen,
+				IssueType: types.TypeTask, Priority: 2,
+				Description: heavy, Design: heavy, Notes: heavy, AcceptanceCriteria: heavy,
+			},
+			DependencyType: types.DepBlocks,
+		}}
+		return fx
+	}
+
+	findDep := func(t *testing.T, details *types.IssueDetails) *types.IssueWithDependencyMetadata {
+		t.Helper()
+		for _, dep := range details.Dependencies {
+			if dep.ID == "bd-blocker" {
+				return dep
+			}
+		}
+		t.Fatalf("dependency bd-blocker missing from %d rows", len(details.Dependencies))
+		return nil
+	}
+
+	t.Run("default keeps the full body", func(t *testing.T) {
+		fx := newFixture()
+		store, _ := fixtureSources(fx)
+		details, err := BuildIssueDetails(ctx, store, fx.issues["bd-1"], false, DetailOptions{})
+		if err != nil {
+			t.Fatalf("BuildIssueDetails: %v", err)
+		}
+		if got := findDep(t, details); got.Description != heavy || got.Notes != heavy {
+			t.Errorf("default must not drop dependency text: description=%d notes=%d",
+				len(got.Description), len(got.Notes))
+		}
+	})
+
+	t.Run("BriefDeps strips text and keeps identity", func(t *testing.T) {
+		fx := newFixture()
+		store, _ := fixtureSources(fx)
+		details, err := BuildIssueDetails(ctx, store, fx.issues["bd-1"], false, DetailOptions{BriefDeps: true})
+		if err != nil {
+			t.Fatalf("BuildIssueDetails: %v", err)
+		}
+		got := findDep(t, details)
+		if got.Title != "Blocker" || got.Status != types.StatusOpen ||
+			got.IssueType != types.TypeTask || got.Priority != 2 || got.DependencyType != types.DepBlocks {
+			t.Errorf("identity fields not preserved: %+v", got)
+		}
+		if got.Description != "" || got.Design != "" || got.Notes != "" || got.AcceptanceCriteria != "" {
+			t.Errorf("heavy fields not stripped: %+v", got)
+		}
+	})
+
+	t.Run("BriefDeps does not mutate the source rows", func(t *testing.T) {
+		fx := newFixture()
+		store, _ := fixtureSources(fx)
+		if _, err := BuildIssueDetails(ctx, store, fx.issues["bd-1"], false, DetailOptions{BriefDeps: true}); err != nil {
+			t.Fatalf("BuildIssueDetails: %v", err)
+		}
+		if got := fx.deps["bd-1"][0]; got.Notes != heavy || got.Description != heavy {
+			t.Errorf("source row was shallowed in place: notes=%d description=%d",
+				len(got.Notes), len(got.Description))
+		}
+	})
+
+	t.Run("BriefDeps still resolves Parent", func(t *testing.T) {
+		fx := newFixture()
+		fx.deps["bd-1"] = append(fx.deps["bd-1"], &types.IssueWithDependencyMetadata{
+			Issue:          types.Issue{ID: "bd-parent", Title: "Parent", Notes: heavy},
+			DependencyType: types.DepParentChild,
+		})
+		store, _ := fixtureSources(fx)
+		details, err := BuildIssueDetails(ctx, store, fx.issues["bd-1"], false, DetailOptions{BriefDeps: true})
+		if err != nil {
+			t.Fatalf("BuildIssueDetails: %v", err)
+		}
+		if details.Parent == nil || *details.Parent != "bd-parent" {
+			t.Errorf("parent = %v, want bd-parent", details.Parent)
+		}
+	})
+}
+
 func TestBuildIssueDetailsEpicProgress(t *testing.T) {
 	ctx := context.Background()
 	fx := newDetailFixture()

--- a/internal/workapi/storereader/reader.go
+++ b/internal/workapi/storereader/reader.go
@@ -139,5 +139,6 @@ func (r *storeReader) Get(ctx context.Context, req issueops.GetRequest) (*issueo
 	return workapi.BuildIssueDetails(ctx, src, issue, isWisp, workapi.DetailOptions{
 		IncludeDependents: req.IncludeDependents,
 		IncludeComments:   req.IncludeComments,
+		BriefDeps:         req.BriefDeps,
 	})
 }

--- a/issueops/reader.go
+++ b/issueops/reader.go
@@ -431,6 +431,9 @@ type GetRequest struct {
 	// that wants the rows asks for them.
 	IncludeDependents bool
 	IncludeComments   bool
+
+	// BriefDeps reduces each dependency to its identity-and-shape fields.
+	BriefDeps bool
 }
 
 // IssuePage is one page of work. Ready and List share it deliberately: both


### PR DESCRIPTION
Storage-layer half of #5546. No CLI flag in this PR: per CONTRIBUTING_PR_GUIDELINES.md ("one layer per PR", "primitives at the lowest layer first"), the `cmd/bd` wiring is the follow-up that stacks on this.

## What

`DetailOptions.BriefDeps` reduces each dependency row in the detail view to its identity-and-shape fields and drops the free-form text.

## Why

be-4d36f2 gave the **dependents** side a shallow shape after hub beads made `bd show --json <hub>` allocate 5-13 GB marshaling full Issue records. The **dependencies** side of the same builder never got it. `BuildIssueDetails` populates `details.Dependencies` at full body on every call, thirty lines above the helper that exists because this was already a problem once.

Measured on a 16,051-issue store: one `bd show <id> --json` returned 214,456 bytes, of which 193,039 was the `dependencies` array. A single dependency carried a 180,975-byte `notes` field. Reading one issue costs the full text of everything it depends on.

The existing fixture is why no test caught it: `deps` rows are created with only `ID` and `Title`, so nothing in the suite could observe them carrying free-form text. The new test plants the heavy fields first.

## Default payload is unchanged

`BriefDeps` is opt-in and off by default. Deliberate, given #4122 objects to default payload changes and #5078 records what the last one cost. A test asserts the default still returns the full dependency body, so a later change cannot quietly flip it.

## Notes for review

- The reduction runs **after** the Parent scan, which reads `DependencyType` and `ID` off the full rows.
- It builds a new slice rather than overwriting the one `src.Dependencies` returned; a source that caches that slice would otherwise stay shallow for later callers. Covered by a test.
- `collectDependents` now routes through the same `shallowDep` helper, so the dependent and dependency shapes are identical by construction rather than by coincidence. No behavior change on that path.
- Adjacent, not touched here: the pre-existing Parent scan dereferences `dep` without a nil check. Unchanged by this PR, so left alone rather than folded in.

## Test plan

```
go test ./internal/workapi/... ./issueops/... ./internal/storage/uow/... -count=1
```

All green, including the golden-file-pinned list tests and the 308s `uow` suite. Each new assertion was confirmed to go red against the unfixed builder before being committed: disabling the projection fails `BriefDeps strips text and keeps identity`, and reverting the new-slice allocation fails `BriefDeps does not mutate the source rows`.
