### PR TITLE
ci: simplify js/wasm boundary proof

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -110,112 +110,43 @@ jobs:
           node-version: '24'
 
       - name: Run js/wasm hook boundary
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u BASHOPTS -u SHELLOPTS /usr/bin/bash --noprofile --norc -p -euo pipefail {0}
         env:
-          BASH_ENV: ""
-          ENV: ""
           CGO_ENABLED: "0"
           GOARCH: wasm
-          GOENV: "off"
-          GOFLAGS: ""
           GOOS: js
-          GOTOOLCHAIN: local
-          GOWORK: "off"
-          NODE_OPTIONS: ""
         run: |
           set -euo pipefail
 
-          [[ -n "${BASH_VERSION:-}" ]]
-          [[ "${BASH:-}" == "/usr/bin/bash" ]]
-          [[ /bin/bash -ef /usr/bin/bash ]]
-          [[ "$-" == *p* ]]
-          [[ ! -v BASH_ENV && ! -v ENV ]]
-          [[ "${CGO_ENABLED:-}" == "0" ]]
-          [[ "${GOARCH:-}" == "wasm" ]]
-          [[ "${GOENV:-}" == "off" ]]
-          [[ -z "${GOFLAGS:-}" ]]
-          [[ "${GOOS:-}" == "js" ]]
-          [[ "${GOTOOLCHAIN:-}" == "local" ]]
-          [[ "${GOWORK:-}" == "off" ]]
-          [[ -z "${NODE_OPTIONS:-}" ]]
-          [[ "${RUNNER_TEMP:-}" == /* ]]
-          IFS= read -r kernel_family < /proc/sys/kernel/ostype
-          [[ "$kernel_family" == "Linux" ]]
-
-          go_candidate="$(type -P go)"
-          node_candidate="$(type -P node)"
-          [[ "$go_candidate" == /* && -x "$go_candidate" ]]
-          [[ "$node_candidate" == /* && -x "$node_candidate" ]]
-
-          node_bin="$("$node_candidate" -e 'process.stdout.write(require("node:fs").realpathSync(process.argv[1]))' "$node_candidate")"
-          go_bin="$("$node_bin" -e 'process.stdout.write(require("node:fs").realpathSync(process.argv[1]))' "$go_candidate")"
-          [[ "$node_bin" == /* && -x "$node_bin" && "$node_candidate" -ef "$node_bin" ]]
-          [[ "$go_bin" == /* && -x "$go_bin" && "$go_candidate" -ef "$go_bin" ]]
-
-          go_version="$("$go_bin" env GOVERSION)"
-          node_version="$("$node_bin" --version)"
-          printf 'Go host: %s (%s)\n' "$go_bin" "$go_version"
-          printf 'Node host: %s (%s)\n' "$node_bin" "$node_version"
-
-          [[ "$("$go_bin" env GOHOSTOS)" == "linux" ]]
-          [[ "$("$go_bin" env GOOS)" == "js" ]]
-          [[ "$("$go_bin" env GOARCH)" == "wasm" ]]
-          [[ "$("$go_bin" env CGO_ENABLED)" == "0" ]]
-          case "$node_version" in
-            v24.*) ;;
-            *) printf 'unexpected Node version: %s\n' "$node_version" >&2; exit 1 ;;
-          esac
-          "$node_bin" -e 'if (typeof WebAssembly !== "object" || typeof WebAssembly.instantiate !== "function") process.exit(1)'
-
-          go_root="$("$node_bin" -e 'process.stdout.write(require("node:fs").realpathSync(process.argv[1]))' "$("$go_bin" env GOROOT)")"
-          [[ -x "$go_root/bin/go" && "$go_bin" -ef "$go_root/bin/go" ]]
-          wasm_exec_node="$go_root/lib/wasm/wasm_exec_node.js"
-          wasm_exec_runtime="$go_root/lib/wasm/wasm_exec.js"
-          wasm_test="$RUNNER_TEMP/internal-hooks.test.wasm"
-          [[ -r "$wasm_exec_node" ]]
-          [[ -r "$wasm_exec_runtime" ]]
-
-          "$go_bin" test -tags gms_pure_go -c -o "$wasm_test" ./internal/hooks
-          [[ -s "$wasm_test" ]]
           # This required lane owns the exact js/wasm refusal contract. If the
           # wasm test surface grows, widen this selector and its count guard
           # together rather than assuming compilation executes new tests.
           test_status=0
-          test_output="$("$node_bin" --stack-size=8192 "$wasm_exec_node" "$wasm_test" \
-            -test.v -test.timeout=2m \
-            -test.run '^TestRunHookReportsUnsupportedExecution$' \
-            2>&1)" || test_status=$?
+          test_output="$(go test -tags gms_pure_go -count=1 -timeout=2m \
+            -exec="$(go env GOROOT)/lib/wasm/go_js_wasm_exec" \
+            -run '^TestRunHookReportsUnsupportedExecution$' \
+            -v ./internal/hooks 2>&1)" || test_status=$?
           printf '%s\n' "$test_output"
           (( test_status == 0 )) || exit "$test_status"
 
           run_count=0
-          exact_run_count=0
-          exact_pass_count=0
+          pass_count=0
           nonpass_count=0
-          suite_pass_count=0
           pass_pattern='^--- PASS: TestRunHookReportsUnsupportedExecution \([0-9.]+s\)$'
+          nonpass_pattern='^[[:space:]]*--- (FAIL|SKIP): '
           while IFS= read -r line; do
-            if [[ "$line" == "=== RUN   "* ]]; then
+            if [[ "$line" == "=== RUN   TestRunHookReportsUnsupportedExecution" ]]; then
               ((run_count += 1))
             fi
-            if [[ "$line" == "=== RUN   TestRunHookReportsUnsupportedExecution" ]]; then
-              ((exact_run_count += 1))
-            fi
             if [[ "$line" =~ $pass_pattern ]]; then
-              ((exact_pass_count += 1))
+              ((pass_count += 1))
             fi
-            case "$line" in
-              "--- FAIL: TestRunHookReportsUnsupportedExecution"*|"--- SKIP: TestRunHookReportsUnsupportedExecution"*)
-                ((nonpass_count += 1))
-                ;;
-            esac
-            if [[ "$line" == "PASS" ]]; then
-              ((suite_pass_count += 1))
+            if [[ "$line" =~ $nonpass_pattern ]]; then
+              ((nonpass_count += 1))
             fi
           done <<< "$test_output"
-          if [[ "$run_count" != 1 || "$exact_run_count" != 1 || "$exact_pass_count" != 1 || "$nonpass_count" != 0 || "$suite_pass_count" != 1 ]]; then
-            printf 'expected one exact js/wasm hook test run and pass; got runs=%s exact-runs=%s exact-passes=%s nonpasses=%s suite-passes=%s\n' \
-              "$run_count" "$exact_run_count" "$exact_pass_count" "$nonpass_count" "$suite_pass_count" >&2
+          if (( run_count != 1 || pass_count != 1 || nonpass_count != 0 )); then
+            printf 'expected one exact js/wasm hook test run and pass with no failures or skips; got runs=%s passes=%s nonpasses=%s\n' \
+              "$run_count" "$pass_count" "$nonpass_count" >&2
             exit 1
           fi
 

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -11,8 +11,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const linuxPrivilegedWorkflowShell = "/usr/bin/env -u BASH_ENV -u ENV -u BASHOPTS -u SHELLOPTS /usr/bin/bash --noprofile --norc -p -euo pipefail {0}"
-
 func TestCIWorkflowArtifactOwnership(t *testing.T) {
 	for _, workflowName := range []string{"pr.yml", "main.yml"} {
 		t.Run(workflowName, func(t *testing.T) {
@@ -92,20 +90,10 @@ func TestPRCIGateRequiresJSWasmHookExecution(t *testing.T) {
 	if execute.If != "" {
 		t.Errorf("js/wasm hook step is conditional: %q", execute.If)
 	}
-	if execute.Shell != linuxPrivilegedWorkflowShell {
-		t.Errorf("js/wasm hook shell = %q, want %q", execute.Shell, linuxPrivilegedWorkflowShell)
-	}
 	for key, want := range map[string]string{
-		"BASH_ENV":     "",
-		"ENV":          "",
-		"CGO_ENABLED":  "0",
-		"GOARCH":       "wasm",
-		"GOENV":        "off",
-		"GOFLAGS":      "",
-		"GOOS":         "js",
-		"GOTOOLCHAIN":  "local",
-		"GOWORK":       "off",
-		"NODE_OPTIONS": "",
+		"CGO_ENABLED": "0",
+		"GOARCH":      "wasm",
+		"GOOS":        "js",
 	} {
 		got, ok := execute.Env[key]
 		if !ok || got != want {
@@ -113,27 +101,16 @@ func TestPRCIGateRequiresJSWasmHookExecution(t *testing.T) {
 		}
 	}
 	for _, required := range []string{
-		`[[ "${BASH:-}" == "/usr/bin/bash" ]]`,
-		`[[ /bin/bash -ef /usr/bin/bash ]]`,
-		`[[ "$-" == *p* ]]`,
-		`[[ ! -v BASH_ENV && ! -v ENV ]]`,
-		`IFS= read -r kernel_family < /proc/sys/kernel/ostype`,
-		`type -P go`,
-		`type -P node`,
-		`require("node:fs").realpathSync(process.argv[1])`,
-		`env GOVERSION`,
-		`WebAssembly.instantiate`,
-		`[[ -x "$go_root/bin/go" && "$go_bin" -ef "$go_root/bin/go" ]]`,
-		`lib/wasm/wasm_exec_node.js`,
-		`test -tags gms_pure_go -c`,
-		`-test.run '^TestRunHookReportsUnsupportedExecution$'`,
-		`test_output="$("$node_bin"`,
+		`go test -tags gms_pure_go -count=1 -timeout=2m`,
+		`-exec="$(go env GOROOT)/lib/wasm/go_js_wasm_exec"`,
+		`-run '^TestRunHookReportsUnsupportedExecution$'`,
+		`-v ./internal/hooks`,
 		`|| test_status=$?`,
-		`while IFS= read -r line`,
 		`=== RUN   TestRunHookReportsUnsupportedExecution`,
 		`^--- PASS: TestRunHookReportsUnsupportedExecution`,
-		`--- FAIL: TestRunHookReportsUnsupportedExecution`,
-		`--- SKIP: TestRunHookReportsUnsupportedExecution`,
+		`nonpass_pattern='^[[:space:]]*--- (FAIL|SKIP): '`,
+		`[[ "$line" =~ $nonpass_pattern ]]`,
+		`run_count != 1 || pass_count != 1 || nonpass_count != 0`,
 	} {
 		if !strings.Contains(execute.Run, required) {
 			t.Errorf("js/wasm hook command does not contain %q", required)
@@ -141,15 +118,6 @@ func TestPRCIGateRequiresJSWasmHookExecution(t *testing.T) {
 	}
 	if regexp.MustCompile(`\bgo1\.[0-9]`).MatchString(execute.Run) {
 		t.Errorf("js/wasm hook command duplicates the Go version owned by go.mod")
-	}
-	for _, tool := range []string{"uname", "realpath", "tee", "grep"} {
-		pattern := regexp.MustCompile(`(?m)(^|[|;&[:space:]'"])([^|;&[:space:]'"]*/)?` + regexp.QuoteMeta(tool) + `([[:space:]'"]|$)`)
-		if pattern.MatchString(execute.Run) {
-			t.Errorf("js/wasm hook command delegates proof authority to external %s", tool)
-		}
-	}
-	if strings.Contains(execute.Run, "command -v ") {
-		t.Errorf("js/wasm hook command performs ambient command lookup after startup")
 	}
 
 	gate := workflow.job(t, "ci-gate")


### PR DESCRIPTION
## What

Run the required js/wasm hook test through Go's supported `go_js_wasm_exec` wrapper, and reduce the workflow topology test to the functional boundary the job owns.

## Why

The current job correctly proves the js/wasm refusal contract, but it also carries a large privileged-shell and hosted-runner attestation block. That ceremony is disproportionate to Beads' trusted GitHub-hosted-runner model and makes routine runner or toolchain maintenance risky.

This keeps the load-bearing parts:

- Go remains selected from `go.mod` by the pinned setup action.
- Node 24 remains the declared JavaScript runtime.
- `go test` compiles the complete `internal/hooks` js/wasm package and runs the exact contract with cache reuse disabled.
- The step propagates the real test status and requires exactly one RUN, one timed PASS, and no FAIL or SKIP output.
- `CI Gate / Required` still consumes the job.

A separate repository script or Go driver would add another invocation boundary for one concise command, so this remains directly in the workflow.

## Validation

- Focused workflow topology test
- Full `./scripts` test package
- Functional js/wasm execution through the official wrapper
- `actionlint` and ShellCheck
- Formatting and native/Windows cross-lint constituents

Fixes #5491

_codex-gpt-5-unknown-reasoning on behalf of Ewen Cuthiell_
