### PR TITLE
fix(list): stop bd list --ready asserting an in-progress count its own filter forced to zero

### DIFF
--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -314,7 +314,7 @@ func runListCore(cmd *cobra.Command, _ []string) error {
 				return HandleError("loading dependencies for --deps: %v", depErr)
 			}
 			// Hierarchical --parent walks use an unlimited per-level query, so the tree is never page-truncated.
-			displayPrettyListWithDepsMode(treeIssues, false, allDeps, in.depsMode, false)
+			displayPrettyListWithDepsMode(treeIssues, false, allDeps, in.depsMode, false, in.ReadyFlag)
 			printSkipLabelsFooter(in.SkipLabels)
 			return nil
 		}
@@ -323,7 +323,7 @@ func runListCore(cmd *cobra.Command, _ []string) error {
 		if depErr != nil && in.depsMode != "" {
 			return HandleError("loading dependencies for --deps: %v", depErr)
 		}
-		displayPrettyListWithDepsMode(issues, false, allDeps, in.depsMode, truncated)
+		displayPrettyListWithDepsMode(issues, false, allDeps, in.depsMode, truncated, in.ReadyFlag)
 		printTruncationHint(truncated, in.effectiveLimit)
 		printSkipLabelsFooter(in.SkipLabels)
 		return nil

--- a/cmd/bd/list_footer_counts_test.go
+++ b/cmd/bd/list_footer_counts_test.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// A count printed next to a noun is read as a fact about the database, not as a
+// property of whatever subset happened to survive the filters. When the two
+// diverge the message is worse than silence: "0 in progress" answers "is
+// anything in progress?" with a confident no, and the reader has no way to tell
+// that the rows which would have said otherwise were removed before counting.
+//
+// These tests are the general guard on that class. Every integer a summary line
+// asserts must be justified by the fixture it was rendered from — so a future
+// edit that introduces a new number has to declare what the number means, or
+// fail here.
+
+// footerFacts are the quantities a summary line is allowed to state, keyed by
+// what they mean. assertEveryNumberIsJustified fails on any number in the line
+// that is not one of these values, which is what forces a new number to be
+// declared rather than smuggled in.
+type footerFacts map[string]int
+
+// assertEveryNumberIsJustified checks that each integer appearing in line is
+// explained by facts. It deliberately does NOT check that every fact appears:
+// omitting a count is fine (that is the fix in this very file), asserting an
+// unexplained one is not.
+func assertEveryNumberIsJustified(t *testing.T, line string, facts footerFacts) {
+	t.Helper()
+	allowed := map[int][]string{}
+	for name, v := range facts {
+		allowed[v] = append(allowed[v], name)
+	}
+	for _, tok := range regexp.MustCompile(`\d+`).FindAllString(line, -1) {
+		n, err := strconv.Atoi(tok)
+		if err != nil {
+			t.Fatalf("unparseable integer %q in summary %q", tok, line)
+		}
+		if _, ok := allowed[n]; !ok {
+			t.Errorf("summary asserts the number %d, which no fact about the data explains.\n  summary: %q\n  known facts: %v\n"+
+				"If this number is legitimate, add it to footerFacts so it is checked; if it is a count of something the query filtered out, it should not be asserted at all.",
+				n, line, facts)
+		}
+	}
+}
+
+// The scenarios below are the cross-product that matters: whether the page was
+// cut by --limit, and whether --ready pinned the query to open issues.
+func TestListFooterLineCountsAreJustified(t *testing.T) {
+	tests := []struct {
+		name                     string
+		total, open, inProgress  int
+		truncated, readyFiltered bool
+		facts                    footerFacts
+	}{
+		{
+			name: "mixed statuses, whole result set",
+			// A plain listing may state the breakdown: the query could have
+			// returned any status, so each count is a real finding.
+			total: 9, open: 6, inProgress: 3,
+			facts: footerFacts{"total": 9, "open": 6, "in_progress": 3},
+		},
+		{
+			name:  "mixed statuses, page cut by --limit",
+			total: 2, open: 1, inProgress: 1, truncated: true,
+			facts: footerFacts{"total": 2, "open": 1, "in_progress": 1, "limit-hint": 0},
+		},
+		{
+			// The regression this file exists for. --ready pins the filter to
+			// open, so inProgress is 0 by construction for ANY database. The
+			// summary must not assert it.
+			name:  "ready-filtered, whole result set",
+			total: 6, open: 6, inProgress: 0, readyFiltered: true,
+			facts: footerFacts{"total": 6},
+		},
+		{
+			name:  "ready-filtered and truncated",
+			total: 5, open: 5, inProgress: 0, readyFiltered: true, truncated: true,
+			facts: footerFacts{"total": 5, "limit-hint": 0},
+		},
+		{
+			name:  "empty result set",
+			total: 0, open: 0, inProgress: 0,
+			facts: footerFacts{"total": 0, "open": 0, "in_progress": 0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			line := listFooterLine(tt.total, tt.open, tt.inProgress, tt.truncated, tt.readyFiltered)
+			assertEveryNumberIsJustified(t, line, tt.facts)
+
+			// The headline count always describes the rows actually rendered.
+			if !strings.Contains(line, fmt.Sprintf("%d", tt.total)) {
+				t.Errorf("summary %q omits the rendered row count %d", line, tt.total)
+			}
+		})
+	}
+}
+
+// The specific claim: under --ready the summary must not report an in-progress
+// count, because the filter guarantees it is zero regardless of the data. A
+// reader cannot distinguish "none exist" from "none survived the filter".
+func TestListFooterLineReadyOmitsVacuousInProgressCount(t *testing.T) {
+	// 40 in-progress issues match the same query; --ready removed them all.
+	line := listFooterLine(6, 6, 0, false, true)
+
+	if strings.Contains(line, "in progress)") {
+		t.Errorf("--ready summary asserts an in-progress count that the filter forced to zero: %q", line)
+	}
+	if !strings.Contains(line, "excludes in_progress") {
+		t.Errorf("--ready summary must disclose what it filtered, got: %q", line)
+	}
+	if strings.Contains(line, "0") {
+		t.Errorf("--ready summary states a zero the data does not support: %q", line)
+	}
+}
+
+// Without --ready the breakdown is a genuine finding and must survive: this is
+// the half of the behaviour the fix must not regress.
+func TestListFooterLineUnfilteredKeepsBreakdown(t *testing.T) {
+	line := listFooterLine(9, 6, 3, false, false)
+	for _, want := range []string{"Total: 9 issues", "6 open", "3 in progress"} {
+		if !strings.Contains(line, want) {
+			t.Errorf("unfiltered summary lost %q, got: %q", want, line)
+		}
+	}
+}
+
+// Truncation and readiness are independent scopes and both must be disclosed
+// when both apply — neither may silently mask the other.
+func TestListFooterLineTruncationDisclosedAlongsideReady(t *testing.T) {
+	line := listFooterLine(5, 5, 0, true, true)
+	if !strings.Contains(line, "truncated by --limit") {
+		t.Errorf("truncated page must say so even under --ready, got: %q", line)
+	}
+	if !strings.Contains(line, "excludes in_progress") {
+		t.Errorf("--ready must still disclose its filter when truncated, got: %q", line)
+	}
+	if strings.Contains(line, "Total:") {
+		t.Errorf("a truncated page must never be labelled Total: %q", line)
+	}
+}

--- a/cmd/bd/list_footer_counts_test.go
+++ b/cmd/bd/list_footer_counts_test.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
 )
 
 // A count printed next to a noun is read as a fact about the database, not as a
