### PR TITLE
fix(scripts): scrub Windows environment keys case-insensitively

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -373,6 +373,11 @@ jobs:
         shell: bash
         run: go test '-tags=gms_pure_go' -count=1 -run '^TestGeneratedHookTimeoutProcessBoundary$' ./cmd/bd
 
+      - name: Check benchmark environment scrubbing
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: go test -tags gms_pure_go -count=1 -run '^(TestCleanEnvUsesHostKeySemantics|TestBenchmarkCommandBuildersStripDoltEnvOverrides)$' ./scripts/repro-dolt-prod-timeouts
+
   # Fast check to catch accidental .beads/issues.jsonl changes from contributors
   check-no-beads-changes:
     name: Check for .beads changes

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -60,6 +60,54 @@ func TestPRCIGateRequiresPolicyAndLintWrappers(t *testing.T) {
 	}
 }
 
+func TestPRWorkflowExercisesWindowsBenchmarkEnvScrubbing(t *testing.T) {
+	workflow := readCIWorkflow(t, "pr.yml")
+	job := workflow.job(t, "pr-preflight-platforms")
+
+	if job.RunsOn != "${{ matrix.os }}" {
+		t.Errorf("pr-preflight-platforms runs-on = %q, want matrix.os", job.RunsOn)
+	}
+	if got := job.Strategy.Matrix.OS; !equalStrings(got, []string{"ubuntu-latest", "macos-latest", "windows-latest"}) {
+		t.Errorf("pr-preflight-platforms matrix os = %v, want required three-host matrix", got)
+	}
+	if job.If != "" {
+		t.Errorf("pr-preflight-platforms job is conditional: %q", job.If)
+	}
+	if job.ContinueOnError {
+		t.Error("pr-preflight-platforms job may not continue on error")
+	}
+
+	step := job.step(t, "Check benchmark environment scrubbing")
+	if step.If != "matrix.os == 'windows-latest'" {
+		t.Errorf("benchmark environment scrubbing selector = %q, want native Windows only", step.If)
+	}
+	if step.ContinueOnError != nil && step.ContinueOnError != false {
+		t.Error("benchmark environment scrubbing step may not continue on error")
+	}
+	const command = "go test -tags gms_pure_go -count=1 -run '^(TestCleanEnvUsesHostKeySemantics|TestBenchmarkCommandBuildersStripDoltEnvOverrides)$' ./scripts/repro-dolt-prod-timeouts"
+	if got := strings.TrimSpace(step.Run); got != command {
+		t.Errorf("benchmark environment scrubbing command = %q, want %q", got, command)
+	}
+
+	gate := workflow.job(t, "ci-gate")
+	gateEnv := gate.step(t, "Evaluate CI gate").Env
+	if gate.If != "${{ always() }}" {
+		t.Errorf("ci-gate condition = %q, want always() aggregation", gate.If)
+	}
+	if gate.ContinueOnError {
+		t.Error("ci-gate may not continue on error")
+	}
+	if !contains(gate.Needs, "pr-preflight-platforms") {
+		t.Errorf("ci-gate does not require pr-preflight-platforms: %v", gate.Needs)
+	}
+	if got := gateEnv["PR_PREFLIGHT_PLATFORMS"]; got != "${{ needs.pr-preflight-platforms.result }}" {
+		t.Errorf("ci-gate pr-preflight-platforms result = %q", got)
+	}
+	if !contains(strings.Fields(gateEnv["CI_GATE_REQUIRED"]), "PR_PREFLIGHT_PLATFORMS") {
+		t.Error("ci-gate required set omits pr-preflight-platforms")
+	}
+}
+
 func TestPRCIGateRequiresJSWasmHookExecution(t *testing.T) {
 	workflow := readCIWorkflow(t, "pr.yml")
 	job := workflow.job(t, "check-cmd-bd-puregeo-tests")
@@ -865,12 +913,13 @@ type ciWorkflow struct {
 }
 
 type ciWorkflowJob struct {
-	Needs          ciWorkflowStringList `yaml:"needs"`
-	Steps          []ciWorkflowStep     `yaml:"steps"`
-	RunsOn         string               `yaml:"runs-on"`
-	If             string               `yaml:"if"`
-	TimeoutMinutes int                  `yaml:"timeout-minutes"`
-	Strategy       ciWorkflowStrategy   `yaml:"strategy"`
+	Needs           ciWorkflowStringList `yaml:"needs"`
+	Steps           []ciWorkflowStep     `yaml:"steps"`
+	RunsOn          string               `yaml:"runs-on"`
+	If              string               `yaml:"if"`
+	ContinueOnError bool                 `yaml:"continue-on-error"`
+	TimeoutMinutes  int                  `yaml:"timeout-minutes"`
+	Strategy        ciWorkflowStrategy   `yaml:"strategy"`
 }
 
 type ciWorkflowStrategy struct {

--- a/scripts/repro-dolt-prod-timeouts/main.go
+++ b/scripts/repro-dolt-prod-timeouts/main.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -1136,19 +1137,29 @@ func subprocessEnv(extra ...string) []string {
 func cleanEnv(env []string, keys ...string) []string {
 	drop := make(map[string]struct{}, len(keys))
 	for _, key := range keys {
-		drop[key] = struct{}{}
+		drop[environmentKeyIdentity(key)] = struct{}{}
 	}
 	out := env[:0]
 	for _, e := range env {
 		key, _, ok := strings.Cut(e, "=")
 		if ok {
-			if _, skip := drop[key]; skip {
+			if _, skip := drop[environmentKeyIdentity(key)]; skip {
 				continue
 			}
 		}
 		out = append(out, e)
 	}
 	return out
+}
+
+// environmentKeyIdentity mirrors the key comparison used by os/exec when it
+// prepares a child environment. strings.ToLower is intentional: EqualFold
+// would collapse Unicode near-collisions that os/exec keeps distinct.
+func environmentKeyIdentity(key string) string {
+	if runtime.GOOS == "windows" {
+		return strings.ToLower(key)
+	}
+	return key
 }
 
 func tail(s string, max int) string {

--- a/scripts/repro-dolt-prod-timeouts/main_test.go
+++ b/scripts/repro-dolt-prod-timeouts/main_test.go
@@ -108,9 +108,68 @@ func TestParseFlagsPreservesExplicitExistingWorkspaceSeedMode(t *testing.T) {
 	}
 }
 
+func TestCleanEnvUsesHostKeySemantics(t *testing.T) {
+	env := []string{
+		"FIRST=keep-first",
+		"beads_dir=drop-on-windows",
+		"BEADS_DIR=drop-canonical-first",
+		"ALLOWED=keep-duplicate-first",
+		"MALFORMED",
+		"BeAdS_DoLt_PoRt=drop-on-windows",
+		"BEADS_DOLT_PORT=drop-canonical",
+		"BEADS_DIR=drop-canonical-second",
+		"BEADſ_DIR=keep-unicode-near-collision",
+		"ALLOWED=keep-duplicate-second",
+		"=C:=keep-windows-drive-entry",
+		"LAST=keep-last",
+	}
+
+	got := cleanEnv(slices.Clone(env), "BEADS_DIR", "BEADS_DOLT_PORT")
+	want := []string{
+		"FIRST=keep-first",
+		"beads_dir=drop-on-windows",
+		"ALLOWED=keep-duplicate-first",
+		"MALFORMED",
+		"BeAdS_DoLt_PoRt=drop-on-windows",
+		"BEADſ_DIR=keep-unicode-near-collision",
+		"ALLOWED=keep-duplicate-second",
+		"=C:=keep-windows-drive-entry",
+		"LAST=keep-last",
+	}
+	if runtime.GOOS == "windows" {
+		want = []string{
+			"FIRST=keep-first",
+			"ALLOWED=keep-duplicate-first",
+			"MALFORMED",
+			"BEADſ_DIR=keep-unicode-near-collision",
+			"ALLOWED=keep-duplicate-second",
+			"=C:=keep-windows-drive-entry",
+			"LAST=keep-last",
+		}
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cleanEnv() = %q, want %q on %s", got, want, runtime.GOOS)
+	}
+}
+
 func TestBenchmarkCommandBuildersStripDoltEnvOverrides(t *testing.T) {
+	windowsSpellings := map[string]string{
+		"BEADS_DIR":                "beads_dir",
+		"BEADS_DOLT_SERVER_PORT":   "BeAdS_DoLt_SeRvEr_PoRt",
+		"BEADS_DOLT_PORT":          "beads_dolt_port",
+		"BEADS_DOLT_SERVER_HOST":   "BeAdS_DoLt_SeRvEr_HoSt",
+		"BEADS_DOLT_SERVER_SOCKET": "beads_dolt_server_socket",
+	}
 	for _, key := range subprocessEnvDenylist {
-		t.Setenv(key, "ambient-"+strings.ToLower(key))
+		ambientKey := key
+		if runtime.GOOS == "windows" {
+			var ok bool
+			ambientKey, ok = windowsSpellings[key]
+			if !ok {
+				t.Fatalf("missing mixed-case Windows spelling for denied key %q", key)
+			}
+		}
+		t.Setenv(ambientKey, "ambient-"+strings.ToLower(key))
 	}
 	const allowedAmbient = "BEADS_REPRO_TIMEOUTS_ALLOWED_AMBIENT=present"
 	allowedKey, allowedValue, _ := strings.Cut(allowedAmbient, "=")
@@ -179,7 +238,7 @@ func TestBenchmarkCommandBuildersStripDoltEnvOverrides(t *testing.T) {
 			for _, key := range subprocessEnvDenylist {
 				for _, entry := range cmd.Env {
 					gotKey, _, _ := strings.Cut(entry, "=")
-					if gotKey == key {
+					if environmentKeyIdentity(gotKey) == environmentKeyIdentity(key) {
 						t.Fatalf("Env retained ambient denied override %q", entry)
 					}
 				}


### PR DESCRIPTION
Fixes #5534

## What

- Canonicalize denylist keys and inherited environment keys with
  `strings.ToLower` on Windows, matching Go's `os/exec` environment identity.
- Preserve exact, case-sensitive key identity on non-Windows hosts.
- Keep the existing linear environment scan and constant-time denylist lookup.
- Add coverage for canonical and mixed-case denied keys, retained unrelated and
  malformed entries, and the Unicode near-collision `BEADſ_DIR`.

## Why

The repro harness intends to isolate benchmark children from caller-owned
Beads/Dolt routing overrides. Exact-case filtering allows mixed-case spellings
to escape that boundary on Windows.

## Validation

- Focused regression passed on native Windows.
- All other `scripts/repro-dolt-prod-timeouts` tests passed on native Windows.
  The package's two pre-existing POSIX-shebang fixture failures were excluded
  and are tracked separately.
- Race detector passed with the same two exclusions.
- `go vet ./scripts/repro-dolt-prod-timeouts`
- `golangci-lint run ./scripts/repro-dolt-prod-timeouts/...` (zero issues)
- Linux/amd64 test binary cross-compiled successfully.
- `gofmt` and `git diff --check`

The exact-head hosted required checks remain mandatory.

_codex-gpt-5-unknown-reasoning on behalf of Ewen Cuthiell_
