### PR TITLE
fix(metrics): bound the eventsData queue — TTL + drop-oldest caps in the flusher child

### DIFF
--- a/internal/metrics/flusher.go
+++ b/internal/metrics/flusher.go
@@ -27,6 +27,15 @@ func RunSendMetrics() int {
 		return 1
 	}
 
+	// Bound the queue before flushing: TTL out stale batches and orphaned
+	// emitter temps, cap the rest drop-oldest (bd-ulfod: an unbounded queue
+	// reached 149k files / 1.1GB when emission outran the throttled drain).
+	// Out-of-band by construction — this child is already detached.
+	if dropped, freed := PruneQueue(dir, time.Now()); dropped > 0 {
+		fmt.Fprintf(os.Stderr, "send-metrics: pruned %d queued event file(s), freed %.1f MB\n",
+			dropped, float64(freed)/(1<<20))
+	}
+
 	ga, err := ga4tx.New(ga4tx.Config{Endpoint: Endpoint()})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "send-metrics: ga4: %v\n", err)

--- a/internal/metrics/prune.go
+++ b/internal/metrics/prune.go
@@ -1,0 +1,129 @@
+package metrics
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	// pruneTTL is how long a queued event batch may wait before it is dropped
+	// instead of uploaded. Nothing downstream wants week-old telemetry, and a
+	// drain that has fallen a week behind will never catch up by uploading
+	// history first (one file per HTTPS round trip; see bd-ulfod forensics:
+	// 149k files / 1.1GB of sub-48h backlog on one machine).
+	pruneTTL = 7 * 24 * time.Hour
+
+	// maxQueueFiles / maxQueueBytes bound the queue regardless of the
+	// drain-vs-emission race. When emission outruns drain (a shared $HOME can
+	// emit ~2.3 files/s against a throttled drain of ~0.3-0.4/s) the queue
+	// otherwise grows without bound, and every directory scan pays for it.
+	// Oldest batches are dropped first: recent telemetry is the only kind
+	// worth shipping late.
+	maxQueueFiles = 10_000
+	maxQueueBytes = 64 << 20 // 64 MiB
+
+	// writeTempPrefix matches the eventkit FileEmitter's CreateTemp pattern
+	// (".write-*"). An emitter killed between CreateTemp and Rename strands
+	// one forever: no rename will come, and the flusher and the pending-check
+	// both ignore non-.evtq names, so only the prune ever reclaims them.
+	writeTempPrefix = ".write-"
+)
+
+// PruneQueue bounds the queued-event backlog in dir before a flush: event
+// batches (and orphaned emitter temp files) older than pruneTTL are deleted,
+// and the surviving batches are capped at maxQueueFiles / maxQueueBytes by
+// dropping oldest-first. It returns how many files were removed and the bytes
+// freed. It runs only in the detached send-metrics child, so its full
+// directory scan never lands on an interactive bd invocation.
+//
+// The prune deliberately runs OUTSIDE eventkit.lock (Flush's TryLock treats
+// ErrLocked as "another flusher owns the queue" and silently no-ops, so
+// taking the lock here would turn every prune into a skipped flush). The
+// worst lock-free interleaving: a rare second child mid-upload sees a file
+// this prune deleted and its whole Flush aborts on ENOENT — no event is
+// double-sent, the backlog just waits one more spawn interval. ENOENT
+// tolerance in eventkit's flush loop is the upstream fix (gastownhall/beads
+// GH#5649 lane).
+func PruneQueue(dir string, now time.Time) (dropped int, freed int64) {
+	return pruneQueue(dir, now, pruneTTL, maxQueueFiles, maxQueueBytes)
+}
+
+// queueEntry is one prune-eligible file in the queue directory.
+type queueEntry struct {
+	path    string
+	modTime time.Time
+	size    int64
+}
+
+// pruneQueue is PruneQueue with the knobs exposed for tests.
+func pruneQueue(dir string, now time.Time, ttl time.Duration, maxFiles int, maxBytes int64) (dropped int, freed int64) {
+	dirents, err := os.ReadDir(dir)
+	if err != nil {
+		// Missing/unreadable queue dir: nothing to prune.
+		return 0, 0
+	}
+
+	var live []queueEntry // surviving .evtq batches, candidates for the caps
+	var liveBytes int64
+	for _, de := range dirents {
+		if de.IsDir() {
+			continue
+		}
+		name := de.Name()
+		isBatch := filepath.Ext(name) == queuedEventExt
+		isOrphanTemp := strings.HasPrefix(name, writeTempPrefix)
+		if !isBatch && !isOrphanTemp {
+			// Never touch the throttle marker, the flusher lock, or anything
+			// else that is not queue payload.
+			continue
+		}
+		fi, err := de.Info()
+		if err != nil {
+			// Vanished between ReadDir and Info (a concurrent flusher child
+			// uploads-and-deletes): already gone, nothing to do.
+			continue
+		}
+		if now.Sub(fi.ModTime()) > ttl {
+			if remove(filepath.Join(dir, name)) {
+				dropped++
+				freed += fi.Size()
+			}
+			continue
+		}
+		if isBatch {
+			live = append(live, queueEntry{filepath.Join(dir, name), fi.ModTime(), fi.Size()})
+			liveBytes += fi.Size()
+		}
+	}
+
+	if len(live) <= maxFiles && liveBytes <= maxBytes {
+		return dropped, freed
+	}
+	// Drop oldest-first until both caps are satisfied.
+	sort.Slice(live, func(i, j int) bool { return live[i].modTime.Before(live[j].modTime) })
+	remaining, remainingBytes := len(live), liveBytes
+	for _, e := range live {
+		if remaining <= maxFiles && remainingBytes <= maxBytes {
+			break
+		}
+		if remove(e.path) {
+			dropped++
+			freed += e.size
+		}
+		// A lost race (the file was uploaded-and-deleted concurrently) still
+		// shrinks the queue, so it counts against the caps either way.
+		remaining--
+		remainingBytes -= e.size
+	}
+	return dropped, freed
+}
+
+// remove deletes path, treating "already gone" as success-shaped: a concurrent
+// flusher child may upload-and-delete any batch out from under the prune.
+func remove(path string) bool {
+	err := os.Remove(path)
+	return err == nil
+}

