### PR TITLE
fix(worktree): recognize CRLF gitignore entries

### DIFF
--- a/cmd/bd/worktree_cmd.go
+++ b/cmd/bd/worktree_cmd.go
@@ -2067,6 +2067,7 @@ func addToGitignore(ctx context.Context, repoRoot, entry string) error {
 	// e.g. if ".worktrees" is in .gitignore, ".worktrees/my-branch" is already covered.
 	lines := strings.Split(string(content), "\n")
 	for _, line := range lines {
+		line = strings.TrimSuffix(line, "\r")
 		trimmed := strings.TrimSuffix(filepath.ToSlash(line), "/")
 		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
 			continue

--- a/cmd/bd/worktree_cmd_test.go
+++ b/cmd/bd/worktree_cmd_test.go
@@ -91,6 +91,38 @@ func TestGetRedirectTarget(t *testing.T) {
 }
 
 func TestAddToGitignore(t *testing.T) {
+	t.Run("recognizes existing CRLF entries", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			initial string
+			entry   string
+		}{
+			{name: "exact entry", initial: "worktree-feature/\r\n", entry: "worktree-feature"},
+			{name: "parent pattern", initial: ".worktrees/\r\n", entry: ".worktrees/worktree-one"},
+		}
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				repoRoot := t.TempDir()
+				gitignorePath := filepath.Join(repoRoot, ".gitignore")
+				if err := os.WriteFile(gitignorePath, []byte(test.initial), 0644); err != nil {
+					t.Fatalf("failed to write .gitignore: %v", err)
+				}
+
+				if err := addToGitignore(context.Background(), repoRoot, test.entry); err != nil {
+					t.Fatalf("addToGitignore failed: %v", err)
+				}
+
+				updated, err := os.ReadFile(gitignorePath)
+				if err != nil {
+					t.Fatalf("failed to read .gitignore: %v", err)
+				}
+				if string(updated) != test.initial {
+					t.Fatalf(".gitignore changed despite existing CRLF entry:\nwant: %q\ngot:  %q", test.initial, string(updated))
+				}
+			})
+		}
+	})
+
 	t.Run("skips append when path already ignored by broader pattern", func(t *testing.T) {
 		repoRoot := initGitRepoForGitignoreTest(t)
 		gitignorePath := filepath.Join(repoRoot, ".gitignore")


### PR DESCRIPTION
## What

Strip the carriage return from CRLF `.gitignore` lines before the worktree helper checks exact entries and parent patterns.

## Why

`addToGitignore` splits on line feeds, but its fallback parser previously retained the CR byte. A CRLF-terminated `worktree-feature/` entry therefore failed to match `worktree-feature`, and a CRLF `.worktrees/` parent pattern failed to cover `.worktrees/worktree-one`. The helper then appended duplicate managed content.

The preliminary `git check-ignore` probe normally masks this, but the parser intentionally remains responsible when that subprocess cannot provide an answer. Its duplicate behavior should be independent of platform line endings.

The fix removes exactly one CR belonging to each CRLF line before the existing slash/comment/exact/parent logic. It does not rewrite `.gitignore`; focused tests require byte-for-byte preservation for both exact and parent matches.

## Validation

- Exact-entry and parent-pattern regressions fail on the parent and pass on this head.
- Full `TestAddToGitignore` passes with `gms_pure_go`.
- Formatting and diff hygiene pass.

Fixes #5525

_codex-gpt-5-unknown-reasoning on behalf of Ewen Cuthiell_
