### PR TITLE
fix(show): a close reason too big for a metadata line renders as body text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -421,6 +421,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A long or multi-paragraph close reason renders as body text in `bd show`**
+  ([#5595](https://github.com/gastownhall/beads/pull/5595)). Every other
+  free-text field — description, design, notes, acceptance criteria, comments —
+  reaches the terminal through the markdown renderer, which word wraps and
+  indents. The close reason did not: it was formatted into the metadata block
+  beside `Owner:` and `Created:`, so it never wrapped and its second and later
+  lines read as separate metadata entries, a blank line and a bare `- bullet`
+  sitting directly under `Created:`. `bd close --reason-file` exists so agents
+  can write structured close reports, and those were exactly the reasons that
+  came out corrupted. A reason that still fits one metadata line — nearly all
+  of them, including one-liners that arrive from a file with a trailing
+  newline — is unchanged; anything larger now gets a `CLOSE REASON` section
+  rendered by the same call the other body fields make. The JSON payload is
+  untouched. The compaction savings line moved into the metadata block at the
+  same time, so it can no longer be stranded below that section, and all five
+  `bd show` render paths now report it alike.
+
 - **Script hooks now fire on both write plumbings** (bd-opisf). bd has two write
   plumbings and only one of them ran the workspace's hook scripts. The
   DoltStorage decorator chain fires `on_create`/`on_update`/`on_close` after

--- a/cmd/bd/show.go
+++ b/cmd/bd/show.go
@@ -180,20 +180,6 @@ var showCmd = &cobra.Command{
 			// Metadata: Owner · Type | Created · Updated
 			fmt.Println(formatIssueMetadata(issue))
 
-			// Compaction info (if applicable)
-			if issue.CompactionLevel > 0 {
-				fmt.Println()
-				if issue.OriginalSize > 0 {
-					currentSize := len(issue.Description) + len(issue.Design) + len(issue.Notes) + len(issue.AcceptanceCriteria)
-					saved := issue.OriginalSize - currentSize
-					if saved > 0 {
-						reduction := float64(saved) / float64(issue.OriginalSize) * 100
-						fmt.Printf("📊 %d → %d bytes (%.0f%% reduction)\n",
-							issue.OriginalSize, currentSize, reduction)
-					}
-				}
-			}
-
 			// Content sections — always show DESCRIPTION header so the user
 			// can distinguish "empty" from "hidden" (GH#3336).
 			if issue.Description != "" {

--- a/cmd/bd/show_format.go
+++ b/cmd/bd/show_format.go
@@ -7,9 +7,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
+	"github.com/steveyegge/beads/internal/uimd"
 )
 
 // formatShortIssue returns a compact one-line representation of an issue
@@ -146,9 +148,25 @@ func formatIssueMetadata(issue *types.Issue) string {
 		lines = append(lines, ui.RenderMuted(leaseLine))
 	}
 
-	// Line 3: Close reason (if closed)
-	if issue.Status == types.StatusClosed && issue.CloseReason != "" {
-		lines = append(lines, ui.RenderMuted(fmt.Sprintf("Close reason: %s", issue.CloseReason)))
+	// Line 3: Close reason (if closed). A reason too long or too structured to
+	// sit on a metadata line is body text, not metadata, so it gets the same
+	// markdown section treatment as DESCRIPTION — `bd close --reason-file`
+	// exists to write exactly that. Emitted after the remaining metadata lines
+	// so a multi-line reason cannot split the block it is part of.
+	//
+	// Trimmed first: --reason-file and heredoc content virtually always ends
+	// in a newline, and without this a genuine one-liner would be promoted to
+	// a section on that byte alone.
+	closeReasonSection := ""
+	if issue.Status == types.StatusClosed {
+		if reason := strings.TrimSpace(issue.CloseReason); reason != "" {
+			if line := "Close reason: " + reason; fitsMetadataLine(line) {
+				lines = append(lines, ui.RenderMuted(line))
+			} else {
+				closeReasonSection = fmt.Sprintf("\n\n%s\n%s", ui.RenderBold("CLOSE REASON"),
+					strings.TrimRight(uimd.RenderMarkdown(reason), "\n"))
+			}
+		}
 	}
 
 	// Line 4: External ref (if exists)
@@ -164,7 +182,41 @@ func formatIssueMetadata(issue *types.Issue) string {
 		lines = append(lines, fmt.Sprintf("Wisp type: %s", ui.RenderMuted(string(issue.WispType))))
 	}
 
-	return strings.Join(lines, "\n")
+	// Line 6: Compaction savings. A metadata line rather than a callout the
+	// callers print after the block, so a promoted close reason cannot strand
+	// it below the body text, and so all five show paths report it alike.
+	if line := compactionSavingsLine(issue); line != "" {
+		lines = append(lines, line)
+	}
+
+	return strings.Join(lines, "\n") + closeReasonSection
+}
+
+// compactionSavingsLine reports how much a compacted issue's stored body shrank.
+// Returns "" when the issue was never compacted, or when compaction recorded no
+// saving worth reporting.
+func compactionSavingsLine(issue *types.Issue) string {
+	if issue.CompactionLevel == 0 || issue.OriginalSize <= 0 {
+		return ""
+	}
+	currentSize := len(issue.Description) + len(issue.Design) + len(issue.Notes) + len(issue.AcceptanceCriteria)
+	saved := issue.OriginalSize - currentSize
+	if saved <= 0 {
+		return ""
+	}
+	reduction := float64(saved) / float64(issue.OriginalSize) * 100
+	return fmt.Sprintf("📊 %d → %d bytes (%.0f%% reduction)", issue.OriginalSize, currentSize, reduction)
+}
+
+// fitsMetadataLine reports whether a value can occupy one metadata line without
+// the terminal breaking it for us. Anything that cannot belongs in a rendered
+// section, where it gets the wrapping and indentation body text gets.
+func fitsMetadataLine(s string) bool {
+	if strings.ContainsAny(s, "\n\r") {
+		return false
+	}
+	width := uimd.WrapWidth()
+	return width == 0 || ansi.StringWidth(s) <= width
 }
 
 // formatDependencyLine formats a single dependency with semantic colors

--- a/cmd/bd/show_format_metadata_test.go
+++ b/cmd/bd/show_format_metadata_test.go
@@ -5,8 +5,120 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/internal/uimd"
 )
+
+// closedWithReason builds a closed issue whose remaining metadata lines — the
+// external ref and the compaction stat — are the ones a close reason rendered
+// in place would strand below the body text.
+func closedWithReason(reason string) *types.Issue {
+	return &types.Issue{
+		ID: "test-cr", Title: "t", IssueType: types.TypeTask,
+		Status: types.StatusClosed, CloseReason: reason,
+		ExternalRef:     strPtr("gh#1"),
+		CompactionLevel: 1, OriginalSize: 4096,
+	}
+}
+
+// metadataLine returns the whole output line starting with prefix, unstyled,
+// or "" when no line does. Whole-line equality is what catches a value that
+// passed the fit check trimmed but was then rendered untrimmed.
+func metadataLine(out, prefix string) string {
+	for _, line := range strings.Split(ansi.Strip(out), "\n") {
+		if strings.HasPrefix(line, prefix) {
+			return line
+		}
+	}
+	return ""
+}
+
+// TestFormatIssueMetadata_CloseReason guards the rule that a close reason too
+// long or too structured for a metadata line is rendered as body text, the way
+// DESCRIPTION and NOTES are, instead of being dumped raw into the metadata
+// block where it wraps at the terminal edge and its continuation lines read as
+// separate metadata entries.
+func TestFormatIssueMetadata_CloseReason(t *testing.T) {
+	// Force non-agent mode so the width test is live and deterministic;
+	// in agent mode nothing wraps and WrapWidth reports 0.
+	t.Setenv("BD_AGENT_MODE", "0")
+	t.Setenv("CLAUDE_CODE", "")
+
+	// Surrounding whitespace is not structure. --reason-file and heredoc
+	// content almost always ends in a newline, so a one-liner that arrives
+	// with one has to stay inline, and has to render without it.
+	for name, reason := range map[string]string{
+		"short":            "Fixed",
+		"trailing newline": "Fixed\n",
+		"trailing CRLF":    "Fixed\r\n",
+		"padded":           "\n  Fixed  \n\n",
+	} {
+		t.Run(name+" reason stays on a metadata line", func(t *testing.T) {
+			out := formatIssueMetadata(closedWithReason(reason))
+			if got := metadataLine(out, "Close reason:"); got != "Close reason: Fixed" {
+				t.Errorf("inline reason = %q, want %q; full output:\n%s", got, "Close reason: Fixed", out)
+			}
+			if strings.Contains(out, "CLOSE REASON") {
+				t.Errorf("%s reason should not get its own section, got:\n%s", name, out)
+			}
+		})
+	}
+
+	for name, reason := range map[string]string{
+		"multi-line": "Fixed the leak.\n\n- reverted the cache\n- added a regression test",
+		"overlong":   strings.Repeat("long ", 40),
+	} {
+		t.Run(name+" reason becomes a rendered section", func(t *testing.T) {
+			out := formatIssueMetadata(closedWithReason(reason))
+			if !strings.Contains(out, "CLOSE REASON") {
+				t.Fatalf("%s reason should get its own section, got:\n%s", name, out)
+			}
+			if strings.Contains(out, "Close reason:") {
+				t.Errorf("%s reason should not also appear inline, got:\n%s", name, out)
+			}
+			// The section must come last: metadata lines emitted after the
+			// close reason would otherwise be stranded below the body text.
+			sectionAt := strings.Index(out, "CLOSE REASON")
+			for _, trailing := range []string{"External: gh#1", "reduction)"} {
+				if at := strings.Index(out, trailing); at < 0 || at > sectionAt {
+					t.Errorf("metadata line %q must precede the CLOSE REASON section, got:\n%s", trailing, out)
+				}
+			}
+			// Body text wraps; that is the whole point of promoting it.
+			for _, line := range strings.Split(out[sectionAt:], "\n") {
+				if ansi.StringWidth(line) > uimd.WrapWidth() {
+					t.Errorf("section line exceeds wrap width %d: %q", uimd.WrapWidth(), line)
+				}
+			}
+		})
+	}
+
+	// Agent mode emits body text verbatim, so promotion there is about
+	// getting the reason out of the metadata block, not about wrapping.
+	t.Run("agent mode", func(t *testing.T) {
+		t.Setenv("BD_AGENT_MODE", "1")
+		reason := "Fixed the leak.\n\n- reverted the cache\n- added a regression test"
+
+		out := formatIssueMetadata(closedWithReason(reason))
+		if !strings.Contains(out, "CLOSE REASON") {
+			t.Fatalf("multi-line reason should still get its own section, got:\n%s", out)
+		}
+		if !strings.Contains(out, reason) {
+			t.Errorf("agent mode must emit the reason verbatim, got:\n%s", out)
+		}
+
+		// Nothing wraps here, so width alone never promotes a one-liner.
+		long := strings.Repeat("long ", 40)
+		out = formatIssueMetadata(closedWithReason(long))
+		if strings.Contains(out, "CLOSE REASON") {
+			t.Errorf("an overlong one-liner should stay inline in agent mode, got:\n%s", out)
+		}
+		if got := metadataLine(out, "Close reason:"); got != "Close reason: "+strings.TrimSpace(long) {
+			t.Errorf("inline reason = %q, want the whole trimmed one-liner", got)
+		}
+	})
+}
 
 func TestFormatIssueCustomMetadata_Nil(t *testing.T) {
 	t.Parallel()

--- a/cmd/bd/show_proxied_server.go
+++ b/cmd/bd/show_proxied_server.go
@@ -485,16 +485,6 @@ func proxiedRenderIssue(ctx context.Context, uw uow.UnitOfWork, issue *types.Iss
 	}
 	fmt.Println(formatIssueMetadata(issue))
 
-	if issue.CompactionLevel > 0 && issue.OriginalSize > 0 {
-		currentSize := len(issue.Description) + len(issue.Design) + len(issue.Notes) + len(issue.AcceptanceCriteria)
-		saved := issue.OriginalSize - currentSize
-		if saved > 0 {
-			reduction := float64(saved) / float64(issue.OriginalSize) * 100
-			fmt.Println()
-			fmt.Printf("📊 %d → %d bytes (%.0f%% reduction)\n", issue.OriginalSize, currentSize, reduction)
-		}
-	}
-
 	if issue.Description != "" {
 		fmt.Printf("\n%s\n%s\n", ui.RenderBold("DESCRIPTION"), uimd.RenderMarkdown(issue.Description))
 	} else {

--- a/internal/uimd/markdown.go
+++ b/internal/uimd/markdown.go
@@ -16,12 +16,13 @@ import (
 	"golang.org/x/term"
 )
 
-// RenderMarkdown renders markdown text using glamour's terminal style.
-// Returns the rendered markdown or the original text if rendering fails.
-// Word wraps at terminal width (or 80 columns if width can't be detected).
-func RenderMarkdown(markdown string) string {
+// WrapWidth reports the column width RenderMarkdown wraps body text to, or 0
+// in agent mode, where the text is emitted verbatim and nothing wraps. Callers
+// deciding whether a value is short enough to sit inline instead of becoming a
+// rendered section use this so their idea of "one line" matches the renderer's.
+func WrapWidth() int {
 	if ui.IsAgentMode() {
-		return markdown
+		return 0
 	}
 
 	// Cap at 100 chars for readability; wider lines are harder to scan.
@@ -32,6 +33,17 @@ func RenderMarkdown(markdown string) string {
 	}
 	if wrapWidth > maxReadableWidth {
 		wrapWidth = maxReadableWidth
+	}
+	return wrapWidth
+}
+
+// RenderMarkdown renders markdown text using glamour's terminal style.
+// Returns the rendered markdown or the original text if rendering fails.
+// Word wraps at terminal width (or 80 columns if width can't be detected).
+func RenderMarkdown(markdown string) string {
+	wrapWidth := WrapWidth()
+	if wrapWidth == 0 {
+		return markdown
 	}
 
 	// Markdown rendering and terminal escape emission are separate concerns.


### PR DESCRIPTION
Every other free-text field on an issue — description, design, notes, acceptance criteria, comments — reaches the terminal through uimd.RenderMarkdown, which word wraps at the terminal width and indents two spaces. The close reason did not. It was formatted straight into the metadata block beside Owner: and Created:, so it never wrapped, never indented, and was never rendered.

For `Close reason: Closed` that is correct and this change keeps it. But `bd close --reason-file` exists so agents can write structured multi- paragraph close reports, and those came out corrupted rather than merely ugly: the reason's second and later lines land in the metadata block as peers of the metadata lines, so a blank line and a bare "- bullet one" read as separate metadata entries directly under Created:.

So the rule is now the one the metadata block always implied — a metadata line holds a one-liner. A reason that contains a newline, or that is wider than the renderer's own wrap width, is body text and gets a CLOSE REASON section rendered by the same call every other body field makes. Short reasons, which is nearly all of them, are untouched.

Not changed: bd close still echoes the whole reason on its success line. A long reason-file dumps itself back at you there, but nothing follows it on screen, so it is cosmetic rather than corrupting.