### PR TITLE
perf(recompute): full is_blocked repair runs unbatched semi-join statements (bd-t9ypt)

### DIFF
--- a/internal/storage/dolt/blocked_full_repair_test.go
+++ b/internal/storage/dolt/blocked_full_repair_test.go
@@ -1,0 +1,247 @@
+package dolt
+
+// Differential coverage for the full is_blocked repair (bd-t9ypt): the
+// full-repair SQL must agree with the scoped per-write templates on EVERY
+// leg of the should-be-blocked disjunction — issue blockers, wisp blockers,
+// issue parents, wisp parents, and the waits-for gate in all its metadata
+// modes (default all-children, any-children, also_blocks,
+// also_blocks-over-any-children) — on both the issues table and the wisps
+// table.
+//
+// Ground truth is produced by the scoped write path (blocked_state.go
+// batched templates); then every is_blocked flag in both tables is inverted
+// and the full repair must restore the exact truth, after which detection
+// must count 0 and a second repair must be a no-op. The existing lockstep
+// tests in blocked_consistency_test.go pin legs 1 and 3 (issue blocker,
+// issue parent) with exact corrected-row counts; this test pins the
+// remaining legs, which would otherwise have no full-repair coverage.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func readIsBlockedFlags(t *testing.T, ctx context.Context, store *DoltStore, table string) map[string]bool {
+	t.Helper()
+	out := map[string]bool{}
+	//nolint:gosec // G201: table is a hardcoded "issues" or "wisps" from callers.
+	rows, err := store.db.QueryContext(ctx, "SELECT id, is_blocked FROM "+table)
+	if err != nil {
+		t.Fatalf("read %s flags: %v", table, err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id string
+		var b int
+		if err := rows.Scan(&id, &b); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		out[id] = b != 0
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+	return out
+}
+
+func addDependencyWithMeta(t *testing.T, ctx context.Context, store *DoltStore, source, target string, depType types.DependencyType, metadata string) {
+	t.Helper()
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID: source, DependsOnID: target, Type: depType, Metadata: metadata,
+	}, "tester"); err != nil {
+		t.Fatalf("add dep %s -> %s (%s): %v", source, target, depType, err)
+	}
+}
+
+func TestRecomputeAllIsBlocked_FullRepairAllLegsDifferential(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	dep := func(src, tgt string, ty types.DependencyType) { addDependencyWithMeta(t, ctx, store, src, tgt, ty, "") }
+	closeIssue := func(id string) {
+		t.Helper()
+		if err := store.CloseIssue(ctx, id, "done", "tester", ""); err != nil {
+			t.Fatalf("close %s: %v", id, err)
+		}
+	}
+
+	// ---- Leg 1: issue blocked by issue (blocks / conditional-blocks) ----
+	createPerm(t, ctx, store, "zz-b1")  // open blocker
+	createPerm(t, ctx, store, "zz-b2")  // will be closed
+	createPerm(t, ctx, store, "zz-b3")  // will be pinned
+	createPerm(t, ctx, store, "zz-a1")  // blocked by zz-b1
+	createPerm(t, ctx, store, "zz-a1c") // conditional-blocks on zz-b1
+	createPerm(t, ctx, store, "zz-a2")  // dep on closed blocker => unblocked
+	createPerm(t, ctx, store, "zz-a3")  // dep on pinned blocker => unblocked
+	dep("zz-a1", "zz-b1", types.DepBlocks)
+	dep("zz-a1c", "zz-b1", types.DepConditionalBlocks)
+	dep("zz-a2", "zz-b2", types.DepBlocks)
+	dep("zz-a3", "zz-b3", types.DepBlocks)
+	closeIssue("zz-b2")
+	if err := store.UpdateIssue(ctx, "zz-b3", map[string]interface{}{"status": string(types.StatusPinned)}, "tester"); err != nil {
+		t.Fatalf("pin zz-b3: %v", err)
+	}
+
+	// ---- Leg 2: issue blocked by open WISP ----
+	createWisp(t, ctx, store, "zz-w1") // open wisp blocker
+	createWisp(t, ctx, store, "zz-w2") // closed wisp blocker
+	createPerm(t, ctx, store, "zz-a4") // blocked by open wisp
+	createPerm(t, ctx, store, "zz-a5") // dep on closed wisp => unblocked
+	dep("zz-a4", "zz-w1", types.DepBlocks)
+	dep("zz-a5", "zz-w2", types.DepBlocks)
+	closeIssue("zz-w2")
+
+	// ---- Leg 3: issue child of blocked issue parent, plus grandchild cascade ----
+	createPerm(t, ctx, store, "zz-c1") // child of blocked zz-a1
+	createPerm(t, ctx, store, "zz-c2") // grandchild
+	dep("zz-c1", "zz-a1", types.DepParentChild)
+	dep("zz-c2", "zz-c1", types.DepParentChild)
+
+	// ---- Leg 4: issue child of blocked WISP parent ----
+	createWisp(t, ctx, store, "zz-wp") // wisp blocked by zz-b1
+	dep("zz-wp", "zz-b1", types.DepBlocks)
+	createPerm(t, ctx, store, "zz-c3") // child of blocked wisp
+	dep("zz-c3", "zz-wp", types.DepParentChild)
+
+	// ---- Leg 5: waits-for gates on issues ----
+	// default all-children gate, open child => blocked
+	createPerm(t, ctx, store, "zz-s1")
+	createPerm(t, ctx, store, "zz-sc1")
+	createPerm(t, ctx, store, "zz-d1")
+	dep("zz-sc1", "zz-s1", types.DepParentChild)
+	dep("zz-d1", "zz-s1", types.DepWaitsFor)
+	// any-children gate satisfied by one closed child => unblocked
+	createPerm(t, ctx, store, "zz-s2")
+	createPerm(t, ctx, store, "zz-sc2")
+	createPerm(t, ctx, store, "zz-sc3")
+	createPerm(t, ctx, store, "zz-d2")
+	dep("zz-sc2", "zz-s2", types.DepParentChild)
+	dep("zz-sc3", "zz-s2", types.DepParentChild)
+	addDependencyWithMeta(t, ctx, store, "zz-d2", "zz-s2", types.DepWaitsFor, `{"gate":"any-children"}`)
+	closeIssue("zz-sc2")
+	// also_blocks: spawner open, zero children => blocked
+	createPerm(t, ctx, store, "zz-s3")
+	createPerm(t, ctx, store, "zz-d3")
+	addDependencyWithMeta(t, ctx, store, "zz-d3", "zz-s3", types.DepWaitsFor, `{"gate":"all-children","also_blocks":true}`)
+	// also_blocks overrides any-children early-open: child closed, spawner open => blocked
+	createPerm(t, ctx, store, "zz-s4")
+	createPerm(t, ctx, store, "zz-sc4")
+	createPerm(t, ctx, store, "zz-d4")
+	dep("zz-sc4", "zz-s4", types.DepParentChild)
+	addDependencyWithMeta(t, ctx, store, "zz-d4", "zz-s4", types.DepWaitsFor, `{"gate":"any-children","also_blocks":true}`)
+	closeIssue("zz-sc4")
+
+	// ---- Wisp-table side (wisp_dependencies) ----
+	createWisp(t, ctx, store, "zz-wa") // wisp blocked by open issue
+	dep("zz-wa", "zz-b1", types.DepBlocks)
+	createWisp(t, ctx, store, "zz-wb") // wisp child of blocked wisp parent
+	dep("zz-wb", "zz-wp", types.DepParentChild)
+	createWisp(t, ctx, store, "zz-wneg") // wisp dep on closed issue => unblocked
+	dep("zz-wneg", "zz-b2", types.DepBlocks)
+	// wisp waits-for a wisp spawner with an open wisp child => blocked
+	createWisp(t, ctx, store, "zz-ws")
+	createWisp(t, ctx, store, "zz-wsc")
+	createWisp(t, ctx, store, "zz-wd")
+	dep("zz-wsc", "zz-ws", types.DepParentChild)
+	dep("zz-wd", "zz-ws", types.DepWaitsFor)
+
+	// ---- ground truth from the scoped write path ----
+	truthIssues := readIsBlockedFlags(t, ctx, store, "issues")
+	truthWisps := readIsBlockedFlags(t, ctx, store, "wisps")
+
+	// Sanity-pin the interesting expectations so the fixture itself is not vacuous.
+	expectBlockedIssues := []string{"zz-a1", "zz-a1c", "zz-a4", "zz-c1", "zz-c2", "zz-c3", "zz-d1", "zz-d3", "zz-d4"}
+	expectUnblockedIssues := []string{"zz-a2", "zz-a3", "zz-a5", "zz-d2", "zz-b1", "zz-s1", "zz-s2", "zz-s3", "zz-s4"}
+	for _, id := range expectBlockedIssues {
+		if !truthIssues[id] {
+			t.Fatalf("fixture: expected %s blocked by write path", id)
+		}
+	}
+	for _, id := range expectUnblockedIssues {
+		if truthIssues[id] {
+			t.Fatalf("fixture: expected %s unblocked by write path", id)
+		}
+	}
+	for _, id := range []string{"zz-wp", "zz-wa", "zz-wb", "zz-wd"} {
+		if !truthWisps[id] {
+			t.Fatalf("fixture: expected wisp %s blocked by write path", id)
+		}
+	}
+	for _, id := range []string{"zz-w1", "zz-wneg", "zz-ws", "zz-wsc"} {
+		if truthWisps[id] {
+			t.Fatalf("fixture: expected wisp %s unblocked by write path", id)
+		}
+	}
+
+	// Consistent plane: detection counts 0.
+	if n, err := issueops.CountIsBlockedInconsistenciesInTx(ctx, store.db); err != nil || n != 0 {
+		t.Fatalf("pre-corruption count: want 0/nil, got %d/%v", n, err)
+	}
+
+	// ---- corrupt: invert EVERY flag in both tables ----
+	if _, err := store.db.ExecContext(ctx, "UPDATE issues SET is_blocked = 1 - is_blocked"); err != nil {
+		t.Fatalf("invert issues: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, "UPDATE wisps SET is_blocked = 1 - is_blocked"); err != nil {
+		t.Fatalf("invert wisps: %v", err)
+	}
+	if n, err := issueops.CountIsBlockedInconsistenciesInTx(ctx, store.db); err != nil || n == 0 {
+		t.Fatalf("post-corruption count: want >0/nil, got %d/%v", n, err)
+	}
+
+	// ---- full repair ----
+	tx, err := store.db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	changed, err := issueops.RecomputeAllIsBlockedInTx(ctx, tx)
+	if err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("RecomputeAllIsBlockedInTx: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if changed == 0 {
+		t.Fatal("repair reported 0 corrections over a fully inverted plane")
+	}
+
+	// ---- compare against ground truth ----
+	gotIssues := readIsBlockedFlags(t, ctx, store, "issues")
+	gotWisps := readIsBlockedFlags(t, ctx, store, "wisps")
+	for id, want := range truthIssues {
+		if gotIssues[id] != want {
+			t.Errorf("issues.%s: repair produced is_blocked=%v, write-path truth %v", id, gotIssues[id], want)
+		}
+	}
+	for id, want := range truthWisps {
+		if gotWisps[id] != want {
+			t.Errorf("wisps.%s: repair produced is_blocked=%v, write-path truth %v", id, gotWisps[id], want)
+		}
+	}
+
+	// Detection agrees and the repair is idempotent.
+	if n, err := issueops.CountIsBlockedInconsistenciesInTx(ctx, store.db); err != nil || n != 0 {
+		t.Fatalf("post-repair count: want 0/nil, got %d/%v", n, err)
+	}
+	tx2, err := store.db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin2: %v", err)
+	}
+	again, err := issueops.RecomputeAllIsBlockedInTx(ctx, tx2)
+	if err != nil {
+		_ = tx2.Rollback()
+		t.Fatalf("second repair: %v", err)
+	}
+	if err := tx2.Commit(); err != nil {
+		t.Fatalf("commit2: %v", err)
+	}
+	if again != 0 {
+		t.Fatalf("second repair must be a no-op, corrected %d", again)
+	}
+}

