### PR TITLE
fix(install): stage to a temp name and rename into place so bd is never partial on the live path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,21 +302,27 @@ ifndef SKIP_UPDATE_CHECK
 	fi
 endif
 
-# Install bd to ~/.local/bin (builds, signs on macOS, and copies)
+# Install bd to ~/.local/bin (builds, signs on macOS, then renames into place)
 # Also creates 'beads' symlink as an alias for bd
 # Use install-force to skip the origin/main update check
+#
+# The install stages to a temp name inside INSTALL_DIR and rename(2)s over the
+# final path: the live path must never hold a partial binary. A plain cp onto
+# bd leaves a truncated (on macOS: signature-invalid) binary for the whole
+# ~200MB copy, and any bd exec'd in that window dies at exec with rc 137 and
+# zero bytes of output — indistinguishable from an empty result set to callers.
+# The old rm-first shape added an ENOENT window on top. Same treatment for the
+# beads symlink.
 install install-force: build
 	@mkdir -p $(INSTALL_DIR)
 ifeq ($(OS),Windows_NT)
-	@rm -f $(INSTALL_DIR)/bd $(INSTALL_DIR)/bd.exe
-	@cp $(BUILD_DIR)/bd.exe $(INSTALL_DIR)/bd.exe
+	@cp $(BUILD_DIR)/bd.exe $(INSTALL_DIR)/.bd.exe.install.tmp.$$$$ && mv -f $(INSTALL_DIR)/.bd.exe.install.tmp.$$$$ $(INSTALL_DIR)/bd.exe
+	@rm -f $(INSTALL_DIR)/bd
 	@echo "Installed bd.exe to $(INSTALL_DIR)/bd.exe"
 else
-	@rm -f $(INSTALL_DIR)/bd
-	@cp $(BUILD_DIR)/bd $(INSTALL_DIR)/bd
+	@cp $(BUILD_DIR)/bd $(INSTALL_DIR)/.bd.install.tmp.$$$$ && mv -f $(INSTALL_DIR)/.bd.install.tmp.$$$$ $(INSTALL_DIR)/bd
 	@echo "Installed bd to $(INSTALL_DIR)/bd"
-	@rm -f $(INSTALL_DIR)/beads
-	@ln -s bd $(INSTALL_DIR)/beads
+	@ln -sfn bd $(INSTALL_DIR)/.beads.install.tmp.$$$$ && mv -f $(INSTALL_DIR)/.beads.install.tmp.$$$$ $(INSTALL_DIR)/beads
 	@echo "Created 'beads' alias -> bd"
 endif
 	@git config core.hooksPath .githooks 2>/dev/null && echo "Configured git hooks (.githooks/)" || true


### PR DESCRIPTION
## The failure this fixes

The `install` target overwrites the live `~/.local/bin/bd` with `rm -f` + `cp`. `cp` onto the final path is not atomic: for the entire ~200MB copy, the live path holds a truncated binary — and on macOS a partially-copied **signed** binary fails code-signature validation, so the kernel SIGKILLs it **at exec**: rc 137 with **zero bytes on stdout or stderr**. Any caller that skips the exit code cannot distinguish that from an empty result set. The `rm -f` first adds a second window where the path doesn't exist at all.

Measured incident (2026-08-08, a multi-agent rig driving `bd` continuously): every `bd` call on the host died rc=137 with empty output while the binary was mid-copy — caught byte-level, the binary observed growing `200,235,298 → 200,367,842` between probes — and agents polling `bd ready` during the window read the empty output as an empty ledger and stood down. Fail-open on the work-dispatch path.

## The fix

Stage the copy to a temp name **inside `$(INSTALL_DIR)`** (same filesystem), then `mv -f` over `bd` — `rename(2)` guarantees every exec sees either the old complete binary or the new complete one, never a partial, and removes the ENOENT window. Same treatment for the `beads` alias (`ln -sfn` to a temp name, rename over the link) and the Windows `bd.exe` branch.

## Measured, both directions

Exec loop hammering `bd version` while installs run over it (signed ~200MB `bd`, macOS/APFS):

| recipe | installs | execs during window | failures |
|---|---|---|---|
| old (`rm -f` + `cp`) | 25 | 71 | **67 — every one rc=137** |
| new (`cp` tmp + `mv -f`) | 400 | 13 | **0** |

End state verified via `make install-force INSTALL_DIR=<scratch>`, run twice: `bd` and the `beads` alias both execute, the second install replaces through a fresh inode (rename, not in-place write), no temp litter remains.

## Notes

- Temp names carry the make PID (`$$$$`), so a crashed install leaves at most one dot-prefixed temp file, and a concurrent install cannot collide on the staging name.
- Windows branch: applied the same shape textually (not runtime-tested here). It cannot regress the old behavior — `rm`/`cp` onto a running `.exe` failed under the old recipe too — and it removes the partial-file window on filesystems where rename over an unlocked target succeeds. The stray extensionless `bd` cleanup is kept.
- The `beads` symlink previously had its own `rm -f` + `ln -s` gap; it now renames into place as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
