### PR TITLE
perf(metrics): stop paying telemetry startup costs on every bd invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -446,6 +446,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Telemetry no longer taxes every bd invocation.** Two startup costs paid on
+  every command, measured during the post-wave startup audit, are gone. First,
+  the machine-scoped distinct ID was recomputed on every invocation — a fork
+  of the platform machine-id probe (`ioreg` on macOS, 20.2±1.2ms) — even with
+  `BD_DISABLE_METRICS=1` and even for `bd --version`. The ID is now resolved
+  only when metrics are enabled and cached at `~/.beads/machine-id` (0600), so
+  the probe runs at most once per machine; a probe failure is retried next run
+  rather than cached. Second, every invocation unconditionally spawned a
+  detached `bd send-metrics` child — a full re-exec of the binary plus an
+  HTTPS upload attempt, with no check that anything was queued. The spawn now
+  requires at least one queued event batch and is throttled to one attempt per
+  5 minutes (marker: `eventsData/.last-flush`); queued events still upload,
+  just batched. Telemetry content, opt-out semantics, and the sanctioned
+  endpoint pinning are all unchanged.
+
 - **A long or multi-paragraph close reason renders as body text in `bd show`**
   ([#5595](https://github.com/gastownhall/beads/pull/5595)). Every other
   free-text field — description, design, notes, acceptance criteria, comments —

--- a/internal/metrics/machineid.go
+++ b/internal/metrics/machineid.go
@@ -1,0 +1,117 @@
+package metrics
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// machineIDCacheName is the file under ~/.beads that persists the telemetry
+// distinct ID. eventkit.MachineID shells out to the platform machine-id probe
+// (`ioreg` on macOS, DMI/registry reads elsewhere) via denisbrodbeck/machineid
+// on every call — measured at 20.2±1.2ms per bd invocation — so the computed
+// ID is cached here once and reused by every subsequent invocation, including
+// the detached send-metrics child. The ID is already an app-scoped HMAC of the
+// platform machine ID (machineid.ProtectedID), not the raw machine ID, so the
+// cache stores nothing more sensitive than what every telemetry event carries;
+// it is still written 0600 like the rest of our per-user state.
+const machineIDCacheName = "machine-id"
+
+// maxMachineIDLen bounds what the cache read will accept. ProtectedID today is
+// a 64-char hex HMAC; the bound is loose so an upstream format change does not
+// silently invalidate every cache, while still refusing to feed a corrupt or
+// swapped-in file into every event's distinct_id.
+const maxMachineIDLen = 128
+
+func machineIDCachePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, dataDirName, machineIDCacheName), nil
+}
+
+// validMachineID accepts a cached or freshly computed ID for (re)use: one
+// non-empty token of printable non-space ASCII, bounded length, and not the
+// literal "invalid" that eventkit.MachineID returns when the platform probe
+// fails — a failed probe must be retried next run, never cached.
+func validMachineID(id string) bool {
+	if id == "" || id == "invalid" || len(id) > maxMachineIDLen {
+		return false
+	}
+	for _, r := range id {
+		if r <= ' ' || r > '~' {
+			return false
+		}
+	}
+	return true
+}
+
+func readCachedMachineID(path string) string {
+	// #nosec G304 -- path is derived from os.UserHomeDir + our fixed cache
+	// name (machineIDCachePath), never from user or repository input.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	id := strings.TrimSpace(string(data))
+	if !validMachineID(id) {
+		return ""
+	}
+	return id
+}
+
+// writeMachineIDCache persists id atomically (temp file + rename) so a
+// concurrent reader can never observe a truncated ID. Failures are ignored:
+// the cache is a pure optimization and the caller already holds a usable ID.
+func writeMachineIDCache(path, id string) {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return
+	}
+	tmp, err := os.CreateTemp(dir, machineIDCacheName+".tmp-*")
+	if err != nil {
+		return
+	}
+	name := tmp.Name()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(name)
+		return
+	}
+	if _, err := tmp.WriteString(id + "\n"); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(name)
+		return
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(name)
+		return
+	}
+	if err := os.Rename(name, path); err != nil {
+		_ = os.Remove(name)
+	}
+}
+
+// cachedMachineID returns the stable distinct ID for this machine, reading the
+// ~/.beads/machine-id cache first and falling back to the (slow) platform
+// probe, whose result it caches for every later invocation. Only called when
+// metrics are enabled — a disabled invocation never pays for an ID at all.
+//
+// The probe itself (computeMachineID, backed by eventkit.MachineID) lives in
+// metrics.go: eventkit imports are depguard-fenced to metrics.go/flusher.go
+// (.golangci.yml dolt-storage-boundary), and this file needs none of it.
+func cachedMachineID(appName string) string {
+	path, err := machineIDCachePath()
+	if err != nil {
+		return computeMachineID(appName)
+	}
+	if id := readCachedMachineID(path); id != "" {
+		return id
+	}
+	id := computeMachineID(appName)
+	if validMachineID(id) {
+		writeMachineIDCache(path, id)
+	}
+	return id
+}