--- a/internal/storage/issueops/blocked_consistency.go
+++ b/internal/storage/issueops/blocked_consistency.go
@@ -262,6 +262,15 @@ func RecomputeAllIsBlockedInTx(ctx context.Context, tx DBTX) (int64, error) {
 // recomputeIsBlockedCounting is RecomputeIsBlockedInTx with a corrected-row
 // count: it sums the rows flipped across every fixpoint pass. A parent flip in
 // one pass can cascade to its children in the next, and each correction counts.
+//
+// Unlike the scoped passes, the full repair runs UNBATCHED semi-join statements
+// (markAllBlockedSQL/unmarkAllBlockedSQL): the id lists here cover every row by
+// construction, so an IN-batch adds nothing but statement count, and the
+// batched templates' OR-of-correlated-EXISTS shape cannot be decorrelated by
+// the engine — per-outer-row subquery execution made the full repair cost
+// ~80+ statement-seconds on fast hardware and >600s on small cloud CPUs
+// (bd-t9ypt). The id lists are still captured for the journal snapshot, and
+// len(wispIDs) doubles as the "wisps table exists and has rows" signal.
 func recomputeIsBlockedCounting(ctx context.Context, tx DBTX, issueIDs, wispIDs []string) (int64, error) {
 	if len(issueIDs) == 0 && len(wispIDs) == 0 {
 		return 0, nil
@@ -273,16 +282,20 @@ func recomputeIsBlockedCounting(ctx context.Context, tx DBTX, issueIDs, wispIDs 
 	var total int64
 	for {
 		var changed int64
-		n, err := recomputeIsBlockedPassForIssuesInTx(ctx, tx, issueIDs)
-		if err != nil {
-			return total, err
+		if len(issueIDs) > 0 {
+			n, err := recomputeAllIsBlockedPassInTx(ctx, tx, "issues", "i", "dependencies")
+			if err != nil {
+				return total, err
+			}
+			changed += n
 		}
-		changed += n
-		n, err = recomputeIsBlockedPassForWispsInTx(ctx, tx, wispIDs)
-		if err != nil {
-			return total, err
+		if len(wispIDs) > 0 {
+			n, err := recomputeAllIsBlockedPassInTx(ctx, tx, "wisps", "w", "wisp_dependencies")
+			if err != nil {
+				return total, err
+			}
+			changed += n
 		}
-		changed += n
 		total += changed
 		if changed == 0 {
 			if err := recordBlockedJournalChanges(ctx, tx, before, issueIDs, wispIDs); err != nil {
@@ -291,6 +304,108 @@ func recomputeIsBlockedCounting(ctx context.Context, tx DBTX, issueIDs, wispIDs 
 			return total, nil
 		}
 	}
+}
+
+// recomputeAllIsBlockedPassInTx runs one full-table mark+unmark pass for one
+// table using the unbatched semi-join statements, returning rows corrected.
+// Error wrapping mirrors runMarkUnmarkBatchedInTx verbatim — downstream
+// consumers (wh-bridge-sync among them) match on these strings.
+func recomputeAllIsBlockedPassInTx(ctx context.Context, tx DBTX, table, alias, depTable string) (int64, error) {
+	var changed int64
+	res, err := tx.ExecContext(ctx, markAllBlockedSQL(table, alias, depTable))
+	if err != nil {
+		return changed, fmt.Errorf("recompute is_blocked (mark): %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return changed, fmt.Errorf("recompute is_blocked (mark rows affected): %w", err)
+	}
+	changed += n
+
+	res, err = tx.ExecContext(ctx, unmarkAllBlockedSQL(table, alias, depTable))
+	if err != nil {
+		return changed, fmt.Errorf("recompute is_blocked (unmark): %w", err)
+	}
+	n, err = res.RowsAffected()
+	if err != nil {
+		return changed, fmt.Errorf("recompute is_blocked (unmark rows affected): %w", err)
+	}
+	changed += n
+	return changed, nil
+}
+
+// markAllBlockedSQL is the full-table analog of the batched mark template:
+// same predicate, restructured so the engine can execute it as a semi-join.
+//
+//nolint:gosec // G201: table, alias, and depTable are constants from the only two callers.
+func markAllBlockedSQL(table, alias, depTable string) string {
+	return fmt.Sprintf(`
+		UPDATE %[1]s %[2]s SET %[2]s.is_blocked = 1, %[2]s.updated_at = %[2]s.updated_at
+		WHERE %[2]s.is_blocked = 0
+		  AND %[2]s.status <> 'closed' AND %[2]s.status <> 'pinned'
+		  AND %[2]s.id IN (%[3]s)
+	`, table, alias, shouldBeBlockedIDsUnionSQL(depTable))
+}
+
+// unmarkAllBlockedSQL is the full-table analog of the batched unmark
+// template. NOT IN is null-hostile — one NULL in the subquery result makes the
+// predicate UNKNOWN for every row and the unmark silently stops firing — which
+// is why every leg of shouldBeBlockedIDsUnionSQL carries an explicit
+// d.issue_id IS NOT NULL guard.
+//
+//nolint:gosec // G201: table, alias, and depTable are constants from the only two callers.
+func unmarkAllBlockedSQL(table, alias, depTable string) string {
+	return fmt.Sprintf(`
+		UPDATE %[1]s %[2]s SET %[2]s.is_blocked = 0, %[2]s.updated_at = %[2]s.updated_at
+		WHERE %[2]s.is_blocked = 1
+		  AND ( %[2]s.status = 'closed' OR %[2]s.status = 'pinned'
+		        OR %[2]s.id NOT IN (%[3]s) )
+	`, table, alias, shouldBeBlockedIDsUnionSQL(depTable))
+}
+
+// shouldBeBlockedIDsUnionSQL selects, UNCORRELATED with any outer row, every
+// depTable issue_id that currently has a reason to be blocked: one UNION leg
+// per branch of the correlated disjunction inside the batched mark/unmark
+// templates in blocked_state.go, in the same order. Semantically,
+// `<alias>.id IN (this select)` ≡ that disjunction: every branch
+// of the disjunction correlates with the outer row ONLY through
+// d.issue_id = <alias>.id, so membership of the outer id in the union of each
+// branch's issue_ids is the same predicate — but the engine evaluates this
+// form once as hash lookups instead of per outer row (bd-t9ypt). The lockstep
+// test pins the two forms to each other.
+//
+//nolint:gosec // G201: depTable is constant; waitsForGateBlockedSQL is a constant template.
+func shouldBeBlockedIDsUnionSQL(depTable string) string {
+	return fmt.Sprintf(`
+		SELECT d.issue_id FROM %[1]s d
+		JOIN issues t ON t.id = d.depends_on_issue_id
+		WHERE d.issue_id IS NOT NULL
+		  AND (d.type = 'blocks' OR d.type = 'conditional-blocks')
+		  AND t.status <> 'closed' AND t.status <> 'pinned'
+		UNION
+		SELECT d.issue_id FROM %[1]s d
+		JOIN wisps t ON t.id = d.depends_on_wisp_id
+		WHERE d.issue_id IS NOT NULL
+		  AND (d.type = 'blocks' OR d.type = 'conditional-blocks')
+		  AND t.status <> 'closed' AND t.status <> 'pinned'
+		UNION
+		SELECT d.issue_id FROM %[1]s d
+		JOIN issues p ON p.id = d.depends_on_issue_id
+		WHERE d.issue_id IS NOT NULL
+		  AND d.type = 'parent-child'
+		  AND p.is_blocked = 1
+		UNION
+		SELECT d.issue_id FROM %[1]s d
+		JOIN wisps p ON p.id = d.depends_on_wisp_id
+		WHERE d.issue_id IS NOT NULL
+		  AND d.type = 'parent-child'
+		  AND p.is_blocked = 1
+		UNION
+		SELECT d.issue_id FROM %[1]s d
+		WHERE d.issue_id IS NOT NULL
+		  AND d.type = 'waits-for'
+		  AND (%[2]s)
+	`, depTable, waitsForGateBlockedSQL)
 }
 
 // CountIsBlockedInconsistenciesInTx reports how many issue and wisp rows carry a
@@ -327,77 +442,33 @@ func CountIsBlockedInconsistenciesInTx(ctx context.Context, tx DBTX) (int64, err
 
 // countStaleIsBlockedSQL builds a COUNT(*) of rows whose stored is_blocked
 // disagrees with the dependency graph for one table (issues or wisps). The two
-// OR branches mirror the mark and unmark UPDATE templates in blocked_state.go
-// exactly:
+// OR branches mirror the mark and unmark UPDATE shapes exactly:
 //
 //   - mark-eligible:   is_blocked = 0 on an open row that should be blocked.
 //   - unmark-eligible: is_blocked = 1 on a row that should not be blocked
-//     (closed/pinned, or no remaining reason — De Morgan of NOT EXISTS ... is
-//     NOT (the shouldBeBlocked disjunction)).
+//     (closed/pinned, or its id absent from the should-be-blocked union — the
+//     set-membership form of De Morgan over the shouldBeBlocked disjunction).
 //
 // is_blocked is 0 or 1, so the branches are mutually exclusive and the count is
-// their sum. table/alias/depTable are hardcoded constants supplied by the only
-// two callers.
+// their sum. Built on the uncorrelated shouldBeBlockedIDsUnionSQL for the same
+// reason as the full repair (bd-t9ypt): the correlated disjunction form ran per
+// outer row and cost whole-table scans per branch. table/alias/depTable are
+// hardcoded constants supplied by the only two callers.
 //
 //nolint:gosec // G201: table, alias, and depTable are constant; only the constant gate SQL is interpolated.
 func countStaleIsBlockedSQL(table, alias, depTable string) string {
-	disjunction := shouldBeBlockedDisjunction(alias, depTable)
+	union := shouldBeBlockedIDsUnionSQL(depTable)
 	return fmt.Sprintf(`
 		SELECT COUNT(*) FROM %[1]s %[2]s
 		WHERE
 		  ( %[2]s.is_blocked = 0
 		    AND %[2]s.status <> 'closed' AND %[2]s.status <> 'pinned'
-		    AND ( %[3]s ) )
+		    AND %[2]s.id IN (%[3]s) )
 		  OR
 		  ( %[2]s.is_blocked = 1
 		    AND ( %[2]s.status = 'closed' OR %[2]s.status = 'pinned'
-		          OR NOT ( %[3]s ) ) )
-	`, table, alias, disjunction)
-}
-
-// shouldBeBlockedDisjunction is the OR of every reason a row should have
-// is_blocked = 1: an open hard blocker (issue or wisp), a blocked parent (issue
-// or wisp), or an ungated waits-for spawner. It mirrors the disjunction inside
-// the mark/unmark templates in blocked_state.go; the lockstep test keeps the
-// two from drifting. alias is the row's table alias, depTable its dependency
-// table; the joined target tables (issues/wisps) are the same for both.
-func shouldBeBlockedDisjunction(alias, depTable string) string {
-	//nolint:gosec // G201: alias and depTable are constant; waitsForGateBlockedSQL is a constant template.
-	return fmt.Sprintf(`
-		    EXISTS (
-		      SELECT 1 FROM %[2]s d
-		      JOIN issues t ON t.id = d.depends_on_issue_id
-		      WHERE d.issue_id = %[1]s.id
-		        AND (d.type = 'blocks' OR d.type = 'conditional-blocks')
-		        AND t.status <> 'closed' AND t.status <> 'pinned'
-		    )
-		    OR EXISTS (
-		      SELECT 1 FROM %[2]s d
-		      JOIN wisps t ON t.id = d.depends_on_wisp_id
-		      WHERE d.issue_id = %[1]s.id
-		        AND (d.type = 'blocks' OR d.type = 'conditional-blocks')
-		        AND t.status <> 'closed' AND t.status <> 'pinned'
-		    )
-		    OR EXISTS (
-		      SELECT 1 FROM %[2]s d
-		      JOIN issues p ON p.id = d.depends_on_issue_id
-		      WHERE d.issue_id = %[1]s.id
-		        AND d.type = 'parent-child'
-		        AND p.is_blocked = 1
-		    )
-		    OR EXISTS (
-		      SELECT 1 FROM %[2]s d
-		      JOIN wisps p ON p.id = d.depends_on_wisp_id
-		      WHERE d.issue_id = %[1]s.id
-		        AND d.type = 'parent-child'
-		        AND p.is_blocked = 1
-		    )
-		    OR EXISTS (
-		      SELECT 1 FROM %[2]s d
-		      WHERE d.issue_id = %[1]s.id AND d.type = 'waits-for'
-		        AND (%[3]s)
-		    )
-	`, alias, depTable, waitsForGateBlockedSQL)
+		          OR %[2]s.id NOT IN (%[3]s) ) )
+	`, table, alias, union)
 }
 
 // countRows runs a single COUNT(*) query and returns the scalar.


### PR DESCRIPTION
## Problem

`bd recompute-blocked` (and the owed post-pull full repair) runs mark/unmark UPDATEs whose predicate is an OR of five correlated EXISTS subqueries. Each branch alone decorrelates to a semi-join and is instant; ORed together, go-mysql-server cannot decorrelate and evaluates every branch **per outer row**.

Measured on a real 8,068-issue / 5,764-dependency plane (fresh clone, dolt CLI):
- one 200-id mark batch: **~1s** (M-series)
- full repair = ~41 batches × 2 statements × N fixpoint passes = **80+ statement-seconds** on the fastest hardware
- on an e2-standard-2 cloud VM: **>600s**, killed every tick by a 120s cap → `is_blocked` stale fleet-wide (wyvern wy-lqsk2u; aggravated by dolt not cancelling server-side queries on client disconnect, so each kill left a zombie query grinding)

Indexes are all present and unused for the disjunction; stats are innocent (decorrelation is rule-based — a fresh clone's empty `dolt_statistics` changes nothing).

## Fix

Every branch correlates with the outer row **only** through `d.issue_id = <row>.id`, so the disjunction is set membership: `id IN (UNION of the five branches' issue_ids)`, evaluated once as hash lookups.

- Full repair (`recomputeIsBlockedCounting`) now runs **unbatched** `markAllBlockedSQL`/`unmarkAllBlockedSQL` per table per pass — the batched id lists covered every row by construction, so batching only multiplied statement count. Ids are still listed for the journal snapshot; `len(wispIDs)` doubles as the wisps-table-present signal, as before.
- `countStaleIsBlockedSQL` (bd doctor's Blocked State check): same rewrite, same reason.
- Every UNION leg carries `d.issue_id IS NOT NULL`: `NOT IN` is null-hostile — one NULL makes the predicate UNKNOWN for every row and the unmark side silently stops firing.
- `shouldBeBlockedDisjunction` deleted (its only caller was the count SQL).
- The **scoped per-write path is untouched**: small id sets are cheap under the correlated form and that path is latency-sensitive; making it pay a whole-graph UNION per write would be a regression.
- Error-wrapping strings (`recompute is_blocked (mark)` / `(unmark)`) preserved verbatim — downstream retry logic (wyvern's bridge among others) matches on them.

## Verification

- **Differential equivalence on the real plane**: old correlated predicate vs new union predicate over all 8,068 issues → identical 481-row should-be-blocked sets. **40s vs <1s.**
- Full-table mark+unmark UPDATE pass with the new shape: **<1s total** (was 80+ statement-seconds).
- `go test ./internal/storage/issueops/ ./internal/storage/embeddeddolt/` green; `./internal/storage/dolt/` behavioral repair tests (`TestRecomputeAllIsBlocked_{RepairsStaleClearedFlag,ClearsStuckBlockedFlag,CascadesThroughParentChild}`) green. The four `TestRecomputeAllBlocked_*` guard-family tests fail **identically on unmodified main** in this dev env (bd-7xtsq, pre-existing baseline red) — FAIL-set diff against baseline is byte-identical.

Prior art: bd-bn8jo / #5090 moved the recompute to the 5m long-timeout connection — symptom relief. This removes the cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)