### PR TITLE
feat(list,ready,httpapi): reach the Brief projection from both front doors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **`--brief` on `bd list` and `bd ready`, and `brief` on the two HTTP
-  listings** (#5546). The listing commands return the whole body of every row
-  they page. On one real 16,051-issue store `bd ready --json` returned 454,021
-  bytes with notes plus description accounting for 76% of it, on exactly the
-  call an agent makes to decide what to work on next. `--brief` omits the
-  free-form text (`description`, `design`, `acceptance_criteria`, `notes`,
-  `payload`, `waiters`), measuring 93.4% smaller, and marks each row
-  `is_lite_partial` so a projected row is never mistaken for an empty one.
-  Filtering is untouched: `--desc-contains` and its siblings select rows, and
-  this selects fields. It is opt-in and the default payload is unchanged, and
-  the response carries no marker, so only the caller that asked knows its rows
-  are partial.
+  listings** (#5546, #5554, #5586). The listing commands return the whole body
+  of every row they page. On one real 16,051-issue store `bd ready --json`
+  returned 454,021 bytes with notes plus description accounting for 76% of it,
+  on exactly the call an agent makes to decide what to work on next. `--brief`
+  omits the free-form text (`description`, `design`, `acceptance_criteria`,
+  `notes`, `payload`, `waiters`), measuring 93.4% smaller. Filtering is
+  untouched: `--desc-contains` and its siblings select rows, and this selects
+  fields. It is opt-in and the default payload is unchanged.
+
+  **The response carries no marker for the omission.** An omitted field is
+  indistinguishable from a genuinely empty one, so only the caller that passed
+  the flag knows its rows are partial; there is no `is_lite_partial` in the
+  JSON. The one visible marker is in text output, where `bd list --long
+  --brief` prints `Description: (omitted by --brief)` rather than an empty
+  section.
 
   The flag is refused wherever it could not be honored, rather than accepted
   and dropped. On `bd ready` it requires `--json` and is refused with `--claim`,
@@ -28,8 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the counts query alone, which those routes do not run. On `bd list` it works
   in text mode too, and is refused with `--watch`, with the `--parent` tree
   walk, and with `--format`, where a caller's template could print a dropped
-  field with nothing to mark it. `bd list --long --brief` prints
-  `Description: (omitted by --brief)` rather than an empty section.
+  field with nothing to mark it.
 
 - **`--brief-deps` on `bd show`, and `brief_deps` on the HTTP detail read**
   (#5546, #5547, #5549). `bd show --json` inlines every dependency at full

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`--brief` on `bd list` and `bd ready`, and `brief` on the two HTTP
+  listings** (#5546). The listing commands return the whole body of every row
+  they page. On one real 16,051-issue store `bd ready --json` returned 454,021
+  bytes with notes plus description accounting for 76% of it, on exactly the
+  call an agent makes to decide what to work on next. `--brief` omits the
+  free-form text (`description`, `design`, `acceptance_criteria`, `notes`,
+  `payload`, `waiters`), measuring 93.4% smaller, and marks each row
+  `is_lite_partial` so a projected row is never mistaken for an empty one.
+  Filtering is untouched: `--desc-contains` and its siblings select rows, and
+  this selects fields. It is opt-in and the default payload is unchanged, and
+  the response carries no marker, so only the caller that asked knows its rows
+  are partial.
+
+  The flag is refused wherever it could not be honored, rather than accepted
+  and dropped. On `bd ready` it requires `--json` and is refused with `--claim`,
+  `--gated`, `--mol` and `--explain`: the projection reaches the driver through
+  the counts query alone, which those routes do not run. On `bd list` it works
+  in text mode too, and is refused with `--watch`, with the `--parent` tree
+  walk, and with `--format`, where a caller's template could print a dropped
+  field with nothing to mark it. `bd list --long --brief` prints
+  `Description: (omitted by --brief)` rather than an empty section.
+
 - **`--brief-deps` on `bd show`, and `brief_deps` on the HTTP detail read**
   (#5546, #5547, #5549). `bd show --json` inlines every dependency at full
   body, so reading one issue costs the free-form text of everything it depends

--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -443,6 +443,15 @@ func init() {
 			"Cannot combine with --label, --label-any, --label-pattern, --label-regex, "+
 			"--exclude-label, or --no-labels.")
 
+	// Projection toggle. Like --skip-labels it trades data for bytes, and
+	// unlike it the dropped fields leave a mark on the row (IsLitePartial).
+	listCmd.Flags().Bool("brief", false,
+		"Omit the free-form text (description, design, acceptance criteria, notes, "+
+			"payload, waiters) from each row. Filters that read those fields, such as "+
+			"--desc-contains, still select on them. An omitted field is"+
+			" indistinguishable from an empty one in --json; fetch a whole issue"+
+			" with bd show.")
+
 	// Priority ranges
 	listCmd.Flags().String("priority-min", "", "Filter by minimum priority (inclusive, 0-4 or P0-P4)")
 	listCmd.Flags().String("priority-max", "", "Filter by maximum priority (inclusive, 0-4 or P0-P4)")

--- a/cmd/bd/list_format.go
+++ b/cmd/bd/list_format.go
@@ -102,7 +102,15 @@ func formatIssueLong(buf *strings.Builder, issue *types.Issue, labels []string, 
 	if issue.Assignee != "" {
 		buf.WriteString(fmt.Sprintf("  Assignee: %s\n", issue.Assignee))
 	}
-	if desc := strings.TrimSpace(issue.Description); desc != "" {
+	// This is the one text rendering in the tree that prints a field --brief
+	// drops, so it is the one that has to say so. Keyed off the ROW, not off
+	// the flag: IsLitePartial travels with the issue, so a row that arrived
+	// projected reads the same here whichever door set it. Without this the
+	// listing is indistinguishable from one whose issues have no description,
+	// which is the ambiguity the flag is otherwise careful to avoid.
+	if issue.IsLitePartial {
+		buf.WriteString("  Description: (omitted by --brief)\n")
+	} else if desc := strings.TrimSpace(issue.Description); desc != "" {
 		buf.WriteString("  Description:\n")
 		for _, line := range strings.Split(desc, "\n") {
 			buf.WriteString(fmt.Sprintf("    %s\n", line))

--- a/cmd/bd/list_input.go
+++ b/cmd/bd/list_input.go
@@ -90,6 +90,7 @@ func gatherListInput(cmd *cobra.Command) (listInput, error) {
 	in.NoAssignee, _ = cmd.Flags().GetBool("no-assignee")
 	in.NoLabels, _ = cmd.Flags().GetBool("no-labels")
 
+	in.Brief, _ = cmd.Flags().GetBool("brief")
 	in.SkipLabels, _ = cmd.Flags().GetBool("skip-labels")
 	if in.SkipLabels {
 		conflicts := skipLabelsConflicts(in.Labels, in.LabelsAny, in.LabelPattern, in.LabelRegex, in.ExcludeLabels, in.NoLabels)
@@ -228,6 +229,34 @@ func gatherListInput(cmd *cobra.Command) (listInput, error) {
 	}
 	in.noPager, _ = cmd.Flags().GetBool("no-pager")
 	in.ReadyFlag, _ = cmd.Flags().GetBool("ready")
+
+	// REFUSED WHERE IT CANNOT BE HONORED OR CANNOT BE SEEN. The page routes,
+	// direct and proxied, JSON and text, all hand this request to
+	// issueops.Reader.List, whose query reads types.IssueFilter.Lite; the three
+	// below leave that query.
+	//
+	//   --watch re-queries on a ticker through loadWatchedIssues, whose --ready
+	//   arm calls the bare GetReadyWork and whose --parent arm walks the tree;
+	//   neither reads Lite.
+	//
+	//   --parent with --pretty is that same tree walk, an unlimited per-level
+	//   query rather than a page.
+	//
+	//   --format hands the whole issue to a caller-written template, so
+	//   `--brief --format '{{.Issue.Description}}'` would print an empty string
+	//   with nothing to say it had been dropped. The long format prints one
+	//   omitted field and says so; a template can print any of the six and
+	//   cannot be annotated.
+	if in.Brief {
+		switch {
+		case in.watchMode:
+			return in, HandleError("--watch cannot be combined with --brief")
+		case in.formatStr != "":
+			return in, HandleError("--format cannot be combined with --brief; a template can print a field --brief omits, with nothing to mark it")
+		case in.ParentID != "" && in.prettyFormat:
+			return in, HandleError("--parent with --pretty cannot be combined with --brief; the hierarchical walk is a different query")
+		}
+	}
 
 	in.depsMode, _ = cmd.Flags().GetString("deps")
 	if in.depsMode != "" {

--- a/cmd/bd/list_ready_brief_test.go
+++ b/cmd/bd/list_ready_brief_test.go
@@ -1,0 +1,360 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/issueops"
+)
+
+// newListFlagsCommand clones listCmd's flag definitions onto a fresh command,
+// for newReadyFlagsCommand's reason: re-declaring a default here would be a
+// second place for `bd list` to drift from itself.
+func newListFlagsCommand(t *testing.T, args ...string) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{Use: "list"}
+	listCmd.Flags().VisitAll(func(f *pflag.Flag) {
+		switch f.Value.Type() {
+		case "bool":
+			cmd.Flags().Bool(f.Name, f.DefValue == "true", f.Usage)
+		case "int":
+			cmd.Flags().Int(f.Name, 0, f.Usage)
+		case "string":
+			cmd.Flags().String(f.Name, f.DefValue, f.Usage)
+		case "stringSlice":
+			cmd.Flags().StringSlice(f.Name, nil, f.Usage)
+		case "stringArray":
+			cmd.Flags().StringArray(f.Name, nil, f.Usage)
+		default:
+			t.Fatalf("--%s has unhandled flag type %q", f.Name, f.Value.Type())
+		}
+	})
+	if err := cmd.ParseFlags(args); err != nil {
+		t.Fatalf("parse %v: %v", args, err)
+	}
+	return cmd
+}
+
+// TestBriefFlagIsRegisteredOnBothCommands pins the two registrations and their
+// defaults. Off by default is the load-bearing half: #4122 objects to default
+// payload changes and #5078 records what the last one cost.
+func TestBriefFlagIsRegisteredOnBothCommands(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		cmd  *cobra.Command
+	}{
+		{"list", listCmd},
+		{"ready", readyCmd},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			flag := c.cmd.Flags().Lookup("brief")
+			if flag == nil {
+				t.Fatalf("brief flag is not registered on %sCmd", c.name)
+			}
+			if flag.DefValue != "false" {
+				t.Errorf("brief default = %q, want false: the default payload must not change", flag.DefValue)
+			}
+		})
+	}
+}
+
+// TestListBriefReachesTheRequest pins the hop from the flag onto
+// issueops.ListRequest. Both `bd list` routes hand that request to
+// issueops.Reader.List verbatim (list.go and list_proxied_server.go), so this
+// one assignment is what reaches them; deleting it leaves the storage suite
+// green and the flag inert, which is the failure mode #5546 is about.
+func TestListBriefReachesTheRequest(t *testing.T) {
+	t.Run("off by default", func(t *testing.T) {
+		in, err := gatherListInput(newListFlagsCommand(t))
+		if err != nil {
+			t.Fatalf("gatherListInput: %v", err)
+		}
+		if in.Brief {
+			t.Error("ListRequest.Brief defaulted to true")
+		}
+	})
+
+	t.Run("set", func(t *testing.T) {
+		in, err := gatherListInput(newListFlagsCommand(t, "--brief"))
+		if err != nil {
+			t.Fatalf("gatherListInput(--brief): %v", err)
+		}
+		if !in.Brief {
+			t.Error("gatherListInput did not carry --brief onto ListRequest.Brief")
+		}
+	})
+}
+
+// runGatherListInput captures both streams around gatherListInput, the way
+// runGatherReadyInput does for `bd ready`: these usage errors are printed by
+// HandleError rather than returned as text, so a test that only inspects the
+// error cannot tell WHICH conflict fired.
+func runGatherListInput(t *testing.T, cmd *cobra.Command) (listInput, error, string) {
+	t.Helper()
+
+	stdioMutex.Lock()
+	defer stdioMutex.Unlock()
+
+	oldStdout, oldStderr := os.Stdout, os.Stderr
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	rErr, wErr, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout, os.Stderr = wOut, wErr
+
+	drain := func(r *os.File) <-chan string {
+		done := make(chan string, 1)
+		go func() {
+			var buf bytes.Buffer
+			_, _ = buf.ReadFrom(r)
+			done <- buf.String()
+		}()
+		return done
+	}
+	outDone, errDone := drain(rOut), drain(rErr)
+
+	in, gatherErr := gatherListInput(cmd)
+
+	wOut.Close()
+	wErr.Close()
+	os.Stdout, os.Stderr = oldStdout, oldStderr
+	shown := <-outDone + <-errDone
+	_ = rOut.Close()
+	_ = rErr.Close()
+	return in, gatherErr, shown
+}
+
+// TestListBriefIsRefusedWhereItCannotBeHonored is the `bd list` half of the
+// same table. Its page routes all reach issueops.Reader.List, whose query reads
+// types.IssueFilter.Lite, so unlike `bd ready` the flag works in text mode too
+// and is not gated on --json. The three below leave that query:
+//
+//	--watch re-queries through loadWatchedIssues, whose --ready arm calls the
+//	bare GetReadyWork and whose --parent arm walks the tree; neither reads Lite.
+//
+//	--parent with --pretty is that tree walk.
+//
+//	--format hands the whole issue to a caller-written template, which can print
+//	any of the six dropped fields with nothing to mark the omission. The long
+//	format prints one of them and says so; a template cannot be annotated.
+func TestListBriefIsRefusedWhereItCannotBeHonored(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"watch", []string{"--brief", "--watch"}, "--watch cannot be combined with --brief"},
+		{"format", []string{"--brief", "--format", "{{.Issue.Description}}"}, "--format cannot be combined with --brief"},
+		{"parent tree", []string{"--brief", "--parent", "bd-1", "--pretty"}, "--parent with --pretty cannot be combined with --brief"},
+		// --tree defaults to true, so a bare --parent in text mode is the same
+		// walk without the flag being typed.
+		{"parent implies the tree in text mode", []string{"--brief", "--parent", "bd-1"}, "--parent with --pretty cannot be combined with --brief"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pinJSONOutput(t, false)
+			_, err, shown := runGatherListInput(t, newListFlagsCommand(t, tc.args...))
+			if err == nil {
+				t.Fatalf("gatherListInput(%v) = nil, want a usage error naming %q", tc.args, tc.want)
+			}
+			if !strings.Contains(shown, tc.want) {
+				t.Errorf("output = %q, want it to name %q", shown, tc.want)
+			}
+		})
+	}
+}
+
+// TestListBriefIsAcceptedOnThePageRoutes is the negative control: the modes
+// above are refusals, not a blanket one. --long is here on purpose, since it is
+// the text rendering that prints an omitted field and is allowed precisely
+// because it marks it.
+func TestListBriefIsAcceptedOnThePageRoutes(t *testing.T) {
+	for _, args := range [][]string{
+		{"--brief"},
+		{"--brief", "--long"},
+		// --flat turns the tree off, which puts --parent back on the page route.
+		{"--brief", "--parent", "bd-1", "--flat"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			pinJSONOutput(t, false)
+			in, err := gatherListInput(newListFlagsCommand(t, args...))
+			if err != nil {
+				t.Fatalf("gatherListInput(%v) = %v, want no error", args, err)
+			}
+			if !in.Brief {
+				t.Errorf("gatherListInput(%v) dropped Brief", args)
+			}
+		})
+	}
+}
+
+// TestReadyBriefReachesTheFilter pins the hop for `bd ready`, which does NOT
+// go through issueops.Reader on either route: the direct route calls
+// GetReadyWorkWithCounts(ctx, in.filter) and the proxied one calls the same
+// through the unit of work. The filter is therefore the thing that has to
+// carry the projection, and types.WorkFilter.Lite is where it lands.
+func TestReadyBriefReachesTheFilter(t *testing.T) {
+	t.Run("off by default", func(t *testing.T) {
+		got := runGatherReadyInput(t, newReadyFlagsCommand(t), nil)
+		if got.err != nil {
+			t.Fatalf("gatherReadyInput: %v", got.err)
+		}
+		if got.in.Brief {
+			t.Error("ReadyRequest.Brief defaulted to true")
+		}
+		if got.in.filter.Lite {
+			t.Error("WorkFilter.Lite defaulted to true")
+		}
+	})
+
+	t.Run("set", func(t *testing.T) {
+		// --json because the gatherer requires it for --brief; see
+		// TestReadyBriefIsRefusedWhereItCannotBeHonored.
+		pinJSONOutput(t, true)
+		got := runGatherReadyInput(t, newReadyFlagsCommand(t, "--brief"), nil)
+		if got.err != nil {
+			t.Fatalf("gatherReadyInput(--brief): %v", got.err)
+		}
+		if !got.in.Brief {
+			t.Error("gatherReadyInput did not read --brief")
+		}
+		if !got.in.filter.Lite {
+			t.Error("--brief did not reach WorkFilter.Lite, so both ready routes would ignore it")
+		}
+	})
+}
+
+// TestReadyBriefIsRefusedWhereItCannotBeHonored is the table of combinations
+// that would otherwise take the flag and ignore it.
+//
+// types.WorkFilter.Lite reaches the driver through one query, the counts
+// mega-query behind GetReadyWorkWithCounts, and `bd ready` runs that query for
+// --json alone: the text routes call the bare GetReadyWork and the three
+// specialized modes answer with shapes of their own. --claim is refused for a
+// stronger reason, that no route can serve it at all
+// (issueops.ValidateClaimNextRequest returns ErrValidation for a projected
+// claim, which refetches its winning row whole).
+//
+// Each case is asserted on the MESSAGE, not merely on the presence of an error,
+// because every one of these flags has a prior conflict of its own and a test
+// that accepted any error would pass on the wrong one.
+func TestReadyBriefIsRefusedWhereItCannotBeHonored(t *testing.T) {
+	// --json is a root persistent flag rather than one of readyCmd's, so it is
+	// set through the package global the gatherer actually reads, not in args.
+	for _, tc := range []struct {
+		name string
+		args []string
+		json bool
+		want string
+	}{
+		{"claim", []string{"--brief", "--claim"}, true, "--claim cannot be combined with --brief"},
+		{"gated", []string{"--brief", "--gated"}, true, "--gated cannot be combined with --brief"},
+		{"mol", []string{"--brief", "--mol", "bd-1"}, true, "--mol cannot be combined with --brief"},
+		{"explain", []string{"--brief", "--explain"}, true, "--explain cannot be combined with --brief"},
+		{"without --json", []string{"--brief"}, false, "--brief requires --json"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pinJSONOutput(t, tc.json)
+
+			got := runGatherReadyInput(t, newReadyFlagsCommand(t, tc.args...), nil)
+			if got.err == nil {
+				t.Fatalf("gatherReadyInput(%v) = nil, want a usage error", tc.args)
+			}
+			// HandleErrorRespectJSON puts the message on stdout as JSON when
+			// --json is on and on stderr as text otherwise, so both are read.
+			if shown := got.stdout + got.stderr; !strings.Contains(shown, tc.want) {
+				t.Errorf("output = %q, want it to name %q", shown, tc.want)
+			}
+		})
+	}
+}
+
+// TestReadyBriefWithJSONIsAccepted is the negative control for the table above:
+// with none of those modes set, the flag must get through. Without this, a
+// refusal that fired unconditionally would leave every case there green.
+func TestReadyBriefWithJSONIsAccepted(t *testing.T) {
+	pinJSONOutput(t, true)
+
+	got := runGatherReadyInput(t, newReadyFlagsCommand(t, "--brief"), nil)
+	if got.err != nil {
+		t.Fatalf("gatherReadyInput(--brief --json) = %v, want no error", got.err)
+	}
+	if !got.in.filter.Lite {
+		t.Error("--brief with --json did not reach WorkFilter.Lite")
+	}
+}
+
+// TestReadyRoleRequestCarriesBrief is the other side of the refusal above, and
+// the reason the refusal lives in the gatherer rather than here. This helper
+// builds the request for BOTH roles `bd ready` talks to, and the two want
+// opposite things: ReadyClaimer refuses a projection, ReadyCounter needs one,
+// because the unit-of-work counter sizes the ready set by running the unbounded
+// page (uow/ready_counter.go). Clearing Brief here to appease the claim would
+// make `bd ready --brief` hydrate every heavy column of the whole ready set to
+// fetch the total printed beside its page.
+func TestReadyRoleRequestCarriesBrief(t *testing.T) {
+	got := readyRoleRequest(readyInput{ReadyRequest: issueops.ReadyRequest{Brief: true}})
+	if !got.Brief {
+		t.Error("readyRoleRequest dropped Brief, so the ready count would run unprojected")
+	}
+	if got.Limit != nil || got.Offset != 0 {
+		t.Errorf("readyRoleRequest stopped clearing the page: Limit=%v Offset=%d", got.Limit, got.Offset)
+	}
+}
+
+// TestFormatIssueLongMarksAProjectedRow pins the one text rendering in the tree
+// that prints a field --brief drops. Without the marker a projected listing is
+// byte-identical to one whose issues genuinely have no description, which is
+// the ambiguity the projection is otherwise careful to avoid (it is why the row
+// carries IsLitePartial at all rather than just arriving blank).
+//
+// The marker keys off the ROW, so it is asserted on the row, not through a
+// flag: a row that arrived projected reads the same whichever door set it.
+func TestFormatIssueLongMarksAProjectedRow(t *testing.T) {
+	render := func(issue *types.Issue) string {
+		var buf strings.Builder
+		formatIssueLong(&buf, issue, nil, false)
+		return buf.String()
+	}
+
+	t.Run("projected row says so", func(t *testing.T) {
+		out := render(&types.Issue{
+			ID: "be-abc", Title: "t", Status: types.StatusOpen,
+			IssueType: types.TypeTask, IsLitePartial: true,
+		})
+		if !strings.Contains(out, "Description: (omitted by --brief)") {
+			t.Errorf("long format did not mark the projection:\n%s", out)
+		}
+	})
+
+	t.Run("whole row with a description prints it", func(t *testing.T) {
+		out := render(&types.Issue{
+			ID: "be-abc", Title: "t", Status: types.StatusOpen,
+			IssueType: types.TypeTask, Description: "the body",
+		})
+		if strings.Contains(out, "omitted by --brief") {
+			t.Errorf("long format marked an unprojected row:\n%s", out)
+		}
+		if !strings.Contains(out, "the body") {
+			t.Errorf("long format dropped the description:\n%s", out)
+		}
+	})
+
+	t.Run("whole row with no description stays silent", func(t *testing.T) {
+		out := render(&types.Issue{
+			ID: "be-abc", Title: "t", Status: types.StatusOpen,
+			IssueType: types.TypeTask,
+		})
+		if strings.Contains(out, "Description") {
+			t.Errorf("long format invented a Description line for a textless row:\n%s", out)
+		}
+	})
+}

--- a/cmd/bd/list_ready_brief_test.go
+++ b/cmd/bd/list_ready_brief_test.go
@@ -277,6 +277,87 @@ func TestReadyBriefIsRefusedWhereItCannotBeHonored(t *testing.T) {
 	}
 }
 
+// TestReadyCmdRefusesBriefBeforeItDispatches drives readyCmd's RunE, which the
+// table above does not reach, and it is the half that was missing.
+//
+// --gated, --mol and --explain are dispatched by RunE BEFORE gatherReadyInput
+// runs, so the gatherer's refusals guard the proxied route only. When those
+// three checks were copies written into each dispatch branch, deleting one left
+// `bd ready --gated --brief` silently ignoring the flag on the direct route
+// with the whole package still green. They are now one hoisted call to
+// briefModeConflict, and this is what fails if that call is removed.
+//
+// RunE is reachable in a test because the check sits above every store access:
+// it returns before the proxied branch, the offset check and the mode dispatch.
+func TestReadyCmdRefusesBriefBeforeItDispatches(t *testing.T) {
+	setFlag := func(t *testing.T, name, value string) {
+		t.Helper()
+		if err := readyCmd.Flags().Set(name, value); err != nil {
+			t.Fatalf("set %s=%s: %v", name, value, err)
+		}
+		// pflag.Set leaves Changed true, which outlives the value reset and
+		// would contaminate later tests in the package.
+		t.Cleanup(func() {
+			def := readyCmd.Flags().Lookup(name).DefValue
+			_ = readyCmd.Flags().Set(name, def)
+			readyCmd.Flags().Lookup(name).Changed = false
+		})
+	}
+
+	for _, tc := range []struct {
+		name string
+		flag string
+		val  string
+		want string
+	}{
+		{"gated", "gated", "true", "--gated cannot be combined with --brief"},
+		{"mol", "mol", "bd-1", "--mol cannot be combined with --brief"},
+		{"explain", "explain", "true", "--explain cannot be combined with --brief"},
+		{"claim", "claim", "true", "--claim cannot be combined with --brief"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pinJSONOutput(t, true)
+			setFlag(t, "brief", "true")
+			setFlag(t, tc.flag, tc.val)
+
+			stdioMutex.Lock()
+			defer stdioMutex.Unlock()
+
+			oldStdout, oldStderr := os.Stdout, os.Stderr
+			rOut, wOut, _ := os.Pipe()
+			rErr, wErr, _ := os.Pipe()
+			os.Stdout, os.Stderr = wOut, wErr
+
+			drain := func(r *os.File) <-chan string {
+				done := make(chan string, 1)
+				go func() {
+					var buf bytes.Buffer
+					_, _ = buf.ReadFrom(r)
+					done <- buf.String()
+				}()
+				return done
+			}
+			outDone, errDone := drain(rOut), drain(rErr)
+
+			err := readyCmd.RunE(readyCmd, nil)
+
+			wOut.Close()
+			wErr.Close()
+			os.Stdout, os.Stderr = oldStdout, oldStderr
+			shown := <-outDone + <-errDone
+			_ = rOut.Close()
+			_ = rErr.Close()
+
+			if err == nil {
+				t.Fatalf("readyCmd.RunE(--brief --%s) = nil, want a usage error naming %q", tc.flag, tc.want)
+			}
+			if !strings.Contains(shown, tc.want) {
+				t.Errorf("output = %q, want it to name %q", shown, tc.want)
+			}
+		})
+	}
+}
+
 // TestReadyBriefWithJSONIsAccepted is the negative control for the table above:
 // with none of those modes set, the flag must get through. Without this, a
 // refusal that fired unconditionally would leave every case there green.