--- a/internal/metrics/machineid_test.go
+++ b/internal/metrics/machineid_test.go
@@ -1,0 +1,170 @@
+package metrics
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestCachedMachineIDReusesCacheWithoutRecomputing seeds the on-disk cache
+// with a sentinel and asserts cachedMachineID returns it verbatim — proving
+// the cached path never reaches the (slow, forking) platform probe, which
+// could not produce the sentinel.
+func TestCachedMachineIDReusesCacheWithoutRecomputing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", home)
+	}
+
+	sentinel := strings.Repeat("ab12", 16) // 64 chars, valid shape
+	dir := filepath.Join(home, ".beads")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, machineIDCacheName), []byte(sentinel+"\n"), 0o600); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+
+	if got := cachedMachineID(AppName); got != sentinel {
+		t.Errorf("cachedMachineID = %q, want cached sentinel %q", got, sentinel)
+	}
+}
+
+// TestCachedMachineIDComputesAndPersistsOnMiss exercises the cold path: no
+// cache file, so the ID is computed once and written to ~/.beads/machine-id
+// (0600) for every later invocation to reuse.
+func TestCachedMachineIDComputesAndPersistsOnMiss(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", home)
+	}
+
+	first := cachedMachineID(AppName)
+	if first == "" {
+		t.Fatalf("cachedMachineID returned empty ID")
+	}
+
+	path := filepath.Join(home, ".beads", machineIDCacheName)
+	if !validMachineID(first) {
+		// The platform probe failed (returns "invalid" in sandboxed CI);
+		// a failure must NOT be cached, so the next run retries.
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("invalid probe result was cached at %s (stat err=%v)", path, err)
+		}
+		return
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("cache not written: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != first {
+		t.Errorf("cache content = %q, want %q", got, first)
+	}
+	if runtime.GOOS != "windows" {
+		fi, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat cache: %v", err)
+		}
+		if perm := fi.Mode().Perm(); perm != 0o600 {
+			t.Errorf("cache perms = %o, want 0600", perm)
+		}
+	}
+
+	// Second call returns the identical ID (now from cache).
+	if second := cachedMachineID(AppName); second != first {
+		t.Errorf("second cachedMachineID = %q, want %q", second, first)
+	}
+}
+
+// TestReadCachedMachineIDRejectsGarbage: a corrupt, oversized, multi-token, or
+// probe-failure ("invalid") cache must read as a miss so the ID is recomputed,
+// never fed into every event's distinct_id.
+func TestReadCachedMachineIDRejectsGarbage(t *testing.T) {
+	dir := t.TempDir()
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{name: "empty", content: ""},
+		{name: "whitespace-only", content: " \n\t\n"},
+		{name: "probe-failure-marker", content: "invalid\n"},
+		{name: "embedded-space", content: "abc def\n"},
+		{name: "multi-line", content: "abc123\nxyz789\n"},
+		{name: "control-chars", content: "abc\x01def\n"},
+		{name: "non-ascii", content: "abcédef\n"},
+		{name: "oversized", content: strings.Repeat("a", maxMachineIDLen+1) + "\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(dir, "cache-"+tc.name)
+			if err := os.WriteFile(path, []byte(tc.content), 0o600); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			if got := readCachedMachineID(path); got != "" {
+				t.Errorf("readCachedMachineID(%q content=%q) = %q, want miss", tc.name, tc.content, got)
+			}
+		})
+	}
+
+	// Positive control: a well-formed single-token cache is accepted, with
+	// surrounding whitespace trimmed.
+	path := filepath.Join(dir, "cache-good")
+	if err := os.WriteFile(path, []byte("  deadbeef42\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if got := readCachedMachineID(path); got != "deadbeef42" {
+		t.Errorf("readCachedMachineID(good) = %q, want %q", got, "deadbeef42")
+	}
+}
+
+// TestInitDisabledDoesNotTouchMachineID: a disabled invocation (the
+// BD_DISABLE_METRICS / DO_NOT_TRACK path — and every `bd --version`) must not
+// compute, read, or write a machine ID at all. The observable half of that
+// contract is that no cache file appears.
+func TestInitDisabledDoesNotTouchMachineID(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", home)
+	}
+
+	if _, err := Init("0.0.0-test", false, ""); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	path := filepath.Join(home, ".beads", machineIDCacheName)
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("disabled Init created machine-id cache at %s (stat err=%v)", path, err)
+	}
+}
+
+// TestWriteMachineIDCacheAtomicReplace: writing over an existing cache goes
+// through temp-file + rename, so no reader can observe a truncated ID and no
+// tmp litter survives.
+func TestWriteMachineIDCacheAtomicReplace(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, machineIDCacheName)
+	if err := os.WriteFile(path, []byte("oldvalue\n"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	writeMachineIDCache(path, "newvalue")
+
+	if got := readCachedMachineID(path); got != "newvalue" {
+		t.Errorf("after replace, cache = %q, want %q", got, "newvalue")
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp-") {
+			t.Errorf("temp file litter left behind: %s", e.Name())
+		}
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -19,6 +19,12 @@ const (
 	EnvDoNotTrack        = "DO_NOT_TRACK"
 
 	DefaultEndpoint = "https://gastownhall-eventsapi.com/mp/collect"
+
+	// queuedEventExt is the extension the eventkit FileEmitter gives queued
+	// event batches in DataDir. Re-exported here (this file holds the fenced
+	// eventkit import — see computeMachineID) so spawn.go's pending-events
+	// check can recognize them.
+	queuedEventExt = eventkit.DefaultFileExt
 )
 
 var (

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -50,6 +50,11 @@ func Init(version string, enable bool, metricsEndpoint string) (func(context.Con
 	}
 
 	var emitter eventkit.Emitter = eventkit.NullEmitter{}
+	// The distinct ID is resolved only on the enabled path: computing it can
+	// fork a platform probe (see cachedMachineID), and a disabled collector
+	// never emits an event that would carry it. The placeholder below is inert
+	// — NullEmitter drops everything and WithDisabled gates emission anyway.
+	distinctID := "disabled"
 	if enabled {
 		dir, err := DataDir()
 		if err != nil {
@@ -60,10 +65,11 @@ func Init(version string, enable bool, metricsEndpoint string) (func(context.Con
 			return func(context.Context) {}, fmt.Errorf("metrics: file emitter: %w", err)
 		}
 		emitter = fe
+		distinctID = cachedMachineID(AppName)
 	}
 
 	c := eventkit.NewCollector(emitter,
-		eventkit.WithDistinctID(eventkit.MachineID(AppName)),
+		eventkit.WithDistinctID(distinctID),
 		eventkit.WithAppName(AppName),
 		eventkit.WithAppVersion(version),
 		eventkit.WithDisabled(func() bool { return !enabled }),
@@ -77,6 +83,14 @@ func Init(version string, enable bool, metricsEndpoint string) (func(context.Con
 
 func Global() *eventkit.Collector {
 	return eventkit.Global()
+}
+
+// computeMachineID is the raw (slow) platform machine-id probe. It lives here
+// rather than in machineid.go because eventkit imports are depguard-fenced to
+// this file and flusher.go (.golangci.yml dolt-storage-boundary). Callers want
+// cachedMachineID, which pays this cost at most once per machine.
+func computeMachineID(appName string) string {
+	return eventkit.MachineID(appName)
 }
 
 // closeFlushTimeout bounds how long CloseAndFlush waits for the collector to

--- a/internal/metrics/spawn.go
+++ b/internal/metrics/spawn.go
@@ -3,7 +3,9 @@ package metrics
 import (
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
+	"time"
 )
 
 const SendMetricsSubcommand = "send-metrics"
@@ -28,16 +30,85 @@ func inTestMode() bool {
 	return os.Getenv(EnvTestMode) == "1"
 }
 
-// shouldSpawnFlusher is the whole spawn gate, extracted so tests can assert
-// the decision without forking a real detached child.
+// shouldSpawnFlusher is the env/config half of the spawn gate, extracted so
+// tests can assert the decision without forking a real detached child. The
+// stateful half (pending events + throttle) is flusherDue.
 func shouldSpawnFlusher() bool {
 	return os.Getenv(EnvIsFlusher) != "1" && Enabled() && !flushDisabledByEnv() && !inTestMode()
+}
+
+// flushInterval is the minimum spacing between detached send-metrics spawns.
+// Every bd invocation used to spawn one unconditionally — a full re-exec of
+// the ~200MB binary plus an HTTPS POST, measured at 8.5-14.1ms in-band before
+// the child even starts, ~10k spawns/day on a busy machine. Events tolerate
+// batching: nothing downstream needs sub-5-minute telemetry latency, and any
+// backlog uploads in one flush.
+const flushInterval = 5 * time.Minute
+
+// flushMarkerName is the throttle marker inside the eventsData dir. Its mtime
+// records the last spawn ATTEMPT (not success: the parent detaches before the
+// child's outcome is knowable, and attempt-based throttling is what bounds the
+// spawn rate even when uploads keep failing). The eventkit FileFlusher only
+// touches `*.evtq` entries, so the marker is inert to it.
+const flushMarkerName = ".last-flush"
+
+// flusherDue reports whether a detached flush is worth spawning: at least one
+// queued event batch exists, and the last spawn attempt is at least
+// flushInterval old. A marker mtime more than one interval in the future
+// (clock stepped back) reads as due rather than suppressing uploads until the
+// wall clock catches up; smaller negative ages are ordinary timestamp skew
+// (e.g. the caller sampled now just before the marker was written) and stay
+// throttled.
+func flusherDue(dir string, now time.Time) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		// Unreadable/missing queue dir: the emitter never wrote, so there is
+		// nothing a flusher child could upload.
+		return false
+	}
+	pending := false
+	for _, e := range entries {
+		if !e.IsDir() && filepath.Ext(e.Name()) == queuedEventExt {
+			pending = true
+			break
+		}
+	}
+	if !pending {
+		return false
+	}
+	fi, err := os.Stat(filepath.Join(dir, flushMarkerName))
+	if err != nil {
+		return true
+	}
+	age := now.Sub(fi.ModTime())
+	return age >= flushInterval || age <= -flushInterval
+}
+
+// touchFlushMarker stamps the throttle marker with the current time. Failures
+// are ignored: the marker is a rate limiter, and on a filesystem where it
+// cannot be written the worst case is the old always-spawn behavior.
+func touchFlushMarker(dir string) {
+	path := filepath.Join(dir, flushMarkerName)
+	now := time.Now()
+	if err := os.Chtimes(path, now, now); err == nil {
+		return
+	}
+	// Marker doesn't exist yet (or Chtimes failed): (re)create it.
+	_ = os.WriteFile(path, nil, 0o600)
 }
 
 func MaybeSpawnFlusher() {
 	if !shouldSpawnFlusher() {
 		return
 	}
+	dir, err := DataDir()
+	if err != nil {
+		return
+	}
+	if !flusherDue(dir, time.Now()) {
+		return
+	}
+	touchFlushMarker(dir)
 	self, err := os.Executable()
 	if err != nil {
 		return

--- a/internal/metrics/spawn.go
+++ b/internal/metrics/spawn.go
@@ -52,36 +52,58 @@ const flushInterval = 5 * time.Minute
 // touches `*.evtq` entries, so the marker is inert to it.
 const flushMarkerName = ".last-flush"
 
-// flusherDue reports whether a detached flush is worth spawning: at least one
-// queued event batch exists, and the last spawn attempt is at least
-// flushInterval old. A marker mtime more than one interval in the future
-// (clock stepped back) reads as due rather than suppressing uploads until the
-// wall clock catches up; smaller negative ages are ordinary timestamp skew
-// (e.g. the caller sampled now just before the marker was written) and stay
-// throttled.
+// flusherDue reports whether a detached flush is worth spawning: the last
+// spawn attempt is at least flushInterval old, and at least one queued event
+// batch exists. The marker stat runs FIRST so the throttled path — the common
+// case, every invocation inside the interval — costs one stat and never scans
+// the queue: when uploads keep failing the queue backs up without bound
+// (148k entries / 1.1GB observed on one dev machine), and a scan of a
+// directory that size costs ~250ms. A marker mtime more than one interval in
+// the future (clock stepped back) reads as due rather than suppressing
+// uploads until the wall clock catches up; smaller negative ages are ordinary
+// timestamp skew (e.g. the caller sampled now just before the marker was
+// written) and stay throttled.
 func flusherDue(dir string, now time.Time) bool {
-	entries, err := os.ReadDir(dir)
+	if fi, err := os.Stat(filepath.Join(dir, flushMarkerName)); err == nil {
+		age := now.Sub(fi.ModTime())
+		if age < flushInterval && age > -flushInterval {
+			return false
+		}
+	}
+	return scanQueue(dir)
+}
+
+// scanQueue is hasQueuedEvents behind a seam so tests can assert the
+// throttled path never reaches the scan — the perf property the marker-first
+// ordering exists for.
+var scanQueue = hasQueuedEvents
+
+// hasQueuedEvents reports whether dir holds at least one queued event batch.
+// It reads the directory in small unsorted chunks and returns at the first
+// match, instead of os.ReadDir, which reads and sorts EVERY entry before the
+// caller sees one — on a backed-up queue that is the whole cost flusherDue
+// exists to avoid paying per invocation.
+func hasQueuedEvents(dir string) bool {
+	f, err := os.Open(dir) // #nosec G304 -- dir is the metrics DataDir, not user input
 	if err != nil {
 		// Unreadable/missing queue dir: the emitter never wrote, so there is
 		// nothing a flusher child could upload.
 		return false
 	}
-	pending := false
-	for _, e := range entries {
-		if !e.IsDir() && filepath.Ext(e.Name()) == queuedEventExt {
-			pending = true
-			break
+	defer f.Close()
+	for {
+		entries, err := f.ReadDir(64)
+		for _, e := range entries {
+			if !e.IsDir() && filepath.Ext(e.Name()) == queuedEventExt {
+				return true
+			}
+		}
+		if err != nil {
+			// io.EOF (scanned everything) or a read error mid-listing: either
+			// way no queued batch was seen.
+			return false
 		}
 	}
-	if !pending {
-		return false
-	}
-	fi, err := os.Stat(filepath.Join(dir, flushMarkerName))
-	if err != nil {
-		return true
-	}
-	age := now.Sub(fi.ModTime())
-	return age >= flushInterval || age <= -flushInterval
 }
 
 // touchFlushMarker stamps the throttle marker with the current time. Failures

--- a/internal/metrics/spawn_throttle_test.go
+++ b/internal/metrics/spawn_throttle_test.go
@@ -1,0 +1,141 @@
+package metrics
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// The stateful half of the spawn gate (bd-p6o3y): a detached send-metrics
+// child is a full re-exec of the bd binary plus an HTTPS POST, so it must only
+// spawn when there is something to upload AND the last attempt is at least
+// flushInterval old. These tests drive flusherDue/touchFlushMarker directly —
+// calling MaybeSpawnFlusher with every env gate open would fork the test
+// binary as a detached child on regression, which is exactly the failure mode
+// the extracted decisions exist to keep out of `go test`.
+
+func writeQueuedEvent(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "batch1"+queuedEventExt), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write event file: %v", err)
+	}
+}
+
+func TestFlusherDueRequiresPendingEvents(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+
+	if flusherDue(dir, now) {
+		t.Errorf("flusherDue(empty dir) = true, want false")
+	}
+
+	// Non-event litter (the eventkit lock file, our own marker, a stray dir)
+	// must not count as pending work.
+	if err := os.WriteFile(filepath.Join(dir, "eventkit.lock"), nil, 0o600); err != nil {
+		t.Fatalf("write lock: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "sub.evtq"), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// A directory whose name ends in the event extension is still a directory.
+	if flusherDue(dir, now) {
+		t.Errorf("flusherDue(litter only) = true, want false")
+	}
+
+	writeQueuedEvent(t, dir)
+	if !flusherDue(dir, now) {
+		t.Errorf("flusherDue(queued event, no marker) = false, want true")
+	}
+}
+
+func TestFlusherDueMissingDirIsNotDue(t *testing.T) {
+	if flusherDue(filepath.Join(t.TempDir(), "never-created"), time.Now()) {
+		t.Errorf("flusherDue(missing dir) = true, want false")
+	}
+}
+
+func TestFlusherDueThrottlesByMarkerAge(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	writeQueuedEvent(t, dir)
+	marker := filepath.Join(dir, flushMarkerName)
+
+	// Fresh marker: throttled.
+	touchFlushMarker(dir)
+	if flusherDue(dir, now) {
+		t.Errorf("flusherDue(fresh marker) = true, want false")
+	}
+
+	// Marker just under the interval: still throttled.
+	almost := now.Add(-flushInterval + time.Second)
+	if err := os.Chtimes(marker, almost, almost); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	if flusherDue(dir, now) {
+		t.Errorf("flusherDue(marker %v old) = true, want false", flushInterval-time.Second)
+	}
+
+	// Marker past the interval: due again.
+	old := now.Add(-flushInterval - time.Second)
+	if err := os.Chtimes(marker, old, old); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	if !flusherDue(dir, now) {
+		t.Errorf("flusherDue(marker %v old) = false, want true", flushInterval+time.Second)
+	}
+
+	// Marker mtime slightly in the future (ordinary timestamp skew — e.g.
+	// now was sampled just before the marker write): still throttled.
+	nearFuture := now.Add(time.Second)
+	if err := os.Chtimes(marker, nearFuture, nearFuture); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	if flusherDue(dir, now) {
+		t.Errorf("flusherDue(marker slightly in future) = true, want false")
+	}
+
+	// Marker mtime far in the future (clock stepped back): due, not
+	// suppressed until the wall clock catches up.
+	future := now.Add(time.Hour)
+	if err := os.Chtimes(marker, future, future); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	if !flusherDue(dir, now) {
+		t.Errorf("flusherDue(marker far in future) = false, want true")
+	}
+}
+
+func TestTouchFlushMarkerCreatesThenBumps(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, flushMarkerName)
+
+	touchFlushMarker(dir)
+	fi, err := os.Stat(marker)
+	if err != nil {
+		t.Fatalf("marker not created: %v", err)
+	}
+
+	// Age the marker, touch again, and the mtime must come back to ~now.
+	old := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(marker, old, old); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	touchFlushMarker(dir)
+	fi, err = os.Stat(marker)
+	if err != nil {
+		t.Fatalf("stat after touch: %v", err)
+	}
+	if age := time.Since(fi.ModTime()); age > time.Minute {
+		t.Errorf("marker mtime not bumped: %v old", age)
+	}
+}
+
+// TestFlusherMarkerInertToFileFlusher pins the layout assumption the marker
+// relies on: it does not carry the queued-event extension, so the eventkit
+// FileFlusher's `*.evtq` scan can never try to parse or delete it.
+func TestFlusherMarkerInertToFileFlusher(t *testing.T) {
+	if filepath.Ext(flushMarkerName) == queuedEventExt {
+		t.Fatalf("flushMarkerName %q must not use the queued-event extension %q", flushMarkerName, queuedEventExt)
+	}
+}

--- a/internal/metrics/spawn_throttle_test.go
+++ b/internal/metrics/spawn_throttle_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -17,7 +18,12 @@ import (
 
 func writeQueuedEvent(t *testing.T, dir string) {
 	t.Helper()
-	if err := os.WriteFile(filepath.Join(dir, "batch1"+queuedEventExt), []byte("x"), 0o600); err != nil {
+	writeQueuedEventNamed(t, dir, "batch1")
+}
+
+func writeQueuedEventNamed(t *testing.T, dir, stem string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, stem+queuedEventExt), []byte("x"), 0o600); err != nil {
 		t.Fatalf("write event file: %v", err)
 	}
 }
@@ -103,6 +109,52 @@ func TestFlusherDueThrottlesByMarkerAge(t *testing.T) {
 	}
 	if !flusherDue(dir, now) {
 		t.Errorf("flusherDue(marker far in future) = false, want true")
+	}
+}
+
+// TestHasQueuedEventsAcrossChunks pins the chunked directory scan: a queued
+// batch sitting past the first ReadDir(64) chunk must still be found, and a
+// large all-litter directory must come back empty rather than false-positive.
+func TestHasQueuedEventsAcrossChunks(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < 200; i++ {
+		if err := os.WriteFile(filepath.Join(dir, fmt.Sprintf("litter-%03d.tmp", i)), nil, 0o600); err != nil {
+			t.Fatalf("write litter: %v", err)
+		}
+	}
+	if hasQueuedEvents(dir) {
+		t.Errorf("hasQueuedEvents(200 litter files) = true, want false")
+	}
+	// The all-litter pass above is the deterministic pin on the loop: 200
+	// entries force at least four 64-entry chunks plus the io.EOF exit. The
+	// found-a-match pass is chunk-position-deterministic only where directory
+	// enumeration is sorted (e.g. NTFS, which CI exercises); elsewhere the
+	// batch may surface in any chunk, and the assertion is just "found".
+	writeQueuedEventNamed(t, dir, "zz-last")
+	if !hasQueuedEvents(dir) {
+		t.Errorf("hasQueuedEvents(batch among 200 litter files) = false, want true")
+	}
+}
+
+// TestFlusherDueFreshMarkerSkipsQueueScan pins the evaluation order: inside
+// the throttle interval the queue must not be scanned at all — the property
+// that keeps a backed-up queue (148k entries observed) from taxing every bd
+// invocation. The scanQueue seam is stubbed so any scan attempt fails the
+// test outright.
+func TestFlusherDueFreshMarkerSkipsQueueScan(t *testing.T) {
+	dir := t.TempDir()
+	writeQueuedEvent(t, dir)
+	touchFlushMarker(dir)
+
+	orig := scanQueue
+	scanQueue = func(string) bool {
+		t.Error("flusherDue scanned the queue despite a fresh marker")
+		return true
+	}
+	defer func() { scanQueue = orig }()
+
+	if flusherDue(dir, time.Now()) {
+		t.Errorf("flusherDue(fresh marker, queued events) = true, want false")
 	}
 }
 


### PR DESCRIPTION
## What

Two measured per-invocation telemetry costs from the post-wave startup audit (rig beads bd-rzweb, bd-p6o3y under the bd-7x3ov audit program), fixed as one PR because they share the small `internal/metrics` package and one review context. One commit per finding.

**1. Machine-ID probe forked every invocation (bd-rzweb, commit 1).** `metrics.Init` eagerly computed `eventkit.MachineID` — `denisbrodbeck/machineid` forks `ioreg -rd1 -c IOPlatformExpertDevice` on macOS, measured 20.2±1.2ms — on **every** bd command, even with `BD_DISABLE_METRICS=1` and even for `bd --version` (the enabled gate only selected the emitter). Now:
- Disabled path never touches a machine ID at all (inert `"disabled"` placeholder behind `NullEmitter` + `WithDisabled`).
- Enabled path reads `~/.beads/machine-id` (0600, atomic temp+rename write) and falls back to the probe **at most once per machine**, caching the result. eventkit's probe-failure sentinel (`"invalid"`) is never cached; a corrupt/oversized/multi-token cache reads as a miss and is recomputed.
- The `eventkit` import stays fenced: the probe lives in `metrics.go` behind `computeMachineID`, so the `.golangci.yml` depguard `dolt-storage-boundary` file list is unchanged.
- Privacy note: the cached value is the app-scoped HMAC (`machineid.ProtectedID`), not the raw machine ID — the same value every event already carries.

**2. Unconditional detached flusher spawn (bd-p6o3y, commit 2).** `CloseAndFlush` always called `MaybeSpawnFlusher` — a detached re-exec of the full ~200MB binary as `bd send-metrics` (which re-ran init, including a second ioreg before commit 1) plus an HTTPS POST, 8.5–14.1ms in-band, no queue-empty check, no throttle. At this machine's 45-clone constellation scale that's ~10k daily full-binary re-execs + POSTs. Now the spawn requires:
- at least one queued `*.evtq` batch in `eventsData/`, AND
- the last spawn **attempt** ≥5 minutes old (marker `eventsData/.last-flush`, mtime-based; attempt-based so the rate stays bounded even when uploads keep failing; skew tolerance: a marker more than one interval in the future — clock stepped back — reads as due).

The marker has no `.evtq` extension, so the eventkit `FileFlusher` scan ignores it (pinned by test). Queued events still upload — batched, worst case one interval plus one bd invocation late. All existing env/config gates (`BD_IS_FLUSHER`, `BD_DISABLE_METRICS`, `BD_DISABLE_EVENT_FLUSH`, `BEADS_TEST_MODE`) are unchanged and checked first.

## What is deliberately unchanged

Telemetry content, opt-out semantics, endpoint resolution and the sanctioned-endpoint pinning of the child env (`flusherChildEnv`), the no-recursion guard, and the send-metrics child itself.

## Tests

- `machineid_test.go`: cache reuse without recompute (sentinel), cold-path compute+persist with 0600 perms, garbage/probe-failure rejection table, disabled-Init-writes-nothing, atomic replace leaves no tmp litter.
- `spawn_throttle_test.go`: pending-events requirement (lock file / marker / `sub.evtq` directory don't count), missing dir, marker age ladder (fresh / just-under / past-interval / slight-future skew / far-future clock-step), touch-creates-then-bumps, marker-inert-to-FileFlusher pin.
- Full `internal/metrics` package green; `make ci-pr-core` run locally.

CHANGELOG entry included under Unreleased → Fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)