### PR TITLE
fix(wisp): purgeClosed must not cascade into live molecule steps

### DIFF
--- a/cmd/bd/wisp.go
+++ b/cmd/bd/wisp.go
@@ -808,7 +808,14 @@ func runWispGC(cmd *cobra.Command, args []string) error {
 	for i, issue := range abandoned {
 		ids[i] = issue.ID
 	}
-	if err := deleteBatch(nil, ids, true, false, true, jsonOutput, false, "wisp gc"); err != nil {
+	// Cascade must stay OFF here too. findAbandonedWisps has already expanded
+	// dependents and kept only the unprotected ones, so a deleteBatch cascade
+	// would re-expand from that set to ALL transitive dependents — including
+	// blocked/in-progress steps that isProtectedWisp just excluded (GH#4394's
+	// protection is only enforced in the pre-filter; cascade bypasses it).
+	// Without cascade the list is deleted exactly as filtered and live
+	// dependents are orphaned (edges dropped, is_blocked recomputed).
+	if err := deleteBatch(nil, ids, true, false, false, jsonOutput, false, "wisp gc"); err != nil {
 		return HandleError("%v", err)
 	}
 	return nil
@@ -969,7 +976,16 @@ func runWispPurgeClosed(ctx context.Context, dryRun bool, force bool, excludeTyp
 		fmt.Println()
 	}
 
-	if err := deleteBatch(nil, ids, force, dryRun, true, jsonOutput, false, "wisp gc --closed"); err != nil {
+	// Cascade must stay OFF here. The closed set above is already the complete
+	// purge candidate list, so cascade can only ever add NON-closed dependents
+	// to the batch. In a linear molecule DAG a closed step's transitive
+	// dependents are every other (live) step — cascading swept whole active
+	// molecules into deletion, steps, dependency links and events all at once
+	// (wisp gc --closed --force self-destructed the deacon patrol).
+	// Without cascade, closed wisps are deleted and live dependents are
+	// orphaned (edges dropped, is_blocked recomputed) — the same semantics as
+	// a plain `bd delete`.
+	if err := deleteBatch(nil, ids, force, dryRun, false, jsonOutput, false, "wisp gc --closed"); err != nil {
 		return HandleError("%v", err)
 	}
 

--- a/cmd/bd/wisp_gc_purge_closed_embedded_test.go
+++ b/cmd/bd/wisp_gc_purge_closed_embedded_test.go
@@ -1,0 +1,126 @@
+//go:build cgo
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// bdShowSucceeds reports whether "bd show <id> --json" succeeds. Non-fatal
+// so a cascade sweep reports every deleted step instead of aborting on the
+// first one.
+func bdShowSucceeds(t *testing.T, bd, dir, id string) bool {
+	t.Helper()
+	cmd := exec.Command(bd, "show", id, "--json")
+	cmd.Dir = dir
+	cmd.Env = bdEnv(dir)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Logf("bd show %s failed (expected for deleted): %v\n%s", id, err, out)
+		return false
+	}
+	return true
+}
+
+// TestWispGCPurgeClosedDoesNotCascadeIntoLiveSteps is the regression test for
+// the patrol self-destruct bug: `bd mol wisp gc --closed --force` on a
+// molecule that has closed its first step deleted the ENTIRE molecule.
+//
+// purgeClosed handed cascade=true to deleteBatch, and deleteMany(Cascade)
+// expands every closed wisp to ALL transitive dependents. In a linear
+// molecule DAG, step 1's dependents are every other step, so the first
+// closed step dragged all 26 open steps of mol-deacon-patrol into deletion
+// (plus its dependency links and events). Wisps live in an ignored
+// (non-versioned) table, so the deletion was permanent.
+//
+// The closed set is complete: every closed, non-pinned, non-infra wisp is
+// already a GC candidate. Cascade can only ever add NON-closed dependents to
+// the batch — exactly the live steps it must not touch.
+func TestWispGCPurgeClosedDoesNotCascadeIntoLiveSteps(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "pc")
+
+	// Deacon patrol shape: an open mol root (the husk that survives) plus a
+	// linear chain of 26 steps. Each step depends on its predecessor (the
+	// first step is dependency-free — the patrol closes it, so it cannot be
+	// blocked on an open root), and step 1's transitive dependents are every
+	// other step.
+	root := bdCreate(t, bd, dir, "patrol molecule", "--ephemeral", "--type", "molecule")
+
+	const steps = 26
+	stepIDs := make([]string, steps)
+	prev := ""
+	for i := 0; i < steps; i++ {
+		id := bdCreate(t, bd, dir, fmt.Sprintf("patrol step %d", i+1), "--ephemeral").ID
+		stepIDs[i] = id
+		if prev != "" {
+			bdDepAdd(t, bd, dir, id, prev) // step N depends on step N-1
+		}
+		prev = id
+	}
+
+	// Patrol cycle: the completed first step is closed, then the formula's GC
+	// step purges closed wisps. The other 25 steps are live work (open) and
+	// must survive the purge.
+	bdClose(t, bd, dir, stepIDs[0])
+	bdCommand(t, bd, dir, "mol", "wisp", "gc", "--closed", "--force")
+
+	// The closed step itself is gone.
+	bdShowFail(t, bd, dir, stepIDs[0])
+
+	// Every live step survives.
+	for i := 1; i < steps; i++ {
+		if bdShowSucceeds(t, bd, dir, stepIDs[i]) {
+			continue
+		}
+		t.Errorf("live step %s (index %d) was cascade-deleted by purgeClosed; only the first closed step should be removed", stepIDs[i], i)
+	}
+
+	// The open molecule root survives too (the husk must keep its steps).
+	if bdShowSucceeds(t, bd, dir, root.ID) {
+		return
+	}
+	t.Error("open molecule root was deleted by purgeClosed")
+}
+
+// TestWispGCPurgeClosedStillPurgesFullyClosedMolecules guards the other side
+// of the fix: when EVERY step is closed, gc --closed --force must still remove
+// the whole molecule. Restricting cascade must not break complete cleanup.
+func TestWispGCPurgeClosedStillPurgesFullyClosedMolecules(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "pc2")
+
+	const steps = 5
+	stepIDs := make([]string, steps)
+	prev := ""
+	for i := 0; i < steps; i++ {
+		id := bdCreate(t, bd, dir, fmt.Sprintf("finished step %d", i+1), "--ephemeral").ID
+		stepIDs[i] = id
+		if prev != "" {
+			bdDepAdd(t, bd, dir, id, prev)
+		}
+		prev = id
+	}
+	for _, id := range stepIDs {
+		bdClose(t, bd, dir, id)
+	}
+
+	bdCommand(t, bd, dir, "mol", "wisp", "gc", "--closed", "--force")
+
+	for _, id := range stepIDs {
+		bdShowFail(t, bd, dir, id)
+	}
+}