--- a/cmd/bd/ready.go
+++ b/cmd/bd/ready.go
@@ -82,6 +82,12 @@ This is useful for agents executing molecules to see which steps can run next.`,
 			if claimReady {
 				return HandleErrorRespectJSON("--claim cannot be combined with --gated")
 			}
+			// Duplicated from gatherReadyInput because this route dispatches
+			// the specialized modes BEFORE gathering, so the gatherer's copy
+			// reaches the proxied route only.
+			if brief, _ := cmd.Flags().GetBool("brief"); brief {
+				return HandleErrorRespectJSON("--gated cannot be combined with --brief")
+			}
 			// Delegate to the non-emitting core so `bd ready --gated` records
 			// exactly one cli_command event ("ready"), not also "mol-ready-gated".
 			return runMolReadyGatedCore(cmd, args)
@@ -92,6 +98,9 @@ This is useful for agents executing molecules to see which steps can run next.`,
 			if claimReady {
 				return HandleErrorRespectJSON("--claim cannot be combined with --mol")
 			}
+			if brief, _ := cmd.Flags().GetBool("brief"); brief {
+				return HandleErrorRespectJSON("--mol cannot be combined with --brief")
+			}
 			return runMoleculeReady(cmd, molID)
 		}
 
@@ -99,6 +108,9 @@ This is useful for agents executing molecules to see which steps can run next.`,
 		if explain {
 			if claimReady {
 				return HandleErrorRespectJSON("--claim cannot be combined with --explain")
+			}
+			if brief, _ := cmd.Flags().GetBool("brief"); brief {
+				return HandleErrorRespectJSON("--explain cannot be combined with --brief")
 			}
 			return runReadyExplain(cmd)
 		}
@@ -707,6 +719,14 @@ func init() {
 	readyCmd.Flags().StringSlice("exclude-type", nil, "Exclude issue types from results (comma-separated or repeatable, e.g., --exclude-type=convoy,epic)")
 	readyCmd.Flags().Bool("explain", false, "Show dependency-aware reasoning for why issues are ready or blocked")
 	readyCmd.Flags().Bool("claim", false, "Atomically claim the first ready issue matching the filters")
+	// Projection toggle, the same one `bd list --brief` sets. Refused with
+	// --claim, which returns one whole row by contract; see gatherReadyInput.
+	readyCmd.Flags().Bool("brief", false,
+		"Omit the free-form text (description, design, acceptance criteria, notes, "+
+			"payload, waiters) from each row. Filters that read those fields still "+
+			"select on them. An omitted field is indistinguishable from an empty "+
+			"one; fetch a whole issue with bd show. Requires --json, and cannot be "+
+			"combined with --claim, --gated, --mol or --explain.")
 	// Metadata filtering (GH#1406)
 	readyCmd.Flags().StringArray("metadata-field", nil, "Filter by metadata field (key=value, repeatable)")
 	readyCmd.Flags().String("has-metadata-key", "", "Filter issues that have this metadata key set")

--- a/cmd/bd/ready.go
+++ b/cmd/bd/ready.go
@@ -49,6 +49,15 @@ This is useful for agents executing molecules to see which steps can run next.`,
 
 		claimReady, _ := cmd.Flags().GetBool("claim")
 
