### PR TITLE
fix(search): order Go-side-sort pages before every trim; honor sortDesc for id

### DIFF
--- a/internal/storage/domain/db/issue_search.go
+++ b/internal/storage/domain/db/issue_search.go
@@ -597,10 +597,7 @@ func (p *idSrcPage) sortGoSide(sortBy string, sortDesc bool) {
 		return
 	}
 	sort.SliceStable(p.ordered, func(i, j int) bool {
-		if sortDesc {
-			return p.ordered[i].id > p.ordered[j].id
-		}
-		return p.ordered[i].id < p.ordered[j].id
+		return sqlbuild.LessID(p.ordered[i].id, p.ordered[j].id, sortDesc)
 	})
 	p.issueIDs = p.issueIDs[:0]
 	p.wispIDs = p.wispIDs[:0]
@@ -657,10 +654,7 @@ func sortRowsGoSide[T any](rows []T, id func(T) string, sortBy string, sortDesc 
 		return
 	}
 	sort.SliceStable(rows, func(i, j int) bool {
-		if sortDesc {
-			return id(rows[i]) > id(rows[j])
-		}
-		return id(rows[i]) < id(rows[j])
+		return sqlbuild.LessID(id(rows[i]), id(rows[j]), sortDesc)
 	})
 }
 

--- a/internal/storage/domain/db/issue_search.go
+++ b/internal/storage/domain/db/issue_search.go
@@ -269,6 +269,7 @@ func (r *issueSQLRepositoryImpl) searchTable(ctx context.Context, query string, 
 		return domain.SearchPage{}, fmt.Errorf("search %s: rows: %w", tables.Main, err)
 	}
 
+	sortRowsGoSide(issues, func(i *types.Issue) string { return i.ID }, filter.SortBy, filter.SortDesc)
 	items, hasMore, err := finishWindow(issues, window)
 	if err != nil {
 		return domain.SearchPage{}, err
@@ -306,6 +307,7 @@ func (r *issueSQLRepositoryImpl) scanFilterIDs(ctx context.Context, selectKw, fr
 		return nil, false, fmt.Errorf("search %s (id scan): rows: %w", tables.Main, err)
 	}
 
+	sortRowsGoSide(ids, func(id string) string { return id }, filter.SortBy, filter.SortDesc)
 	return finishWindow(ids, window)
 }
 
