### PR TITLE
Publish PUT and DELETE /v0/beads/config/{key}, the write half of issueops.WorkspaceConfig (ga-098zm)

### DIFF
--- a/cmd/bd/serve_config_write_proxied_integration_test.go
+++ b/cmd/bd/serve_config_write_proxied_integration_test.go
@@ -225,6 +225,55 @@ func TestProxiedServerServeSettingsWrites(t *testing.T) {
 		}
 	})
 
+	// THE VALUE BOUND, against the real column, in both directions. This is the
+	// hazard settingWriteKey already guards on the key half: config.value is a
+	// TEXT column, and before the bound a 100 KiB PUT was a generic 500 from the
+	// column — a request the caller could have fixed, answered with the one code
+	// that says nothing about how to fix it.
+	//
+	// The accepted case is the half that keeps the refusal honest: a value at
+	// the ceiling must reach the column and land, or the bound is stricter than
+	// the storage it claims to describe.
+	t.Run("an oversized value is refused and a ceiling value lands", func(t *testing.T) {
+		oversized, err := json.Marshal(map[string]string{"value": strings.Repeat("v", 100*1024)})
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+		status, body := sp.putJSON(t, "/v0/beads/config/notes.big", string(oversized))
+		if status != http.StatusBadRequest {
+			t.Fatalf("a 100 KiB value: status = %d, want 400 — refused at the edge, not by the column: %v", status, body)
+		}
+		if body["code"] != "invalid_argument" || body["param"] != "value" {
+			t.Errorf("problem = %v, want invalid_argument on param value", body)
+		}
+
+		// Nothing landed, which a 400 asserts and a read-back proves.
+		readStatus, read, _ := sp.get(t, "/v0/beads/config/notes.big")
+		if readStatus != http.StatusOK {
+			t.Fatalf("read back: status = %d", readStatus)
+		}
+		if _, present := read["value"]; present {
+			t.Errorf("the refused write landed: %v", read)
+		}
+
+		// And exactly the column's ceiling goes all the way through to Dolt.
+		ceiling, err := json.Marshal(map[string]string{"value": strings.Repeat("c", 65535)})
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+		status, body = sp.putJSON(t, "/v0/beads/config/notes.ceiling", string(ceiling))
+		if status != http.StatusOK {
+			t.Fatalf("a 65535-byte value: status = %d, want 200 — this value fits the column: %v", status, body)
+		}
+		readStatus, read, _ = sp.get(t, "/v0/beads/config/notes.ceiling")
+		if readStatus != http.StatusOK {
+			t.Fatalf("read back: status = %d", readStatus)
+		}
+		if got, _ := read["value"].(string); len(got) != 65535 {
+			t.Errorf("stored %d bytes of a 65535-byte value; the column truncated it", len(got))
+		}
+	})
+
 	// THE REMOVAL, against the table: it removes, and removing again succeeds
 	// rather than reporting a miss this role cannot see.
 	t.Run("the removal is idempotent and reports no miss", func(t *testing.T) {

--- a/cmd/bd/serve_config_write_proxied_integration_test.go
+++ b/cmd/bd/serve_config_write_proxied_integration_test.go
@@ -1,0 +1,254 @@
+//go:build cgo
+
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// End-to-end for the two settings writes, against real Dolt through a real
+// `bd serve` subprocess.
+//
+// The pure tests in internal/httpapi cover the wire edge on a fake role — the
+// request projection, the response projection, every refusal this edge owns.
+// What only this level can prove is what the STORAGE TRANSACTION did, and on
+// this plane that is most of the contract:
+//
+//   - the write LANDS and the CLI sees it, which is the whole point of a
+//     configuration write nothing else in the process is going to re-read;
+//   - `status.custom` is PROJECTED into custom_statuses in the same transaction
+//     as the row, so `bd` starts accepting the status the write configured — a
+//     row without its table is a value that has been stored and has no effect,
+//     and no fake can be asked about a second table;
+//   - the ROLE's refusals are real refusals against a real workspace: writing
+//     `issue_prefix` is a 400 and the prefix is unchanged, and an unparseable
+//     `status.custom` writes NOTHING — not the row and not the table;
+//   - a CREDENTIAL-BEARING key is WRITABLE and its value never comes back, on
+//     either the write or the read that follows it;
+//   - the removal is idempotent against the table, not merely against the
+//     handler.
+
+// putJSON puts body to path with the documented media type and returns the
+// status and decoded body.
+func (sp *serveProcess) putJSON(t *testing.T, path, body string) (int, map[string]any) {
+	t.Helper()
+	return sp.bodyRequest(t, http.MethodPut, path, body)
+}
+
+// deleteAt sends the bodyless removal and returns the status and decoded body.
+func (sp *serveProcess) deleteAt(t *testing.T, path string) (int, map[string]any) {
+	t.Helper()
+	return sp.bodyRequest(t, http.MethodDelete, path, "")
+}
+
+func (sp *serveProcess) bodyRequest(t *testing.T, method, path, body string) (int, map[string]any) {
+	t.Helper()
+	var reader io.Reader
+	if body != "" {
+		reader = strings.NewReader(body)
+	}
+	req, err := http.NewRequest(method, sp.url(path), reader)
+	if err != nil {
+		t.Fatalf("new request %s %s: %v", method, path, err)
+	}
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := sp.client.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v\nstderr:\n%s", method, path, err, sp.stderr.String())
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read %s %s: %v", method, path, err)
+	}
+	var m map[string]any
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &m); err != nil {
+			t.Fatalf("decode %s %s body %q: %v", method, path, raw, err)
+		}
+	}
+	return resp.StatusCode, m
+}
+
+func TestProxiedServerServeSettingsWrites(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+	p := newSharedProxiedProject(t, bd, "srvcfgw")
+	sp := startServe(t, bd, p.dir, bdProxiedEnv(p.dir))
+
+	// THE ROW LANDS, and the CLI is the read-back rather than this surface's own
+	// GET: a write only this API can see would be a plane of its own rather than
+	// the settings plane `bd config` reads.
+	t.Run("the value lands and the CLI reads it", func(t *testing.T) {
+		status, body := sp.putJSON(t, "/v0/beads/config/notes.wire", `{"value":"written over http"}`)
+		if status != http.StatusOK {
+			t.Fatalf("status = %d, want 200: %v", status, body)
+		}
+		if body["key"] != "notes.wire" || body["value"] != "written over http" {
+			t.Errorf("body = %v, want the stored setting", body)
+		}
+
+		out, err := bdProxiedRun(t, bd, p.dir, "config", "get", "notes.wire")
+		if err != nil {
+			t.Fatalf("bd config get: %v\n%s", err, out)
+		}
+		if !strings.Contains(string(out), "written over http") {
+			t.Errorf("bd config get printed %q, want the value the HTTP write stored", out)
+		}
+	})
+
+	// THE PROJECTION, which is the reason SetSetting is not a thin REPLACE INTO
+	// and the one property no fake can be asked about: `status.custom` is
+	// rewritten into custom_statuses IN THE SAME TRANSACTION as the row, and the
+	// visible consequence is that `bd` starts accepting the status it configured.
+	t.Run("status.custom is projected into the table reads consult", func(t *testing.T) {
+		issue := bdProxiedCreate(t, bd, p.dir, "an issue to park", "-p", "2")
+
+		// Before the write the status is not in the workspace's vocabulary.
+		if out, err := bdProxiedRun(t, bd, p.dir, "update", issue.ID, "--status", "awaiting_review"); err == nil {
+			t.Fatalf("the workspace already accepts awaiting_review; this test proves nothing:\n%s", out)
+		}
+
+		status, body := sp.putJSON(t, "/v0/beads/config/status.custom", `{"value":"awaiting_review:active"}`)
+		if status != http.StatusOK {
+			t.Fatalf("status = %d, want 200: %v", status, body)
+		}
+
+		if out, err := bdProxiedRun(t, bd, p.dir, "update", issue.ID, "--status", "awaiting_review"); err != nil {
+			t.Fatalf("the row landed without its table: %v\n%s", err, out)
+		}
+	})
+
+	// THE PROTECTED KEY, refused by the ROLE against a real workspace, with the
+	// prefix left exactly as it was. A wire that let this through would leave the
+	// beads created before the write and the beads created after it disagreeing
+	// about their own namespace.
+	t.Run("the issue prefix is refused in either spelling and nothing changes", func(t *testing.T) {
+		before := bdProxiedCreate(t, bd, p.dir, "a bead minted before", "-p", "2")
+
+		for _, key := range []string{"issue_prefix", "issue-prefix"} {
+			status, body := sp.putJSON(t, "/v0/beads/config/"+key, `{"value":"zz"}`)
+			if status != http.StatusBadRequest {
+				t.Fatalf("writing %s: status = %d, want 400: %v", key, status, body)
+			}
+			if body["code"] != "invalid_argument" {
+				t.Errorf("writing %s: code = %v, want invalid_argument", key, body["code"])
+			}
+			if detail, _ := body["detail"].(string); !strings.Contains(detail, "bd init --prefix") {
+				t.Errorf("writing %s: detail = %q, want the role's own sentence", key, detail)
+			}
+		}
+
+		after := bdProxiedCreate(t, bd, p.dir, "a bead minted after", "-p", "2")
+		beforePrefix := before.ID[:strings.LastIndex(before.ID, "-")]
+		afterPrefix := after.ID[:strings.LastIndex(after.ID, "-")]
+		if beforePrefix != afterPrefix {
+			t.Errorf("the workspace's prefix moved from %q to %q; the refusal did not hold", beforePrefix, afterPrefix)
+		}
+	})
+
+	// AN UNPARSEABLE PROJECTION WRITES NOTHING — not the row and not the table.
+	// The parse is in the role rather than at a front door precisely so a value
+	// that cannot be projected cannot become a row that one door accepted and
+	// another refused.
+	t.Run("a status.custom that does not parse leaves the row alone", func(t *testing.T) {
+		const good = "triage_hold:active"
+		if status, body := sp.putJSON(t, "/v0/beads/config/status.custom", `{"value":"`+good+`"}`); status != http.StatusOK {
+			t.Fatalf("seeding a parseable value: status = %d: %v", status, body)
+		}
+
+		status, body := sp.putJSON(t, "/v0/beads/config/status.custom", `{"value":"::not a status::"}`)
+		if status != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400: %v", status, body)
+		}
+
+		readStatus, read, _ := sp.get(t, "/v0/beads/config/status.custom")
+		if readStatus != http.StatusOK {
+			t.Fatalf("read back: status = %d", readStatus)
+		}
+		if read["value"] != good {
+			t.Errorf("value = %v, want the previous value %q — the refused write must change nothing", read["value"], good)
+		}
+	})
+
+	// THE DOCTRINE, against a real workspace: a credential-bearing key is
+	// WRITABLE, and neither the write nor the read hands the value back. Refusing
+	// the write would protect nothing a writer does not already hold; withholding
+	// it from every reader is what redaction actually is.
+	t.Run("a credential key is writable and is never handed back", func(t *testing.T) {
+		const secret = "not-a-real-token-9f13"
+		status, body := sp.putJSON(t, "/v0/beads/config/notion.token", `{"value":"`+secret+`"}`)
+		if status != http.StatusOK {
+			t.Fatalf("status = %d, want 200 — a credential-bearing key is writable: %v", status, body)
+		}
+		if body["redacted"] != true {
+			t.Errorf("redacted = %v, want true", body["redacted"])
+		}
+		if _, present := body["value"]; present {
+			t.Errorf("the write handed the credential back: %v", body)
+		}
+
+		// The read agrees, and the enumeration agrees: one rule, decided on the
+		// key, for every operation that could carry the value.
+		readStatus, read, _ := sp.get(t, "/v0/beads/config/notion.token")
+		if readStatus != http.StatusOK {
+			t.Fatalf("read back: status = %d", readStatus)
+		}
+		if read["redacted"] != true || read["value"] != nil {
+			t.Errorf("the read published the credential: %v", read)
+		}
+		listStatus, list, _ := sp.get(t, "/v0/beads/config")
+		if listStatus != http.StatusOK {
+			t.Fatalf("list: status = %d", listStatus)
+		}
+		if raw, err := json.Marshal(list); err != nil {
+			t.Fatalf("marshal the settings page: %v", err)
+		} else if strings.Contains(string(raw), secret) {
+			t.Errorf("the settings enumeration carries the stored credential")
+		}
+
+		// And the CLI, which holds the database, prints it: the withholding is
+		// this SURFACE's and not a claim that the value was not stored.
+		out, err := bdProxiedRun(t, bd, p.dir, "config", "get", "notion.token")
+		if err != nil {
+			t.Fatalf("bd config get: %v\n%s", err, out)
+		}
+		if !strings.Contains(string(out), secret) {
+			t.Errorf("bd config get printed %q; the write did not store the value it accepted", out)
+		}
+	})
+
+	// THE REMOVAL, against the table: it removes, and removing again succeeds
+	// rather than reporting a miss this role cannot see.
+	t.Run("the removal is idempotent and reports no miss", func(t *testing.T) {
+		if status, body := sp.putJSON(t, "/v0/beads/config/notes.temp", `{"value":"transient"}`); status != http.StatusOK {
+			t.Fatalf("seed: status = %d: %v", status, body)
+		}
+
+		for i := range 2 {
+			status, body := sp.deleteAt(t, "/v0/beads/config/notes.temp")
+			if status != http.StatusOK {
+				t.Fatalf("removal %d: status = %d, want 200 — this operation has no miss to report: %v", i+1, status, body)
+			}
+			if body["key"] != "notes.temp" {
+				t.Errorf("removal %d: key = %v, want the key the path named", i+1, body["key"])
+			}
+			if _, present := body["removed"]; present {
+				t.Errorf("removal %d publishes a `removed` flag: %v", i+1, body)
+			}
+		}
+
+		// Gone from the CLI's view too, which is the read-back that matters.
+		out, err := bdProxiedRun(t, bd, p.dir, "config", "get", "notes.temp")
+		if err == nil && strings.Contains(string(out), "transient") {
+			t.Errorf("bd config get still prints the removed value: %s", out)
+		}
+	})
+}

