### PR TITLE
feat(show,httpapi): reach BriefDeps from both front doors, with conformance coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`--brief-deps` on `bd show`, and `brief_deps` on the HTTP detail read**
+  (#5546, #5547, #5549). `bd show --json` inlines every dependency at full
+  body, so reading one issue costs the free-form text of everything it depends
+  on. On one real 16,051-issue store a single `bd show --json` returned 214,456
+  bytes, of which 193,039 was the `dependencies` array and one dependency
+  carried a 180,975-byte `notes` field. The dependents side of the same detail
+  view already had a shallow shape for this reason (be-4d36f2, where hub beads
+  cost 5-13 GB); dependencies never got it. The new flag projects each
+  dependency down to `id`, `title`, `status`, `issue_type`, `priority` and
+  `dependency_type`, which measured 89.3% smaller on that call. It is opt-in
+  and the default payload is unchanged.
+
 - **`bd serve` gets optional bearer authentication, and requires it beyond
   loopback** ([#5516](https://github.com/gastownhall/beads/pull/5516)). The
   help used to say "no authentication and no TLS", and the first half of that

--- a/backend/conformance/reader_contract.go
+++ b/backend/conformance/reader_contract.go
@@ -1333,6 +1333,57 @@ func RunReaderGetOptionalRowListsAreOffByDefault(t *testing.T, ctx context.Conte
 	}
 }
 
+// RunReaderGetBriefDepsProjectsTheDependencyRows pins BriefDeps on the public
+// Get contract (#5546). Without a case here an out-of-tree Reader can ignore
+// the field and still pass the suite, which is the failure the sibling row
+// options already have a case against.
+func RunReaderGetBriefDepsProjectsTheDependencyRows(t *testing.T, ctx context.Context, fixture ReaderFixture) {
+	t.Helper()
+	subject := readerID(fixture, "briefdeps", "subject")
+	blocker := readerID(fixture, "briefdeps", "blocker")
+	const heavy = "the free-form body a brief projection is meant to drop"
+
+	seedReaderIssue(t, ctx, fixture, readerIssue(subject, types.TypeTask, ""))
+	blockerIssue := readerIssue(blocker, types.TypeTask, "")
+	blockerIssue.Description = heavy
+	blockerIssue.Notes = heavy
+	seedReaderIssue(t, ctx, fixture, blockerIssue)
+	if err := fixture.AddDependency(ctx, &types.Dependency{
+		IssueID: subject, DependsOnID: blocker, Type: types.DepBlocks,
+	}, "seed"); err != nil {
+		t.Fatalf("seed the outgoing edge: %v", err)
+	}
+
+	details, err := fixture.Reader.Get(ctx, publicops.GetRequest{ID: subject})
+	if err != nil {
+		t.Fatalf("Get with BriefDeps off: %v", err)
+	}
+	if len(details.Dependencies) != 1 {
+		t.Fatalf("Get returned %d dependency rows, want 1", len(details.Dependencies))
+	}
+	if got := details.Dependencies[0]; got.Description != heavy || got.Notes != heavy {
+		t.Errorf("BriefDeps off must return the full body, got description=%d notes=%d",
+			len(got.Description), len(got.Notes))
+	}
+
+	details, err = fixture.Reader.Get(ctx, publicops.GetRequest{ID: subject, BriefDeps: true})
+	if err != nil {
+		t.Fatalf("Get with BriefDeps on: %v", err)
+	}
+	if len(details.Dependencies) != 1 {
+		t.Fatalf("BriefDeps returned %d dependency rows, want 1", len(details.Dependencies))
+	}
+	got := details.Dependencies[0]
+	if got.ID != blocker || got.Status != types.StatusOpen || got.IssueType != types.TypeTask ||
+		got.Priority != 2 || got.DependencyType != types.DepBlocks {
+		t.Errorf("BriefDeps dropped an identity field: %+v", got)
+	}
+	if got.Description != "" || got.Design != "" || got.Notes != "" || got.AcceptanceCriteria != "" {
+		t.Errorf("BriefDeps left free-form text on the row: %+v", got)
+	}
+	assertReaderCount(t, "DependencyCount under BriefDeps", details.DependencyCount, 1)
+}
+
 // RunReaderGetDetailShapeMatchesTheSeededIssue pins the shape of the detail view
 // against what was actually stored (reader.go:15, reader.go:364-369): the
 // issue's own fields, its labels, its OUTGOING edges with their types, and the

--- a/backend/conformance/reader_contract.go
+++ b/backend/conformance/reader_contract.go
@@ -1346,6 +1346,8 @@ func RunReaderGetBriefDepsProjectsTheDependencyRows(t *testing.T, ctx context.Co
 	seedReaderIssue(t, ctx, fixture, readerIssue(subject, types.TypeTask, ""))
 	blockerIssue := readerIssue(blocker, types.TypeTask, "")
 	blockerIssue.Description = heavy
+	blockerIssue.Design = heavy
+	blockerIssue.AcceptanceCriteria = heavy
 	blockerIssue.Notes = heavy
 	seedReaderIssue(t, ctx, fixture, blockerIssue)
 	if err := fixture.AddDependency(ctx, &types.Dependency{
@@ -1361,9 +1363,10 @@ func RunReaderGetBriefDepsProjectsTheDependencyRows(t *testing.T, ctx context.Co
 	if len(details.Dependencies) != 1 {
 		t.Fatalf("Get returned %d dependency rows, want 1", len(details.Dependencies))
 	}
-	if got := details.Dependencies[0]; got.Description != heavy || got.Notes != heavy {
-		t.Errorf("BriefDeps off must return the full body, got description=%d notes=%d",
-			len(got.Description), len(got.Notes))
+	if got := details.Dependencies[0]; got.Description != heavy || got.Design != heavy ||
+		got.AcceptanceCriteria != heavy || got.Notes != heavy {
+		t.Errorf("BriefDeps off must return the full body, got description=%d design=%d acceptance=%d notes=%d",
+			len(got.Description), len(got.Design), len(got.AcceptanceCriteria), len(got.Notes))
 	}
 
 	details, err = fixture.Reader.Get(ctx, publicops.GetRequest{ID: subject, BriefDeps: true})
@@ -1374,8 +1377,8 @@ func RunReaderGetBriefDepsProjectsTheDependencyRows(t *testing.T, ctx context.Co
 		t.Fatalf("BriefDeps returned %d dependency rows, want 1", len(details.Dependencies))
 	}
 	got := details.Dependencies[0]
-	if got.ID != blocker || got.Status != types.StatusOpen || got.IssueType != types.TypeTask ||
-		got.Priority != 2 || got.DependencyType != types.DepBlocks {
+	if got.ID != blocker || got.Title != blocker || got.Status != types.StatusOpen ||
+		got.IssueType != types.TypeTask || got.Priority != 2 || got.DependencyType != types.DepBlocks {
 		t.Errorf("BriefDeps dropped an identity field: %+v", got)
 	}
 	if got.Description != "" || got.Design != "" || got.Notes != "" || got.AcceptanceCriteria != "" {

--- a/backend/conformance/role_bundle_cases.go
+++ b/backend/conformance/role_bundle_cases.go
@@ -502,6 +502,7 @@ var roleContractCases = []roleContract{
 		RunReaderGetResolvesTheExactIDAcrossBothPlanes,
 		RunReaderGetMissIsNotFoundAndBackendFailureDoesNotDecay,
 		RunReaderGetOptionalRowListsAreOffByDefault,
+		RunReaderGetBriefDepsProjectsTheDependencyRows,
 		RunReaderGetDetailShapeMatchesTheSeededIssue,
 		RunReaderDoesNotMutateTheCallerRequest,
 		RunReaderListLimitBoundaryUnderASortTheDatabaseCanExpress,

--- a/cmd/bd/show.go
+++ b/cmd/bd/show.go
@@ -161,12 +161,7 @@ var showCmd = &cobra.Command{
 					result.Close()
 					return HandleErrorRespectJSON("%v", rerr)
 				}
-				details, derr := rd.Get(ctx, issueops.GetRequest{
-					ID:                issue.ID,
-					IncludeDependents: includeDepends,
-					IncludeComments:   includeComments,
-					BriefDeps:         briefDeps,
-				})
+				details, derr := rd.Get(ctx, showGetRequest(issue.ID, includeDepends, includeComments, briefDeps))
 				if derr != nil {
 					result.Close()
 					return HandleErrorRespectJSON("%v", derr)
@@ -311,4 +306,16 @@ func init() {
 	showCmd.Flags().Bool("brief-deps", false, "Reduce each dependency to its identity fields in JSON output (--json only; drops description, design, notes and acceptance criteria)")
 	showCmd.ValidArgsFunction = issueIDCompletion
 	rootCmd.AddCommand(showCmd)
+}
+
+// showGetRequest carries the show flags onto the read contract. Extracted so
+// the hop is reachable from a test: both show routes build this request
+// independently, and a dropped field here is invisible to every other test.
+func showGetRequest(id string, includeDependents, includeComments, briefDeps bool) issueops.GetRequest {
+	return issueops.GetRequest{
+		ID:                id,
+		IncludeDependents: includeDependents,
+		IncludeComments:   includeComments,
+		BriefDeps:         briefDeps,
+	}
 }

--- a/cmd/bd/show.go
+++ b/cmd/bd/show.go
@@ -46,6 +46,7 @@ var showCmd = &cobra.Command{
 		currentMode, _ := cmd.Flags().GetBool("current")
 		includeDepends, _ := cmd.Flags().GetBool("include-dependents")
 		includeComments, _ := cmd.Flags().GetBool("include-comments")
+		briefDeps, _ := cmd.Flags().GetBool("brief-deps")
 		ctx := rootCtx
 
 		// Helper to format timestamp based on --local-time flag
@@ -164,6 +165,7 @@ var showCmd = &cobra.Command{
 					ID:                issue.ID,
 					IncludeDependents: includeDepends,
 					IncludeComments:   includeComments,
+					BriefDeps:         briefDeps,
 				})
 				if derr != nil {
 					result.Close()
@@ -306,6 +308,7 @@ func init() {
 	showCmd.Flags().Bool("current", false, "Show the currently active issue (in-progress, hooked, or last touched)")
 	showCmd.Flags().Bool("include-dependents", false, "Stream full dependent issues in JSON output (--json only; may be slow on hub beads)")
 	showCmd.Flags().Bool("include-comments", false, "Stream full comment bodies in JSON output (--json only; may be slow on issues with many comments)")
+	showCmd.Flags().Bool("brief-deps", false, "Reduce each dependency to its identity fields in JSON output (--json only; drops description, design, notes and acceptance criteria)")
 	showCmd.ValidArgsFunction = issueIDCompletion
 	rootCmd.AddCommand(showCmd)
 }

--- a/cmd/bd/show_brief_deps_test.go
+++ b/cmd/bd/show_brief_deps_test.go
@@ -1,0 +1,41 @@
+package main
+
+import "testing"
+
+// TestShowBriefDepsFlag guards the wiring for #5546: the flag must exist, must
+// default to off so the JSON payload is unchanged for callers that do not ask,
+// and must be read by the proxied route. The direct route and the
+// proxied-server route gather flags separately, so a flag added to one reaches
+// neither by implication.
+func TestShowBriefDepsFlag(t *testing.T) {
+	flag := showCmd.Flags().Lookup("brief-deps")
+	if flag == nil {
+		t.Fatal("brief-deps flag is not registered on showCmd")
+	}
+	if flag.DefValue != "false" {
+		t.Errorf("brief-deps default = %q, want false: the default payload must not change", flag.DefValue)
+	}
+
+	setBriefDeps := func(t *testing.T, v string) {
+		t.Helper()
+		if err := showCmd.Flags().Set("brief-deps", v); err != nil {
+			t.Fatalf("set brief-deps=%s: %v", v, err)
+		}
+		t.Cleanup(func() {
+			_ = showCmd.Flags().Set("brief-deps", "false")
+		})
+	}
+
+	t.Run("proxied route defaults off", func(t *testing.T) {
+		if in := gatherShowProxiedInput(showCmd, []string{"be-abc"}); in.briefDeps {
+			t.Error("brief-deps defaulted to on")
+		}
+	})
+
+	t.Run("proxied route reads it", func(t *testing.T) {
+		setBriefDeps(t, "true")
+		if in := gatherShowProxiedInput(showCmd, []string{"be-abc"}); !in.briefDeps {
+			t.Error("gatherShowProxiedInput did not carry brief-deps to the proxied request")
+		}
+	})
+}

--- a/cmd/bd/show_brief_deps_test.go
+++ b/cmd/bd/show_brief_deps_test.go
@@ -21,8 +21,10 @@ func TestShowBriefDepsFlag(t *testing.T) {
 		if err := showCmd.Flags().Set("brief-deps", v); err != nil {
 			t.Fatalf("set brief-deps=%s: %v", v, err)
 		}
+		// pflag.Set leaves Changed true, which outlives the value reset.
 		t.Cleanup(func() {
 			_ = showCmd.Flags().Set("brief-deps", "false")
+			showCmd.Flags().Lookup("brief-deps").Changed = false
 		})
 	}
 

--- a/cmd/bd/show_brief_deps_test.go
+++ b/cmd/bd/show_brief_deps_test.go
@@ -41,3 +41,35 @@ func TestShowBriefDepsFlag(t *testing.T) {
 		}
 	})
 }
+
+// TestShowGetRequestCarriesBriefDeps pins the hop from the gathered flags onto
+// the read contract, for both show routes. The HTTP door has the equivalent in
+// TestGetIssueBriefDepsReachesTheRequest; without this, deleting either
+// assignment leaves the whole suite green.
+func TestShowGetRequestCarriesBriefDeps(t *testing.T) {
+	t.Run("direct route", func(t *testing.T) {
+		if got := showGetRequest("be-abc", false, false, true); !got.BriefDeps {
+			t.Errorf("showGetRequest dropped BriefDeps: %+v", got)
+		}
+		if got := showGetRequest("be-abc", false, false, false); got.BriefDeps {
+			t.Errorf("showGetRequest invented BriefDeps: %+v", got)
+		}
+	})
+
+	t.Run("proxied route", func(t *testing.T) {
+		in := &showProxiedInput{briefDeps: true}
+		if got := in.getRequest("be-abc"); !got.BriefDeps {
+			t.Errorf("showProxiedInput.getRequest dropped BriefDeps: %+v", got)
+		}
+		if got := (&showProxiedInput{}).getRequest("be-abc"); got.BriefDeps {
+			t.Errorf("showProxiedInput.getRequest invented BriefDeps: %+v", got)
+		}
+	})
+
+	t.Run("sibling options are unaffected", func(t *testing.T) {
+		got := showGetRequest("be-abc", true, true, false)
+		if !got.IncludeDependents || !got.IncludeComments || got.ID != "be-abc" {
+			t.Errorf("sibling fields disturbed: %+v", got)
+		}
+	})
+}

--- a/cmd/bd/show_proxied_server.go
+++ b/cmd/bd/show_proxied_server.go
@@ -427,12 +427,7 @@ func runShowProxiedDefault(ctx context.Context, uw uow.UnitOfWork, in *showProxi
 	foundCount := 0
 	for idx, id := range in.ids {
 		if rd != nil {
-			details, derr := rd.Get(ctx, issueops.GetRequest{
-				ID:                id,
-				IncludeDependents: in.includeDepends,
-				BriefDeps:         in.briefDeps,
-				IncludeComments:   in.includeComments,
-			})
+			details, derr := rd.Get(ctx, in.getRequest(id))
 			if derr != nil {
 				if errors.Is(derr, storage.ErrNotFound) {
 					// The corpus pins this pair for a missing id: the human
@@ -563,4 +558,10 @@ func proxiedRenderIssue(ctx context.Context, uw uow.UnitOfWork, issue *types.Iss
 	}
 
 	fmt.Println()
+}
+
+// getRequest carries the proxied show flags onto the read contract. See
+// showGetRequest: the two routes build this independently.
+func (in *showProxiedInput) getRequest(id string) issueops.GetRequest {
+	return showGetRequest(id, in.includeDepends, in.includeComments, in.briefDeps)
 }

--- a/cmd/bd/show_proxied_server.go
+++ b/cmd/bd/show_proxied_server.go
@@ -34,6 +34,7 @@ type showProxiedInput struct {
 	watchMode       bool
 	currentMode     bool
 	includeDepends  bool
+	briefDeps       bool
 	includeComments bool
 }
 
@@ -49,6 +50,7 @@ func gatherShowProxiedInput(cmd *cobra.Command, args []string) *showProxiedInput
 	in.watchMode, _ = cmd.Flags().GetBool("watch")
 	in.currentMode, _ = cmd.Flags().GetBool("current")
 	in.includeDepends, _ = cmd.Flags().GetBool("include-dependents")
+	in.briefDeps, _ = cmd.Flags().GetBool("brief-deps")
 	in.includeComments, _ = cmd.Flags().GetBool("include-comments")
 
 	idFlags, _ := cmd.Flags().GetStringArray("id")
@@ -428,6 +430,7 @@ func runShowProxiedDefault(ctx context.Context, uw uow.UnitOfWork, in *showProxi
 			details, derr := rd.Get(ctx, issueops.GetRequest{
 				ID:                id,
 				IncludeDependents: in.includeDepends,
+				BriefDeps:         in.briefDeps,
 				IncludeComments:   in.includeComments,
 			})
 			if derr != nil {

--- a/internal/httpapi/apigen/types.gen.go
+++ b/internal/httpapi/apigen/types.gen.go
@@ -2106,6 +2106,9 @@ type GetIssueParams struct {
 
 	// IncludeDependents Populate `dependents` with the issues that depend on this one, each carrying its edge type — the shape `dependencies` already carries. Default false, for `include_comments`'s reason.
 	IncludeDependents *bool `form:"include_dependents,omitempty" json:"include_dependents,omitempty"`
+
+	// BriefDeps Reduce each row in `dependencies` to its identity-and-shape fields (`id`, `title`, `status`, `issue_type`, `priority`, `dependency_type`), dropping `description`, `design`, `notes` and `acceptance_criteria`. Default false, so the payload is unchanged for a client that does not ask.
+	BriefDeps *bool `form:"brief_deps,omitempty" json:"brief_deps,omitempty"`
 }
 
 // ListRelatedIssuesParams defines parameters for ListRelatedIssues.

--- a/internal/httpapi/get_issue_test.go
+++ b/internal/httpapi/get_issue_test.go
@@ -518,3 +518,21 @@ func TestListIssuesRowsCarryNoRevision(t *testing.T) {
 		}
 	}
 }
+
+// TestGetIssueBriefDepsReachesTheRequest is the HTTP half of #5546. The CLI and
+// this handler build GetRequest separately, so wiring one leaves the field
+// unreachable from the other.
+func TestGetIssueBriefDepsReachesTheRequest(t *testing.T) {
+	ts, rd := newGetIssueServer(t)
+
+	if resp := ts.get(t, "/v0/beads/issues/bd-1?brief_deps=true"); resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	reqs := rd.getRequests()
+	if len(reqs) != 1 {
+		t.Fatalf("%d detail reads, want 1", len(reqs))
+	}
+	if want := (issueops.GetRequest{ID: "bd-1", BriefDeps: true}); reqs[0] != want {
+		t.Errorf("GetRequest = %+v, want %+v", reqs[0], want)
+	}
+}

--- a/internal/httpapi/reads.go
+++ b/internal/httpapi/reads.go
@@ -465,6 +465,7 @@ func (s *Server) handleGetIssue(w http.ResponseWriter, r *http.Request) {
 	req := issueops.GetRequest{
 		IncludeComments:   q.boolean("include_comments"),
 		IncludeDependents: q.boolean("include_dependents"),
+		BriefDeps:         q.boolean("brief_deps"),
 	}
 
 	// Before the id bound, which is the order this operation had when

--- a/internal/httpapi/spec/openapi.v0.yaml
+++ b/internal/httpapi/spec/openapi.v0.yaml
@@ -1959,6 +1959,17 @@ paths:
           schema:
             type: boolean
             default: false
+        - name: brief_deps
+          in: query
+          description: >-
+            Reduce each row in `dependencies` to its identity-and-shape fields
+            (`id`, `title`, `status`, `issue_type`, `priority`,
+            `dependency_type`), dropping `description`, `design`, `notes` and
+            `acceptance_criteria`. Default false, so the payload is unchanged
+            for a client that does not ask.
+          schema:
+            type: boolean
+            default: false
       security:
         - bearerToken: []
       responses:

--- a/internal/storage/dolt/reader_contract_test.go
+++ b/internal/storage/dolt/reader_contract_test.go
@@ -150,6 +150,7 @@ func TestReaderGetOptionalRowListsAreOffByDefault(t *testing.T) {
 	fixture, ctx, cleanup := newDoltReaderFixture(t, "rdr")
 	defer cleanup()
 	conformance.RunReaderGetOptionalRowListsAreOffByDefault(t, ctx, fixture)
+	conformance.RunReaderGetBriefDepsProjectsTheDependencyRows(t, ctx, fixture)
 }
 
 func TestReaderGetDetailShapeMatchesTheSeededIssue(t *testing.T) {

--- a/internal/storage/dolt/reader_contract_test.go
+++ b/internal/storage/dolt/reader_contract_test.go
@@ -150,6 +150,11 @@ func TestReaderGetOptionalRowListsAreOffByDefault(t *testing.T) {
 	fixture, ctx, cleanup := newDoltReaderFixture(t, "rdr")
 	defer cleanup()
 	conformance.RunReaderGetOptionalRowListsAreOffByDefault(t, ctx, fixture)
+}
+
+func TestReaderGetBriefDepsProjectsTheDependencyRows(t *testing.T) {
+	fixture, ctx, cleanup := newDoltReaderFixture(t, "rdr")
+	defer cleanup()
 	conformance.RunReaderGetBriefDepsProjectsTheDependencyRows(t, ctx, fixture)
 }
 

--- a/internal/storage/embeddeddolt/reader_contract_test.go
+++ b/internal/storage/embeddeddolt/reader_contract_test.go
@@ -149,6 +149,11 @@ func TestEmbeddedReaderGetOptionalRowListsAreOffByDefault(t *testing.T) {
 	skipUnlessEmbeddedDolt(t)
 	ctx := t.Context()
 	conformance.RunReaderGetOptionalRowListsAreOffByDefault(t, ctx, newEmbeddedReaderFixture(t, "rdr"))
+}
+
+func TestEmbeddedReaderGetBriefDepsProjectsTheDependencyRows(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	ctx := t.Context()
 	conformance.RunReaderGetBriefDepsProjectsTheDependencyRows(t, ctx, newEmbeddedReaderFixture(t, "rdr"))
 }
 

--- a/internal/storage/embeddeddolt/reader_contract_test.go
+++ b/internal/storage/embeddeddolt/reader_contract_test.go
@@ -149,6 +149,7 @@ func TestEmbeddedReaderGetOptionalRowListsAreOffByDefault(t *testing.T) {
 	skipUnlessEmbeddedDolt(t)
 	ctx := t.Context()
 	conformance.RunReaderGetOptionalRowListsAreOffByDefault(t, ctx, newEmbeddedReaderFixture(t, "rdr"))
+	conformance.RunReaderGetBriefDepsProjectsTheDependencyRows(t, ctx, newEmbeddedReaderFixture(t, "rdr"))
 }
 
 func TestEmbeddedReaderGetDetailShapeMatchesTheSeededIssue(t *testing.T) {

--- a/internal/storage/uow/reader_contract_test.go
+++ b/internal/storage/uow/reader_contract_test.go
@@ -97,6 +97,8 @@ func TestReaderContract(t *testing.T) {
 	})
 	t.Run("GetOptionalRowListsAreOffByDefault", func(t *testing.T) {
 		conformance.RunReaderGetOptionalRowListsAreOffByDefault(t, ctx, fixture)
+	})
+	t.Run("GetBriefDepsProjectsTheDependencyRows", func(t *testing.T) {
 		conformance.RunReaderGetBriefDepsProjectsTheDependencyRows(t, ctx, fixture)
 	})
 	t.Run("GetDetailShapeMatchesTheSeededIssue", func(t *testing.T) {

--- a/internal/storage/uow/reader_contract_test.go
+++ b/internal/storage/uow/reader_contract_test.go
@@ -97,6 +97,7 @@ func TestReaderContract(t *testing.T) {
 	})
 	t.Run("GetOptionalRowListsAreOffByDefault", func(t *testing.T) {
 		conformance.RunReaderGetOptionalRowListsAreOffByDefault(t, ctx, fixture)
+		conformance.RunReaderGetBriefDepsProjectsTheDependencyRows(t, ctx, fixture)
 	})
 	t.Run("GetDetailShapeMatchesTheSeededIssue", func(t *testing.T) {
 		conformance.RunReaderGetDetailShapeMatchesTheSeededIssue(t, ctx, fixture)


### PR DESCRIPTION
Application half of #5546, stacking on #5547. Makes `DetailOptions.BriefDeps` reachable and pins it on the public contract.

## What

`--brief-deps` on `bd show`, `brief_deps` on `GET /v0/beads/issues/{id}`, and a conformance case for the field.

Measured against a 16,051-issue store with a binary built from this branch:

| call | bytes |
|---|---|
| `bd show <id> --json` | 216,605 |
| `bd show <id> --json --brief-deps` | 23,287 |

89.3% smaller, identity fields intact, zero bytes of dependency text.

## Carried from the #5547 review

**Conformance coverage (the blocking one).** `backend/conformance` pins `IncludeDependents`/`IncludeComments` precisely so an out-of-tree `Reader` cannot silently ignore them, and `BriefDeps` landed on the same public contract with no case. `RunReaderGetBriefDepsProjectsTheDependencyRows` registered at all four call sites (`role_bundle_cases.go` plus the dolt, embeddeddolt and uow contract tests).

One correction: the review named `RunReaderGetHonorsDetailOptions`. The function pinning those options is `RunReaderGetOptionalRowListsAreOffByDefault` at `reader_contract.go:1285`, which is what the new case is modeled on.

**Two front doors.** `internal/httpapi/reads.go` builds `GetRequest` independently of the CLI, so wiring `cmd/bd` alone would have left the field reachable from one door of two. Adds the query parameter to `openapi.v0.yaml` and regenerates `apigen` types; `make api-check` is green.

Both `bd show` routes are wired, too: the direct route and `gatherShowProxiedInput` gather flags separately.

## Default payload unchanged

`brief-deps` and `brief_deps` both default false. The existing `TestGetIssueWithoutTheIncludeParametersIsUnchanged` asserts the exact `GetRequest` struct for a caller that sends nothing, so the new field is pinned to its zero value there by construction.

## Not included

The `dependencies_brief: true` echo suggested as a nit. Brief rows remain indistinguishable from genuinely textless dependencies, which is the ambiguity `CommentsOmitted` was added to resolve for comments. It needs a `types.IssueDetails` field and its own marshaling test, so it belongs in its own change rather than riding along here. Happy to follow up if you want it.

## Test plan

```
go test ./cmd/bd/ ./internal/httpapi/ ./internal/workapi/... ./internal/storage/uow/ -count=1
make api-check
./scripts/generate-cli-docs.sh --check
```

All green: `cmd/bd` full suite (212s), `TestReaderContract` on uow (29s), api-check, and the CLI docs drift check.

Every new assertion was confirmed to go red before green:

- disabling the projection fails `TestReaderContract/GetOptionalRowListsAreOffByDefault` against a real backend with `BriefDeps left free-form text on the row`
- removing the proxied-route flag read fails `TestShowBriefDepsFlag/proxied_route_reads_it`