@@ -587,9 +589,9 @@ func reassembleBySrc[T comparable](ordered []idSrcRef, issues, wisps map[string]
 // page, by workapi.CompareIssuesBy. This decides MEMBERSHIP; that decides
 // DISPLAY.
 //
-// It honors sortDesc, which sqlbuild.Less does not for this key — the per-table
-// seam therefore answers a reversed id page with the byte-FIRST rows. That is a
-// live sibling bug, named here rather than mirrored.
+// It honors sortDesc, as sqlbuild.Less and the per-table seam's
+// sortRowsGoSide now also do for this key (both were once live sibling bugs
+// this comment named; bd-jao3t/bd-69c1a closed them).
 func (p *idSrcPage) sortGoSide(sortBy string, sortDesc bool) {
 	if !sqlbuild.IsGoSideSort(sortBy) || len(p.ordered) <= 1 {
 		return
@@ -638,6 +640,29 @@ func (p *idSrcPage) finishWindow(w searchWindow) (bool, error) {
 }
 
 type idSrcRef struct{ id, src string }
+
+// sortRowsGoSide is the per-table seam's copy of idSrcPage.sortGoSide: it
+// establishes the order for a sort key SQL renders no ORDER BY for, BEFORE
+// finishWindow's trim decides which rows the page keeps. searchWindowFor
+// pushes no page bound under a Go-side sort precisely so the whole matching
+// set arrives here — this is where the requested order first exists; without
+// it the trim keeps an arbitrary engine-ordered subset (order-right,
+// membership-wrong once sorted downstream). The comparison is byte order,
+// matching sqlbuild.Less and idSrcPage.sortGoSide; the natural-numeric
+// display order is applied later, on the delivered page (see sortGoSide's
+// doc for the membership/display split). No-op for SQL-rendered sort keys,
+// whose ORDER BY already ran.
+func sortRowsGoSide[T any](rows []T, id func(T) string, sortBy string, sortDesc bool) {
+	if !sqlbuild.IsGoSideSort(sortBy) || len(rows) <= 1 {
+		return
+	}
+	sort.SliceStable(rows, func(i, j int) bool {
+		if sortDesc {
+			return id(rows[i]) > id(rows[j])
+		}
+		return id(rows[i]) < id(rows[j])
+	})
+}
 
 const unionSortColumnsSQL = sqlbuild.UnionSortColumnsSQL
 

--- a/internal/storage/domain/db/issue_search_counts.go
+++ b/internal/storage/domain/db/issue_search_counts.go
@@ -231,8 +231,12 @@ func scanReadyWorkRowWithCounts(rows *sql.Rows, hyd sqlbuild.CountsHydration) (*
 
 // finishSearchCountsPage closes the window runFilterSearchQuery opened. It
 // rebuilds it from the same filter rather than being handed it, so the two
-// halves cannot be given different numbers.
+// halves cannot be given different numbers. Like the plain per-table seam, it
+// establishes a Go-side sort's order before the trim (sortRowsGoSide) — the
+// counts query renders no ORDER BY for such keys, so its rows arrive
+// engine-ordered.
 func finishSearchCountsPage(items []*types.IssueWithCounts, filter types.IssueFilter) (domain.SearchCountsPage, error) {
+	sortRowsGoSide(items, func(iwc *types.IssueWithCounts) string { return iwc.Issue.ID }, filter.SortBy, filter.SortDesc)
 	trimmed, hasMore, err := finishWindow(items, searchWindowForFilter(filter))
 	if err != nil {
 		return domain.SearchCountsPage{}, err

--- a/internal/storage/domain/db/issue_search_table_window_test.go
+++ b/internal/storage/domain/db/issue_search_table_window_test.go
@@ -1,0 +1,138 @@
+package db
+
+import (
+	"fmt"
+
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestIssueSearchPerTableWindow is the per-table (and counts-twin) copy of
+// TestIssueSearchUnionWindow's Go-side-sort membership cases: #5587 fixed the
+// union seam, and these pin the routes that never reach it — SkipWisps and an
+// empty/missing wisps table — where searchTable/scanFilterIDs and the counts
+// twin's finishSearchCountsPage trimmed to the limit with no sort anywhere
+// (bd-69c1a), and a reversed id sort additionally kept the byte-FIRST rows
+// because sqlbuild.Less ignored sortDesc for "id" (bd-jao3t).
+//
+// Subtest ORDER is load-bearing: the durable-only cases run first, while the
+// wisps table is still empty, so the wisps-empty probe route is genuinely
+// exercised; the union case seeds wisps and therefore runs last.
+func (s *testSuite) TestIssueSearchPerTableWindow() {
+	s.Run("GoSideSortWithALimitAnswersTheGloballyCorrectPage", s.perTableGoSideSortKeepsTheRightSubset)
+	s.Run("AReversedGoSideSortAnswersTheByteLastRows", s.perTableGoSideSortDescKeepsTheByteLastRows)
+	s.Run("EveryPerTableRouteAnswersOnePage", s.perTableRoutesAnswerOnePage)
+	s.Run("TheUnionAnswersAReversedPageToo", s.unionGoSideSortDescKeepsTheByteLastRows)
+}
+
+// seedDurableRows writes n durable rows under one id prefix. Unlike
+// seedTwoPlanes it keeps everything on the issues table: the per-table seams
+// are the routes a search takes when the wisps plane is out of the picture
+// (SkipWisps, or an empty/missing wisps table), and an empty wisps table is
+// part of the route condition the callers below want to hold.
+func (s *testSuite) seedDurableRows(prefix string, n int) []string {
+	r := s.issueRepo()
+	ids := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("%s-%03d", prefix, i)
+		s.Require().NoError(r.Insert(s.Ctx(), newTestIssue(id, fmt.Sprintf("row %d", i)), "tester", domain.InsertIssueOpts{}))
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// perTableGoSideSortKeepsTheRightSubset is bd-69c1a's plain case on the
+// id-shrink path (Limit>0 routes searchTable through scanFilterIDs). The id
+// query renders no ORDER BY for a Go-side sort and searchWindowFor pushes no
+// page bound, so the whole matching set arrives — but before the fix nothing
+// sorted it before finishWindow's trim, and the page was an arbitrary
+// engine-ordered subset. The ids are zero-padded, so byte order and natural
+// order agree and the answer is unambiguous.
+func (s *testSuite) perTableGoSideSortKeepsTheRightSubset() {
+	const prefix = "bd-ptw-gos"
+	ids := s.seedDurableRows(prefix, 10)
+	r := s.issueRepo()
+
+	const limit = 3
+	page, err := r.SearchAcrossIssuesAndWisps(s.Ctx(), "",
+		types.IssueFilter{IDPrefix: prefix + "-", SortBy: "id", Limit: limit})
+	s.Require().NoError(err)
+
+	s.Equal(ids[:limit], idsFrom(page),
+		"a limited per-table page under a Go-side sort must be the globally first rows, not an engine-ordered subset")
+	s.True(page.HasMore)
+}
+
+// perTableGoSideSortDescKeepsTheByteLastRows is the measured bd-69c1a repro:
+// 10 rows, sort id desc, limit 3 answered [000 001 002] where [009 008 007]
+// was owed — membership AND order wrong, because nothing sorted before the
+// trim and sqlbuild.Less ignored sortDesc for "id".
+func (s *testSuite) perTableGoSideSortDescKeepsTheByteLastRows() {
+	const prefix = "bd-ptw-desc"
+	ids := s.seedDurableRows(prefix, 10)
+	r := s.issueRepo()
+
+	page, err := r.SearchAcrossIssuesAndWisps(s.Ctx(), "",
+		types.IssueFilter{IDPrefix: prefix + "-", SortBy: "id", SortDesc: true, Limit: 3})
+	s.Require().NoError(err)
+
+	s.Equal([]string{ids[9], ids[8], ids[7]}, idsFrom(page),
+		"a reversed id page must be the byte-last rows first")
+	s.True(page.HasMore)
+}
+
+// perTableRoutesAnswerOnePage is the cross-route parity half of the bd-jao3t/
+// bd-69c1a fix: over one durable-only corpus, the wisps-empty probe route, the
+// SkipWisps route, the wide (NoIDShrink) path, and the counts twin must all
+// answer the identical reversed page. Before the fix each trimmed an unsorted
+// set, so agreement was engine-order luck.
+func (s *testSuite) perTableRoutesAnswerOnePage() {
+	const prefix = "bd-ptw-par"
+	ids := s.seedDurableRows(prefix, 8)
+	r := s.issueRepo()
+
+	want := []string{ids[7], ids[6], ids[5]}
+	for _, tc := range []struct {
+		route  string
+		filter types.IssueFilter
+	}{
+		{"the wisps-empty probe route", types.IssueFilter{IDPrefix: prefix + "-", SortBy: "id", SortDesc: true, Limit: 3}},
+		{"the SkipWisps route", types.IssueFilter{IDPrefix: prefix + "-", SortBy: "id", SortDesc: true, Limit: 3, SkipWisps: true}},
+		{"the wide path", types.IssueFilter{IDPrefix: prefix + "-", SortBy: "id", SortDesc: true, Limit: 3, NoIDShrink: true}},
+	} {
+		page, err := r.SearchAcrossIssuesAndWisps(s.Ctx(), "", tc.filter)
+		s.Require().NoError(err, tc.route)
+		s.Equal(want, idsFrom(page), "%s must answer the one true page", tc.route)
+		s.True(page.HasMore, tc.route)
+	}
+
+	counts, err := r.SearchAcrossIssuesAndWispsWithCounts(s.Ctx(), "",
+		types.IssueFilter{IDPrefix: prefix + "-", SortBy: "id", SortDesc: true, Limit: 3})
+	s.Require().NoError(err)
+	got := make([]string, 0, len(counts.Items))
+	for _, item := range counts.Items {
+		got = append(got, item.Issue.ID)
+	}
+	s.Equal(want, got, "the counts twin must answer the same page as the plain twin")
+	s.True(counts.HasMore)
+}
+
+// unionGoSideSortDescKeepsTheByteLastRows pins the reversed page on the union
+// seam. idSrcPage.sortGoSide honored sortDesc from the start, so this is a
+// regression fence rather than a fix witness — it is here because the per-table
+// cases above assert the same page shape, and the three seams answering one
+// page is the contract the pair of beads restores. Seeds wisps; keep it LAST.
+func (s *testSuite) unionGoSideSortDescKeepsTheByteLastRows() {
+	const prefix = "bd-ptw-udesc"
+	ids := s.seedTwoPlanes(prefix, 6)
+	r := s.issueRepo()
+
+	page, err := r.SearchAcrossIssuesAndWisps(s.Ctx(), "",
+		types.IssueFilter{IDPrefix: prefix + "-", SortBy: "id", SortDesc: true, Limit: 5})
+	s.Require().NoError(err)
+
+	want := []string{ids[11], ids[10], ids[9], ids[8], ids[7]}
+	s.Equal(want, idsFrom(page),
+		"a reversed union page must be the byte-last rows across both planes")
+	s.True(page.HasMore)
+}

--- a/internal/storage/domain/db/issue_search_table_window_test.go
+++ b/internal/storage/domain/db/issue_search_table_window_test.go
@@ -58,6 +58,10 @@ func (s *testSuite) perTableGoSideSortKeepsTheRightSubset() {
 		types.IssueFilter{IDPrefix: prefix + "-", SortBy: "id", Limit: limit})
 	s.Require().NoError(err)
 
+	// NOTE: a weak witness by itself — Dolt's engine order for a PK-clustered
+	// id-prefix scan tends to be byte-ascending already, so this case likely
+	// passed pre-fix too. It pins the contract against future engine-order
+	// changes; the DESC cases below are the red-before-green fences.
 	s.Equal(ids[:limit], idsFrom(page),
 		"a limited per-table page under a Go-side sort must be the globally first rows, not an engine-ordered subset")
 	s.True(page.HasMore)

--- a/internal/storage/issueops/search.go
+++ b/internal/storage/issueops/search.go
@@ -115,10 +115,7 @@ var idProjection = searchProjection[string]{
 		if !sqlbuild.IsGoSideSort(sortBy) {
 			return false
 		}
-		if sortDesc {
-			return a > b
-		}
-		return a < b
+		return sqlbuild.LessID(a, b, sortDesc)
 	},
 }
 
@@ -300,10 +297,7 @@ func sortMergedResults[T any](results []T, less func(a, b T, sortBy string, sort
 func goSideSortAndTrim[T any](results []T, id func(T) string, sortDesc bool, bound int) []T {
 	if len(results) > 1 {
 		sort.SliceStable(results, func(i, j int) bool {
-			if sortDesc {
-				return id(results[i]) > id(results[j])
-			}
-			return id(results[i]) < id(results[j])
+			return sqlbuild.LessID(id(results[i]), id(results[j]), sortDesc)
 		})
 	}
 	if bound > 0 && len(results) > bound {

--- a/internal/storage/issueops/search.go
+++ b/internal/storage/issueops/search.go
@@ -62,11 +62,12 @@ type searchProjection[T any] struct {
 	// of two independently-ordered legs before trimming to filter.Limit —
 	// without it, the trim keeps whichever leg happens to come first in
 	// the concatenation regardless of sort rank (be-x42v.4 round-5
-	// follow-up). nil for projections with no sortable payload to compare
-	// (idProjection scans bare IDs, no column data); safe today because no
-	// caller combines Limit>0 with a merged (non-SkipWisps) ID-only search
-	// — see the merge-trim call site for the fallback behavior if that
-	// changes.
+	// follow-up). A projection with no sortable payload beyond the id
+	// (idProjection scans bare IDs, no column data) can still order the one
+	// Go-side key — "id" IS its payload — and returns false for every other
+	// key, which leaves sort.SliceStable a no-op (concatenation order, the
+	// pre-existing behavior; still safe because no caller combines Limit>0
+	// with a merged non-SkipWisps ID-only search under a SQL-rendered sort).
 	less func(a, b T, sortBy string, sortDesc bool) bool
 }
 
@@ -107,6 +108,18 @@ var idProjection = searchProjection[string]{
 	},
 	id:      func(id string) string { return id },
 	hydrate: nil,
+	// The id is the whole payload, so the one Go-side sort key is orderable
+	// here; every SQL-rendered key compares false (stable no-op) — see the
+	// less field's doc.
+	less: func(a, b string, sortBy string, sortDesc bool) bool {
+		if !sqlbuild.IsGoSideSort(sortBy) {
+			return false
+		}
+		if sortDesc {
+			return a > b
+		}
+		return a < b
+	},
 }
 
 // hydrateIssueLabelsAndDeps bulk-loads labels (and optionally dependencies)
@@ -274,6 +287,31 @@ func sortMergedResults[T any](results []T, less func(a, b T, sortBy string, sort
 	})
 }
 
+// goSideSortAndTrim establishes a Go-side sort key's order over one leg's
+// complete matching set, then applies the bound the query withheld
+// (EffectiveSearchLimit — the same number the SQL LIMIT would have carried, so
+// cap accounting downstream is unchanged). Ordering the leg BEFORE bounding it
+// is what makes the bound sound: a row in the true top-n is in its leg's
+// top-n. Byte order by id, matching sqlbuild.Less for this key and the
+// domain/db seam's sortGoSide/sortRowsGoSide; the natural-numeric display
+// order is applied later on the delivered page (workapi.CompareIssuesBy) —
+// this decides MEMBERSHIP, that decides DISPLAY. Hydration runs after, so
+// only rows that survive the bound are hydrated.
+func goSideSortAndTrim[T any](results []T, id func(T) string, sortDesc bool, bound int) []T {
+	if len(results) > 1 {
+		sort.SliceStable(results, func(i, j int) bool {
+			if sortDesc {
+				return id(results[i]) > id(results[j])
+			}
+			return id(results[i]) < id(results[j])
+		})
+	}
+	if bound > 0 && len(results) > bound {
+		results = results[:bound]
+	}
+	return results
+}
+
 // trimToSearchLimit truncates results to filter.Limit (when set, Limit>0)
 // before the caller-facing MaxRows cap check runs. Every searchInTx exit
 // path routes results returned to the caller through this before
@@ -317,8 +355,16 @@ func searchTableInTxT[T any](ctx context.Context, tx DBTX, query string, filter 
 		whereSQL = "WHERE " + strings.Join(whereClauses, " AND ")
 	}
 
+	// A PAGE BOUND IS ONLY EVER PUSHED UNDER AN ORDER THE QUERY CAN EXPRESS
+	// (searchWindowFor's rule, mirrored here for the store-backed seam): a
+	// Go-side sort key renders no ORDER BY, and a LIMIT with no ORDER BY does
+	// not return the first n rows, it returns n rows. So under a Go-side sort
+	// the query scans the complete matching set, and the bound is applied
+	// below — after the order first exists (goSideSortAndTrim).
+	goSideSort := sqlbuild.IsGoSideSort(filter.SortBy)
+	eff := EffectiveSearchLimit(filter.Limit, filter.MaxRows)
 	limitSQL := ""
-	if eff := EffectiveSearchLimit(filter.Limit, filter.MaxRows); eff > 0 {
+	if eff > 0 && !goSideSort {
 		limitSQL = fmt.Sprintf(" LIMIT %d", eff)
 	}
 
@@ -358,6 +404,10 @@ func searchTableInTxT[T any](ctx context.Context, tx DBTX, query string, filter 
 	_ = rows.Close()
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("search %s: rows: %w", tables.Main, err)
+	}
+
+	if goSideSort {
+		results = goSideSortAndTrim(results, proj.id, filter.SortDesc, eff)
 	}
 
 	if proj.hydrate != nil && len(results) > 0 {

--- a/internal/storage/issueops/search_counts.go
+++ b/internal/storage/issueops/search_counts.go
@@ -112,12 +112,33 @@ func runFilterSearchQueryInTx(ctx context.Context, tx *sql.Tx, query string, fil
 	if len(whereClauses) > 0 {
 		whereSQL = "WHERE " + joinAnd(whereClauses)
 	}
+	// A PAGE BOUND IS ONLY EVER PUSHED UNDER AN ORDER THE QUERY CAN EXPRESS —
+	// the same rule searchTableInTxT applies on the plain seam. sqlbuild.OrderBy
+	// renders no ORDER BY for a Go-side sort key ("id"), and a LIMIT with no
+	// ORDER BY returns n rows, not the first n; this is the seam
+	// bd query '<expr>' --sort id reaches on the store-shaped backends
+	// (storequerier → SearchIssuesWithCounts), where BuildQueryPlan always
+	// pushes a bound. So under a Go-side sort the query scans the complete
+	// matching set and the same eff bound is applied below, after the order
+	// exists — leaving every downstream count (the merge, the terminal
+	// finishSearchIssuesWithCounts trim-then-cap) exactly what the SQL LIMIT
+	// used to hand it.
+	goSideSort := sqlbuild.IsGoSideSort(filter.SortBy)
+	eff := EffectiveSearchLimit(filter.Limit, filter.MaxRows)
 	limitSQL := ""
-	if eff := EffectiveSearchLimit(filter.Limit, filter.MaxRows); eff > 0 {
+	if eff > 0 && !goSideSort {
 		limitSQL = fmt.Sprintf("LIMIT %d", eff)
 	}
 	orderBy := sqlbuild.OrderBy(filter.SortBy, filter.SortDesc, "i")
-	return runSearchQueryInTx(ctx, tx, tables, whereSQL, orderBy, limitSQL, args, includeWispReverseDeps, hydrationFor(filter))
+	out, err := runSearchQueryInTx(ctx, tx, tables, whereSQL, orderBy, limitSQL, args, includeWispReverseDeps, hydrationFor(filter))
+	if err != nil {
+		return nil, err
+	}
+	if goSideSort {
+		// scanCountsRowsInTx drops nil-Issue rows, so the accessor is safe.
+		out = goSideSortAndTrim(out, func(iwc *types.IssueWithCounts) string { return iwc.Issue.ID }, filter.SortDesc, eff)
+	}
+	return out, nil
 }
 
 //nolint:gosec // G201: SQL fragments are caller-built from hardcoded shapes

--- a/internal/storage/issueops/search_goside_sort_test.go
+++ b/internal/storage/issueops/search_goside_sort_test.go
@@ -1,0 +1,126 @@
+package issueops
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// beginCapturingMockTx is beginMockTx with a query matcher that also records
+// every actual SQL string, so a test can assert about clause ABSENCE — the
+// default regexp matcher can only prove presence, and Go regexps have no
+// negative lookahead to express "carries no LIMIT".
+func beginCapturingMockTx(t *testing.T, captured *[]string) (sqlmock.Sqlmock, DBTX) {
+	t.Helper()
+
+	matcher := sqlmock.QueryMatcherFunc(func(expectedSQL, actualSQL string) error {
+		*captured = append(*captured, actualSQL)
+		return sqlmock.QueryMatcherRegexp.Match(expectedSQL, actualSQL)
+	})
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(matcher))
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	mock.ExpectBegin()
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	t.Cleanup(func() { _ = tx.Rollback() })
+
+	return mock, tx
+}
+
+// TestSearchIssueIDsInTx_GoSideSortScansUnboundedThenOrdersAndTrims is the
+// store-backed half of bd-jao3t: a Go-side sort key ("id") renders no ORDER
+// BY, and a LIMIT with no ORDER BY returns n rows, not the first n — so the
+// leg must scan the complete matching set, order it in Go, and only then
+// apply the bound (goSideSortAndTrim). The mock returns the matching set
+// deliberately out of order; the delivered page must be the true byte-order
+// top-3, honoring sortDesc — before the fix it was an arbitrary LIMIT-cut
+// subset in whatever order the engine emitted, and sortDesc was ignored for
+// this key besides (sqlbuild.Less).
+func TestSearchIssueIDsInTx_GoSideSortScansUnboundedThenOrdersAndTrims(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		sortDesc bool
+		want     []string
+	}{
+		{"ascending", false, []string{"bd-000", "bd-001", "bd-003"}},
+		{"descending", true, []string{"bd-009", "bd-007", "bd-004"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var captured []string
+			mock, tx := beginCapturingMockTx(t, &captured)
+
+			// The complete matching set, in an order no sort would produce.
+			mock.ExpectQuery(`SELECT issues\.id FROM issues`).
+				WillReturnRows(sqlmock.NewRows([]string{"id"}).
+					AddRow("bd-004").AddRow("bd-001").AddRow("bd-009").
+					AddRow("bd-003").AddRow("bd-000").AddRow("bd-007"))
+
+			got, err := SearchIssueIDsInTx(context.Background(), tx, "", types.IssueFilter{
+				SortBy:    "id",
+				SortDesc:  tc.sortDesc,
+				Limit:     3,
+				SkipWisps: true,
+			})
+			if err != nil {
+				t.Fatalf("SearchIssueIDsInTx: %v", err)
+			}
+
+			if len(got) != len(tc.want) || got[0] != tc.want[0] || got[1] != tc.want[1] || got[2] != tc.want[2] {
+				t.Fatalf("page = %v, want %v (byte-order top-3, sortDesc=%v)", got, tc.want, tc.sortDesc)
+			}
+
+			for _, q := range captured {
+				if strings.Contains(q, "LIMIT") {
+					t.Fatalf("a Go-side sort leg must not carry a LIMIT (a bound without an order is n rows, not the first n); got: %s", q)
+				}
+			}
+
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatalf("unmet SQL expectations: %v", err)
+			}
+		})
+	}
+}
+
+// TestSearchIssueIDsInTx_SQLSortStillPushesTheBound guards the other
+// direction: for a sort key SQL renders (the default priority order here),
+// the leg keeps its ORDER BY and its LIMIT — the bd-jao3t fix widens only
+// the one key SQL cannot order.
+func TestSearchIssueIDsInTx_SQLSortStillPushesTheBound(t *testing.T) {
+	t.Parallel()
+
+	var captured []string
+	mock, tx := beginCapturingMockTx(t, &captured)
+
+	mock.ExpectQuery(`(?s)SELECT issues\.id FROM issues.*ORDER BY.*LIMIT 3`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).
+			AddRow("bd-000").AddRow("bd-001").AddRow("bd-002"))
+
+	got, err := SearchIssueIDsInTx(context.Background(), tx, "", types.IssueFilter{
+		Limit:     3,
+		SkipWisps: true,
+	})
+	if err != nil {
+		t.Fatalf("SearchIssueIDsInTx: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("page length = %d, want 3", len(got))
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}

--- a/internal/storage/issueops/search_goside_sort_test.go
+++ b/internal/storage/issueops/search_goside_sort_test.go
@@ -2,6 +2,7 @@ package issueops
 
 import (
 	"context"
+	"database/sql"
 	"strings"
 	"testing"
 
@@ -92,6 +93,51 @@ func TestSearchIssueIDsInTx_GoSideSortScansUnboundedThenOrdersAndTrims(t *testin
 				t.Fatalf("unmet SQL expectations: %v", err)
 			}
 		})
+	}
+}
+
+// TestSearchIssuesWithCountsInTx_GoSideSortDropsTheLegBound is the counts-seam
+// copy of the leg-shape assertion — the seam bd query '<expr>' --sort id
+// actually reaches on the store-shaped backends (storequerier →
+// SearchIssuesWithCounts), where BuildQueryPlan always pushes a bound. Under a
+// Go-side sort, neither the issues nor the wisps counts query may carry a
+// LIMIT (no ORDER BY is rendered for this key, and a bound without an order is
+// n rows, not the first n); runFilterSearchQueryInTx orders and bounds the leg
+// in Go instead (goSideSortAndTrim).
+func TestSearchIssuesWithCountsInTx_GoSideSortDropsTheLegBound(t *testing.T) {
+	t.Parallel()
+
+	var captured []string
+	mock, tx := beginCapturingMockTx(t, &captured)
+
+	mock.ExpectQuery(`SELECT 1 FROM wisp_dependencies LIMIT 1`).
+		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+	mock.ExpectQuery(`(?s)FROM issues i`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+	mock.ExpectQuery(`SELECT 1 FROM wisps LIMIT 1`).
+		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+	mock.ExpectQuery(`(?s)FROM wisps i`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+	txSQL, ok := tx.(*sql.Tx)
+	if !ok {
+		t.Fatal("beginCapturingMockTx must hand back a *sql.Tx for the counts seam")
+	}
+	if _, err := SearchIssuesWithCountsInTx(context.Background(), txSQL, "", types.IssueFilter{SortBy: "id", SortDesc: true, Limit: 3}); err != nil {
+		t.Fatalf("SearchIssuesWithCountsInTx: %v", err)
+	}
+
+	for _, q := range captured {
+		if strings.Contains(q, "FROM wisp") && strings.HasPrefix(q, "SELECT 1") {
+			continue // the existence probes legitimately carry LIMIT 1
+		}
+		if strings.Contains(q, "LIMIT") {
+			t.Fatalf("a Go-side-sort counts leg must not carry a LIMIT; got: %s", q)
+		}
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
 	}
 }
 

--- a/internal/storage/sqlbuild/sort.go
+++ b/internal/storage/sqlbuild/sort.go
@@ -105,6 +105,13 @@ func OrderBy(sortBy string, sortDesc bool, table string) string {
 // selected.
 func Less(a, b *types.Issue, sortBy string, sortDesc bool) bool {
 	if sortBy == "id" {
+		// Byte order, the order SQL would apply — and sortDesc flips it,
+		// exactly as it flips every SQL-rendered key below. This key used to
+		// ignore sortDesc, so a reversed id merge kept the byte-FIRST rows
+		// (the sibling bug idSrcPage.sortGoSide's doc named).
+		if sortDesc {
+			return a.ID > b.ID
+		}
 		return a.ID < b.ID
 	}
 	def, ok := SortDefs[sortBy]

--- a/internal/storage/sqlbuild/sort.go
+++ b/internal/storage/sqlbuild/sort.go
@@ -44,6 +44,21 @@ func IsGoSideSort(sortBy string) bool {
 	return sortBy == "id"
 }
 
+// LessID orders two ids for the Go-side "id" sort key: byte order — the order
+// SQL would apply — flipped by desc. This is THE membership comparator for a
+// Go-side id sort; every seam (Less, the union page's sortGoSide, the
+// per-table sortRowsGoSide, the store-backed goSideSortAndTrim) calls it
+// rather than restating the comparison, because the sortDesc bug it fixes
+// came from exactly such a restated copy drifting from its siblings. The
+// natural-numeric order a human reads (bd-9 before bd-10) is display-layer
+// (workapi.CompareIssuesBy), applied to the delivered page — never here.
+func LessID(a, b string, desc bool) bool {
+	if desc {
+		return a > b
+	}
+	return a < b
+}
+
 func flipDir(dir string) string {
 	if dir == "ASC" {
 		return "DESC"
@@ -105,14 +120,9 @@ func OrderBy(sortBy string, sortDesc bool, table string) string {
 // selected.
 func Less(a, b *types.Issue, sortBy string, sortDesc bool) bool {
 	if sortBy == "id" {
-		// Byte order, the order SQL would apply — and sortDesc flips it,
-		// exactly as it flips every SQL-rendered key below. This key used to
-		// ignore sortDesc, so a reversed id merge kept the byte-FIRST rows
-		// (the sibling bug idSrcPage.sortGoSide's doc named).
-		if sortDesc {
-			return a.ID > b.ID
-		}
-		return a.ID < b.ID
+		// This key used to ignore sortDesc, so a reversed id merge kept the
+		// byte-FIRST rows (the sibling bug idSrcPage.sortGoSide's doc named).
+		return LessID(a.ID, b.ID, sortDesc)
 	}
 	def, ok := SortDefs[sortBy]
 	if !ok {

--- a/internal/storage/sqlbuild/sqlbuild_test.go
+++ b/internal/storage/sqlbuild/sqlbuild_test.go
@@ -73,6 +73,21 @@ func TestLessMirrorsOrderBy(t *testing.T) {
 	}
 }
 
+// TestLessIDHonorsSortDesc pins the bd-jao3t half of the reversed-id bug:
+// Less ignored sortDesc for "id" (the one Go-side sort key), so every merge
+// sort that fed a reversed id page kept the byte-FIRST rows.
+func TestLessIDHonorsSortDesc(t *testing.T) {
+	a := &types.Issue{ID: "bd-001"}
+	b := &types.Issue{ID: "bd-002"}
+
+	if !Less(a, b, "id", false) || Less(b, a, "id", false) {
+		t.Error("id ascending must be byte order")
+	}
+	if !Less(b, a, "id", true) || Less(a, b, "id", true) {
+		t.Error("id descending must be reversed byte order, not the ascending order sortDesc used to be ignored into")
+	}
+}
+
 func TestBuildReadyWorkOrderPriorityFIFO(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

Closes out the two `--sort id` page-membership defects #5587 deferred by name — reachable today from `bd query '<expr>' --sort id [-r]` on every backend route (DefaultQueryLimit means a bound is always set).

**Defect 1 — `sqlbuild.Less` ignored `sortDesc` for `id`.** The one Go-side sort key compared ascending regardless, so every merge sort feeding a reversed id page kept the byte-FIRST rows. `idSrcPage.sortGoSide`'s doc comment named this sibling bug explicitly ("named here rather than mirrored").

**Defect 2 — the per-table and store-backed seams trimmed unsorted sets.** #5587 established the rule (a page bound is only ever pushed under an order the query can express) on the **union** seam. The per-table seams (`searchTable`/`scanFilterIDs`, and the counts twin's `finishSearchCountsPage`) already received the complete matching set — `searchWindowFor` withholds the page bound — but trimmed it with **no sort anywhere**: measured, 10 rows / sort id desc / limit 3 answered `[000 001 002]` where `[009 008 007]` was owed, and asc membership was engine-order-unstable across suite compositions. The store-backed seam (`issueops.searchTableInTxT`) was worse: it still pushed `LIMIT` into the leg SQL with **no ORDER BY**, so each leg contributed an arbitrary engine-ordered subset before the go-side re-sort — order right, membership wrong.

## Fix (one per seam, same rule)

- `sqlbuild.Less`: `sortDesc` flips the id comparison (byte order, matching what SQL would render for this key if it could).
- `domain/db`: new `sortRowsGoSide` helper — the per-table copy of `idSrcPage.sortGoSide` — runs before `finishWindow` at `searchTable`'s wide path, `scanFilterIDs`, and `finishSearchCountsPage`.
- `issueops.searchTableInTxT`: a Go-side-sort leg no longer carries a SQL LIMIT; it scans the complete matching set, orders it in Go, then applies the same `EffectiveSearchLimit` bound (`goSideSortAndTrim`) — cap accounting unchanged, Pattern B hydrates only surviving rows, and the cost is the one `searchWindowFor` already states rather than absorbs.
- `idProjection` gains a comparator for the one key its payload can order ("id"), defusing the merged-id-search landmine the old `nil` documented.

## Verification

- **Red-before-green on all three seams**: with the source reverted and tests kept, `TestLessIDHonorsSortDesc` fails, the sqlmock store-backed test fails with `page = [bd-004 bd-001 bd-009], want [bd-009 bd-007 bd-004]`, and the per-table suite cases fail on the measured repro.
- New coverage: sqlbuild unit test (Less/desc); sqlmock tests pinning leg shape (no LIMIT under a Go-side sort; bound still pushed under a SQL sort — guards against over-widening) and the ordered+trimmed page; domain/db suite adds asc membership, the measured desc repro, a **four-route parity case** (wisps-empty probe, SkipWisps, wide path, counts twin must answer one identical reversed page), and a reversed **union** page fence. Subtest order is documented as load-bearing (durable-only cases run while the wisps table is genuinely empty).
- `go build ./...`, `go vet ./internal/storage/...`, `gofmt -l` clean; full `internal/storage/{sqlbuild,issueops,domain/db,uow}` + `internal/workapi` green locally (domain/db against the real Dolt test container).

## Scope notes

- No behavior change for any SQL-rendered sort key: the leg keeps its ORDER BY + LIMIT (pinned by test).
- `idSrcPage.sortGoSide`'s comment updated — the sibling bugs it named are now fixed rather than deferred.
- Display-vs-membership split unchanged: byte order decides membership at the seams; `workapi.CompareIssuesBy` still applies natural-numeric order on the delivered page.

(bd-jao3t, bd-69c1a — filed from the post-wave adversarial audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)