--- a/internal/metrics/prune_test.go
+++ b/internal/metrics/prune_test.go
@@ -1,0 +1,165 @@
+package metrics
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeQueueFile creates a file in dir with the given content and mtime.
+func writeQueueFile(t *testing.T, dir, name string, size int, mtime time.Time) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, make([]byte, size), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func names(t *testing.T, dir string) map[string]bool {
+	t.Helper()
+	dirents, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]bool{}
+	for _, de := range dirents {
+		got[de.Name()] = true
+	}
+	return got
+}
+
+func TestPruneTTLDropsStaleBatchesAndOrphanTemps(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	writeQueueFile(t, dir, "old.evtq", 10, now.Add(-8*24*time.Hour))
+	writeQueueFile(t, dir, ".write-orphan", 10, now.Add(-8*24*time.Hour))
+	writeQueueFile(t, dir, "young.evtq", 10, now.Add(-time.Hour))
+	writeQueueFile(t, dir, ".write-live", 10, now.Add(-time.Minute))
+
+	dropped, freed := pruneQueue(dir, now, 7*24*time.Hour, 100, 1<<20)
+	if dropped != 2 || freed != 20 {
+		t.Fatalf("dropped=%d freed=%d, want 2/20", dropped, freed)
+	}
+	got := names(t, dir)
+	if got["old.evtq"] || got[".write-orphan"] {
+		t.Fatalf("stale files survived: %v", got)
+	}
+	if !got["young.evtq"] || !got[".write-live"] {
+		t.Fatalf("young files pruned: %v", got)
+	}
+}
+
+func TestPruneCountCapDropsOldestFirst(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	// 5 young batches, distinct mtimes, oldest = q0.
+	for i := 0; i < 5; i++ {
+		writeQueueFile(t, dir, "q"+string(rune('0'+i))+".evtq", 10,
+			now.Add(-time.Duration(5-i)*time.Minute))
+	}
+	dropped, _ := pruneQueue(dir, now, 7*24*time.Hour, 3, 1<<20)
+	if dropped != 2 {
+		t.Fatalf("dropped=%d, want 2", dropped)
+	}
+	got := names(t, dir)
+	for _, want := range []string{"q2.evtq", "q3.evtq", "q4.evtq"} {
+		if !got[want] {
+			t.Fatalf("newest survivor %s missing: %v", want, got)
+		}
+	}
+	for _, gone := range []string{"q0.evtq", "q1.evtq"} {
+		if got[gone] {
+			t.Fatalf("oldest %s survived: %v", gone, got)
+		}
+	}
+}
+
+func TestPruneByteCapDropsOldestFirst(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	writeQueueFile(t, dir, "a.evtq", 400, now.Add(-3*time.Minute))
+	writeQueueFile(t, dir, "b.evtq", 400, now.Add(-2*time.Minute))
+	writeQueueFile(t, dir, "c.evtq", 400, now.Add(-time.Minute))
+
+	// 1000-byte cap: dropping only "a" (oldest) brings the total to 800.
+	dropped, freed := pruneQueue(dir, now, 7*24*time.Hour, 100, 1000)
+	if dropped != 1 || freed != 400 {
+		t.Fatalf("dropped=%d freed=%d, want 1/400", dropped, freed)
+	}
+	got := names(t, dir)
+	if got["a.evtq"] || !got["b.evtq"] || !got["c.evtq"] {
+		t.Fatalf("wrong survivor set: %v", got)
+	}
+}
+
+func TestPruneNeverTouchesMarkerOrLock(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	ancient := now.Add(-365 * 24 * time.Hour)
+	writeQueueFile(t, dir, ".last-flush", 1, ancient)
+	writeQueueFile(t, dir, "eventkit.lock", 1, ancient)
+	writeQueueFile(t, dir, "unrelated.txt", 1, ancient)
+
+	dropped, _ := pruneQueue(dir, now, 7*24*time.Hour, 0, 0)
+	if dropped != 0 {
+		t.Fatalf("dropped=%d, want 0", dropped)
+	}
+	got := names(t, dir)
+	for _, want := range []string{".last-flush", "eventkit.lock", "unrelated.txt"} {
+		if !got[want] {
+			t.Fatalf("non-queue file %s pruned", want)
+		}
+	}
+}
+
+func TestPruneCapNeverTakesYoungWriteTemps(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	// Young emitter temps: a live emitter may hold one between CreateTemp and
+	// Rename — cap-deleting it would make that Rename fail and lose a live
+	// event. Only TTL (7d) may ever reclaim a .write-* file.
+	writeQueueFile(t, dir, ".write-a", 10, now.Add(-time.Second))
+	writeQueueFile(t, dir, ".write-b", 10, now.Add(-time.Hour))
+	// Enough over-cap batches, all OLDER than the temps, that a buggy
+	// implementation counting temps as cap candidates would delete them first.
+	for i := 0; i < 4; i++ {
+		writeQueueFile(t, dir, "q"+string(rune('0'+i))+".evtq", 10,
+			now.Add(-time.Duration(10-i)*time.Hour))
+	}
+	dropped, _ := pruneQueue(dir, now, 7*24*time.Hour, 1, 1<<20)
+	if dropped != 3 {
+		t.Fatalf("dropped=%d, want 3 (oldest batches only)", dropped)
+	}
+	got := names(t, dir)
+	if !got[".write-a"] || !got[".write-b"] {
+		t.Fatalf("young emitter temp cap-deleted: %v", got)
+	}
+	if !got["q3.evtq"] {
+		t.Fatalf("newest batch should survive: %v", got)
+	}
+}
+
+func TestPruneMissingDirIsNoop(t *testing.T) {
+	dropped, freed := pruneQueue(filepath.Join(t.TempDir(), "nope"), time.Now(), time.Hour, 1, 1)
+	if dropped != 0 || freed != 0 {
+		t.Fatalf("dropped=%d freed=%d, want 0/0", dropped, freed)
+	}
+}
+
+func TestPruneWithinCapsIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	writeQueueFile(t, dir, "a.evtq", 10, now.Add(-time.Minute))
+	dropped, _ := pruneQueue(dir, now, 7*24*time.Hour, 10, 1<<20)
+	if dropped != 0 {
+		t.Fatalf("dropped=%d, want 0", dropped)
+	}
+	if !names(t, dir)["a.evtq"] {
+		t.Fatal("in-cap file pruned")
+	}
+}


