### PR TITLE
fix(build): restore freebsd compilation — unsupported-platform stubs for procid + unverified-process

### DIFF
--- a/internal/procid/procid_unsupported.go
+++ b/internal/procid/procid_unsupported.go
@@ -1,0 +1,39 @@
+//go:build !linux && !darwin && !windows
+
+package procid
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+)
+
+// ErrUnsupported marks platforms with no process-birth identity
+// implementation (no /proc, no pidfd, no SysctlKinfoProc in x/sys). The
+// dbproxy machinery that needs birth identity refuses cleanly at startup
+// there instead of running with an unverifiable PID: reattach-and-signal
+// without birth identity is exactly the PID-reuse race this package exists
+// to close. Everything outside dbproxy is independent of procid, so ordinary
+// bd use on these platforms is unaffected — which matches what they had
+// before dbproxy existed (v1.1.2 shipped FreeBSD with no dbproxy at all).
+var ErrUnsupported = fmt.Errorf("procid: process-birth identity is not implemented on %s", runtime.GOOS)
+
+// Handle exists so cross-platform callers type-check; no instance can be
+// constructed because Open always fails.
+type Handle struct{}
+
+func Capture(pid int) (Token, error) { return "", ErrUnsupported }
+
+func Verify(pid int, tok Token) (bool, error) { return false, ErrUnsupported }
+
+func Open(pid int, tok Token) (*Handle, error) { return nil, ErrUnsupported }
+
+func (h *Handle) Signal(sig os.Signal) error { return ErrUnsupported }
+
+func (h *Handle) Kill() error { return ErrUnsupported }
+
+func (h *Handle) Close() error { return nil }
+
+// IsProcessGone reports false: ErrUnsupported is a capability statement, not
+// evidence about any process, and this platform can produce no other error.
+func IsProcessGone(err error) bool { return false }

--- a/internal/storage/dbproxy/proxy/unverified_process_unsupported.go
+++ b/internal/storage/dbproxy/proxy/unverified_process_unsupported.go
@@ -1,0 +1,38 @@
+//go:build !linux && !darwin && !windows
+
+package proxy
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// errUnverifiedUnsupported mirrors procid.ErrUnsupported for the force-stop
+// path: on platforms with no process-inspection implementation the proxy
+// machinery refuses cleanly rather than guessing at a PID's identity.
+var errUnverifiedUnsupported = fmt.Errorf(
+	"dbproxy: unverified-process inspection is not implemented on %s", runtime.GOOS)
+
+type unverifiedProcess struct{}
+
+func openUnverifiedProcess(pid int) (proc *unverifiedProcess, gone bool, err error) {
+	return nil, false, errUnverifiedUnsupported
+}
+
+func (p *unverifiedProcess) executableBasename() (basename string, gone bool, err error) {
+	return "", false, errUnverifiedUnsupported
+}
+
+func (p *unverifiedProcess) commandLineContains(needle string) (matched bool, gone bool, err error) {
+	return false, false, errUnverifiedUnsupported
+}
+
+func (p *unverifiedProcess) kill() (gone bool, err error) {
+	return false, errUnverifiedUnsupported
+}
+
+func (p *unverifiedProcess) exited() (bool, error) {
+	return false, errUnverifiedUnsupported
+}
+
+func (p *unverifiedProcess) close() {}


### PR DESCRIPTION
Release v1.2.0 blocker: goreleaser run 31533013414 failed pre-publish on `bd-freebsd-amd64` — `internal/storage/dbproxy/server/doltserver.go:269: undefined: procid.Capture`, then the same class in dbproxy/proxy (`openUnverifiedProcess`). The dbproxy arc's platform files cover linux/darwin/windows only; freebsd ships in every release but nothing cross-compiles it before tag time.

Fix: `//go:build !linux && !darwin && !windows` stubs for both surfaces, refusing with a named `ErrUnsupported` — honest capability statements, not guesses (PID reattach without birth identity is the exact race these packages close). FreeBSD's ordinary bd is unaffected; dbproxy never ran there (v1.1.2 shipped freebsd with no dbproxy).

Verification: full release matrix cross-compiles with `-tags gms_pure_go` (linux amd64+arm64, android arm64, windows amd64+arm64, freebsd amd64, darwin arm64); native lint + tests green; `IsProcessGone` deliberately reports false for `ErrUnsupported` (a capability error is not evidence a process is gone).

Follow-ups filed separately: PR-CI cross-compile gate for the release matrix; v1.2.0 number is burned (v1.1.1 precedent), release re-cuts as v1.2.1 after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)