### PR TITLE
fix(hooks): trace unsupported js/wasm execution

### DIFF
--- a/internal/hooks/hooks_wasm.go
+++ b/internal/hooks/hooks_wasm.go
@@ -3,13 +3,37 @@
 package hooks
 
 import (
+	"context"
 	"errors"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/steveyegge/beads/internal/types"
 )
 
 var errHookExecutionUnsupported = errors.New("hook execution is not supported on js/wasm")
 
-func (*Runner) runHook(_ string, _ string, _ *types.Issue) error {
+func (*Runner) runHook(hookPath, event string, issue *types.Issue) (retErr error) {
+	// Hooks are fire-and-forget so they have no parent span; create the same
+	// root span as native runners so asynchronous refusals remain observable.
+	tracer := otel.Tracer("github.com/steveyegge/beads/hooks")
+	_, span := tracer.Start(context.Background(), "hook.exec",
+		trace.WithAttributes(
+			attribute.String("hook.event", event),
+			attribute.String("hook.path", hookPath),
+			attribute.String("bd.issue_id", issue.ID),
+		),
+	)
+	defer func() {
+		if retErr != nil {
+			span.RecordError(retErr)
+			span.SetStatus(codes.Error, retErr.Error())
+		}
+		span.End()
+	}()
+
 	return errHookExecutionUnsupported
 }

--- a/internal/hooks/hooks_wasm_test.go
+++ b/internal/hooks/hooks_wasm_test.go
@@ -3,20 +3,96 @@
 package hooks
 
 import (
+	"context"
 	"errors"
 	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
 	"github.com/steveyegge/beads/internal/types"
 )
 
 func TestRunHookReportsUnsupportedExecution(t *testing.T) {
+	spanRecorder := tracetest.NewSpanRecorder()
+	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	previousTracerProvider := otel.GetTracerProvider()
+	otel.SetTracerProvider(tracerProvider)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(previousTracerProvider)
+		if err := tracerProvider.Shutdown(context.Background()); err != nil {
+			t.Errorf("shut down tracer provider: %v", err)
+		}
+	})
+
 	runner := NewRunner(t.TempDir())
+	hookPath := "not-executable-on-wasm"
+	issue := &types.Issue{ID: "wasm-test"}
 	err := runner.runHook(
-		"not-executable-on-wasm",
+		hookPath,
 		EventCreate,
-		&types.Issue{ID: "wasm-test"},
+		issue,
 	)
 	if !errors.Is(err, errHookExecutionUnsupported) {
 		t.Fatalf("runHook error = %v, want %v", err, errHookExecutionUnsupported)
+	}
+
+	spans := spanRecorder.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("ended spans = %d, want 1", len(spans))
+	}
+	span := spans[0]
+	if span.Name() != "hook.exec" {
+		t.Errorf("span name = %q, want %q", span.Name(), "hook.exec")
+	}
+	if span.Parent().IsValid() {
+		t.Errorf("span parent = %v, want invalid root parent", span.Parent())
+	}
+
+	gotAttributes := make(map[attribute.Key]attribute.Value, len(span.Attributes()))
+	for _, attr := range span.Attributes() {
+		gotAttributes[attr.Key] = attr.Value
+	}
+	wantAttributes := map[attribute.Key]string{
+		"hook.event":  EventCreate,
+		"hook.path":   hookPath,
+		"bd.issue_id": issue.ID,
+	}
+	if len(gotAttributes) != len(wantAttributes) {
+		t.Errorf("span attributes = %v, want exactly %v", span.Attributes(), wantAttributes)
+	}
+	for key, want := range wantAttributes {
+		got, ok := gotAttributes[key]
+		if !ok || got.AsString() != want {
+			t.Errorf("span attribute %q = %v, want %q", key, got, want)
+		}
+	}
+
+	if span.Status().Code != codes.Error {
+		t.Errorf("span status code = %v, want %v", span.Status().Code, codes.Error)
+	}
+	if span.Status().Description != errHookExecutionUnsupported.Error() {
+		t.Errorf("span status description = %q, want %q", span.Status().Description, errHookExecutionUnsupported)
+	}
+
+	events := span.Events()
+	if len(events) != 1 {
+		t.Fatalf("span events = %v, want one recorded error", events)
+	}
+	if events[0].Name != "exception" {
+		t.Errorf("span event name = %q, want %q", events[0].Name, "exception")
+	}
+	var recordedError string
+	for _, attr := range events[0].Attributes {
+		if attr.Key == "exception.message" {
+			recordedError = attr.Value.AsString()
+			break
+		}
+	}
+	if recordedError != errHookExecutionUnsupported.Error() {
+		t.Errorf("recorded error = %q, want %q", recordedError, errHookExecutionUnsupported)
 	}
 }


### PR DESCRIPTION
## What

Give the js/wasm hook-execution refusal the same root `hook.exec` trace shape as the native runners.

The wasm runner now records the hook event, hook path, and issue ID, records the existing unsupported-execution sentinel as an error, marks the span failed, and returns that same sentinel unchanged.

## Why

`Runner.Run` intentionally ignores hook errors so a post-commit hook cannot fail the triggering mutation. Before this change, the js/wasm runner returned its unsupported-execution sentinel without creating a span, making an asynchronous refusal invisible to telemetry.

This keeps the fire-and-forget API and the synchronous error contract intact while making the refusal observable. Unix and Windows execution behavior is unchanged.

## Validation

- Exact js/wasm `TestRunHookReportsUnsupportedExecution` execution under Node
- js/wasm package compilation with `gms_pure_go`
- Focused native `internal/hooks` tests
- js/wasm `golangci-lint` for `internal/hooks`
- `gofmt` and `git diff --check`

Fixes #5490

_codex-gpt-5-unknown-reasoning on behalf of Ewen Cuthiell_