### PR DESCRIPTION
## Problem (bd-ulfod, P1)

The eventkit file queue has no cap, TTL, or size bound. When emission outruns the throttled drain (one event per file, one HTTPS round trip each, one 30s flusher child per 5 minutes since #5646), the queue grows without bound — **149k `.evtq` files / 1.1GB observed on one shared-$HOME machine, all <48h old** (measured emission ~2.3 files/s vs drain ~1.7/s pre-#5646, ~0.3-0.4/s post). Orphaned `.write-*` temps (emitter killed between CreateTemp and Rename) additionally leak forever — invisible to both the flusher and the pending-check. Disclosed on #5646 at merge time; this is the child-side prune recommended there, landing **before the next release rolls** so the throttle can't compound the backlog on busy boxes.

## Fix

`PruneQueue`, called in the detached `send-metrics` child before `Flush` — out-of-band by construction, so the full directory scan never lands on an interactive `bd` invocation:

- **TTL 7d**: drops `.evtq` batches and orphaned `.write-*` temps older than a week — nothing downstream wants week-old telemetry, and a drain that far behind never catches up by uploading history first.
- **Caps 10k files / 64 MiB**, drop-oldest, on surviving batches — bounds the queue regardless of the drain-vs-emission race. Young `.write-*` temps are never cap candidates (a live emitter may hold one; only TTL reclaims temps).
- Never touches `.last-flush`, `eventkit.lock`, or any non-queue name; tolerates losing every race with a concurrent flusher (already-deleted counts as success-shaped).
- Runs deliberately outside `eventkit.lock` (taking it would turn Flush's TryLock into a silent no-op); worst interleaving documented in `prune.go` — a rare second child's Flush aborts on ENOENT, self-heals next interval. ENOENT tolerance in eventkit's flush loop is the upstream follow-up (#5649 lane).

## Verification

- 7 new tests: TTL both classes, count-cap oldest-first, byte-cap oldest-first, temps-never-cap-taken, protected names, missing dir, within-caps no-op.
- `gofmt` / `go vet` / `golangci-lint` (repo config): 0 issues.
- `cmd/bd` suite FAIL-set diff vs clean main on the same box: **identical** (9 known ambient env failures, zero added).
- Fresh-agent adversarial review: verdict **MERGE**, no blocking findings; both should-fixes folded in (posting verdict below).

Not addressed here (tracked in #5649): drain-rate work — batch aggregation per GA4 request (~25x), adaptive flush window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)