### PR TITLE
fix(scripts): validate doc freshness max age

### DIFF
--- a/scripts/check-doc-freshness.sh
+++ b/scripts/check-doc-freshness.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
-MAX_AGE_DAYS="${DOC_FRESHNESS_MAX_AGE_DAYS:-90}"
+MAX_AGE_DAYS_INPUT="${DOC_FRESHNESS_MAX_AGE_DAYS:-90}"
 TODAY="${DOC_FRESHNESS_TODAY:-}"
 TODAY_SOURCE="override"
 TODAY_DAY=""
@@ -112,6 +112,38 @@ path_exists_or_glob_matches() {
     fi
 }
 
+normalize_max_age_days() {
+    local value="$1"
+    local normalized
+
+    [[ "$value" =~ ^[0-9]+$ ]] || return 1
+
+    # Keep the policy value as decimal text. It must never become a Bash
+    # arithmetic expression, and it may be larger than Bash's integer range.
+    normalized="${value#"${value%%[!0]*}"}"
+    [[ -n "$normalized" ]] || normalized=0
+    printf '%s\n' "$normalized"
+}
+
+decimal_greater_than() {
+    local left="$1"
+    local right="$2"
+    local LC_ALL=C
+
+    if ((${#left} > ${#right})); then
+        return 0
+    fi
+    if ((${#left} < ${#right})); then
+        return 1
+    fi
+    [[ "$left" > "$right" ]]
+}
+
+if ! MAX_AGE_DAYS="$(normalize_max_age_days "$MAX_AGE_DAYS_INPUT")"; then
+    echo "ERROR: DOC_FRESHNESS_MAX_AGE_DAYS must be a nonnegative decimal integer" >&2
+    exit 2
+fi
+
 if [[ -z "$TODAY" ]]; then
     TODAY_SOURCE="provider"
     if ! TODAY="$(date '+%Y-%m-%d' 2>/dev/null)"; then
@@ -166,7 +198,7 @@ for entry in "${DOCS[@]}"; do
         elif (( age_days < 0 )); then
             echo "FAIL: Last reviewed date is in the future: $reviewed"
             ERRORS=$((ERRORS + 1))
-        elif (( age_days > MAX_AGE_DAYS )); then
+        elif decimal_greater_than "$age_days" "$MAX_AGE_DAYS"; then
             echo "FAIL: Last reviewed date is stale: $reviewed (${age_days} days old)"
             ERRORS=$((ERRORS + 1))
         else

--- a/scripts/check_doc_freshness_test.go
+++ b/scripts/check_doc_freshness_test.go
@@ -80,6 +80,79 @@ func TestDocFreshnessDoesNotRequirePython(t *testing.T) {
 	}
 }
 
+func TestDocFreshnessValidatesMaxAge(t *testing.T) {
+	t.Run("unset uses default", func(t *testing.T) {
+		run := runDocFreshnessWithoutMaxAge(t, "2026-01-15", "2026-04-15")
+		if run.err != nil {
+			t.Fatalf("check-doc-freshness rejected the default max age: %v\n%s", run.err, run.output)
+		}
+		if !strings.Contains(run.output, "Max age: 90 days") {
+			t.Fatalf("missing default max-age result:\n%s", run.output)
+		}
+	})
+
+	valid := []struct {
+		name     string
+		reviewed string
+		today    string
+		maxAge   string
+		want     string
+	}{
+		{name: "empty uses default", reviewed: "2026-01-15", today: "2026-01-31", maxAge: "", want: "Max age: 90 days"},
+		{name: "zero", reviewed: "2026-01-15", today: "2026-01-15", maxAge: "0", want: "Max age: 0 days"},
+		{name: "leading zeroes", reviewed: "2026-01-15", today: "2026-01-31", maxAge: "000000090", want: "Max age: 90 days"},
+		{name: "full calendar span", reviewed: "0001-01-01", today: "9999-12-31", maxAge: "3652058", want: "PASS: Last reviewed marker is current: 0001-01-01 (3652058 days old)"},
+		{name: "larger than Bash integer range", reviewed: "2026-01-15", today: "2026-01-31", maxAge: strings.Repeat("9", 100), want: "PASS: Last reviewed marker is current: 2026-01-15 (16 days old)"},
+	}
+	for _, test := range valid {
+		t.Run(test.name, func(t *testing.T) {
+			run := runDocFreshness(t, test.reviewed, test.today, test.maxAge)
+			if run.err != nil {
+				t.Fatalf("check-doc-freshness rejected max age %q: %v\n%s", test.maxAge, run.err, run.output)
+			}
+			if !strings.Contains(run.output, test.want) {
+				t.Fatalf("missing %q:\n%s", test.want, run.output)
+			}
+		})
+	}
+
+	invalid := []struct {
+		name   string
+		maxAge string
+	}{
+		{name: "negative", maxAge: "-1"},
+		{name: "signed", maxAge: "+90"},
+		{name: "expression", maxAge: "1+2"},
+		{name: "variable reference", maxAge: "TODAY_DAY"},
+		{name: "whitespace", maxAge: " 90"},
+	}
+	for _, test := range invalid {
+		t.Run(test.name, func(t *testing.T) {
+			run := runDocFreshness(t, "2026-01-15", "2026-01-31", test.maxAge)
+			if exitCode(run.err) != 2 {
+				t.Fatalf("exit = %d, want 2; error=%v\n%s", exitCode(run.err), run.err, run.output)
+			}
+			if !strings.Contains(run.output, "ERROR: DOC_FRESHNESS_MAX_AGE_DAYS must be a nonnegative decimal integer") {
+				t.Fatalf("missing max-age diagnostic:\n%s", run.output)
+			}
+			if strings.Contains(run.output, "Checking reference doc freshness markers") {
+				t.Fatalf("invalid max age reached document checks:\n%s", run.output)
+			}
+		})
+	}
+
+	t.Run("long leading-zero value keeps decimal semantics", func(t *testing.T) {
+		run := runDocFreshness(t, "2026-01-15", "2026-01-31", strings.Repeat("0", 100)+"15")
+		if exitCode(run.err) != 1 {
+			t.Fatalf("exit = %d, want 1; error=%v\n%s", exitCode(run.err), run.err, run.output)
+		}
+		if !strings.Contains(run.output, "Max age: 15 days") ||
+			!strings.Contains(run.output, "FAIL: Last reviewed date is stale: 2026-01-15 (16 days old)") {
+			t.Fatalf("long leading-zero threshold did not compare as decimal 15:\n%s", run.output)
+		}
+	})
+}
+
 func TestDocFreshnessBashProbeIgnoresStartupEnvironment(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Git Bash discovery is Windows-specific")
@@ -289,20 +362,25 @@ func TestDocFreshnessReportsInvalidTodayOverride(t *testing.T) {
 
 func runDocFreshness(t *testing.T, reviewed, today, maxAge string) freshnessRun {
 	t.Helper()
-	return runDocFreshnessWithDateFunction(t, reviewed, today, maxAge, "")
+	return runDocFreshnessWithDateFunction(t, reviewed, today, &maxAge, "")
 }
 
-func runDocFreshnessWithDateFunction(t *testing.T, reviewed, today, maxAge, dateFunction string) freshnessRun {
+func runDocFreshnessWithoutMaxAge(t *testing.T, reviewed, today string) freshnessRun {
+	t.Helper()
+	return runDocFreshnessWithDateFunction(t, reviewed, today, nil, "")
+}
+
+func runDocFreshnessWithDateFunction(t *testing.T, reviewed, today string, maxAge *string, dateFunction string) freshnessRun {
 	t.Helper()
 	return runDocFreshnessProcess(t, reviewed, &today, maxAge, dateFunction)
 }
 
 func runDocFreshnessWithDefaultToday(t *testing.T, reviewed, maxAge, dateFunction string) freshnessRun {
 	t.Helper()
-	return runDocFreshnessProcess(t, reviewed, nil, maxAge, dateFunction)
+	return runDocFreshnessProcess(t, reviewed, nil, &maxAge, dateFunction)
 }
 
-func runDocFreshnessProcess(t *testing.T, reviewed string, today *string, maxAge, dateFunction string) freshnessRun {
+func runDocFreshnessProcess(t *testing.T, reviewed string, today, maxAge *string, dateFunction string) freshnessRun {
 	t.Helper()
 	bash := docFreshnessBash(t)
 
@@ -330,8 +408,10 @@ func runDocFreshnessProcess(t *testing.T, reviewed string, today *string, maxAge
 		"BASH_ENV=" + msysPath(bashEnvironment),
 		"ENV=",
 		"DATE_BACKEND_MARKER=" + msysPath(dateMarker),
-		"DOC_FRESHNESS_MAX_AGE_DAYS=" + maxAge,
 		"PYTHON_POISON_MARKER=" + msysPath(pythonMarker),
+	}
+	if maxAge != nil {
+		cmd.Env = append(cmd.Env, "DOC_FRESHNESS_MAX_AGE_DAYS="+*maxAge)
 	}
 	if today != nil {
 		cmd.Env = append(cmd.Env, "DOC_FRESHNESS_TODAY="+*today)

--- a/scripts/docs.md
+++ b/scripts/docs.md
@@ -49,13 +49,17 @@ make check-docs
 
 The script currently checks the reference docs named in `engdocs/DOC_INVENTORY.md`: `CONFIG.md`, `SETUP.md`, `ADO_CONFIG.md`, `JSON_SCHEMA.md`, `RECOVERY.md`, `ERROR_HANDLING.md`, `LINTING.md`, and `design/otel/otel-data-model.md`. Each doc must be listed in the inventory, include a recent `Last reviewed:` marker, include a `Freshness source:` marker, and name source paths or globs that exist in the repository.
 
-Set `DOC_FRESHNESS_MAX_AGE_DAYS` to override the default 90-day review window. Set `DOC_FRESHNESS_TODAY=YYYY-MM-DD` when testing date behaviour.
+Set `DOC_FRESHNESS_MAX_AGE_DAYS` to a nonnegative decimal integer to override
+the default 90-day review window. The policy threshold is compared as decimal
+text, so values larger than Bash's integer range remain valid and cannot become
+arithmetic expressions or overflow. Set `DOC_FRESHNESS_TODAY=YYYY-MM-DD` when
+testing date behaviour.
 Date validation uses Bash integer arithmetic over the proleptic Gregorian
-calendar, preserves the `0001-01-01` through `9999-12-31` ISO domain, and does
-not require Python or platform-specific date parsing. The native `date` command
-is used only to supply today's value when `DOC_FRESHNESS_TODAY` is unset. Pull
-requests exercise the real process boundary on Linux, macOS, and Git Bash on
-Windows.
+calendar, preserves the script's four-digit `YYYY-MM-DD` domain from
+`0001-01-01` through `9999-12-31`, and does not require Python or
+platform-specific date parsing. The native `date` command is used only to
+supply today's value when `DOC_FRESHNESS_TODAY` is unset. Pull requests exercise
+the real process boundary on Linux, macOS, and Git Bash on Windows.
 
 ### How it fits into the larger codebase
 


### PR DESCRIPTION
## What

Validate `DOC_FRESHNESS_MAX_AGE_DAYS` before the doc-freshness script uses it
to classify review markers.

## Why

Bash arithmetic treats unvalidated text as an expression. An override such as
`1+2` is currently accepted as three days, variable names can resolve shell
state, and oversized decimal input can overflow.

The override is a review-policy threshold, not a date-parser bound. The script
now accepts any nonnegative decimal integer, normalizes leading zeroes, and
keeps the result as decimal text. A length-aware lexical comparison against the
bounded computed document age avoids both expression evaluation and integer
overflow without imposing an artificial calendar-derived maximum.

An unset or explicitly empty value still defaults to 90. Nonempty malformed
input exits 2 before document checks begin; arbitrarily large valid thresholds
retain their natural policy meaning.

## Validation

- Unset default, zero, leading-zero, exact calendar-span, and arbitrary-length
  decimal cases
- Signed, expression, variable-reference, and whitespace cases
- Existing leap-calendar, invalid-date, native-date-provider, and document
  freshness process tests
- Bash syntax, ShellCheck, and diff hygiene

Fixes #5524

_codex-gpt-5-unknown-reasoning on behalf of Ewen Cuthiell_
