### PR TITLE
fix(gc): report active database size

### DIFF
--- a/cmd/bd/compact_dolt.go
+++ b/cmd/bd/compact_dolt.go
@@ -180,7 +180,7 @@ Examples:
 		// Prune remote-tracking refs before GC: they still anchor the
 		// pre-compact chain, and with them in place GC reclaims nothing on any
 		// workspace that has ever pushed or fetched (bd-agctw).
-		sizeBefore := storeSizeBytes()
+		sizeBefore := storeSizeBytes(ctx)
 		pruned, tags := pruneRemoteRefsForGC(ctx)
 		if !jsonOutput {
 			printPruneReport(pruned, tags)
@@ -192,7 +192,7 @@ Examples:
 				WarnError("dolt gc after compact failed: %v", err)
 			}
 		}
-		sizeAfter := storeSizeBytes()
+		sizeAfter := storeSizeBytes(ctx)
 
 		elapsed := time.Since(start)
 		resultCommits := len(recentHashes) + 1

--- a/cmd/bd/flatten.go
+++ b/cmd/bd/flatten.go
@@ -79,15 +79,16 @@ Examples:
 		if flattenDryRun {
 			remoteRefs, tags := listRemoteRefsAndTags(ctx)
 			if jsonOutput {
-				return outputJSON(map[string]interface{}{
-					"dry_run":           true,
-					"commit_count":      commitCount,
-					"initial_hash":      initialHash,
-					"would_flatten":     commitCount > 1,
-					"remote_refs":       remoteRefs,
-					"tags":              tags,
-					"size_before_bytes": storeSizeBytes(),
-				})
+				result := map[string]interface{}{
+					"dry_run":       true,
+					"commit_count":  commitCount,
+					"initial_hash":  initialHash,
+					"would_flatten": commitCount > 1,
+					"remote_refs":   remoteRefs,
+					"tags":          tags,
+				}
+				addGCSizeJSON(result, storeSizeBytes(ctx), -1)
+				return outputJSON(result)
 			}
 			fmt.Printf("DRY RUN — Flatten preview\n\n")
 			fmt.Printf("  Commits:        %d\n", commitCount)
@@ -136,7 +137,7 @@ Examples:
 		// Prune remote-tracking refs before GC: they still anchor the entire
 		// pre-flatten chain, and with them in place GC reclaims nothing on any
 		// workspace that has ever pushed or fetched (bd-agctw).
-		sizeBefore := storeSizeBytes()
+		sizeBefore := storeSizeBytes(ctx)
 		pruned, tags := pruneRemoteRefsForGC(ctx)
 		if !jsonOutput {
 			printPruneReport(pruned, tags)
@@ -147,7 +148,7 @@ Examples:
 				WarnError("dolt gc after flatten failed: %v", err)
 			}
 		}
-		sizeAfter := storeSizeBytes()
+		sizeAfter := storeSizeBytes(ctx)
 
 		elapsed := time.Since(start)
 

--- a/cmd/bd/gc.go
+++ b/cmd/bd/gc.go
@@ -198,13 +198,13 @@ Examples:
 				// refs are left alone here (they cache the remote tip for the
 				// migrate gate); flatten/compact prune them before their GC
 				// (bd-agctw). Sizes are reported so a no-op reclaim is visible.
