### PR TITLE
fix(make): quote install paths containing spaces

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1025,6 +1025,82 @@ jobs:
             throw 'Native Make shell smoke failed'
           }
 
+          function Get-TreeManifest {
+            param([Parameter(Mandatory)][string]$Root)
+
+            @(
+              Get-ChildItem -LiteralPath $Root -Recurse -Force | ForEach-Object {
+                $relative = [IO.Path]::GetRelativePath($Root, $_.FullName).Replace('\', '/')
+                if ($_.PSIsContainer) {
+                  "D $relative"
+                } else {
+                  $hash = (Get-FileHash -LiteralPath $_.FullName -Algorithm SHA256).Hash
+                  "F $relative $hash"
+                }
+              }
+            ) | Sort-Object
+          }
+
+          $proofRoot = Join-Path $env:RUNNER_TEMP ("make install proof " + [guid]::NewGuid().ToString('N'))
+          $fixtureRepo = Join-Path $proofRoot 'fixture repo'
+          $buildDir = Join-Path $fixtureRepo 'build output'
+          $installRoot = Join-Path $proofRoot 'install sandbox'
+          $installProfile = Join-Path $installRoot 'profile with spaces'
+          New-Item -ItemType Directory -Force -Path $buildDir, $installProfile | Out-Null
+          Copy-Item -LiteralPath (Join-Path $env:GITHUB_WORKSPACE 'Makefile') -Destination $fixtureRepo
+          Copy-Item -LiteralPath (Join-Path $env:GITHUB_WORKSPACE 'go.mod') -Destination $fixtureRepo
+
+          $sentinel = Join-Path $buildDir 'bd.exe'
+          Set-Content -LiteralPath $sentinel -Encoding ascii -NoNewline -Value 'native-install-sentinel'
+          $sentinelHash = (Get-FileHash -LiteralPath $sentinel -Algorithm SHA256).Hash
+
+          & $git -C $fixtureRepo init --quiet
+          & $git -C $fixtureRepo config core.hooksPath .githooks
+          if ($LASTEXITCODE -ne 0) {
+            throw 'Could not initialize the isolated install fixture repository'
+          }
+          & $git -C $fixtureRepo -c user.name=install-proof -c user.email=install-proof@example.invalid `
+            -c commit.gpgsign=false commit --allow-empty --quiet -m 'Initialize install proof'
+          if ($LASTEXITCODE -ne 0) {
+            throw 'Could not commit the isolated install fixture repository'
+          }
+          $fixtureBefore = @(Get-TreeManifest -Root $fixtureRepo)
+
+          $env:USERPROFILE = $installProfile
+          Push-Location $fixtureRepo
+          try {
+            & $make --no-print-directory -o build "BUILD_DIR=$buildDir" GIT_BUILD=install-proof install-force
+            if ($LASTEXITCODE -ne 0) {
+              throw 'Native Make install-force failed for a spaced USERPROFILE'
+            }
+          } finally {
+            Pop-Location
+          }
+
+          $installed = Join-Path $installProfile '.local\bin\bd.exe'
+          if (-not (Test-Path -LiteralPath $installed -PathType Leaf)) {
+            throw "Native Make did not install bd.exe at the exact destination '$installed'"
+          }
+          if ((Get-FileHash -LiteralPath $installed -Algorithm SHA256).Hash -ne $sentinelHash) {
+            throw 'Native Make installed bd.exe with unexpected contents'
+          }
+
+          $expectedInstall = @(
+            'D profile with spaces'
+            'D profile with spaces/.local'
+            'D profile with spaces/.local/bin'
+            "F profile with spaces/.local/bin/bd.exe $sentinelHash"
+          ) | Sort-Object
+          $actualInstall = @(Get-TreeManifest -Root $installRoot)
+          if (Compare-Object -ReferenceObject $expectedInstall -DifferenceObject $actualInstall) {
+            throw "Native Make changed paths outside the exact install destination:`n$($actualInstall -join "`n")"
+          }
+
+          $fixtureAfter = @(Get-TreeManifest -Root $fixtureRepo)
+          if (Compare-Object -ReferenceObject $fixtureBefore -DifferenceObject $fixtureAfter) {
+            throw 'Native Make split the spaced install path or otherwise mutated the fixture repository'
+          }
+
       - name: Exercise MSYS2-hosted Make
         if: matrix.host == 'msys2'
         shell: msys2 {0}

--- a/Makefile
+++ b/Makefile
@@ -313,11 +313,16 @@ endif
 # zero bytes of output — indistinguishable from an empty result set to callers.
 # The old rm-first shape added an ENOENT window on top. Same treatment for the
 # beads symlink.
