### PR TITLE
fix(doctor): propagate TLS and password to federation checks

### DIFF
--- a/cmd/bd/doctor/federation.go
+++ b/cmd/bd/doctor/federation.go
@@ -38,6 +38,8 @@ func doltServerConfig(beadsDir, doltPath string) *dolt.Config {
 		cfg.ServerHost = bcfg.GetDoltServerHost()
 		cfg.ServerPort = doltserver.DefaultConfig(beadsDir).Port
 		cfg.ServerUser = bcfg.GetDoltServerUser()
+		cfg.ServerTLS = bcfg.GetDoltServerTLS()
+		cfg.ServerPassword = bcfg.GetDoltServerPasswordForPort(cfg.ServerPort)
 	}
 	dolt.ApplyCLIAutoStart(beadsDir, cfg)
 	return cfg


### PR DESCRIPTION
ate `doltServerConfig()` in `cmd/bd/doctor/federation.go` copies `ServerHost`, `ServerPort` and `ServerUser` out of `metadata.json` but leaves `ServerTLS` and `ServerPassword` at their zero values. Every federation check therefore dials the configured Dolt server in plaintext and unauthenticated.

Against a server with `require_secure_transport` on, all four federation checks fail:

```
⚠  Peer Connectivity: Unable to open database
    failed to check if database "borabot_platform" exists on server dolt.example.com:3307:
    Error 1105 (HY000): unknown error: Code: UNAVAILABLE
    server does not allow insecure connections, client must use SSL/TLS
```

…even though `metadata.json` has `"dolt_server_tls": true` and normal `bd` commands against the same server work fine.

## Why only federation

The two sibling open paths already do this correctly, which is exactly why CRUD and the non-federation doctor checks succeed against the same server:

- `internal/storage/dolt/open.go` (`applyResolvedConfig`) — sets both:
  ```go
  if cfg.ServerPassword == "" {
      cfg.ServerPassword = fileCfg.GetDoltServerPasswordForPort(cfg.ServerPort)
  }
  if !cfg.ServerTLS {
      cfg.ServerTLS = fileCfg.GetDoltServerTLS()
  }
  ```
- `cmd/bd/doctor/dolt.go` (`openDoltDB`) — builds a `doltutil.ServerDSN` with `TLS: cfg.GetDoltServerTLS()` and the port-keyed password.

`federation.go` is the only one of the three that omits them.

## Verification

Against a real remote TLS-only Dolt server (`dolt_server_tls: true`, password in `~/.config/beads/credentials`), same repo and same `metadata.json`, back to back:

| binary | result |
|---|---|
| stock `v1.1.2` (Homebrew) | `FEDERATION (2/6 passed)` |
| this patch | `FEDERATION (5/6 passed)` |

Peer Connectivity, Sync Staleness, Federation Conflicts and Dolt Mode all connect instead of erroring. The one remaining warning is unrelated (`Federation remotesapi: Server not running (2 peers configured)` — a local-server condition), and note it reports `2 peers configured`, information the check could not previously reach at all.

`gofmt` clean, `go vet ./cmd/bd/doctor/` clean.