--- a/internal/httpapi/apigen/types.gen.go
+++ b/internal/httpapi/apigen/types.gen.go
@@ -1728,7 +1728,11 @@ type ReopenIssueResponse struct {
 //
 // THERE IS NO `actor`, unlike every issue mutation on this surface, and no guard member either. This plane records no history entry to attribute a write on and holds no row version to compare, so both would be members with nothing behind them.
 type SetSettingRequest struct {
-	// Value The value to store, VERBATIM. It is not trimmed, not bounded beyond the 1 MiB every body on this surface shares, and not character-filtered: the column is `TEXT`, and two of the keys this plane holds carry structured configuration a filter would corrupt.
+	// Value The value to store, VERBATIM. It is not trimmed and not character-filtered: two of the keys this plane holds carry structured configuration a filter would corrupt.
+	//
+	// IT IS BOUNDED AT 65535 BYTES, which is the storage column, and the refusal is a `400` naming this member rather than the `500` the column would otherwise produce for a request the caller could have fixed. BYTES rather than characters, because that is how the column counts: 40000 multi-byte characters overflow it and 65000 ASCII ones do not. The 1 MiB body cap every operation shares still applies above this and is never the binding limit here.
+	//
+	// The bound is NOT the one `addComment`'s `text` carries, and the difference is what the two members are for. A comment is a document — a stack trace, a diff, a captured transcript — so its column is `LONGTEXT`. A setting is a value: nothing this plane holds is a megabyte of configuration, so the narrow bound is the honest description rather than a limitation to widen later.
 	//
 	// The empty string is a legal value and is stored. Read back it is INDISTINGUISHABLE from a key nothing ever set — `Setting.value` is absent for both — which is this plane's shipped conflation rather than something this operation introduces. A caller that means "remove it" sends `DELETE`.
 	//

--- a/internal/httpapi/apigen/types.gen.go
+++ b/internal/httpapi/apigen/types.gen.go
@@ -970,7 +970,7 @@ type ContextResponse struct {
 	// BeadsDir Absolute path of the served workspace's `.beads` directory. A host path, kept because it is the single-workspace server's only workspace-identity handshake; disclosing it to network peers is part of what an operator accepts when binding beyond loopback.
 	BeadsDir string `json:"beads_dir"`
 
-	// Capabilities The tokens this server advertises: the OPERATIONS it implements, derived from its route table, and the server-wide BEHAVIORS it enforces. v0's operation vocabulary is `ready.list`, `ready.count`, `issues.list`, `issues.query`, `issues.count`, `issues.get`, `issues.related`, `issues.create`, `issues.addComment`, `issues.batchClose`, `issues.claim`, `issues.claimNext`, `issues.release`, `issues.close`, `issues.reopen`, `issues.update`, `issues.sweep`, `issues.delete`, `issues.batchCreate`, `issues.batchApply`, `stats.get`, `config.list`, `config.get`, `dependencies.cycles`, `dependencies.list`, `dependencies.count`, `dependencies.blocking`, `dependencies.tree`, `dependencies.add`, `dependencies.remove`, `memories.list`, `memories.get`, `memories.remember`, `memories.forget`, `events.list`, `events.watch`, `issues.casMetadata`; the one behavior token is `project.enforce`, which announces that a `Bd-Project-Id` stamp for the wrong workspace is refused here rather than silently ignored. The list grows additively, and an operation never appears here unless it is fully implemented. This is how a client checks for an operation or a behavior — never the version string.
+	// Capabilities The tokens this server advertises: the OPERATIONS it implements, derived from its route table, and the server-wide BEHAVIORS it enforces. v0's operation vocabulary is `ready.list`, `ready.count`, `issues.list`, `issues.query`, `issues.count`, `issues.get`, `issues.related`, `issues.create`, `issues.addComment`, `issues.batchClose`, `issues.claim`, `issues.claimNext`, `issues.release`, `issues.close`, `issues.reopen`, `issues.update`, `issues.sweep`, `issues.delete`, `issues.batchCreate`, `issues.batchApply`, `stats.get`, `config.list`, `config.get`, `config.set`, `config.unset`, `dependencies.cycles`, `dependencies.list`, `dependencies.count`, `dependencies.blocking`, `dependencies.tree`, `dependencies.add`, `dependencies.remove`, `memories.list`, `memories.get`, `memories.remember`, `memories.forget`, `events.list`, `events.watch`, `issues.casMetadata`; the one behavior token is `project.enforce`, which announces that a `Bd-Project-Id` stamp for the wrong workspace is refused here rather than silently ignored. The list grows additively, and an operation never appears here unless it is fully implemented. This is how a client checks for an operation or a behavior — never the version string.
 	//
 	// THIS LIST IS BUILD-LEVEL, NOT WORKSPACE-LEVEL. It says which operations this binary serves, and for every entry but two that is the whole answer. `events.list` and `events.watch` are the exceptions: the durable events journal is a per-workspace setting that is OFF by default, so a server that advertises them may still refuse every request to both with 409 `events_journal_disabled` — correctly, because the operations exist and the workspace has no journal. A consumer of either MUST treat the capability as "this server speaks it" and the 409 as "not on this workspace", and must not read the capability as a promise that records will arrive.
 	Capabilities []string `json:"capabilities"`
@@ -1688,6 +1688,14 @@ type RemoveDependencyResponse struct {
 	Removed bool `json:"removed"`
 }
 
+// RemovedSetting The outcome of removing one setting.
+//
+// IT CARRIES THE KEY AND NOTHING ELSE, and the absence is the contract rather than an unfinished shape. There is no `removed` flag because the storage seam discards the affected-row count on every implementation, so the member would be a value one of them had to invent — and no `value`, because reporting what was there would publish, on the one operation that withholds nothing, exactly the credential `GET /v0/beads/config/{key}` redacts.
+type RemovedSetting struct {
+	// Key The key that now holds nothing, echoed verbatim.
+	Key string `json:"key"`
+}
+
 // ReopenIssueRequest defines model for ReopenIssueRequest.
 type ReopenIssueRequest struct {
 	// Actor Who is reopening the issue. `ClaimRequest.actor`'s rules exactly: the server trims it, then refuses an empty result, anything longer than 256 BYTES (the `maxLength` above counts characters — the byte limit is the binding one), and any control character including newline. The value reaches the `reopened` event's attribution and the storage commit message, so an unvalidated newline would forge audit-trail lines.
@@ -1714,6 +1722,18 @@ type ReopenIssueResponse struct {
 
 	// Revision The row's optimistic-concurrency token AFTER this reopen, spelled the way `CloseIssueResponse.revision` spells it and here for the same reason: a recovery flow that reopens and then re-closes composes its next `expected_version` from this value. DECODE IT AS A 64-BIT INTEGER.
 	Revision int64 `json:"revision"`
+}
+
+// SetSettingRequest What to store under the key the path names. The key is not a member here: it has one spelling, and a body carrying it too would give one request two anchors and a question about what to do when they disagree.
+//
+// THERE IS NO `actor`, unlike every issue mutation on this surface, and no guard member either. This plane records no history entry to attribute a write on and holds no row version to compare, so both would be members with nothing behind them.
+type SetSettingRequest struct {
+	// Value The value to store, VERBATIM. It is not trimmed, not bounded beyond the 1 MiB every body on this surface shares, and not character-filtered: the column is `TEXT`, and two of the keys this plane holds carry structured configuration a filter would corrupt.
+	//
+	// The empty string is a legal value and is stored. Read back it is INDISTINGUISHABLE from a key nothing ever set — `Setting.value` is absent for both — which is this plane's shipped conflation rather than something this operation introduces. A caller that means "remove it" sends `DELETE`.
+	//
+	// What comes back is this value, for every key this plane accepts: the one stored key with a normalization step is `issue_prefix`, which is also the one key this plane refuses, so no write through this door is transformed on its way in. The one thing the response may not repeat is a value the KEY marks credential-bearing; see the operation.
+	Value string `json:"value"`
 }
 
 // Setting One entry of the workspace's stored settings plane.
@@ -2478,6 +2498,9 @@ type GetStatsParams struct {
 	// IGNORED when `assignee` is set: that answer computes both numbers by a route with no fast path, and it is not an error to ask.
 	SkipBlocked *bool `form:"skip_blocked,omitempty" json:"skip_blocked,omitempty"`
 }
+
+// SetSettingJSONRequestBody defines body for SetSetting for application/json ContentType.
+type SetSettingJSONRequestBody = SetSettingRequest
 
 // AddDependenciesJSONRequestBody defines body for AddDependencies for application/json ContentType.
 type AddDependenciesJSONRequestBody = AddDependenciesRequest

--- a/internal/httpapi/problem.go
+++ b/internal/httpapi/problem.go
@@ -412,6 +412,17 @@ const (
 	OpListSettings         = "listSettings"
 	OpGetSetting           = "getSetting"
 	OpListDependencyCycles = "listDependencyCycles"
+	// OpSetSetting stores one setting, replacing whatever was there. It is the
+	// surface's first PUT, and the method IS the argument: the caller names the
+	// resource by path and sends the value that becomes its whole state.
+	// rememberMemory posts to a COLLECTION because its key may be derived from
+	// the content; here the caller can always name what it is writing.
+	OpSetSetting = "setSetting"
+	// OpUnsetSetting removes one setting. It is the second DELETE on this
+	// surface and the one that does NOT 404 on a key nothing stored: this role
+	// reports no affected-row count, so the operation states an intended end
+	// state rather than an act performed. See its operationCodes row.
+	OpUnsetSetting = "unsetSetting"
 	// OpListDependencies reads STORED EDGE ROWS for several issues at once.
 	// It is a separate operation from getIssue's embedded `dependencies`
 	// member because it answers per named issue, reports the ids that named
@@ -622,6 +633,29 @@ var operationCodes = map[string][]Code{
 	// answer on this surface, so the only refusal a key can earn is the 400
 	// that says it was not a key.
 	OpGetSetting: {CodeInvalidArgument, CodeUnauthenticated, CodeBusy, CodeDBUnavailable, CodeInternal},
+	// getSetting's row PLUS the ROLE's refusals, which is the whole difference
+	// between the read half and the write half. Two of the role's three are
+	// reachable — `issue_prefix` in either spelling, and a `status.custom` that
+	// does not parse — and both arrive as the 400 they are, on the sentinel,
+	// through the shared ErrValidation line every role-backed handler here draws.
+	//
+	// NO 404 and no conflict code, both inherited from the read beside it. A key
+	// nothing stored and a key stored empty are one answer on this plane, so
+	// there is no resource this write can fail to address; and the write is an
+	// unconditional replace, so there is no state for it to lose a race against.
+	// A `revision` guard would need a row version this plane does not hold.
+	OpSetSetting: {CodeInvalidArgument, CodeUnauthenticated, CodeBusy, CodeDBUnavailable, CodeInternal},
+	// getSetting's row EXACTLY, and that is this operation's whole error story:
+	// it takes the same parameter, judges it the same way, and reaches a role
+	// whose only refusal — an empty key — the path bound has already made
+	// unreachable. Its 400 is therefore entirely the transport's.
+	//
+	// THE ABSENT 404 IS THE DIVERGENCE FROM forgetMemory, which addresses the
+	// same shape of resource with the same method and answers 404 for a key it
+	// held nothing under. That role reports Found; this one cannot — the storage
+	// seam discards the affected-row count on all three legs — so a 404 here
+	// would publish a distinction this server would have to invent.
+	OpUnsetSetting: {CodeInvalidArgument, CodeUnauthenticated, CodeBusy, CodeDBUnavailable, CodeInternal},
 	// The 400 here is this operation's own, not the document-level
 	// unknown-parameter rule: a malformed `skip_blocked`, and the EMPTY
 	// `assignee` the document refuses rather than answering with the rows that

--- a/internal/httpapi/roles_test.go
+++ b/internal/httpapi/roles_test.go
@@ -774,9 +774,19 @@ type roleSettings struct {
 	value    string
 	settings map[string]string
 	err      error
+	// writeErr is what the two writes refuse with, so a case can drive a role
+	// refusal without making the reads fail too.
+	writeErr error
+	// stored is what SetSetting reports back. Empty means "the value that was
+	// sent", which is the role's own promise for every key this plane accepts;
+	// a case that wants to prove the response carries the STORED value rather
+	// than the request sets it.
+	stored string
 
-	mu   sync.Mutex
-	gets []issueops.GetSettingRequest
+	mu     sync.Mutex
+	gets   []issueops.GetSettingRequest
+	sets   []issueops.SetSettingRequest
+	unsets []issueops.UnsetSettingRequest
 }
 
 func (c *roleSettings) GetSetting(_ context.Context, req issueops.GetSettingRequest) (issueops.SettingResult, error) {
@@ -796,18 +806,46 @@ func (c *roleSettings) ListSettings(context.Context, issueops.ListSettingsReques
 	return issueops.ListSettingsResult{Settings: c.settings}, nil
 }
 
-func (c *roleSettings) SetSetting(context.Context, issueops.SetSettingRequest) (issueops.SetSettingResult, error) {
-	return issueops.SetSettingResult{}, errors.New("this surface publishes no settings write")
+func (c *roleSettings) SetSetting(_ context.Context, req issueops.SetSettingRequest) (issueops.SetSettingResult, error) {
+	c.mu.Lock()
+	c.sets = append(c.sets, req)
+	c.mu.Unlock()
+	if c.writeErr != nil {
+		return issueops.SetSettingResult{}, c.writeErr
+	}
+	value := req.Value
+	if c.stored != "" {
+		value = c.stored
+	}
+	return issueops.SetSettingResult{Key: req.Key, Value: value}, nil
 }
 
-func (c *roleSettings) UnsetSetting(context.Context, issueops.UnsetSettingRequest) (issueops.UnsetSettingResult, error) {
-	return issueops.UnsetSettingResult{}, errors.New("this surface publishes no settings write")
+func (c *roleSettings) UnsetSetting(_ context.Context, req issueops.UnsetSettingRequest) (issueops.UnsetSettingResult, error) {
+	c.mu.Lock()
+	c.unsets = append(c.unsets, req)
+	c.mu.Unlock()
+	if c.writeErr != nil {
+		return issueops.UnsetSettingResult{}, c.writeErr
+	}
+	return issueops.UnsetSettingResult{Key: req.Key}, nil
 }
 
 func (c *roleSettings) getRequests() []issueops.GetSettingRequest {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return append([]issueops.GetSettingRequest(nil), c.gets...)
+}
+
+func (c *roleSettings) setRequests() []issueops.SetSettingRequest {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]issueops.SetSettingRequest(nil), c.sets...)
+}
+
+func (c *roleSettings) unsetRequests() []issueops.UnsetSettingRequest {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]issueops.UnsetSettingRequest(nil), c.unsets...)
 }
 
 type roleStats struct {

--- a/internal/httpapi/routes.go
+++ b/internal/httpapi/routes.go
@@ -358,6 +358,33 @@ var routeTable = []route{
 		handler:     (*Server).handleGetSetting,
 	},
 	{
+		op:     OpSetSetting,
+		method: http.MethodPut,
+		// THE SURFACE'S FIRST PUT, and the method is what the operation means
+		// rather than a preference: the caller names the resource by path and
+		// sends the value that becomes its whole state, which is what PUT
+		// already means, and the write is idempotent in the strict sense.
+		//
+		// It shares its pattern with the read above and the delete below and
+		// differs only in method, which ServeMux registers together — the same
+		// arrangement the memory key already has, so the three rows cannot
+		// collide.
+		pattern:     "/v0/beads/config/{key}",
+		capability:  "config.set",
+		implemented: true,
+		handler:     (*Server).handleSetSetting,
+	},
+	{
+		op:     OpUnsetSetting,
+		method: http.MethodDelete,
+		// The surface's second DELETE, and forgetMemory's argument unchanged:
+		// one named resource, no body, no flags.
+		pattern:     "/v0/beads/config/{key}",
+		capability:  "config.unset",
+		implemented: true,
+		handler:     (*Server).handleUnsetSetting,
+	},
+	{
 		op:          OpListDependencies,
 		method:      http.MethodGet,
 		pattern:     "/v0/beads/dependencies",

--- a/internal/httpapi/settings.go
+++ b/internal/httpapi/settings.go
@@ -1,16 +1,21 @@
 package httpapi
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"slices"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/httpapi/apigen"
+	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/issueops"
 )
 
-// The two settings operations. Each one decodes its parameters, hands the whole
+// The four settings operations. Each one decodes its parameters, hands the whole
 // request to the workspace-settings role, and shapes the answer onto the wire.
 //
 // WHAT IS NOT HERE, as in reads.go: no key is routed to a source, no value is
@@ -23,11 +28,21 @@ import (
 //
 // THE ONE THING THIS FILE DECIDES THAT THE ROLE DOES NOT is redaction, and that
 // is a wire decision rather than a storage one. The CLI prints stored values in
-// full because its caller already holds the database; this server has no
-// authentication at all, so every process that can reach the port would
-// otherwise be able to read a stored credential. A withheld value is OMITTED
-// rather than masked, so a client can never mistake a placeholder for
-// configuration.
+// full because its caller already holds the database; a value on this surface
+// travels to whoever the port admits, over no TLS, and a bearer does not narrow
+// it — where one is configured at all it is a single shared token that names
+// nobody, so it decides WHO may call and never what a caller who is let in may
+// read. A withheld value is OMITTED rather than masked, so a client can never
+// mistake a placeholder for configuration.
+//
+// REDACTION IS A RULE ABOUT DISCLOSURE, WHICH IS WHY IT DOES NOT REACH THE
+// WRITES. A credential-bearing key is writable and removable here: the role
+// refuses no such key, a writer already holds the value, and a refusal would
+// leave a workspace's credentials visible as PRESENT and permanently
+// unconfigurable through this door. What the writes owe is the projection —
+// every answer that carries a stored value goes through wireSetting, so there is
+// one statement of the rule and the response to a write is what the read that
+// follows it returns.
 
 // handleListSettings answers GET /v0/beads/config.
 func (s *Server) handleListSettings(w http.ResponseWriter, r *http.Request) {
@@ -83,6 +98,199 @@ func (s *Server) handleGetSetting(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, wireSetting(result.Key, result.Value))
+}
+
+// setSettingValueMember is the one member SetSettingRequest carries. The schema
+// is additionalProperties: false, so anything else is refused BY NAME.
+const setSettingValueMember = "value"
+
+// setSettingRequestMembers is the document's member list for SetSettingRequest.
+//
+// THE KEY IS NOT ON IT. It is the path's, so a body carrying it too would give
+// one request two anchors and a question about what to do when they disagree.
+var setSettingRequestMembers = []string{setSettingValueMember}
+
+// handleSetSetting answers PUT /v0/beads/config/{key}.
+//
+// WHAT IS NOT HERE, as in the reads above: no key is routed to a source, no
+// value is parsed, and the projection of status.custom and types.custom into
+// their normalized tables is the ROLE's, inside the same transaction as the row.
+// A handler that projected for itself would put the table write outside that
+// transaction, which is the split the projection exists to prevent.
+//
+// THE REDACTION IS THIS FILE'S, and the write half reuses it rather than
+// restating it. A key whose NAME marks it credential-bearing is perfectly
+// writable — the role refuses no such key, and refusing here would protect
+// nothing the caller does not already hold while leaving a workspace's
+// credentials permanently unconfigurable through this door. What the wire owes
+// is that the RESPONSE not hand the value back: wireSetting is the same
+// projection the read uses, so the answer to a write is byte-identical to the
+// read that follows it, and redaction stays one rule decided on the key alone.
+// The echo costs nothing either — the role promises the stored value equals the
+// value sent for every key it accepts.
+func (s *Server) handleSetSetting(w http.ResponseWriter, r *http.Request) {
+	if !s.requireNoQuery(w, r) {
+		return
+	}
+	if !s.requireJSONContent(w, r) {
+		return
+	}
+	key, ok := s.settingWriteKey(w, r)
+	if !ok {
+		return
+	}
+	value, ok := s.settingValue(w, r)
+	if !ok {
+		return
+	}
+
+	settings, err := s.workspaceConfig(r)
+	if err != nil {
+		s.failSettingWrite(w, r, err)
+		return
+	}
+	result, err := settings.SetSetting(r.Context(), issueops.SetSettingRequest{Key: key, Value: value})
+	if err != nil {
+		s.failSettingWrite(w, r, err)
+		return
+	}
+	writeJSON(w, wireSetting(result.Key, result.Value))
+}
+
+// handleUnsetSetting answers DELETE /v0/beads/config/{key}.
+//
+// NO 404, which is the one place this diverges from DELETE
+// /v0/beads/memories/{key}. That role reports whether a row was found; this one
+// cannot — the storage seam discards the affected-row count on all three legs —
+// and an absent key and a key stored empty are one answer on this plane anyway.
+// So the operation states an intended END STATE, and a caller clearing
+// configuration it is not sure was ever written does not have to classify an
+// error to learn it was already absent.
+//
+// The key is bounded by settingKey rather than settingWriteKey: a removal is a
+// COMPARISON and never an insert, so a key no column could hold simply matches
+// nothing, and refusing it would be a refusal the role does not have. That is
+// releaseExpectedAssignee's rule, applied to the other keyed plane.
+//
+// The failure path is handleGetSetting's, unchanged and for its reason: the two
+// take the same parameter and judge it the same way, and the role's one refusal
+// — an empty key — the path bound has already made unreachable.
+func (s *Server) handleUnsetSetting(w http.ResponseWriter, r *http.Request) {
+	if !s.requireNoQuery(w, r) {
+		return
+	}
+	key, ok := s.settingKey(w, r)
+	if !ok {
+		return
+	}
+
+	settings, err := s.workspaceConfig(r)
+	if err != nil {
+		s.failErr(w, r, err)
+		return
+	}
+	result, err := settings.UnsetSetting(r.Context(), issueops.UnsetSettingRequest{Key: key})
+	if err != nil {
+		s.failErr(w, r, err)
+		return
+	}
+	// The key and nothing else. There is deliberately no `removed` flag — the
+	// seam discards the count — and deliberately no `value`: reporting what was
+	// there would publish, on the one operation that withholds nothing, exactly
+	// the credential the read redacts.
+	writeJSON(w, apigen.RemovedSetting{Key: result.Key})
+}
+
+// settingWriteKey is settingKey plus the bound a WRITE needs, and reports
+// whether the request may proceed.
+//
+// THE LENGTH CHECK IS THE WRITE'S ALONE, and the asymmetry with the read and the
+// removal beside it is the hazard rather than an oversight. `config.key` is
+// VARCHAR(255) and this operation INSERTS into it, so an over-long key is an
+// error from the column — a 500 for a request the caller could have fixed. The
+// read and the removal COMPARE the same value and never store it, so a key no
+// column could hold matches nothing and already has an answer; refusing it there
+// would be a refusal the role does not have, which is releaseExpectedAssignee's
+// rule exactly.
+//
+// It is keyed on storage's own constant rather than a second copy of the
+// schema's number, the actor precedent.
+func (s *Server) settingWriteKey(w http.ResponseWriter, r *http.Request) (string, bool) {
+	key, ok := s.settingKey(w, r)
+	if !ok {
+		return "", false
+	}
+	if types.CheckFieldLen("key", key) != nil {
+		s.fail(w, r, InvalidArgument("key", ReasonInvalidValue,
+			fmt.Sprintf("`key` is %d characters; storage holds at most %d",
+				utf8.RuneCountInString(key), types.MaxFieldLen)))
+		return "", false
+	}
+	return key, true
+}
+
+// settingValue decodes the body's one member.
+//
+// NOTHING IS TRIMMED, BOUNDED OR FILTERED. The column is TEXT, two of the keys
+// this plane holds carry structured configuration a filter would corrupt, and
+// the role's promise is that a successful write stored the value that was sent.
+// The only cap is decodeJSONObjectBody's 1 MiB, which every body here shares.
+//
+// THE EMPTY STRING IS ACCEPTED and is stored. It reads back indistinguishably
+// from a key nothing ever set, which is this plane's shipped conflation rather
+// than something this operation introduces — the document says so, and a caller
+// that meant "remove it" has DELETE.
+//
+// Explicit `null` is a 400 naming the member rather than a clear, the rule every
+// optional member on this surface follows and, here, the one that keeps the
+// clear on the operation that performs one.
+func (s *Server) settingValue(w http.ResponseWriter, r *http.Request) (string, bool) {
+	members, res := decodeJSONObjectBody(w, r)
+	if res != nil {
+		s.fail(w, r, *res)
+		return "", false
+	}
+	if offender, unknown := unknownMember(members, setSettingRequestMembers); unknown {
+		s.failUnknownMember(w, r, offender, setSettingRequestMembers)
+		return "", false
+	}
+	raw, ok := members[setSettingValueMember]
+	if !ok {
+		s.fail(w, r, InvalidArgument(setSettingValueMember, ReasonInvalidValue,
+			"`"+setSettingValueMember+"` is required"))
+		return "", false
+	}
+	var value *string
+	if err := json.Unmarshal(raw, &value); err != nil || value == nil {
+		s.fail(w, r, InvalidArgument(setSettingValueMember, ReasonInvalidValue,
+			"`"+setSettingValueMember+"` must be a string"))
+		return "", false
+	}
+	return *value, true
+}
+
+// failSettingWrite answers a failed write.
+//
+// It draws the ErrValidation-is-a-400 line the sweep, delete, tree, edges,
+// batch-create and memory handlers each draw, in the same shape and for the same
+// reason: the role performs request validation this handler does not duplicate,
+// and widening ClassifyError instead would change what every other operation
+// returns for an error it has never produced.
+//
+// NO `param`, and this is failMemoryErr's posture rather than a shortcut. Two of
+// the role's refusals are reachable here and they are about different members —
+// the protected key, and a status.custom value that does not parse — and telling
+// them apart takes the role's protected-key VOCABULARY, which this package
+// cannot hold: depguard denies internal/workapi from every non-test file here,
+// precisely so a second copy of a shared rule cannot exist to drift. The detail
+// carries the role's own sentence, which names what to send instead; the
+// refusals this handler owns all name their member above.
+func (s *Server) failSettingWrite(w http.ResponseWriter, r *http.Request, err error) {
+	if !errors.Is(err, issueops.ErrValidation) {
+		s.failErr(w, r, err)
+		return
+	}
+	s.fail(w, r, InvalidArgument("", ReasonInvalidValue, err.Error()))
 }
 
 // settingKey validates the path parameter and reports whether the request may

--- a/internal/httpapi/settings.go
+++ b/internal/httpapi/settings.go
@@ -231,10 +231,23 @@ func (s *Server) settingWriteKey(w http.ResponseWriter, r *http.Request) (string
 
 // settingValue decodes the body's one member.
 //
-// NOTHING IS TRIMMED, BOUNDED OR FILTERED. The column is TEXT, two of the keys
-// this plane holds carry structured configuration a filter would corrupt, and
-// the role's promise is that a successful write stored the value that was sent.
-// The only cap is decodeJSONObjectBody's 1 MiB, which every body here shares.
+// NOTHING IS TRIMMED OR FILTERED. Two of the keys this plane holds carry
+// structured configuration a filter would corrupt, and the role's promise is
+// that a successful write stored the value that was sent.
+//
+// IT IS BOUNDED, THOUGH, and that is settingWriteKey's rule applied to the other
+// half of the row rather than a second opinion about it. `config.value` is a
+// TEXT column, so a value past 65535 BYTES is an error from the column — a
+// generic 500 for a request the caller could have fixed, which is the exact
+// failure the key's bound exists to prevent. Keyed on storage's own constant,
+// and counted in BYTES because that is how the column counts.
+//
+// It is NOT widened the way the ephemeral comment column was. A comment is a
+// document — a stack trace, a diff, a transcript — and the planes disagreeing
+// about one was a bug. A setting is a VALUE: nothing this plane holds is a
+// megabyte of configuration, and the narrow bound is the honest description of
+// what a settings row is for. decodeJSONObjectBody's 1 MiB still applies above
+// it and is now never the binding limit here.
 //
 // THE EMPTY STRING IS ACCEPTED and is stored. It reads back indistinguishably
 // from a key nothing ever set, which is this plane's shipped conflation rather
@@ -264,6 +277,12 @@ func (s *Server) settingValue(w http.ResponseWriter, r *http.Request) (string, b
 	if err := json.Unmarshal(raw, &value); err != nil || value == nil {
 		s.fail(w, r, InvalidArgument(setSettingValueMember, ReasonInvalidValue,
 			"`"+setSettingValueMember+"` must be a string"))
+		return "", false
+	}
+	if types.CheckTextLen(setSettingValueMember, *value) != nil {
+		s.fail(w, r, InvalidArgument(setSettingValueMember, ReasonInvalidValue,
+			fmt.Sprintf("`%s` is %d bytes; storage holds at most %d",
+				setSettingValueMember, len(*value), types.MaxTextBytes)))
 		return "", false
 	}
 	return *value, true

--- a/internal/httpapi/settings_write_test.go
+++ b/internal/httpapi/settings_write_test.go
@@ -1,6 +1,7 @@
 package httpapi
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -197,16 +198,23 @@ func TestSetSettingWithholdsACredentialItJustAccepted(t *testing.T) {
 	if reqs := settings.setRequests(); len(reqs) != 1 || reqs[0].Value != "shhh-real-secret" {
 		t.Fatalf("the role received %+v, want the value the caller sent", reqs)
 	}
-	body := decodeBody(t, resp)
+	raw := readAll(t, resp)
+	var body map[string]any
+	if err := json.Unmarshal([]byte(raw), &body); err != nil {
+		t.Fatalf("decode %q: %v", raw, err)
+	}
 	if body["redacted"] != true {
 		t.Errorf("redacted = %v, want true", body["redacted"])
 	}
 	if _, present := body["value"]; present {
 		t.Errorf("the write handed the credential back: %v", body)
 	}
-	// And the whole response, not just the member: nothing else may carry it.
-	if raw := fmt.Sprint(body); strings.Contains(raw, "shhh-real-secret") {
-		t.Errorf("the response body carries the stored credential: %s", raw)
+	// THE RAW RESPONSE BYTES, not the decoded map. A decoded-map grep only sees
+	// members this test thought to look at — an extension member, a duplicated
+	// key, an echo inside a `detail` string would all pass it — and what a
+	// client, a proxy log and an access log actually receive is the bytes.
+	if strings.Contains(raw, "shhh-real-secret") {
+		t.Errorf("the response bytes carry the stored credential: %s", raw)
 	}
 }
 
@@ -250,6 +258,16 @@ func TestSetSettingRefusesTheRequest(t *testing.T) {
 			body:  `{"value":"v"}`,
 			param: "key",
 		},
+		{
+			// The SAME hazard on the other half of the row: config.value is a
+			// TEXT column, so one byte past it is an error from the column — a
+			// generic 500 for a request the caller could have fixed, which is
+			// precisely what the key's bound above exists to prevent.
+			name:  "a value past the storage column",
+			path:  "notes",
+			body:  `{"value":"` + strings.Repeat("v", types.MaxTextBytes+1) + `"}`,
+			param: "value",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			settings := &roleSettings{}
@@ -270,6 +288,102 @@ func TestSetSettingRefusesTheRequest(t *testing.T) {
 				t.Errorf("%d writes ran on a refused request", len(got))
 			}
 		})
+	}
+}
+
+// TestSetSettingAcceptsAValueAtTheColumnsCeiling is the other direction of the
+// bound, and it is the half that stops a refusal from quietly becoming stricter
+// than the column it is keyed on: exactly MaxTextBytes must be ACCEPTED and
+// reach the role, because that value fits.
+//
+// The multi-byte case is what pins BYTES rather than characters. 40000 two-byte
+// characters are 80000 bytes — well inside any rune count and well past the
+// column — so a bound that counted runes would accept it and hand the 500 back
+// to the caller, which is the failure this whole check exists to prevent.
+func TestSetSettingAcceptsAValueAtTheColumnsCeiling(t *testing.T) {
+	t.Run("exactly the ceiling is accepted", func(t *testing.T) {
+		settings := &roleSettings{}
+		ts := newSettingsServer(t, settings)
+
+		value := strings.Repeat("v", types.MaxTextBytes)
+		raw, err := json.Marshal(map[string]string{"value": value})
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+		resp := ts.setSetting(t, "/v0/beads/config/notes", string(raw))
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200 — this value fits the column: %s", resp.StatusCode, readAll(t, resp))
+		}
+		if reqs := settings.setRequests(); len(reqs) != 1 || len(reqs[0].Value) != types.MaxTextBytes {
+			t.Errorf("the role received %d bytes, want the %d sent", len(reqs[0].Value), types.MaxTextBytes)
+		}
+	})
+
+	t.Run("multi-byte is counted in bytes", func(t *testing.T) {
+		settings := &roleSettings{}
+		ts := newSettingsServer(t, settings)
+
+		// Two bytes per character, so this is inside any rune-based bound and
+		// past the column.
+		value := strings.Repeat("é", types.MaxTextBytes/2+1)
+		if len(value) <= types.MaxTextBytes {
+			t.Fatalf("the fixture is %d bytes, which the column accepts; this test proves nothing", len(value))
+		}
+		raw, err := json.Marshal(map[string]string{"value": value})
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+		resp := ts.setSetting(t, "/v0/beads/config/notes", string(raw))
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400 — the column counts bytes: %s", resp.StatusCode, readAll(t, resp))
+		}
+		if body := decodeBody(t, resp); body["param"] != "value" {
+			t.Errorf("param = %v, want value", body["param"])
+		}
+		if got := settings.setRequests(); len(got) != 0 {
+			t.Errorf("%d writes ran on a refused request", len(got))
+		}
+	})
+}
+
+// TestSetSettingTwiceIsTheSameAnswerAndTheSameState is PUT's defining property,
+// pinned rather than assumed: the method is idempotent, so the second request
+// must answer byte-for-byte what the first did and leave the plane where the
+// first left it.
+//
+// It is worth a case of its own because nothing else here would catch a handler
+// that grew a "first write wins" or an "already set" member — both of which are
+// shapes this surface has elsewhere (claimIssue's `already_claimed`,
+// closeIssue's `already_closed`) and neither of which belongs on a PUT.
+func TestSetSettingTwiceIsTheSameAnswerAndTheSameState(t *testing.T) {
+	settings := &roleSettings{}
+	ts := newSettingsServer(t, settings)
+
+	first := ts.setSetting(t, settingPath, `{"value":"awaiting_review:active"}`)
+	if first.StatusCode != http.StatusOK {
+		t.Fatalf("first PUT status = %d, want 200: %s", first.StatusCode, readAll(t, first))
+	}
+	firstBody := decodeBody(t, first)
+
+	second := ts.setSetting(t, settingPath, `{"value":"awaiting_review:active"}`)
+	if second.StatusCode != http.StatusOK {
+		t.Fatalf("second PUT status = %d, want 200: %s", second.StatusCode, readAll(t, second))
+	}
+	if secondBody := decodeBody(t, second); !reflect.DeepEqual(firstBody, secondBody) {
+		t.Errorf("the second PUT answered %v, the first answered %v; this method is idempotent", secondBody, firstBody)
+	}
+
+	// BOTH reached the role, which is the state half: the role performs the
+	// write and its projection unconditionally — a no-op detection would make
+	// repairing a drifted table depend on the row having changed, which is
+	// exactly the state that needs repairing — so this surface must not
+	// short-circuit the second call either.
+	reqs := settings.setRequests()
+	if len(reqs) != 2 {
+		t.Fatalf("%d writes reached the role, want 2", len(reqs))
+	}
+	if !reflect.DeepEqual(reqs[0], reqs[1]) {
+		t.Errorf("the two writes reached the role as %+v and %+v; want the same request twice", reqs[0], reqs[1])
 	}
 }
 

--- a/internal/httpapi/settings_write_test.go
+++ b/internal/httpapi/settings_write_test.go
@@ -1,0 +1,473 @@
+package httpapi
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/issueops"
+)
+
+// The wire edge of the two settings WRITES, on a fake role.
+//
+// Which keys the plane refuses, what the projection of status.custom does, and
+// whether a removal removed anything are issueops.WorkspaceConfig's, held to on
+// three legs by its own contract and shown against real Dolt in cmd/bd. What
+// only these cases can show is that the request a caller SENDS becomes the
+// request the role RECEIVES, that the response is projected by the SAME rule the
+// read is projected by — which is the whole of what stops a write leaking what a
+// read withholds — and that the removal has no 404 to give.
+
+const settingPath = "/v0/beads/config/status.custom"
+
+func (ts *testServer) setSetting(t *testing.T, path, body string) *http.Response {
+	t.Helper()
+	return ts.putBody(t, path, "application/json", body)
+}
+
+func (ts *testServer) putBody(t *testing.T, path, contentType, body string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPut, ts.base+path, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	resp, err := ts.client.Do(req)
+	if err != nil {
+		t.Fatalf("PUT %s: %v", path, err)
+	}
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	return resp
+}
+
+func (ts *testServer) unsetSetting(t *testing.T, path string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodDelete, ts.base+path, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := ts.client.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE %s: %v", path, err)
+	}
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	return resp
+}
+
+func newSettingsServer(t *testing.T, settings *roleSettings) *testServer {
+	t.Helper()
+	return newTestServer(t, rolesConfig(Config{Settings: settings}))
+}
+
+// TestSetSettingProjectsTheWholeRequest drives the two halves of the request,
+// which come from two different places: the key off the path and the value off
+// the body. The verbatim cases are the ones with teeth — this plane's keys and
+// values are both stored as sent, so a trim at this edge would produce a write
+// the caller can never find again under the name it used.
+func TestSetSettingProjectsTheWholeRequest(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		path string
+		body string
+		want issueops.SetSettingRequest
+	}{
+		{
+			name: "the key comes from the path and the value from the body",
+			path: "status.custom",
+			body: `{"value":"awaiting_review:active"}`,
+			want: issueops.SetSettingRequest{Key: "status.custom", Value: "awaiting_review:active"},
+		},
+		{
+			// One path segment, percent-decoded once. Keys routinely carry dots
+			// and this surface walks no namespace.
+			name: "a percent-escaped key is decoded once",
+			path: "custom%2Fslash",
+			body: `{"value":"v"}`,
+			want: issueops.SetSettingRequest{Key: "custom/slash", Value: "v"},
+		},
+		{
+			// The EMPTY STRING is a legal value and reaches the role. A caller
+			// that meant "remove it" has DELETE; conflating the two here would
+			// make one request mean whichever the handler guessed.
+			name: "the empty value is stored, not treated as a removal",
+			path: "notes",
+			body: `{"value":""}`,
+			want: issueops.SetSettingRequest{Key: "notes", Value: ""},
+		},
+		{
+			// Neither trimmed nor filtered: the column is TEXT and two of this
+			// plane's keys carry structured configuration.
+			name: "the value keeps its newlines and its surrounding space",
+			path: "notes",
+			body: `{"value":"  one\ntwo  "}`,
+			want: issueops.SetSettingRequest{Key: "notes", Value: "  one\ntwo  "},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			settings := &roleSettings{}
+			ts := newSettingsServer(t, settings)
+
+			resp := ts.setSetting(t, "/v0/beads/config/"+tc.path, tc.body)
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+			}
+			reqs := settings.setRequests()
+			if len(reqs) != 1 {
+				t.Fatalf("%d writes ran, want 1", len(reqs))
+			}
+			if !reflect.DeepEqual(reqs[0], tc.want) {
+				t.Errorf("SetSettingRequest = %+v, want %+v", reqs[0], tc.want)
+			}
+		})
+	}
+}
+
+// TestSetSettingAnswersWhatTheReadWouldAnswer is the redaction property, stated
+// as an equality rather than as two assertions that could drift: the body of a
+// write is byte-for-byte the body of the read that follows it.
+//
+// THIS IS THE WHOLE NO-ECHO GUARANTEE. Redaction on this surface decides on the
+// KEY and never on the caller, so a write that handed a credential-bearing value
+// back would be one operation exempting itself from a rule the schema states in
+// one place — and `Setting.redacted` would mean two different things depending on
+// which operation produced it. Comparing the two responses is what makes a second
+// projection impossible to add without failing here.
+func TestSetSettingAnswersWhatTheReadWouldAnswer(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{name: "an ordinary key", key: "status.custom", value: "awaiting_review:active"},
+		{name: "a credential-bearing key", key: "notion.token", value: "shhh-real-secret"},
+		{name: "a key stored empty", key: "notes", value: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// The two servers answer the SAME stored value, so any difference in
+			// the bodies is the projection's rather than the fixture's.
+			writer := newSettingsServer(t, &roleSettings{})
+			reader := newSettingsServer(t, &roleSettings{value: tc.value})
+
+			wrote := writer.setSetting(t, "/v0/beads/config/"+tc.key, fmt.Sprintf(`{"value":%q}`, tc.value))
+			if wrote.StatusCode != http.StatusOK {
+				t.Fatalf("PUT status = %d, want 200: %s", wrote.StatusCode, readAll(t, wrote))
+			}
+			read := reader.get(t, "/v0/beads/config/"+tc.key)
+			if read.StatusCode != http.StatusOK {
+				t.Fatalf("GET status = %d, want 200: %s", read.StatusCode, readAll(t, read))
+			}
+			wroteBody, readBody := decodeBody(t, wrote), decodeBody(t, read)
+			if !reflect.DeepEqual(wroteBody, readBody) {
+				t.Errorf("PUT answered %v, the GET beside it answers %v; the write must be projected by the same rule",
+					wroteBody, readBody)
+			}
+		})
+	}
+}
+
+// TestSetSettingWithholdsACredentialItJustAccepted is the doctrine, asserted
+// directly rather than only through the equality above: the write is PERMITTED
+// and the value does not come back.
+//
+// PERMITTED because redaction is a rule about DISCLOSURE. The role refuses no
+// credential-bearing key — `bd config set`'s own secret guard is about writing
+// one into a git-tracked config.yaml, a different plane with a different hazard —
+// and a writer already holds the value, so refusing here would protect nothing
+// while leaving a workspace's credentials visible as PRESENT and permanently
+// unconfigurable through this door.
+func TestSetSettingWithholdsACredentialItJustAccepted(t *testing.T) {
+	const key = "notion.token"
+	if !config.IsSecretKey(key) {
+		t.Fatalf("%q is no longer a credential-bearing key; this test proves nothing", key)
+	}
+	settings := &roleSettings{}
+	ts := newSettingsServer(t, settings)
+
+	resp := ts.setSetting(t, "/v0/beads/config/"+key, `{"value":"shhh-real-secret"}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 — a credential-bearing key is writable: %s", resp.StatusCode, readAll(t, resp))
+	}
+	// The role got the value: the refusal is not smuggled in as a silent drop.
+	if reqs := settings.setRequests(); len(reqs) != 1 || reqs[0].Value != "shhh-real-secret" {
+		t.Fatalf("the role received %+v, want the value the caller sent", reqs)
+	}
+	body := decodeBody(t, resp)
+	if body["redacted"] != true {
+		t.Errorf("redacted = %v, want true", body["redacted"])
+	}
+	if _, present := body["value"]; present {
+		t.Errorf("the write handed the credential back: %v", body)
+	}
+	// And the whole response, not just the member: nothing else may carry it.
+	if raw := fmt.Sprint(body); strings.Contains(raw, "shhh-real-secret") {
+		t.Errorf("the response body carries the stored credential: %s", raw)
+	}
+}
+
+// TestSetSettingAnswersTheStoredValueNotTheRequest is the other half of the
+// projection: the body is built from what the ROLE reported, so a role whose
+// answer differed from the request would be reported honestly rather than
+// papered over by an echo.
+func TestSetSettingAnswersTheStoredValueNotTheRequest(t *testing.T) {
+	ts := newSettingsServer(t, &roleSettings{stored: "what-the-plane-holds"})
+
+	resp := ts.setSetting(t, settingPath, `{"value":"what-the-caller-sent"}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if body := decodeBody(t, resp); body["value"] != "what-the-plane-holds" {
+		t.Errorf("value = %v, want the STORED value; this response is echoing the request", body["value"])
+	}
+}
+
+// TestSetSettingRefusesTheRequest walks every refusal this edge owns, each named
+// by the member it is about.
+func TestSetSettingRefusesTheRequest(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		path  string
+		body  string
+		param string
+	}{
+		{name: "an unknown member", path: "status.custom", body: `{"value":"v","key":"status.custom"}`, param: "key"},
+		{name: "a missing value", path: "status.custom", body: `{}`, param: "value"},
+		{name: "a null value", path: "status.custom", body: `{"value":null}`, param: "value"},
+		{name: "a non-string value", path: "status.custom", body: `{"value":7}`, param: "value"},
+		{name: "a key that is empty after trimming", path: "%20%20", body: `{"value":"v"}`, param: "key"},
+		{name: "a key carrying a control character", path: "a%0Ab", body: `{"value":"v"}`, param: "key"},
+		{
+			// The bound the WRITE needs and the read does not: this operation
+			// inserts into a VARCHAR(255) primary key, so an over-long key would
+			// otherwise be a 500 from the column.
+			name:  "a key past the storage column",
+			path:  strings.Repeat("k", types.MaxFieldLen+1),
+			body:  `{"value":"v"}`,
+			param: "key",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			settings := &roleSettings{}
+			ts := newSettingsServer(t, settings)
+
+			resp := ts.setSetting(t, "/v0/beads/config/"+tc.path, tc.body)
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
+			}
+			body := decodeBody(t, resp)
+			if body["code"] != string(CodeInvalidArgument) {
+				t.Errorf("code = %v, want %s", body["code"], CodeInvalidArgument)
+			}
+			if body["param"] != tc.param {
+				t.Errorf("param = %v, want %q", body["param"], tc.param)
+			}
+			if got := settings.setRequests(); len(got) != 0 {
+				t.Errorf("%d writes ran on a refused request", len(got))
+			}
+		})
+	}
+}
+
+// TestSetSettingRefusesEverythingButAJSONBody covers the two document-level
+// rules on this operation, because both are enforced per handler.
+func TestSetSettingRefusesEverythingButAJSONBody(t *testing.T) {
+	t.Run("a query parameter", func(t *testing.T) {
+		ts := newSettingsServer(t, &roleSettings{})
+		resp := ts.setSetting(t, settingPath+"?force=true", `{"value":"v"}`)
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
+		}
+		if body := decodeBody(t, resp); body["reason"] != string(ReasonUnknownParameter) {
+			t.Errorf("reason = %v, want %s", body["reason"], ReasonUnknownParameter)
+		}
+	})
+
+	t.Run("a form encoding", func(t *testing.T) {
+		ts := newSettingsServer(t, &roleSettings{})
+		resp := ts.putBody(t, settingPath, "application/x-www-form-urlencoded", `value=v`)
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
+		}
+		if body := decodeBody(t, resp); body["param"] != "Content-Type" {
+			t.Errorf("param = %v, want Content-Type", body["param"])
+		}
+	})
+}
+
+// TestSetSettingCarriesTheRolesRefusal is the ROLE's 400 reaching the wire as
+// the 400 it is, with the role's own sentence.
+//
+// It carries NO `param`, deliberately. The two reachable refusals are about
+// different members — the protected key, and a status.custom that does not parse
+// — and telling them apart needs the role's protected-key vocabulary, which this
+// package cannot hold: depguard denies internal/workapi from every non-test file
+// here, precisely so a second copy of a shared rule cannot exist to drift.
+func TestSetSettingCarriesTheRolesRefusal(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  string
+	}{
+		{
+			name: "the protected prefix key",
+			err:  `"issue_prefix" is set by bd init --prefix, bd bootstrap or bd rename-prefix, not by a config write`,
+		},
+		{
+			name: "a status.custom value that does not parse",
+			err:  "invalid status.custom value: bad shape",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := newSettingsServer(t, &roleSettings{
+				writeErr: fmt.Errorf("%w: %s", issueops.ErrValidation, tc.err),
+			})
+
+			resp := ts.setSetting(t, settingPath, `{"value":"whatever"}`)
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
+			}
+			body := decodeBody(t, resp)
+			if body["code"] != string(CodeInvalidArgument) {
+				t.Errorf("code = %v, want %s", body["code"], CodeInvalidArgument)
+			}
+			if _, present := body["param"]; present {
+				t.Errorf("the role's refusal names a member this surface cannot know: %v", body)
+			}
+			if detail, _ := body["detail"].(string); !strings.Contains(detail, tc.err) {
+				t.Errorf("detail = %q, want the role's own sentence", detail)
+			}
+		})
+	}
+}
+
+// TestUnsetSettingRemovesTheNamedKey is the removal's happy path, and the
+// response shape is the assertion: the key and nothing else.
+func TestUnsetSettingRemovesTheNamedKey(t *testing.T) {
+	settings := &roleSettings{}
+	ts := newSettingsServer(t, settings)
+
+	resp := ts.unsetSetting(t, settingPath)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	reqs := settings.unsetRequests()
+	if len(reqs) != 1 || reqs[0].Key != "status.custom" {
+		t.Fatalf("unset requests = %+v, want one for status.custom", reqs)
+	}
+	body := decodeBody(t, resp)
+	if body["key"] != "status.custom" {
+		t.Errorf("key = %v, want the key the path named", body["key"])
+	}
+	// No `removed` flag: the storage seam discards the affected-row count, so
+	// the member would be a value one implementation had to invent. No `value`
+	// either — on the one operation that withholds nothing, reporting what was
+	// there would publish exactly the credential the read redacts.
+	for _, member := range []string{"removed", "value", "redacted"} {
+		if _, present := body[member]; present {
+			t.Errorf("the removal publishes %q: %v", member, body)
+		}
+	}
+}
+
+// TestUnsetSettingHasNo404 is the divergence from DELETE
+// /v0/beads/memories/{key}, which answers 404 for a key it held nothing under.
+// This role reports no affected-row count, so the operation states an intended
+// END STATE: removing a key nothing set succeeds, and removing the same key
+// twice is 200 and then 200.
+func TestUnsetSettingHasNo404(t *testing.T) {
+	settings := &roleSettings{}
+	ts := newSettingsServer(t, settings)
+
+	for i := range 2 {
+		resp := ts.unsetSetting(t, "/v0/beads/config/never.set")
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("removal %d: status = %d, want 200 — this operation has no miss to report: %s",
+				i+1, resp.StatusCode, readAll(t, resp))
+		}
+	}
+	if got := settings.unsetRequests(); len(got) != 2 {
+		t.Errorf("%d removals reached the role, want 2", len(got))
+	}
+}
+
+// TestUnsetSettingRefusesTheKeyTheReadRefuses pins the deliberate SAMENESS: the
+// removal takes the read's parameter and judges it the read's way.
+//
+// The over-long key is the case that pins the deliberate DIFFERENCE from the
+// write. A removal is a comparison and never an insert, so a key no column could
+// hold matches nothing and already has an answer; refusing it would be a refusal
+// the role does not have — releaseExpectedAssignee's rule, on the other keyed
+// plane.
+func TestUnsetSettingRefusesTheKeyTheReadRefuses(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		path string
+		want int
+	}{
+		{name: "a key that is empty after trimming", path: "%20%20", want: http.StatusBadRequest},
+		{name: "a key carrying a control character", path: "a%0Ab", want: http.StatusBadRequest},
+		{
+			name: "a key past the storage column is not refused",
+			path: strings.Repeat("k", types.MaxFieldLen+1),
+			want: http.StatusOK,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			settings := &roleSettings{}
+			ts := newSettingsServer(t, settings)
+
+			removed := ts.unsetSetting(t, "/v0/beads/config/"+tc.path)
+			if removed.StatusCode != tc.want {
+				t.Fatalf("DELETE status = %d, want %d: %s", removed.StatusCode, tc.want, readAll(t, removed))
+			}
+			// The read answers the same way, which is what "the read's parameter,
+			// judged the read's way" means.
+			read := ts.get(t, "/v0/beads/config/"+tc.path)
+			if read.StatusCode != tc.want {
+				t.Errorf("GET status = %d, DELETE answered %d; the two must judge one parameter one way",
+					read.StatusCode, tc.want)
+			}
+		})
+	}
+}
+
+// TestSettingWritesRefuseAQueryParameterOnTheRemoval keeps the document-level
+// rule true on the one write with no body to carry it.
+func TestSettingWritesRefuseAQueryParameterOnTheRemoval(t *testing.T) {
+	ts := newSettingsServer(t, &roleSettings{})
+
+	resp := ts.unsetSetting(t, settingPath+"?force=true")
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if body := decodeBody(t, resp); body["reason"] != string(ReasonUnknownParameter) {
+		t.Errorf("reason = %v, want %s", body["reason"], ReasonUnknownParameter)
+	}
+}
+
+// TestSettingPathReachesEachMethodsHandler drives all three methods on the one
+// pattern against the real router. ServeMux registers method and pattern
+// together, so this is what proves the three rows are three operations rather
+// than one shadowing the others.
+func TestSettingPathReachesEachMethodsHandler(t *testing.T) {
+	settings := &roleSettings{value: "stored"}
+	ts := newSettingsServer(t, settings)
+
+	if resp := ts.get(t, settingPath); resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if resp := ts.setSetting(t, settingPath, `{"value":"v"}`); resp.StatusCode != http.StatusOK {
+		t.Fatalf("PUT status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if resp := ts.unsetSetting(t, settingPath); resp.StatusCode != http.StatusOK {
+		t.Fatalf("DELETE status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+	}
+	if len(settings.getRequests()) != 1 || len(settings.setRequests()) != 1 || len(settings.unsetRequests()) != 1 {
+		t.Errorf("the three methods reached %d reads, %d writes and %d removals; want one each",
+			len(settings.getRequests()), len(settings.setRequests()), len(settings.unsetRequests()))
+	}
+}

--- a/internal/httpapi/spec/openapi.v0.yaml
+++ b/internal/httpapi/spec/openapi.v0.yaml
@@ -4461,8 +4461,9 @@ paths:
         '400':
           description: >-
             Invalid request: an unknown query parameter, an unparseable or
-            oversized body, an unknown body member, a `value` that is missing or
-            is not a string, a `key` that is empty after trimming, carries a
+            oversized body, an unknown body member, a `value` that is missing,
+            is not a string or is longer than the 65535-byte column, a `key`
+            that is empty after trimming, carries a
             control character or is longer than the 255-character column — or a
             value this workspace's own validation refuses, which is `issue_prefix`
             in either spelling and a `status.custom` that does not parse. NOTHING
@@ -8052,10 +8053,26 @@ components:
         value:
           type: string
           description: >-
-            The value to store, VERBATIM. It is not trimmed, not bounded beyond
-            the 1 MiB every body on this surface shares, and not
-            character-filtered: the column is `TEXT`, and two of the keys this
-            plane holds carry structured configuration a filter would corrupt.
+            The value to store, VERBATIM. It is not trimmed and not
+            character-filtered: two of the keys this plane holds carry
+            structured configuration a filter would corrupt.
+
+
+            IT IS BOUNDED AT 65535 BYTES, which is the storage column, and the
+            refusal is a `400` naming this member rather than the `500` the
+            column would otherwise produce for a request the caller could have
+            fixed. BYTES rather than characters, because that is how the column
+            counts: 40000 multi-byte characters overflow it and 65000 ASCII ones
+            do not. The 1 MiB body cap every operation shares still applies above
+            this and is never the binding limit here.
+
+
+            The bound is NOT the one `addComment`'s `text` carries, and the
+            difference is what the two members are for. A comment is a document —
+            a stack trace, a diff, a captured transcript — so its column is
+            `LONGTEXT`. A setting is a value: nothing this plane holds is a
+            megabyte of configuration, so the narrow bound is the honest
+            description rather than a limitation to widen later.
 
 
             The empty string is a legal value and is stored. Read back it is

--- a/internal/httpapi/spec/openapi.v0.yaml
+++ b/internal/httpapi/spec/openapi.v0.yaml
@@ -63,7 +63,7 @@ info:
       outside its own parameter table with `400` / `code: invalid_argument` /
       `reason: "unknown_parameter"` and `param` naming the offending key.
       Operations that declare no QUERY parameter at all reject every query key
-      the same way. Today that is twenty-three of the thirty-nine operations
+      the same way. Today that is twenty-five of the forty-one operations
       here — `GET /healthz`, `GET /v0/beads/context`,
       `GET /v0/beads/dependencies/cycles`, `POST /v0/beads/issues`,
       `PATCH /v0/beads/issues/{id}`,
@@ -77,7 +77,8 @@ info:
       `POST /v0/beads/issues:batchCreate`,
       `POST /v0/beads/issues:batchApply`,
       `POST /v0/beads/issues:batchClose`, `GET /v0/beads/config`,
-      `GET /v0/beads/config/{key}`, `POST /v0/beads/dependencies:add`,
+      `GET /v0/beads/config/{key}`, `PUT /v0/beads/config/{key}`,
+      `DELETE /v0/beads/config/{key}`, `POST /v0/beads/dependencies:add`,
       `POST /v0/beads/dependencies:remove`, `POST /v0/beads/memories`,
       `GET /v0/beads/memories/{key}` and `DELETE /v0/beads/memories/{key}`.
       A path parameter is not a query parameter: several of those carry
@@ -4277,8 +4278,14 @@ paths:
         SETTINGS WHOSE KEY MARKS THEM AS CREDENTIAL-BEARING ARE WITHHELD. Their
         entry is present with `redacted: true` and no `value`, so a client can
         see that the key is configured without the surface handing a secret to
-        every process that can reach the port — this API has no
-        authentication. See `Setting`.
+        every process that can reach the port. A CONFIGURED BEARER DOES NOT
+        NARROW IT: authentication on this surface is a deployment posture and the
+        credential, where there is one, is a single shared token that names
+        nobody — it decides WHO may call, never what a caller who is let in may
+        read — and there is no TLS either. The rule is the KEY's and is the same
+        for every caller. See `Setting`, and `PUT` on this key's own path for the
+        write half, which withholds the value in its response for the same
+        reason and permits the write.
 
 
         The envelope is the paginated one and `has_more` is always false today:
@@ -4332,6 +4339,222 @@ paths:
           description: >-
             Invalid request: an unknown query parameter, or a `key` that is
             empty after trimming or carries a control character.
+          x-bd-codes: [invalid_argument]
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
+        '500':
+          $ref: '#/components/responses/InternalError'
+        '503':
+          $ref: '#/components/responses/Unavailable'
+
+    put:
+      operationId: setSetting
+      summary: Store one setting
+      description: >-
+        Stores one setting, REPLACING any value already there — the write
+        `bd config set` spells, on the durable settings plane this document's
+        reads already publish.
+
+
+        `PUT` RATHER THAN A COLLECTION `POST`, and the method is the whole
+        argument: the resource has a canonical URI, the caller names it, and the
+        request carries the value that becomes its whole state. That is what
+        `PUT` already means, and it is idempotent in the strict sense — the same
+        request sent twice leaves the same row.
+        `POST /v0/beads/memories` is the operation this is NOT: that one posts to
+        the COLLECTION because its key may be derived from the content, so the
+        caller cannot always name the resource it is creating. Here the caller
+        always can.
+
+
+        THE KEY IS THE PATH'S and appears nowhere in the body: one anchor, one
+        spelling, and no question about what to do when two disagree. It is used
+        verbatim — no namespace completion, no case folding, no dash/underscore
+        equivalence — and stored UNTRIMMED, because a key differing from another
+        only by surrounding space is a key a reader will never match and
+        trimming it would produce a write the caller cannot find again.
+
+
+        ## What this plane refuses, and what it does not
+
+
+        `issue_prefix` — in either spelling — is a `400` and NOTHING is written.
+        The prefix is owned by `bd init --prefix`, `bd bootstrap` and
+        `bd rename-prefix`, each of which does work this plane cannot: rewriting
+        existing ids, or seeding a workspace that has none. Storing a new one
+        here would leave the beads created before the write and the beads created
+        after it disagreeing about their own namespace with nothing to reconcile
+        them.
+
+
+        A `status.custom` value that does not PARSE is a `400` and nothing is
+        written. That key is not merely stored — it is projected into the
+        `custom_statuses` table, which reads consult first, IN THE SAME
+        TRANSACTION as the row. `types.custom` is projected into `custom_types`
+        the same way. A row without its table is a value that has been stored and
+        has no effect for as long as the table holds something else, so the write
+        and the projection are one durable act or neither happens.
+
+
+        A KEY WHOSE NAME MARKS IT CREDENTIAL-BEARING IS WRITABLE, and that is
+        deliberate rather than an oversight in the redaction posture. Redaction
+        is a rule about DISCLOSURE: it withholds a value from a reader because a
+        bearer on this surface is shared and surface-wide and cannot decide that
+        one caller may read a credential and another may not. A writer supplies
+        the value, so refusing the write protects nothing that is not already in
+        the caller's hand — and it would leave a workspace whose credentials can
+        be seen to EXIST and never configured. The role refuses no such key
+        either; `bd config set`'s own secret guard is about writing a credential
+        into a git-tracked `config.yaml`, which is a different plane with a
+        different hazard, and it returns clean for every key this operation
+        reaches.
+
+
+        THE RESPONSE THEREFORE WITHHOLDS IT ANYWAY. The body is a `Setting`
+        projected by the same rule `GET /v0/beads/config/{key}` projects with, so
+        a `redacted: true` key comes back with no `value` — the response to a
+        write is byte-identical to the read that follows it. It costs the caller
+        nothing: the role promises the stored value equals the value sent for
+        every key this plane accepts, so the echo carries no information the
+        caller does not already hold, and publishing it would make one schema say
+        two different things about `redacted`.
+
+
+        A key belonging to another SOURCE is not refused here and is worth
+        knowing about: `export.*`, `dolt.*`, `federation.*`, `storage-class.*`
+        and the rest of the yaml-only list live in `config.yaml`, and
+        `beads.role` lives in git config. Written through this operation they
+        land a row no reader consults. The role does not police that routing and
+        neither can this server — three of the five sources `bd config show`
+        reads are files on the CLIENT's machine, which is the same reason that
+        command has no operation here.
+
+
+        Hooks do not fire, as for every write on this surface — and on this plane
+        there are none to fire in any case: the workspace hook vocabulary is
+        `on_create`/`on_update`/`on_close`, each of which hands a script an
+        ISSUE, and a settings write has none to name.
+      parameters:
+        - $ref: '#/components/parameters/SettingKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetSettingRequest'
+      security:
+        - bearerToken: []
+      responses:
+        '200':
+          description: >-
+            The setting as it now stands, projected exactly as the `GET` beside
+            it projects it — including the redaction, which is decided on the KEY
+            and never on the caller.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Setting'
+        '400':
+          description: >-
+            Invalid request: an unknown query parameter, an unparseable or
+            oversized body, an unknown body member, a `value` that is missing or
+            is not a string, a `key` that is empty after trimming, carries a
+            control character or is longer than the 255-character column — or a
+            value this workspace's own validation refuses, which is `issue_prefix`
+            in either spelling and a `status.custom` that does not parse. NOTHING
+            IS WRITTEN in any of these cases.
+
+
+            The role's two refusals carry no `param`, unlike the transport's
+            above: telling them apart would take a second copy of the protected-key
+            vocabulary on this side of the seam, and `detail` carries the role's
+            own sentence, which names what to send instead.
+          x-bd-codes: [invalid_argument]
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
+        '500':
+          $ref: '#/components/responses/InternalError'
+        '503':
+          $ref: '#/components/responses/Unavailable'
+
+    delete:
+      operationId: unsetSetting
+      summary: Remove one stored setting
+      description: >-
+        Removes the setting stored under one key — the write `bd config unset`
+        spells. `DELETE` for `DELETE /v0/beads/memories/{key}`'s reason: it names
+        ONE resource by path, carries no body and takes no flags, which is what
+        the method already means.
+
+
+        REMOVING A KEY NOTHING SET SUCCEEDS, and this is where the operation
+        parts company with the memory delete beside it. That one answers `404`
+        for a key it held nothing under, because its role reports whether a row
+        was found and `bd recall` already has an exit-code contract for the
+        miss. THIS role reports no such thing: the storage seam discards the
+        affected-row count on all three implementations, and an absent key and a
+        key stored as the empty string are one answer on this plane — the same
+        conflation `GET /v0/beads/config/{key}` has no `404` for. So this
+        operation states an INTENDED END STATE rather than an act performed, and
+        a caller clearing configuration it is not sure was ever written does not
+        have to classify an error to learn it was already absent.
+
+
+        THERE IS CONSEQUENTLY NO `removed` MEMBER, and there must not be one: it
+        would be a value one implementation had to invent. Sending the same
+        request twice is `200` and then `200`.
+
+
+        UNSET DOES NOT UNDO `PUT`'s PROJECTION. Removing `status.custom` or
+        `types.custom` deletes the row and LEAVES the normalized table exactly as
+        the last write left it, so the custom statuses and types keep applying
+        after the key that configured them is gone. All three implementations
+        agree, so it is the plane's behavior rather than a divergence, and it is
+        stated here so no reader infers a symmetry with `PUT` that the code does
+        not have.
+
+
+        THE PROTECTED KEY IS NOT REFUSED HERE. `issue_prefix` cannot be WRITTEN
+        through this plane and can be removed through it — an asymmetry that is
+        shipped behavior on all three implementations rather than a decision this
+        document makes, recorded as bd-yby99.34. Removing it does not rename
+        anything; it leaves the workspace resolving its prefix from `config.yaml`
+        or from nothing.
+
+
+        A CREDENTIAL-BEARING KEY IS REMOVABLE, on `PUT`'s reasoning: redaction
+        withholds a value from a READER, and a removal discloses nothing at all.
+
+
+        Hooks do not fire, and this plane has none to fire; see `PUT`.
+      parameters:
+        - $ref: '#/components/parameters/SettingKey'
+      security:
+        - bearerToken: []
+      responses:
+        '200':
+          description: >-
+            The key holds nothing now. Whether it held anything before is not
+            reported — see the description.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemovedSetting'
+        '400':
+          description: >-
+            Invalid request: an unknown query parameter, or a `key` that is empty
+            after trimming or carries a control character. It is the `GET`
+            beside it's refusal exactly, unchanged, because the two take the same
+            parameter and judge it the same way. Nothing is removed in either
+            case.
           x-bd-codes: [invalid_argument]
           content:
             application/problem+json:
@@ -6922,7 +7145,8 @@ components:
             `issues.close`, `issues.reopen`, `issues.update`,
             `issues.sweep`, `issues.delete`, `issues.batchCreate`,
             `issues.batchApply`,
-            `stats.get`, `config.list`, `config.get`, `dependencies.cycles`,
+            `stats.get`, `config.list`, `config.get`, `config.set`,
+            `config.unset`, `dependencies.cycles`,
             `dependencies.list`, `dependencies.count`,
             `dependencies.blocking`, `dependencies.tree`,
             `dependencies.add`, `dependencies.remove`,
@@ -7809,6 +8033,63 @@ components:
             conflation showing through, and it is stated rather than smoothed
             over, because smoothing it would mean this member reporting
             "nothing was there" about a write that overwrote something.
+
+    SetSettingRequest:
+      type: object
+      additionalProperties: false
+      required: [value]
+      description: >-
+        What to store under the key the path names. The key is not a member
+        here: it has one spelling, and a body carrying it too would give one
+        request two anchors and a question about what to do when they disagree.
+
+
+        THERE IS NO `actor`, unlike every issue mutation on this surface, and no
+        guard member either. This plane records no history entry to attribute a
+        write on and holds no row version to compare, so both would be members
+        with nothing behind them.
+      properties:
+        value:
+          type: string
+          description: >-
+            The value to store, VERBATIM. It is not trimmed, not bounded beyond
+            the 1 MiB every body on this surface shares, and not
+            character-filtered: the column is `TEXT`, and two of the keys this
+            plane holds carry structured configuration a filter would corrupt.
+
+
+            The empty string is a legal value and is stored. Read back it is
+            INDISTINGUISHABLE from a key nothing ever set — `Setting.value` is
+            absent for both — which is this plane's shipped conflation rather
+            than something this operation introduces. A caller that means
+            "remove it" sends `DELETE`.
+
+
+            What comes back is this value, for every key this plane accepts:
+            the one stored key with a normalization step is `issue_prefix`,
+            which is also the one key this plane refuses, so no write through
+            this door is transformed on its way in. The one thing the response
+            may not repeat is a value the KEY marks credential-bearing; see the
+            operation.
+
+    RemovedSetting:
+      type: object
+      required: [key]
+      description: >-
+        The outcome of removing one setting.
+
+
+        IT CARRIES THE KEY AND NOTHING ELSE, and the absence is the contract
+        rather than an unfinished shape. There is no `removed` flag because the
+        storage seam discards the affected-row count on every implementation, so
+        the member would be a value one of them had to invent — and no `value`,
+        because reporting what was there would publish, on the one operation that
+        withholds nothing, exactly the credential `GET /v0/beads/config/{key}`
+        redacts.
+      properties:
+        key:
+          type: string
+          description: The key that now holds nothing, echoed verbatim.
 
     SettingsPage:
       type: object

--- a/internal/httpapi/spec_parity_test.go
+++ b/internal/httpapi/spec_parity_test.go
@@ -992,6 +992,62 @@ func TestReleaseRequestMembersMatchTheHandler(t *testing.T) {
 	}
 }
 
+// TestSetSettingRequestMembersMatchTheHandler is the release's gate for the
+// settings write body.
+//
+// The member this is really guarding is the one that is NOT there. The key is
+// the path's, and a `key` member arriving in the body — documented or honored —
+// would give one request two anchors, so both halves of the check matter: the
+// handler refuses it as unknown, and the schema must not promise it.
+func TestSetSettingRequestMembersMatchTheHandler(t *testing.T) {
+	accepted := map[string]bool{}
+	for _, name := range setSettingRequestMembers {
+		accepted[name] = true
+	}
+
+	goFields := jsonTagNames(t, reflect.TypeOf(apigen.SetSettingRequest{}))
+	if extra := diff(goFields, accepted); len(extra) > 0 {
+		t.Errorf("generated SetSettingRequest declares members the settings write refuses as unknown: %v", extra)
+	}
+	if missing := diff(accepted, goFields); len(missing) > 0 {
+		t.Errorf("the settings write accepts members SetSettingRequest does not declare: %v", missing)
+	}
+
+	doc := loadSpec(t)
+	schema := mapAt(t, mapAt(t, mapAt(t, doc, "components"), "schemas"), "SetSettingRequest")
+	specProps := schemaProperties(t, doc, schema)
+	if extra := diff(specProps, accepted); len(extra) > 0 {
+		t.Errorf("the SetSettingRequest schema documents members the settings write refuses: %v", extra)
+	}
+	if missing := diff(accepted, specProps); len(missing) > 0 {
+		t.Errorf("the settings write accepts members the SetSettingRequest schema does not document: %v", missing)
+	}
+
+	if accepted["key"] || specProps["key"] {
+		t.Error("SetSettingRequest publishes `key`; the anchor is the path parameter and must have one spelling")
+	}
+}
+
+// TestRemovedSettingPublishesNothingButTheKey pins the removal's response shape
+// against the document from the SERVER's side, which the schema alone cannot do:
+// `RemovedSetting` is unpinned, so nothing else fails when a member is added to
+// the Go type and to the schema together.
+//
+// Both absences are the contract. `removed` cannot be honest — the storage seam
+// discards the affected-row count on every implementation — and `value` would
+// publish, on the one settings operation that withholds nothing, exactly the
+// credential `GET /v0/beads/config/{key}` redacts.
+func TestRemovedSettingPublishesNothingButTheKey(t *testing.T) {
+	if got := jsonTagNames(t, reflect.TypeOf(apigen.RemovedSetting{})); len(got) != 1 || !got["key"] {
+		t.Errorf("RemovedSetting declares %v, want `key` alone", got)
+	}
+	doc := loadSpec(t)
+	schema := mapAt(t, mapAt(t, mapAt(t, doc, "components"), "schemas"), "RemovedSetting")
+	if got := schemaProperties(t, doc, schema); len(got) != 1 || !got["key"] {
+		t.Errorf("the RemovedSetting schema documents %v, want `key` alone", got)
+	}
+}
+
 // TestAddCommentRequestMembersMatchTheHandler is the release's gate for the
 // comment body.
 //

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -302,6 +302,36 @@ func CheckFieldLen(name, val string) error {
 	return nil
 }
 
+// MaxTextBytes is the maximum size, in BYTES, of a `TEXT` column — the storage
+// ceiling for the values this schema keeps in one rather than in a LONGTEXT.
+//
+// BYTES, NOT CHARACTERS, which is the one place this differs from MaxFieldLen
+// beside it and the reason CheckTextLen does not simply call CheckFieldLen with
+// a bigger number: MySQL and Dolt bound a TEXT column by its encoded length, so
+// a value of 40000 multi-byte characters overflows it while a value of 65000
+// ASCII characters does not.
+//
+// The large-content columns are deliberately NOT bounded by this — issue
+// descriptions and comment bodies are LONGTEXT precisely so an embedded image or
+// a captured transcript fits (migrations 0049 and 0065). This is for the columns
+// that hold a VALUE rather than a document, `config.value` being the one a front
+// door can reach with an arbitrary payload.
+const MaxTextBytes = 65535
+
+// CheckTextLen returns ErrFieldTooLong (wrapped with context) when val exceeds
+// MaxTextBytes bytes. name is the field label used in the message.
+//
+// It exists so a front door can refuse an oversized value with a 400 that names
+// the member, instead of letting the column refuse it — which arrives as a
+// driver error, is classified as a generic 500, and tells the caller nothing it
+// could act on.
+func CheckTextLen(name, val string) error {
+	if n := len(val); n > MaxTextBytes {
+		return fmt.Errorf("%w: %s is %d bytes (max %d)", ErrFieldTooLong, name, n, MaxTextBytes)
+	}
+	return nil
+}
+
 // ValidateIssueTitle checks the canonical issue-title requirements. The title
 // must be nonempty and at most 500 bytes.
 func ValidateIssueTitle(title string) error {


### PR DESCRIPTION
> **Stacked on #5594** (`feat/wire-add-comment`). The two slices collide on one
> surface — the document-level no-query-parameter list and its two operation
> counts — so this branch is built on that one, and **#5594 MERGES FIRST**.
>
> The base is `main` rather than `feat/wire-add-comment` because the PR and
> conformance workflows are gated on `pull_request: branches: [main]`, so a
> stacked base gets no CI at all. The cost is that the diff shown here is BOTH
> commits; review this slice as the second one
> (`Publish PUT and DELETE /v0/beads/config/{key}`), and it collapses to that
> alone the moment #5594 lands.

Settings are read-only over v0: `WorkspaceConfig.SetSetting` and `UnsetSetting`
have no wire operation, which leaves the infra-over-http surface able to see that
a workspace is configured and unable to configure it. These are those operations.
The role, its contract and all three legs already exist; this slice wires them.

Spec first, then `make api-gen`, then the handlers.

PUT AND DELETE ON THE KEY'S OWN PATH, and the methods ARE the argument rather
than a preference. The resource has a canonical URI, the caller names it, and the
request carries the value that becomes its whole state — that is what PUT already
means, and the write is idempotent in the strict sense. `POST /v0/beads/memories`
is the operation this is deliberately NOT: that one posts to the COLLECTION
because its key may be derived from the content, so the caller cannot always name
the resource it is creating. Here it always can. The removal is
`DELETE /v0/beads/memories/{key}`'s shape unchanged — one named resource, no body,
no flags — and all three rows share one pattern, differing only in method, which
ServeMux registers together.

THE KEY IS THE PATH'S AND APPEARS NOWHERE IN THE BODY, so `SetSettingRequest`
carries exactly one member. A body spelling the anchor a second time is one
request with two anchors and a question about what to do when they disagree; the
parity test asserts the absence from both sides.

## The redaction doctrine, and what the write half owes it

A KEY WHOSE NAME MARKS IT CREDENTIAL-BEARING IS WRITABLE, resolved from the
facade's actual behavior rather than from the shape of the read. `ValidateSettingWrite`
refuses an empty key, `issue_prefix` in either spelling, and a `status.custom`
that does not parse — and nothing else; `config.IsSecretKey` appears nowhere in
the write path. The CLI's own secret guard is `CheckSecretKeyGitSafety`, which is
gated on `IsYamlOnlyKey` and protects a git-tracked **config.yaml** — a different
plane with a different hazard, a credential in git history — and returns clean for
every key this operation reaches. The role states the asymmetry itself: the reads
are a firewall, the writes are not, and a write discloses nothing. Refusing here
would be a refusal the role does not have, invented by the projection, and it
would leave a workspace's credentials visible as PRESENT and permanently
unconfigurable through this door.

WHAT THE WIRE OWES INSTEAD IS THE RESPONSE. Redaction is caller-independent and
decided on the KEY, and `Setting.value` says in one place that a `redacted: true`
entry withholds a value that may well be stored — so a write answering with both
would make one schema mean two different things depending on which operation
produced it. The write is therefore projected by `wireSetting`, the SAME function
the read is projected by, and the test states that as an equality rather than as
two assertions that could drift: the body of a PUT is byte-for-byte the body of
the GET that follows it. It costs the caller nothing, because the role promises
the stored value equals the value sent for every key this plane accepts, so the
echo carries no information the caller does not already hold.

The removal publishes `key` and nothing else. No `removed` flag — the storage seam
discards the affected-row count on all three legs, so the member would be a value
one of them had to invent — and no `value`, which on the one settings operation
that withholds nothing would publish exactly the credential the read redacts.

## Absent-vs-empty, and the 404 that is not here

REMOVING A KEY NOTHING SET SUCCEEDS. This is where the operation parts company
with the memory delete it otherwise copies: that role reports Found, and `bd recall`
already has an exit-code contract for the miss. This one cannot — an absent key
and a key stored as the empty string are one answer on this plane, the same
conflation `GET /v0/beads/config/{key}` has no 404 for — so the operation states
an intended END STATE, and the same request twice is 200 and then 200. The
document also records what the removal does NOT undo: `status.custom`'s
projection survives the row it came from, on all three implementations
(bd-yby99.33), as does the protected key's write-refused/remove-permitted
asymmetry (bd-yby99.34).

The empty string is a legal VALUE and is stored, not read as a removal: a caller
that meant "remove it" has DELETE, and conflating the two would make one request
mean whichever the handler guessed.

## The one bound that is the write's alone

`config.key` is VARCHAR(255) and the PUT INSERTS into it, so an over-long key is
an error from the column — a 500 for a request the caller could have fixed. The
GET and the DELETE COMPARE the same value and never store it, so a key no column
could hold matches nothing and already has an answer, and refusing it there would
be a refusal the role does not have. That is `releaseExpectedAssignee`'s rule
applied to the other keyed plane, and the asymmetry is asserted in both
directions.

THE ROLE'S 400 CARRIES NO `param`, and that is the depguard rule doing its job
rather than a shortcut. Two of the role's refusals are reachable and they name
different members — the protected key, and a value that does not parse — and
telling them apart takes the role's protected-key VOCABULARY, which this package
cannot hold: `httpapi-transport-boundary` denies internal/workapi from every
non-test file here, precisely so a second copy of a shared rule cannot exist to
drift. `detail` carries the role's own sentence, which names what to send instead;
every refusal this handler owns names its member.

ONE STALE SENTENCE FIXED ON THIS SURFACE. `listSettings` justified redaction with
"this API has no authentication", which stopped being true when #5516 landed the
optional bearer and which #5545 rewrote everywhere except here; settings.go's file
comment carried the same sentence. Both now say what is actually load-bearing — a
configured bearer is a single shared token that decides WHO may call and never
what a caller who is let in may read — which is the statement this whole slice
depends on. `forgetMemory`'s description carries the same staleness and is left
for that surface's own change.

CENSUS +1 EACH, twice over: two spec paths on one existing path item;
SetSettingRequest and RemovedSetting; the document's no-query-parameter list and
its two counts; two route rows on the pattern the read already registers; two
capability tokens in the ContextResponse prose (the only hand edit — Capabilities()
is derived); OpSetSetting and OpUnsetSetting; two operationCodes rows
(getSetting's vocabulary, no code minted). NOTHING new in the role plumbing:
Config.Settings, sourceRoles, roleSourceNames and s.workspaceConfig() already
carry this role, and the hook decorator's WorkspaceConfig accessor deliberately
wraps nothing — the workspace hook vocabulary hands a script an ISSUE, and a
settings write has none to name, so there is no RoleFiresHooks case to add.


---

## Review round 2 — FIX-REQUIRED addressed

**F3 (MEDIUM-HIGH): `config.value` had no bound and is a `TEXT` column.** A
100 KiB `PUT` was a generic 500 out of the column — the exact hazard
`settingWriteKey` was written to prevent, shipped in the same PR. Now bounded at
the edge on `types.MaxTextBytes`, refusing with `param: "value"` before the role.
Counted in **bytes, not runes**, because that is how the column counts; both
directions and the multi-byte case are pinned, and all three mutations die.
The column is deliberately **not** widened — a setting is a value, not a document.

**Minors:** the `PUT`-twice property is pinned (same response bytes, and BOTH
calls reach the role — no short-circuit), and the unit no-leak assertion now
greps **raw response bytes**, which catches a credential smuggled into an
extension member that every decoded-map assertion walks past.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