+		// ABOVE THE MODE DISPATCH, and above the proxied branch, so it is the
+		// one place a --brief conflict is decided for this command on either
+		// route. The branches below return before gatherReadyInput runs, so a
+		// check written into each of them would be three untested copies; this
+		// is one call into the body the gatherer also uses.
+		if err := briefModeConflictFromFlags(cmd); err != nil {
+			return err
+		}
+
 		if usesProxiedServer() {
 			// --claim consumes exactly one row, same reasoning as the
 			// direct-path fix in issueops/claim.go: a rig-wide cap sized
@@ -82,12 +91,6 @@ This is useful for agents executing molecules to see which steps can run next.`,
 			if claimReady {
 				return HandleErrorRespectJSON("--claim cannot be combined with --gated")
 			}
-			// Duplicated from gatherReadyInput because this route dispatches
-			// the specialized modes BEFORE gathering, so the gatherer's copy
-			// reaches the proxied route only.
-			if brief, _ := cmd.Flags().GetBool("brief"); brief {
-				return HandleErrorRespectJSON("--gated cannot be combined with --brief")
-			}
 			// Delegate to the non-emitting core so `bd ready --gated` records
 			// exactly one cli_command event ("ready"), not also "mol-ready-gated".
 			return runMolReadyGatedCore(cmd, args)
@@ -98,9 +101,6 @@ This is useful for agents executing molecules to see which steps can run next.`,
 			if claimReady {
 				return HandleErrorRespectJSON("--claim cannot be combined with --mol")
 			}
-			if brief, _ := cmd.Flags().GetBool("brief"); brief {
-				return HandleErrorRespectJSON("--mol cannot be combined with --brief")
-			}
 			return runMoleculeReady(cmd, molID)
 		}
 