-				sizeBefore := storeSizeBytes()
+				sizeBefore := storeSizeBytes(ctx)
 				remoteRefs, tags := listRemoteRefsAndTags(ctx)
 				if err := gc.DoltGC(ctx); err != nil {
 					WarnError("dolt gc failed: %v", err)
 					results = append(results, phaseResult{name: "Dolt GC", detail: "failed"})
 				} else {
-					sizeAfter := storeSizeBytes()
+					sizeAfter := storeSizeBytes(ctx)
 					detail := "complete"
 					if line := gcSizeLine(sizeBefore, sizeAfter); line != "" {
 						detail = "complete: " + line

--- a/cmd/bd/gc_prune.go
+++ b/cmd/bd/gc_prune.go
@@ -8,15 +8,20 @@ import (
 	"github.com/steveyegge/beads/internal/storage"
 )
 
-// storeSizeBytes returns the on-disk size of the store's data directory, or
-// -1 when it cannot be determined (no local path, walk error). Measured
-// around DOLT_GC so a no-op reclaim is visible to the operator (bd-agctw).
-func storeSizeBytes() int64 {
-	loc, ok := storage.UnwrapStore(store).(storage.StoreLocator)
-	if !ok || loc.Path() == "" {
+// storeSizeBytes returns the approximate on-disk size of the active database,
+// or -1 when that database cannot be measured. It deliberately does not fall
+// back to StoreLocator.Path: both concrete locator paths can contain sibling
+// databases whose activity is unrelated to the current GC operation.
+func storeSizeBytes(ctx context.Context) int64 {
+	return storeSizeBytesForStore(ctx, store)
+}
+
+func storeSizeBytesForStore(ctx context.Context, candidate storage.DoltStorage) int64 {
+	sizer, ok := storage.UnwrapStore(candidate).(storage.ActiveDatabaseSizer)
+	if !ok {
 		return -1
 	}
-	size, err := getDirSize(loc.Path())
+	size, err := sizer.ActiveDatabaseSize(ctx)
 	if err != nil {
 		return -1
 	}

--- a/cmd/bd/gc_prune_test.go
+++ b/cmd/bd/gc_prune_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+type gcSizeStoreStub struct {
+	storage.DoltStorage
+	size int64
+	err  error
+}
+
+func (s *gcSizeStoreStub) ActiveDatabaseSize(context.Context) (int64, error) {
+	return s.size, s.err
+}
+
+type gcLocatorOnlyStoreStub struct {
+	storage.DoltStorage
+	path string
+}
+
+func (s *gcLocatorOnlyStoreStub) Path() string   { return s.path }
+func (s *gcLocatorOnlyStoreStub) CLIDir() string { return s.path }
+
+func TestStoreSizeBytesForStoreUsesOnlyActiveDatabaseSizer(t *testing.T) {
+	t.Parallel()
+
+	failure := errors.New("measurement failed")
+	tests := []struct {
+		name  string
+		store storage.DoltStorage
+		want  int64
+	}{
+		{
+			name:  "active database available",
+			store: &gcSizeStoreStub{size: 42},
+			want:  42,
+		},
+		{
+			name: "unsupported active database",
+			store: &gcSizeStoreStub{err: &storage.ErrUnsupported{
+				Op:      "ActiveDatabaseSize",
+				Backend: "external",
+			}},
+			want: -1,
+		},
+		{
+			name:  "measurement failure",
+			store: &gcSizeStoreStub{err: failure},
+			want:  -1,
+		},
+		{
+			name:  "legacy locator is not a size fallback",
+			store: &gcLocatorOnlyStoreStub{path: t.TempDir()},
+			want:  -1,
+		},
+		{
+			name: "nil store",
+			want: -1,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := storeSizeBytesForStore(t.Context(), tc.store); got != tc.want {
+				t.Fatalf("storeSizeBytesForStore() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAddGCSizeJSONOmitsUnavailableMeasurements(t *testing.T) {
+	t.Parallel()
+
+	result := map[string]interface{}{}
+	addGCSizeJSON(result, -1, -1)
+	if len(result) != 0 {
+		t.Fatalf("unavailable measurements produced JSON fields: %#v", result)
+	}
+
+	addGCSizeJSON(result, 42, -1)
+	if got := result["size_before_bytes"]; got != int64(42) {
+		t.Fatalf("size_before_bytes = %#v, want 42", got)
+	}
+	if _, ok := result["size_after_bytes"]; ok {
+		t.Fatalf("unavailable size_after_bytes was emitted: %#v", result)
+	}
+	if _, ok := result["freed_bytes"]; ok {
+		t.Fatalf("freed_bytes was emitted without both measurements: %#v", result)
+	}
+}

--- a/cmd/bd/storage_chain_test.go
+++ b/cmd/bd/storage_chain_test.go
@@ -89,6 +89,17 @@ func TestDoltBackupSizeUnwrapsStorageDecorators(t *testing.T) {
 	}
 }
 
+func TestGCStoreSizeUnwrapsStorageDecorators(t *testing.T) {
+	clearTelemetryEnv(t)
+	t.Setenv("BD_OTEL_STDOUT", "true")
+	raw := &stubChainStore{databaseSize: 99}
+	wrapped := wireStorageDecorators(raw, hooks.NewRunner("/nonexistent"), false)
+
+	if got := storeSizeBytesForStore(t.Context(), wrapped); got != 99 {
+		t.Fatalf("storeSizeBytesForStore = %d, want 99", got)
+	}
+}
+
 func TestWireStorageDecorators_TelemetryOn_HookDisabled(t *testing.T) {
 	clearTelemetryEnv(t)
 	t.Setenv("BD_OTEL_STDOUT", "true")


### PR DESCRIPTION
## What

Measure GC before/after bytes through the active store's `storage.ActiveDatabaseSizer` contract instead of recursively walking `StoreLocator.Path()`.

Apply the same adapter to `bd gc`, compact, and flatten reporting, including flatten dry-run JSON. Decorated stores are unwrapped before capability discovery.

## Why

Both concrete locator paths can contain sibling databases, while each GC operation targets only the active database. Walking the shared root lets unrelated sibling data or activity distort `size_before_bytes`, `size_after_bytes`, and `freed_bytes`.

Current main already has backend-specific active-database sizing for backup status. Reusing that authority makes the reported reclaim scope match the operation scope.

## Compatibility

- Size reporting remains best-effort: unsupported backends and measurement errors do not prevent GC.
- There is deliberately no fallback to the broader locator path.
- Unavailable measurements are omitted from JSON. In particular, flatten dry-run no longer emits the sentinel `size_before_bytes: -1`; consumers see the same optional-field contract used by completed GC results.
- Text output remains unchanged when either measurement is unavailable.
- This covers the GC/compact/flatten paths that share `storeSizeBytes`. The older `bd admin compact --dolt` external-command reporter has an independent `.beads/dolt` measurement path and is not changed here.

## Verification

- Active, unsupported, error, nil, and locator-only adapters
- Decorated-store unwrapping
- JSON omission when one or both measurements are unavailable
- Focused compact/flatten/GC tests and race runs
- `go vet -tags gms_pure_go ./cmd/bd`
- `golangci-lint run --build-tags gms_pure_go ./cmd/bd` reports zero issues
- `gofmt` and `git diff --check`

Fixes #5532

_codex-gpt-5-unknown-reasoning on behalf of Ewen Cuthiell_
