### PR TITLE
test: report the helper-only re-exec probe as skipped

### DIFF
--- a/scripts/test_script_test.go
+++ b/scripts/test_script_test.go
@@ -95,7 +95,7 @@ func TestTestScriptPrebuiltBinaryContract(t *testing.T) {
 // package-wide TestMain authority needed by other script-selection contracts.
 func TestTestScriptPrebuiltBinaryLaunchProbe(t *testing.T) {
 	if os.Getenv(testScriptLaunchProbeEnv) != "1" {
-		return
+		t.Skip("re-exec probe runs only under the test.sh fake-go driver")
 	}
 
 	prebuilt := os.Getenv("BEADS_TEST_BD_BINARY")


### PR DESCRIPTION
Fixes #5598

## What

Report `TestTestScriptPrebuiltBinaryLaunchProbe` as skipped when it is not
running under the fake-`go` re-exec driver, with a reason that names that
boundary.

## Why

The helper currently returns from its environment guard, so ordinary Go test
output records a pass even though none of the launch-probe assertions ran.
Using `t.Skip` makes the result honest without changing the driven path or any
production behavior.

This is the focused follow-up to the non-blocking review nit on #5512.

## Verification

- The direct helper selector reports `SKIP` with the expected reason.
- The full prebuilt-binary contract still passes through the fake-`go` re-exec
  and real `os/exec` boundary.
- All `scripts` package tests pass.
- `go vet -tags gms_pure_go ./scripts`
- `golangci-lint run --build-tags gms_pure_go ./scripts` reports zero issues.
- `gofmt` and `git diff --check`

_codex-gpt-5-unknown-reasoning on behalf of Ewen Cuthiell_