+#
+# EXCEPTION — native Windows keeps the rm-first + cp shape: under Git for
+# Windows' bash the staged tmp+rename leaves no bd.exe at the destination even
+# though cp && mv exit 0 (caught by pr.yml's spaced-USERPROFILE install proof;
+# root cause untraced). Restore Windows atomicity only with that proof green.
 install install-force: build
 	@mkdir -p "$(INSTALL_DIR)"
 ifeq ($(OS),Windows_NT)
-	@cp "$(BUILD_DIR)/bd.exe" "$(INSTALL_DIR)/.bd.exe.install.tmp.$$$$" && mv -f "$(INSTALL_DIR)/.bd.exe.install.tmp.$$$$" "$(INSTALL_DIR)/bd.exe"
-	@rm -f "$(INSTALL_DIR)/bd"
+	@rm -f "$(INSTALL_DIR)/bd" "$(INSTALL_DIR)/bd.exe"
+	@cp "$(BUILD_DIR)/bd.exe" "$(INSTALL_DIR)/bd.exe"
 	@echo "Installed bd.exe to $(INSTALL_DIR)/bd.exe"
 else
 	@cp "$(BUILD_DIR)/bd" "$(INSTALL_DIR)/.bd.install.tmp.$$$$" && mv -f "$(INSTALL_DIR)/.bd.install.tmp.$$$$" "$(INSTALL_DIR)/bd"

--- a/Makefile
+++ b/Makefile
@@ -306,17 +306,17 @@ endif
 # Also creates 'beads' symlink as an alias for bd
 # Use install-force to skip the origin/main update check
 install install-force: build
-	@mkdir -p $(INSTALL_DIR)
+	@mkdir -p "$(INSTALL_DIR)"
 ifeq ($(OS),Windows_NT)
-	@rm -f $(INSTALL_DIR)/bd $(INSTALL_DIR)/bd.exe
-	@cp $(BUILD_DIR)/bd.exe $(INSTALL_DIR)/bd.exe
+	@rm -f "$(INSTALL_DIR)/bd" "$(INSTALL_DIR)/bd.exe"
+	@cp "$(BUILD_DIR)/bd.exe" "$(INSTALL_DIR)/bd.exe"
 	@echo "Installed bd.exe to $(INSTALL_DIR)/bd.exe"
 else
-	@rm -f $(INSTALL_DIR)/bd
-	@cp $(BUILD_DIR)/bd $(INSTALL_DIR)/bd
+	@rm -f "$(INSTALL_DIR)/bd"
+	@cp "$(BUILD_DIR)/bd" "$(INSTALL_DIR)/bd"
 	@echo "Installed bd to $(INSTALL_DIR)/bd"
-	@rm -f $(INSTALL_DIR)/beads
-	@ln -s bd $(INSTALL_DIR)/beads
+	@rm -f "$(INSTALL_DIR)/beads"
+	@ln -s bd "$(INSTALL_DIR)/beads"
 	@echo "Created 'beads' alias -> bd"
 endif
 	@git config core.hooksPath .githooks 2>/dev/null && echo "Configured git hooks (.githooks/)" || true


### PR DESCRIPTION
## What

Quote the build and install filesystem operands in the shared `install` / `install-force` Make recipe.

Extend the required native-Windows GNU Make job with an isolated install proof whose build directory and `USERPROFILE` both contain spaces.

## Why

On Windows, `INSTALL_DIR` defaults to `$(USERPROFILE)/.local/bin`. Expanding that path unquoted splits a normal space-bearing profile into separate shell arguments: `install-force` exits without installing the intended `bd.exe` and can create stray directories outside the destination.

Quoting the operands preserves the existing Windows copy and non-Windows copy/symlink behavior while treating each expanded path as one argument. The workflow proof skips the unrelated build recipe, copies a sentinel `bd.exe`, verifies its exact SHA-256 at the intended destination, and compares tree manifests to reject split-path or out-of-scope mutations.

## Validation

- Native UCRT64 GNU Make 4.4.1 base negative control reproduced split paths and no intended binary.
- The candidate passed native install proof with spaces plus `&`, `;`, parentheses, apostrophe, and brackets in build/profile paths.
- Exact installed-file hash, install-tree manifest, and unchanged-fixture assertions passed.
- The POSIX recipe branch passed under MSYS/Cygwin-hosted Make with exact binary and alias behavior.
- `go test -count=1 -tags=gms_pure_go ./scripts`, `actionlint`, PowerShell AST parsing, aggregate-gate falsifiers, and diff hygiene passed.

Hosted Windows/Chocolatey and required aggregate results remain mandatory on the published head.

Fixes #5526

_codex-gpt-5-unknown-reasoning on behalf of Ewen Cuthiell_