@@ -128,6 +131,70 @@ func TestListFooterLineUnfilteredKeepsBreakdown(t *testing.T) {
 		if !strings.Contains(line, want) {
 			t.Errorf("unfiltered summary lost %q, got: %q", want, line)
 		}
+	}
+}
+
+// The footer is correct as a pure function only if every renderer actually
+// tells it that --ready is in force. The display wrappers are where that can be
+// lost: they take readyFiltered as a parameter, and a caller that omits it (or
+// a wrapper that defaults it) silently restores the vacuous count with
+// listFooterLine itself still passing every test above.
+//
+// These two tests pin the wrappers the --watch paths display through — the
+// surface where a stale "0 in progress" is most likely to be read as a live
+// fact, because it is re-rendered every two seconds under a heading that says
+// the data is current.
+//
+// bd list --ready --watch (direct) → displayWatchedIssueList.
+func TestDisplayWatchedIssueListReadyFooterDisclosesFilter(t *testing.T) {
+	// Open by construction: --ready pinned the query, so these are all the
+	// rows any database could return here.
+	issues := []*types.Issue{
+		{ID: "bd-1", Title: "A", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeTask},
+		{ID: "bd-2", Title: "B", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+	}
+	// A nil store is the no-dependency-data arm the function already guards
+	// for; the footer is what is under test, and this keeps the file free of
+	// the cgo-tagged stub so it still compiles under CGO_ENABLED=0.
+	out := captureStdout(t, func() error {
+		displayWatchedIssueList(context.Background(), nil, issues, false, true)
+		return nil
+	})
+
+	if strings.Contains(out, "in progress)") {
+		t.Errorf("--ready --watch summary asserts an in-progress count its own filter forced to zero: %q", out)
+	}
+	if !strings.Contains(out, "excludes in_progress") {
+		t.Errorf("--ready --watch summary must disclose what it filtered, got: %q", out)
+	}
+}
+
+// bd list --ready --watch (proxied) displays through displayPrettyListWithDeps
+// directly, so the parameter has to survive that wrapper too.
+func TestDisplayPrettyListWithDepsReadyFooterDisclosesFilter(t *testing.T) {
+	issues := []*types.Issue{
+		{ID: "bd-1", Title: "A", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeTask},
+	}
+
+	out := captureStdout(t, func() error {
+		displayPrettyListWithDeps(issues, false, nil, false, true)
+		return nil
+	})
+	if strings.Contains(out, "in progress)") {
+		t.Errorf("proxied --ready --watch summary asserts a filtered-out count: %q", out)
+	}
+	if !strings.Contains(out, "excludes in_progress") {
+		t.Errorf("proxied --ready --watch summary must disclose its filter, got: %q", out)
+	}
+
+	// The other half: without --ready the same wrapper must keep the breakdown,
+	// so the fix cannot be "never print counts".
+	plain := captureStdout(t, func() error {
+		displayPrettyListWithDeps(issues, false, nil, false, false)
+		return nil
+	})
+	if !strings.Contains(plain, "in progress)") {
+		t.Errorf("unfiltered listing lost its status breakdown: %q", plain)
 	}
 }
 

--- a/cmd/bd/list_helpers_test.go
+++ b/cmd/bd/list_helpers_test.go
@@ -343,7 +343,7 @@ func TestDisplayWatchedIssueList_UsesDependencyHierarchy(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() error {
-		displayWatchedIssueList(context.Background(), store, []*types.Issue{child, parent}, false)
+		displayWatchedIssueList(context.Background(), store, []*types.Issue{child, parent}, false, false)
 		return nil
 	})
 

--- a/cmd/bd/list_helpers_test.go
+++ b/cmd/bd/list_helpers_test.go
@@ -317,7 +317,7 @@ func TestListDisplayPrettyList_TruncatedSummary(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() error {
-		displayPrettyListWithDepsMode(issues, false, nil, "", true)
+		displayPrettyListWithDepsMode(issues, false, nil, "", true, false)
 		return nil
 	})
 	if !strings.Contains(out, "Showing 2 issues") {

--- a/cmd/bd/list_proxied_server.go
+++ b/cmd/bd/list_proxied_server.go
@@ -238,7 +238,7 @@ func renderProxiedListText(ctx context.Context, issues []*types.Issue, in listIn
 			printTruncationHint(truncated, in.effectiveLimit)
 			return nil
 		}
-		displayPrettyListWithDepsMode(issues, false, depsByIssueID, in.depsMode, truncated)
+		displayPrettyListWithDepsMode(issues, false, depsByIssueID, in.depsMode, truncated, in.ReadyFlag)
 		printTruncationHint(truncated, in.effectiveLimit)
 		printSkipLabelsFooter(in.SkipLabels)
 		return nil

--- a/cmd/bd/list_proxied_server.go
+++ b/cmd/bd/list_proxied_server.go
@@ -155,7 +155,7 @@ func runListProxiedWatch(_ *cobra.Command, ctx context.Context, in listInput) er
 	if err != nil {
 		return fmt.Errorf("initial query: %w", err)
 	}
-	displayPrettyListWithDeps(issues, true, deps, hasMore)
+	displayPrettyListWithDeps(issues, true, deps, hasMore, in.ReadyFlag)
 	printTruncationHint(hasMore, in.effectiveLimit)
 	lastSnapshot := issueSnapshot(issues)
 
@@ -182,7 +182,7 @@ func runListProxiedWatch(_ *cobra.Command, ctx context.Context, in listInput) er
 			snap := issueSnapshot(issues)
 			if snap != lastSnapshot {
 				lastSnapshot = snap
-				displayPrettyListWithDeps(issues, true, deps, hasMore)
+				displayPrettyListWithDeps(issues, true, deps, hasMore, in.ReadyFlag)
 				printTruncationHint(hasMore, in.effectiveLimit)
 				fmt.Fprintf(os.Stderr, "\nWatching for changes... (Press Ctrl+C to exit)\n")
 			}

--- a/cmd/bd/list_show_filter_modes.go
+++ b/cmd/bd/list_show_filter_modes.go
@@ -152,7 +152,11 @@ func loadWatchedIssues(ctx context.Context, store storage.DoltStorage, filter ty
 	return issues, nil
 }
 
-func displayWatchedIssueList(ctx context.Context, store watchListDependencyStore, issues []*types.Issue, truncated bool) {
+// readyFiltered carries watchIssues' own --ready state so the refreshed summary
+// names its scope instead of asserting an in-progress count the ready filter
+// forced to zero. A watch loop is where a stale "0 in progress" is most likely
+// to be read as a live fact, so this is the path that most needs it.
+func displayWatchedIssueList(ctx context.Context, store watchListDependencyStore, issues []*types.Issue, truncated, readyFiltered bool) {
 	var allDeps map[string][]*types.Dependency
 	if store != nil {
 		deps, err := store.GetAllDependencyRecords(ctx)
@@ -160,7 +164,7 @@ func displayWatchedIssueList(ctx context.Context, store watchListDependencyStore
 			allDeps = deps
 		}
 	}
-	displayPrettyListWithDeps(issues, true, allDeps, truncated)
+	displayPrettyListWithDeps(issues, true, allDeps, truncated, readyFiltered)
 }
 
 // watchIssues returns an error only for the initial query — a failure there
@@ -180,7 +184,7 @@ func watchIssues(ctx context.Context, store storage.DoltStorage, filter types.Is
 	// below depends on; what is left is the cut and its verdict, and those are
 	// the shared epilogue's on every other listing this command has.
 	issues, truncated := workapi.FinishPage(issues, "", false, effectiveLimit, false)
-	displayWatchedIssueList(ctx, store, issues, truncated)
+	displayWatchedIssueList(ctx, store, issues, truncated, ready)
 	printTruncationHint(truncated, effectiveLimit)
 	lastSnapshot := issueSnapshot(issues)
 
@@ -210,7 +214,7 @@ func watchIssues(ctx context.Context, store storage.DoltStorage, filter types.Is
 			snap := issueSnapshot(issues)
 			if snap != lastSnapshot {
 				lastSnapshot = snap
-				displayWatchedIssueList(ctx, store, issues, truncated)
+				displayWatchedIssueList(ctx, store, issues, truncated, ready)
 				printTruncationHint(truncated, effectiveLimit)
 				fmt.Fprintf(os.Stderr, "\nWatching for changes... (Press Ctrl+C to exit)\n")
 			}

--- a/cmd/bd/list_show_filter_modes.go
+++ b/cmd/bd/list_show_filter_modes.go
@@ -252,7 +252,7 @@ func runListProxiedHierarchicalParent(ctx context.Context, uw uow.UnitOfWork, in
 	}
 
 	// Hierarchical --parent walks use an unlimited per-level query; never page-truncated.
-	displayPrettyListWithDepsMode(treeIssues, false, depsByIssueID, in.depsMode, false)
+	displayPrettyListWithDepsMode(treeIssues, false, depsByIssueID, in.depsMode, false, in.ReadyFlag)
 	printSkipLabelsFooter(in.SkipLabels)
 	return nil
 }

--- a/cmd/bd/list_tree.go
+++ b/cmd/bd/list_tree.go
@@ -144,13 +144,19 @@ func printPrettyTree(childrenMap map[string][]*types.Issue, parentID string, pre
 
 // displayPrettyList displays issues in pretty tree format (GH#654)
 // Uses buildIssueTree which only supports dotted ID hierarchy
+// There is no --ready arm behind this one: it is the plain tree, so the
+// summary keeps its status breakdown.
 func displayPrettyList(issues []*types.Issue, showHeader bool) {
-	displayPrettyListWithDeps(issues, showHeader, nil, false)
+	displayPrettyListWithDeps(issues, showHeader, nil, false, false)
 }
 
 // displayPrettyListWithDeps displays issues in tree format using dependency data.
-func displayPrettyListWithDeps(issues []*types.Issue, showHeader bool, allDeps map[string][]*types.Dependency, truncated bool) {
-	displayPrettyListWithDepsMode(issues, showHeader, allDeps, "", truncated, false)
+// readyFiltered must be threaded from the caller's --ready state rather than
+// defaulted here: the watch paths reach the summary through this wrapper, and a
+// hardcoded false silently restores the vacuous "(N open, 0 in progress)" that
+// listFooterLine exists to suppress.
+func displayPrettyListWithDeps(issues []*types.Issue, showHeader bool, allDeps map[string][]*types.Dependency, truncated, readyFiltered bool) {
+	displayPrettyListWithDepsMode(issues, showHeader, allDeps, "", truncated, readyFiltered)
 }
 
 // listFooterLine renders the one-line summary under a text listing.

--- a/cmd/bd/list_tree.go
+++ b/cmd/bd/list_tree.go
@@ -150,7 +150,38 @@ func displayPrettyList(issues []*types.Issue, showHeader bool) {
 
 // displayPrettyListWithDeps displays issues in tree format using dependency data.
 func displayPrettyListWithDeps(issues []*types.Issue, showHeader bool, allDeps map[string][]*types.Dependency, truncated bool) {
-	displayPrettyListWithDepsMode(issues, showHeader, allDeps, "", truncated)
+	displayPrettyListWithDepsMode(issues, showHeader, allDeps, "", truncated, false)
+}
+
+// listFooterLine renders the one-line summary under a text listing.
+//
+// The status breakdown is only meaningful when the query could have returned
+// more than one status. Under --ready it cannot: BuildListFilter pins
+// filter.Status to open (internal/workapi/list.go), so every row is open by
+// construction and the breakdown degenerates to a tautology — "(N open, 0 in
+// progress)" is what it prints for ANY database, including one with a thousand
+// in-progress issues matching the same label.
+//
+// Printed next to a real count that number reads as a finding rather than an
+// artifact of the flag: "0 in progress" answers the question "is anything in
+// progress here?" with a confident no, while the rows that would have said
+// otherwise were removed before counting. So when a status filter is in force by
+// construction, say what was excluded instead of asserting a count for it. This
+// is the same principle as the truncation arm below, which refuses to label a
+// cut-off page "Total" (GH#5362): a count is only honest alongside its scope.
+func listFooterLine(total, open, inProgress int, truncated, readyFiltered bool) string {
+	if readyFiltered {
+		// No status breakdown: --ready makes it vacuous. Name the scope instead.
+		if truncated {
+			return fmt.Sprintf("Showing %d ready issues (open only — --ready excludes in_progress); more match (truncated by --limit). Use --limit 0 for all.", total)
+		}
+		return fmt.Sprintf("Ready: %d issues with no active blockers (open only — --ready excludes in_progress)", total)
+	}
+	if truncated {
+		return fmt.Sprintf("Showing %d issues (%d open, %d in progress); more match (truncated by --limit). Use --limit 0 for all.",
+			total, open, inProgress)
+	}
+	return fmt.Sprintf("Total: %d issues (%d open, %d in progress)", total, open, inProgress)
 }
 
 // displayPrettyListWithDepsMode displays issues in tree format. When depsMode is
@@ -158,7 +189,9 @@ func displayPrettyListWithDeps(issues []*types.Issue, showHeader bool, allDeps m
 // orders siblings by their scheduling dependencies (see orderSiblingsByDeps). An
 // empty depsMode is the plain parent-child tree. truncated means the page was cut
 // by --limit; the summary then says "Showing N" instead of "Total: N" (GH#5362).
-func displayPrettyListWithDepsMode(issues []*types.Issue, showHeader bool, allDeps map[string][]*types.Dependency, depsMode string, truncated bool) {
+// readyFiltered means --ready was in force, which pins the query to open issues —
+// see listFooterLine for why the summary must say so.
+func displayPrettyListWithDepsMode(issues []*types.Issue, showHeader bool, allDeps map[string][]*types.Dependency, depsMode string, truncated, readyFiltered bool) {
 	if showHeader {
 		// Clear screen and show header
 		fmt.Print("\033[2J\033[H")
@@ -204,12 +237,7 @@ func displayPrettyListWithDepsMode(issues []*types.Issue, showHeader bool, allDe
 			inProgressCount++
 		}
 	}
-	if truncated {
-		fmt.Printf("Showing %d issues (%d open, %d in progress); more match (truncated by --limit). Use --limit 0 for all.\n",
-			len(issues), openCount, inProgressCount)
-	} else {
-		fmt.Printf("Total: %d issues (%d open, %d in progress)\n", len(issues), openCount, inProgressCount)
-	}
+	fmt.Println(listFooterLine(len(issues), openCount, inProgressCount, truncated, readyFiltered))
 	fmt.Println()
 	fmt.Println("Status: ○ open  ◐ in_progress  ● blocked  ✓ closed  ❄ deferred")
 	fmt.Println("Priority: P0–P4 (label only; not a status icon)")


### PR DESCRIPTION
## The problem

`bd list --ready --label X` prints:

```
Total: 6 issues (6 open, 0 in progress)
```

That `0 in progress` is not a fact about the database. `BuildListFilter` pins the status when `ReadyFlag` is set (`internal/workapi/list.go`):

```go
if in.ReadyFlag {
    s := types.StatusOpen
    filter.Status = &s
}
```

So every row is open by construction and the breakdown is a tautology — the identical line is printed for a database with a thousand in-progress issues matching the same label. Printed next to a real count, it reads as a finding: it answers "is anything in progress here?" with a confident no, while the rows that would have said otherwise were removed before counting. The reader gets no signal that anything was withheld.

This surfaced in real use. A queue of held work was being checked with a ready-scoped listing, and the footer's `0 in progress` was taken as "the queue is empty" while in-progress items sat in it. The count was true of the rendered rows and wrong about the question being asked.

## The change

Under `--ready` the summary names its scope instead of asserting a count it cannot support:

```
Ready: 6 issues with no active blockers (open only — --ready excludes in_progress)
```

Unfiltered listings are untouched and keep the breakdown, which is a genuine finding there:

```
Total: 9 issues (6 open, 3 in progress)
```

This is the same principle as the truncation arm added in GH#5362, which refuses to label a cut-off page `Total:` — a count is only honest alongside its scope. The footer moves into `listFooterLine`, a pure function, so the summary is testable directly rather than through captured stdout.

## Tests

Written as a guard on the bug class rather than on this one string. `assertEveryNumberIsJustified` requires every integer a summary prints to be explained by a declared fact about the fixture; a future edit that introduces an unvalidated number fails.

It catches this bug without being told about `--ready`. With the fix reverted:

```
summary asserts the number 0, which no fact about the data explains.
  summary: "Total: 6 issues (6 open, 0 in progress)"
  known facts: map[total:6]
```

Each new test was verified to fail with the fix reverted, and the existing `TestListDisplayPrettyList_TruncatedSummary` still passes unchanged.

## Verification

Behaviour confirmed against a real database (a copy of a ~1.8 GB working store, not a fixture) using a binary built from this branch:

| command | before | after |
|---|---|---|
| `list --ready --label X` | `Total: 6 issues (6 open, 0 in progress)` | `Ready: 6 issues with no active blockers (open only — --ready excludes in_progress)` |
| `list --label X` | `Total: 9 issues (6 open, 3 in progress)` | unchanged |
| `list --status=in_progress` | `Total: 35 issues (0 open, 35 in progress)` | unchanged |

Gates on the pushed head: `make test` (full, `TEST_TIMEOUT=15m`) and `make ci-pr-core` both green; `check-doc-flags` and `check-doc-freshness` pass; `make ci-pr-lint` gofmt clean, with 5 gosec hits that reproduce identically on an unmodified `main` checkout and none of which are in files this branch touches (`ci-pr-policy`'s first step needs bash 4+ and can't run on this macOS box, so its remaining steps were run individually and pass).

## One open question

`bd list --status=in_progress` prints `(0 open, 35 in progress)` — structurally the same vacuous term, since `--status` also pins the set. I left it alone on the grounds that a user who typed `--status=in_progress` knows what they filtered, whereas `--ready`'s status implication is not visible in the flag name. Happy to generalise `listFooterLine` to suppress any count a status selector forced to zero if you'd prefer the consistency; it's a small change on top of this one, and I'd rather ask than widen the diff uninvited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