--- a/cmd/bd/wisp_proxied_server.go
+++ b/cmd/bd/wisp_proxied_server.go
@@ -174,9 +174,13 @@ func runWispGCProxiedServer(ctx context.Context, dryRun bool, ageThreshold time.
 	}
 
 	res, err := uow.RunTxResult(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (domain.DeleteIssuesResult, string, error) {
+		// Cascade must stay OFF: findAbandonedWisps already expanded dependents
+		// and kept only unprotected ones; a cascade here re-expands to ALL
+		// transitive dependents, bypassing that protection (GH#4394).
+		// Mirrors runWispGC in wisp.go.
 		res, err := uw.IssueUseCase().DeleteIssues(ctx, domain.DeleteIssuesParams{
 			IDs:                  ids,
-			Cascade:              true,
+			Cascade:              false,
 			UpdateTextReferences: true,
 		}, actor)
 		if err != nil {
@@ -301,9 +305,13 @@ func runWispPurgeClosedProxiedServer(ctx context.Context, dryRun, force bool, ex
 	}
 
 	res, err := uow.RunTxResult(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (domain.DeleteIssuesResult, string, error) {
+		// Cascade must stay OFF: the closed set above is already the complete
+		// purge candidate list, so cascade can only add NON-closed dependents
+		// (live molecule steps) to the batch — the patrol self-destruct bug.
+		// Mirrors runWispPurgeClosed in wisp.go.
 		res, err := uw.IssueUseCase().DeleteIssues(ctx, domain.DeleteIssuesParams{
 			IDs:                  ids,
-			Cascade:              true,
+			Cascade:              false,
 			UpdateTextReferences: true,
 		}, actor)
 		if err != nil {


### PR DESCRIPTION
## Summary

`bd mol wisp gc --closed --force` cascade-deleted the entire deacon patrol molecule (26 steps, 54 dependency links, 28 events — hq-wisp-u52) and left the same husk on the previous cycle (hq-wisp-f8v).

**Root cause:** `runWispPurgeClosed` hands `cascade=true` to `deleteBatch` → `deleteMany(Cascade)` → `FindAllDependents`, which walks both dependency tables with **no status filter**. In a linear molecule DAG, a closed step's transitive dependents are every other (live) step, so the first closed step dragged the whole active molecule into deletion. Wisps live in an ignored (non-versioned) table — the deletion is permanent.

**Fix:** the closed set is already the complete purge candidate list, so the cascade can only add NON-closed (live) dependents. Turn cascade **off** in all four wisp GC delete sites (embedded + proxied, `--closed` + age paths). Live dependents are now orphaned (edges dropped, `is_blocked` recomputed) — the same semantics as a plain `bd delete`.

The age path had the same latent hole: `findAbandonedWisps` pre-filters dependents with `isProtectedWisp` (GH#4394), but the deleteBatch cascade re-expanded to ALL transitive dependents, bypassing that protection. The GH#4394 test only exercises `--dry-run`, which returns before the delete — the hole was invisible to it.

## Test Plan

- **New regression tests** (embedded dolt, `BEADS_TEST_EMBEDDED_DOLT=1`):
  - `TestWispGCPurgeClosedDoesNotCascadeIntoLiveSteps` — 26-step linear molecule, close step 1, `gc --closed --force` → exactly the closed step removed, all 25 live steps survive. (Fails on `main` with all 26 deleted — verified RED before the fix.)
  - `TestWispGCPurgeClosedStillPurgesFullyClosedMolecules` — fully-closed molecules still purge completely.
- `TestWispGCProtectsActiveWisps` (existing GH#4394) still passes.
- Full `cmd/bd` package suite: **PASS** (will attach final confirmation).
- Manual scratch-DB verification (26-step chain):
  - old binary: `✓ Deleted 26 issue(s)`, 0 survivors (bug reproduced)
  - fixed binary: `✓ Deleted 1 issue(s)`, 25 survivors (fixed)

## Note

The fixed binary is already deployed in the town that hit this (Gas Town escalation hq-wisp-knt, issue hq-cyo); this PR persists the fix upstream.