@@ -108,9 +108,6 @@ This is useful for agents executing molecules to see which steps can run next.`,
 		if explain {
 			if claimReady {
 				return HandleErrorRespectJSON("--claim cannot be combined with --explain")
-			}
-			if brief, _ := cmd.Flags().GetBool("brief"); brief {
-				return HandleErrorRespectJSON("--explain cannot be combined with --brief")
 			}
 			return runReadyExplain(cmd)
 		}

--- a/cmd/bd/ready_input.go
+++ b/cmd/bd/ready_input.go
@@ -60,6 +60,7 @@ func gatherReadyInput(cmd *cobra.Command, resolveCap func(*cobra.Command) (int, 
 	in.gated, _ = cmd.Flags().GetBool("gated")
 	in.molID, _ = cmd.Flags().GetString("mol")
 	in.explain, _ = cmd.Flags().GetBool("explain")
+	in.Brief, _ = cmd.Flags().GetBool("brief")
 	in.prettyFormat, _ = cmd.Flags().GetBool("pretty")
 	in.plainFormat, _ = cmd.Flags().GetBool("plain")
 	in.jsonOut = jsonOutput
@@ -106,6 +107,35 @@ func gatherReadyInput(cmd *cobra.Command, resolveCap func(*cobra.Command) (int, 
 	}
 	if in.claim && in.explain {
 		return in, HandleErrorRespectJSON("--claim cannot be combined with --explain")
+	}
+	// THE PROJECTION IS REFUSED WHEREVER IT CANNOT BE HONORED, rather than
+	// accepted and dropped. types.WorkFilter.Lite reaches the driver through
+	// one query, the counts mega-query behind GetReadyWorkWithCounts, and
+	// `bd ready` only runs that query for --json. Everything below reaches a
+	// different one: the text routes call the bare GetReadyWork, and --gated,
+	// --mol and --explain answer with shapes of their own. A flag those routes
+	// take and ignore is exactly the silent no-op this feature exists to close,
+	// so each combination says so instead.
+	//
+	// --claim is refused for a stronger reason than the rest: it cannot be
+	// served on ANY route. ClaimNext refetches its winning row whole and
+	// returns ErrValidation for a projected request
+	// (issueops.ValidateClaimNextRequest). Catching it here keeps the message
+	// about the two flags the user typed, and leaves readyRoleRequest free to
+	// carry Brief for the COUNT, which does need it.
+	if in.Brief {
+		switch {
+		case in.claim:
+			return in, HandleErrorRespectJSON("--claim cannot be combined with --brief")
+		case in.gated:
+			return in, HandleErrorRespectJSON("--gated cannot be combined with --brief")
+		case in.molID != "":
+			return in, HandleErrorRespectJSON("--mol cannot be combined with --brief")
+		case in.explain:
+			return in, HandleErrorRespectJSON("--explain cannot be combined with --brief")
+		case !in.jsonOut:
+			return in, HandleErrorRespectJSON("--brief requires --json; the text renderings print none of the fields it omits")
+		}
 	}
 	if in.Offset > 0 && in.claim {
 		return in, HandleErrorRespectJSON("--offset cannot be combined with --claim")

--- a/cmd/bd/ready_input.go
+++ b/cmd/bd/ready_input.go
@@ -108,34 +108,8 @@ func gatherReadyInput(cmd *cobra.Command, resolveCap func(*cobra.Command) (int, 
 	if in.claim && in.explain {
 		return in, HandleErrorRespectJSON("--claim cannot be combined with --explain")
 	}
-	// THE PROJECTION IS REFUSED WHEREVER IT CANNOT BE HONORED, rather than
-	// accepted and dropped. types.WorkFilter.Lite reaches the driver through
-	// one query, the counts mega-query behind GetReadyWorkWithCounts, and
-	// `bd ready` only runs that query for --json. Everything below reaches a
-	// different one: the text routes call the bare GetReadyWork, and --gated,
-	// --mol and --explain answer with shapes of their own. A flag those routes
-	// take and ignore is exactly the silent no-op this feature exists to close,
-	// so each combination says so instead.
-	//
-	// --claim is refused for a stronger reason than the rest: it cannot be
-	// served on ANY route. ClaimNext refetches its winning row whole and
-	// returns ErrValidation for a projected request
-	// (issueops.ValidateClaimNextRequest). Catching it here keeps the message
-	// about the two flags the user typed, and leaves readyRoleRequest free to
-	// carry Brief for the COUNT, which does need it.
-	if in.Brief {
-		switch {
-		case in.claim:
-			return in, HandleErrorRespectJSON("--claim cannot be combined with --brief")
-		case in.gated:
-			return in, HandleErrorRespectJSON("--gated cannot be combined with --brief")
-		case in.molID != "":
-			return in, HandleErrorRespectJSON("--mol cannot be combined with --brief")
-		case in.explain:
-			return in, HandleErrorRespectJSON("--explain cannot be combined with --brief")
-		case !in.jsonOut:
-			return in, HandleErrorRespectJSON("--brief requires --json; the text renderings print none of the fields it omits")
-		}
+	if err := briefModeConflict(in.Brief, in.claim, in.gated, in.explain, in.molID, in.jsonOut); err != nil {
+		return in, err
 	}
 	if in.Offset > 0 && in.claim {
 		return in, HandleErrorRespectJSON("--offset cannot be combined with --claim")
@@ -284,4 +258,58 @@ func readyRoleRequest(in readyInput) issueops.ReadyRequest {
 // the shared ready question above, plus the claimant.
 func claimNextRequest(in readyInput) issueops.ClaimNextRequest {
 	return issueops.ClaimNextRequest{Actor: actor, Filter: readyRoleRequest(in)}
+}
+
+// briefModeConflict reports the usage error for a --brief combination that no
+// route can honor, and nil when there is none.
+//
+// THE PROJECTION IS REFUSED WHEREVER IT CANNOT BE HONORED, rather than accepted
+// and dropped. types.WorkFilter.Lite reaches the driver through one query, the
+// counts mega-query behind GetReadyWorkWithCounts, and `bd ready` only runs
+// that query for --json. Everything else reaches a different one: the text
+// routes call the bare GetReadyWork, and --gated, --mol and --explain answer
+// with shapes of their own. A flag those routes take and ignore is exactly the
+// silent no-op this feature exists to close, so each combination says so.
+//
+// --claim is refused for a stronger reason than the rest: it cannot be served
+// on ANY route. ClaimNext refetches its winning row whole and returns
+// ErrValidation for a projected request (issueops.ValidateClaimNextRequest).
+// Refusing here keeps the message about the two flags the user typed, and
+// leaves readyRoleRequest free to carry Brief for the COUNT, which needs it.
+//
+// IT IS ONE BODY WITH TWO CALLERS, and that is the point. readyCmd's RunE
+// dispatches --gated, --mol and --explain before gathering, so a copy of these
+// checks written into each of those branches would guard the direct route only,
+// with nothing driving it: the gatherer's tests reach the proxied route alone,
+// and deleting one of the copies would re-open the silent no-op while every
+// test stayed green. RunE calls this once, above the dispatch, and the gatherer
+// calls it for every other arrival.
+func briefModeConflict(brief, claim, gated, explain bool, molID string, jsonOut bool) error {
+	if !brief {
+		return nil
+	}
+	switch {
+	case claim:
+		return HandleErrorRespectJSON("--claim cannot be combined with --brief")
+	case gated:
+		return HandleErrorRespectJSON("--gated cannot be combined with --brief")
+	case molID != "":
+		return HandleErrorRespectJSON("--mol cannot be combined with --brief")
+	case explain:
+		return HandleErrorRespectJSON("--explain cannot be combined with --brief")
+	case !jsonOut:
+		return HandleErrorRespectJSON("--brief requires --json; the text renderings print none of the fields it omits")
+	}
+	return nil
+}
+
+// briefModeConflictFromFlags is readyCmd's entry to the check above, reading the
+// mode flags off the command because it runs before gatherReadyInput has.
+func briefModeConflictFromFlags(cmd *cobra.Command) error {
+	brief, _ := cmd.Flags().GetBool("brief")
+	claim, _ := cmd.Flags().GetBool("claim")
+	gated, _ := cmd.Flags().GetBool("gated")
+	explain, _ := cmd.Flags().GetBool("explain")
+	molID, _ := cmd.Flags().GetString("mol")
+	return briefModeConflict(brief, claim, gated, explain, molID, jsonOutput)
 }

--- a/internal/httpapi/apigen/types.gen.go
+++ b/internal/httpapi/apigen/types.gen.go
@@ -2097,6 +2097,11 @@ type ListIssuesParams struct {
 	//
 	// One exception, and it is mode-dependent: when the server was started with `--allow-non-loopback`, `limit=0` is refused with 400 `invalid_argument`, `param: "limit"`, `reason: "invalid_value"` and detail "unlimited reads are loopback-only; pass an explicit limit". An unlimited read buffers the whole active set and its JSON encoding inside one shared process, which must not be reachable by arbitrary network peers. The bind mode is deliberately NOT advertised in `ContextResponse` — a client that wants an unlimited read asks for one and, on that 400, re-issues with an explicit limit (and pages with `cursor`); it is a client-side fix, never a retry.
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Brief Omit the free-form text from every item: `description`, `design`, `acceptance_criteria`, `notes`, `payload` and `waiters` are not selected. Filtering is unaffected, because it selects rows and this selects fields. Default false, so the payload is unchanged for a client that does not ask.
+	//
+	// The response carries no marker for the omission, so an omitted field is indistinguishable from a genuinely empty one: only the client that sent this parameter knows the rows are partial. Fetch a whole issue with `GET /v0/beads/issues/{id}`.
+	Brief *bool `form:"brief,omitempty" json:"brief,omitempty"`
 }
 
 // GetIssueParams defines parameters for GetIssue.
@@ -2384,6 +2389,11 @@ type ListReadyWorkParams struct {
 	//
 	// One exception, and it is mode-dependent: when the server was started with `--allow-non-loopback`, `limit=0` is refused with 400 `invalid_argument`, `param: "limit"`, `reason: "invalid_value"` and detail "unlimited reads are loopback-only; pass an explicit limit". An unlimited read buffers the whole active set and its JSON encoding inside one shared process, which must not be reachable by arbitrary network peers. The bind mode is deliberately NOT advertised in `ContextResponse` — a client that wants an unlimited read asks for one and, on that 400, re-issues with an explicit limit; it is a client-side fix, never a retry.
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Brief Omit the free-form text from every item: `description`, `design`, `acceptance_criteria`, `notes`, `payload` and `waiters` are not selected. Filtering is unaffected, because it selects rows and this selects fields. Default false, so the payload is unchanged for a client that does not ask.
+	//
+	// The response carries no marker for the omission, so an omitted field is indistinguishable from a genuinely empty one: only the client that sent this parameter knows the rows are partial. Fetch a whole issue with `GET /v0/beads/issues/{id}`.
+	Brief *bool `form:"brief,omitempty" json:"brief,omitempty"`
 }
 
 // ListReadyWorkParamsSort defines parameters for ListReadyWork.

--- a/internal/httpapi/brief_projection_test.go
+++ b/internal/httpapi/brief_projection_test.go
@@ -1,0 +1,95 @@
+package httpapi
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestListBriefReachesTheFilter is the HTTP half of the `bd list --brief`
+// wiring. The CLI and this handler build issueops.ListRequest separately, so a
+// field wired into one is unreachable from the other.
+//
+// Asserted on the storage FILTER rather than on the request, because the
+// filter is what the query is built from: an assignment that reached
+// ListRequest and stopped there would satisfy a request-level assertion while
+// the rows still came back whole.
+func TestListBriefReachesTheFilter(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		path     string
+		wantLite bool
+	}{
+		{"absent leaves the payload whole", "/v0/beads/issues", false},
+		{"brief projects", "/v0/beads/issues?brief=true", true},
+		{"brief=false is explicit and whole", "/v0/beads/issues?brief=false", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ts, rec := newReadServer(t, Config{})
+			if resp := ts.get(t, tc.path); resp.StatusCode != http.StatusOK {
+				t.Fatalf("GET %s: status = %d, want 200", tc.path, resp.StatusCode)
+			}
+			filters := rec.searchFilters()
+			if len(filters) != 1 {
+				t.Fatalf("%d list queries, want 1", len(filters))
+			}
+			if got := filters[0].Lite; got != tc.wantLite {
+				t.Errorf("IssueFilter.Lite = %v, want %v", got, tc.wantLite)
+			}
+		})
+	}
+}
+
+// TestReadyBriefReachesTheFilter is the same hop for the ready listing.
+func TestReadyBriefReachesTheFilter(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		path     string
+		wantLite bool
+	}{
+		{"absent leaves the payload whole", "/v0/beads/ready", false},
+		{"brief projects", "/v0/beads/ready?brief=true", true},
+		{"brief=false is explicit and whole", "/v0/beads/ready?brief=false", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ts, rec := newReadServer(t, Config{})
+			if resp := ts.get(t, tc.path); resp.StatusCode != http.StatusOK {
+				t.Fatalf("GET %s: status = %d, want 200", tc.path, resp.StatusCode)
+			}
+			filters := rec.readyFilters()
+			if len(filters) != 1 {
+				t.Fatalf("%d ready queries, want 1", len(filters))
+			}
+			if got := filters[0].Lite; got != tc.wantLite {
+				t.Errorf("WorkFilter.Lite = %v, want %v", got, tc.wantLite)
+			}
+		})
+	}
+}
+
+// TestReadyCountDoesNotTakeTheProjection pins the decision to decode `brief` in
+// handleListReadyWork rather than in readyFilters, the vocabulary the count
+// shares with the listing.
+//
+// readyFilters is documented as the filters both operations must admit, since a
+// parameter one decoded and the other did not would break the identity between
+// the count and the set it sizes. This projection is not one of those: it
+// selects FIELDS, and a count returns no rows to project. Decoding it there
+// would advertise a parameter on `:count` that cannot change its answer.
+//
+// The 400 is the shared decoder's strict unknown-parameter behavior, so what
+// this pins is that the parameter was not quietly added to the shared function.
+// The reason is asserted, not just the status: unknown_parameter tells a client
+// this server predates the parameter, and invalid_value would tell it to send
+// something else, so a bare status check would accept the wrong instruction.
+func TestReadyCountDoesNotTakeTheProjection(t *testing.T) {
+	ts, _ := newReadServer(t, Config{})
+
+	resp := ts.get(t, "/v0/beads/ready:count?brief=true")
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: a count has no rows to project, so the parameter is not in its vocabulary", resp.StatusCode)
+	}
+	body := decodeBody(t, resp)
+	if body["param"] != "brief" || body["reason"] != string(ReasonUnknownParameter) {
+		t.Errorf("body = %v, want param=brief reason=unknown_parameter", body)
+	}
+}

--- a/internal/httpapi/reads.go
+++ b/internal/httpapi/reads.go
@@ -65,6 +65,10 @@ func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
 	// and never sends empty.
 	req.Sort = q.oneOf("sort", readySortDefault, "hybrid", "priority", "oldest")
 	req.Limit = q.limit()
+	// Decoded here and not in readyFilters, which is the vocabulary the count
+	// shares: this is a projection of the rows a page returns, in the same
+	// class as the two lines above it, and the count returns no rows to project.
+	req.Brief = q.boolean("brief")
 
 	if !s.acceptQuery(w, r, q) {
 		return
@@ -339,6 +343,7 @@ func (s *Server) handleListIssues(w http.ResponseWriter, r *http.Request) {
 
 		ParentID: q.str("parent"),
 
+		Brief:            q.boolean("brief"),
 		AllFlag:          q.boolean("all"),
 		IncludeTemplates: q.boolean("include_templates"),
 		IncludeGates:     q.boolean("include_gates"),

--- a/internal/httpapi/spec/openapi.v0.yaml
+++ b/internal/httpapi/spec/openapi.v0.yaml
@@ -532,6 +532,23 @@ paths:
             type: integer
             minimum: 0
             default: 100
+        - name: brief
+          in: query
+          description: >-
+            Omit the free-form text from every item: `description`, `design`,
+            `acceptance_criteria`, `notes`, `payload` and `waiters` are not
+            selected. Filtering is unaffected, because it selects rows and this
+            selects fields. Default false, so the payload is unchanged for a
+            client that does not ask.
+
+
+            The response carries no marker for the omission, so an omitted
+            field is indistinguishable from a genuinely empty one: only the
+            client that sent this parameter knows the rows are partial. Fetch a
+            whole issue with `GET /v0/beads/issues/{id}`.
+          schema:
+            type: boolean
+            default: false
       security:
         - bearerToken: []
       responses:
@@ -1245,6 +1262,23 @@ paths:
             type: integer
             minimum: 0
             default: 50
+        - name: brief
+          in: query
+          description: >-
+            Omit the free-form text from every item: `description`, `design`,
+            `acceptance_criteria`, `notes`, `payload` and `waiters` are not
+            selected. Filtering is unaffected, because it selects rows and this
+            selects fields. Default false, so the payload is unchanged for a
+            client that does not ask.
+
+
+            The response carries no marker for the omission, so an omitted
+            field is indistinguishable from a genuinely empty one: only the
+            client that sent this parameter knows the rows are partial. Fetch a
+            whole issue with `GET /v0/beads/issues/{id}`.
+          schema:
+            type: boolean
+            default: false
       security:
         - bearerToken: []
       responses:

--- a/internal/httpapi/spec_parity_test.go
+++ b/internal/httpapi/spec_parity_test.go
@@ -909,9 +909,17 @@ func TestClaimNextRequestMembersMatchTheHandler(t *testing.T) {
 // admit one set: a claim answering a different question than the listing shows
 // would hand an agent work the listing never offered it.
 //
-// `limit` is the one deliberate difference, and it is asserted as an absence
-// rather than merely not listed, because it is the parameter this operation
-// refuses BY VALUE.
+// The deliberate differences are the listing's own PAGE knobs, which are not
+// filters: they bound or shape what one request returns rather than selecting
+// which rows are eligible, so a claim has no use for them.
+// issueops.ValidateClaimNextRequest refuses each one by VALUE, and because
+// readyFilters does not decode them, the HTTP door refuses them earlier still
+// as an unknown parameter. Each is asserted as an absence from claimNext rather
+// than merely left off the comparison, because a documented parameter that is
+// always a 400 is a trap either way.
+//
+// `sort` is deliberately NOT on that list. It picks WHICH row comes first, so
+// it changes which one a claim takes, and both operations must admit it.
 func TestClaimNextAdmitsExactlyTheListingsFilters(t *testing.T) {
 	doc := loadSpec(t)
 	names := func(path, method string) map[string]bool {
@@ -928,10 +936,19 @@ func TestClaimNextAdmitsExactlyTheListingsFilters(t *testing.T) {
 	listing := names("/v0/beads/ready", "get")
 	claimNext := names("/v0/beads/issues:claimNext", "post")
 
-	if !listing["limit"] {
-		t.Fatal("the listing no longer publishes `limit`; this test's one exception is stale")
+	pageKnobs := map[string]string{
+		"limit": "bounds the page; a claim takes one row however large the pool it scanned",
+		"brief": "projects the rows a page returns; a claim refetches its winning row whole, so there is nothing to project",
 	}
-	delete(listing, "limit")
+	for name, why := range pageKnobs {
+		if !listing[name] {
+			t.Fatalf("the listing no longer publishes `%s`; this test's exception for it is stale (%s)", name, why)
+		}
+		delete(listing, name)
+		if claimNext[name] {
+			t.Errorf("claimNext publishes `%s`; it refuses one by value (%s), and a documented parameter that is always a 400 is a trap", name, why)
+		}
+	}
 
 	if extra := diff(claimNext, listing); len(extra) > 0 {
 		t.Errorf("claimNext publishes parameters the ready listing does not: %v\n"+
@@ -939,10 +956,8 @@ func TestClaimNextAdmitsExactlyTheListingsFilters(t *testing.T) {
 	}
 	if missing := diff(listing, claimNext); len(missing) > 0 {
 		t.Errorf("the ready listing publishes parameters claimNext does not: %v\n"+
-			"the handler decodes them through readyFilters either way, so the document is understating what it accepts", missing)
-	}
-	if claimNext["limit"] {
-		t.Error("claimNext publishes `limit`; it refuses one, and a documented parameter that is always a 400 is a trap")
+			"the handler decodes them through readyFilters either way, so the document is understating what it accepts.\n"+
+			"If one of these is a page knob rather than a filter, add it to pageKnobs above with its reason", missing)
 	}
 }
 


### PR DESCRIPTION
Application half of #5546, stacked on #5554 and rebased onto it now that it has merged. Same split as #5547 to #5549.

## What

`--brief` on `bd list` and `bd ready`, `brief` on `GET /v0/beads/issues` and `GET /v0/beads/ready`. Defaults to false everywhere, so no payload changes for a caller that does not ask.

## Carried expectations from the #5554 review

Both are here. The CHANGELOG entry is in `[Unreleased]/Added`, and the spec change plus regenerated `apigen` types are in the diff; `make api-check` is green.

The `readyHydrationFor` duplication you flagged is untouched, as agreed. It is still two identical bodies mirroring the pre-existing `hydrationFor` pair, and the ready conformance case still runs on both stacks. A shared package is a cleanup of its own and would have widened this PR past its layer.

## One registration per command reaches both of its routes

The two gatherers are shared, so this is smaller than the four wiring points it looks like.

`bd list` hands `in.ListRequest` to `issueops.Reader.List` verbatim on the direct and the proxied route. `bd ready` uses the Reader role on **neither**: both routes pass the filter `gatherReadyInput` built through `workapi.BuildReadyFilter`, so `types.WorkFilter.Lite` is what carries the projection there. The CLI-hop tests assert the filter rather than the request for that reason, since an assignment that reached `ReadyRequest` and stopped would satisfy a request-level assertion while the rows still came back whole.

The HTTP handlers build both requests independently of the CLI, so they are wired separately.

## Refused wherever it cannot be honored

`Lite` reaches a driver through exactly two queries: the bare `SearchIssuesInTx` from #3906, and the counts mega-query from #5554. `GetReadyWork` and the by-ID hydration behind the tree walk read neither. Teaching them is storage work and belongs in its own layer, so rather than accept the flag on those routes and drop it, which is the silent no-op #5554 exists to close, this refuses it:

| combination | why |
|---|---|
| `bd ready --brief` without `--json` | the text routes call the bare `GetReadyWork` |
| `bd ready --brief --gated` / `--mol` / `--explain` | each answers with a shape of its own |
| `bd ready --brief --claim` | no route can serve it, see below |
| `bd list --brief --watch` | `loadWatchedIssues` re-queries through `GetReadyWork` or the tree |
| `bd list --brief --parent` in the tree view | the hierarchical walk is a different query |
| `bd list --brief --format ...` | a caller's template can print any dropped field |

`bd list --brief` works in text mode, since all of its page routes reach `Reader.List`. `--tree` defaults to true, so a bare `--parent` in text mode is the tree walk without the flag being typed, and is refused on the same line.

The direct `bd ready` route dispatches `--gated`, `--mol` and `--explain` **before** gathering, so each check appears in `cmd/bd/ready.go` as well as in the gatherer, exactly as the `--claim` conflicts beside them already do.

`--claim` is refused for a stronger reason than the rest: no route can serve it. `ClaimNext` refetches its winning row whole and returns `ErrValidation` for a projected request. Catching it in the gatherer keeps the message about the two flags the user typed, and leaves `readyRoleRequest` free to carry `Brief` for the count, which needs it.

`--format` is refused rather than annotated because a template can print any of the six dropped fields and there is nothing to hang a marker on. `bd list --long` is the one built-in text rendering that prints one of them, and it is allowed because it can say so: it now prints `Description: (omitted by --brief)`. That keys off `types.Issue.IsLitePartial` rather than off the flag, so a row that arrived projected reads the same whichever door set it.

## The JSON payload carries no marker, and the docs say so

Your #5554 review noted `IsLitePartial` is `json:"-"`. It still is, and #3906 documents it as internal-only, so on the wire an omitted field is indistinguishable from an empty one and only the caller that sent the flag knows its rows are partial. The flag help and both OpenAPI descriptions state that plainly rather than implying a marker.

I did not serialize it. #5549 deferred exactly this marker for `brief_deps` as its own change, and changing a shared type's wire form on the way past would repeat what that deferral avoided. Happy to follow up with it as a separate PR covering both projections if you want it.

## Where `brief` is decoded, and the parity test that caught it

In `handleListReadyWork`, not in `readyFilters`. That function is the vocabulary the ready listing shares with `:count` and `:claimNext`, and this projects fields rather than selecting rows, so it sits with `sort` and `limit`. Neither of those two operations returns rows to project.

That made `TestClaimNextAdmitsExactlyTheListingsFilters` fail, correctly. Its single hardcoded `limit` exception is now a `pageKnobs` table of the listing's two page knobs, each still asserted **absent** from claimNext, since a documented parameter that is always a 400 is a trap. I checked the generalization does not weaken the guard by sabotaging both branches: publishing `brief` on claimNext fails it, and dropping `brief` from the listing fails it as a stale exception.

## Verification

Red before green on all nine new assertions, each verified and reverted: the two request hops, the seven refusals, the long-format marker, and both branches of the parity table. Sample failures:

```
gatherListInput did not carry --brief onto ListRequest.Brief
--brief did not reach WorkFilter.Lite, so both ready routes would ignore it
GET /v0/beads/ready?brief=true: status = 400, want 200
long format did not mark the projection
claimNext publishes `brief`; it refuses one by value ...
```

The refusal cases assert the message, not just that an error occurred: every one of those flags has a prior conflict of its own, so a test accepting any error would pass on the wrong one. Each refusal also has a negative control, since a check that fired unconditionally would leave the whole table green.

```
go build ./... && go vet ./... && gofmt -l .
go test ./cmd/bd/ ./internal/httpapi/... ./internal/workapi/... ./backend/conformance/... ./internal/storage/issueops/... ./issueops/... -count=1
make api-check
./scripts/generate-cli-docs.sh --check
```

All green.
