### PR TITLE
fix: gate symlinked physical roots

### DIFF
--- a/internal/doltserver/physical_root.go
+++ b/internal/doltserver/physical_root.go
@@ -241,9 +241,9 @@ func isRemoteServerHost(host string) bool {
 //     exist). The CLI's nil-config branch honors no other env rescue.
 //
 // Roots are returned absolute. Symlink canonicalization is deliberately NOT
-// performed here: workspacegate.ForPhysicalRoot canonicalizes the gate
-// file's parent itself (and refuses symlinked roots), and resolving here too
-// would double-handle and could disagree with the gate's own rules.
+// performed here: workspacegate.ForPhysicalRoot resolves an existing root
+// symlink and canonicalizes the gate file's parent. Resolving here too would
+// double-handle the path and could disagree with the gate's own rules.
 func ResolvePhysicalRoots(beadsDir string) (PhysicalRoots, error) {
 	abs, err := filepath.Abs(beadsDir)
 	if err != nil {

--- a/internal/workspacegate/gate.go
+++ b/internal/workspacegate/gate.go
@@ -173,9 +173,10 @@ func forDir(dir string) (Gate, error) {
 	// resolving the guarded path itself: full-path resolution would
 	// silently select a different gate once the directory appears as a
 	// symlink, letting two exclusive holders coexist. The flip side is
-	// that a guarded directory that IS a symlink has no stable identity
-	// under this scheme, so it is refused outright rather than gated
-	// ambiguously.
+	// that a literal guarded directory that IS a symlink has no stable
+	// identity under this scheme, so it is refused rather than gated
+	// ambiguously. Callers that deliberately guard physical storage must
+	// resolve the target first; ForPhysicalRoot does that below.
 	if fi, err := os.Lstat(abs); err == nil && fi.Mode()&os.ModeSymlink != 0 {
 		return Gate{}, fmt.Errorf("workspacegate: %s is a symlink; gate the physical directory it points to", abs)
 	}
@@ -201,6 +202,10 @@ func ForWorkspace(beadsDir string) (Gate, error) { return forDir(beadsDir) }
 // Distinct workspaces that point at the same physical root resolve to the
 // same gate file, which is the point: a workspace-level gate alone cannot
 // stop workspace B from restarting the server workspace A is draining.
+// An existing root symlink is resolved before building the gate so callers
+// that name the same physical storage through different aliases converge on
+// one lock. Workspace symlinks remain forbidden by ForWorkspace because a
+// workspace gate must keep its literal identity across create/replace cycles.
 //
 // Cross-user shared roots are unsupported: the gate file is created 0o600
 // (see Acquire), so a second OS user attempting to gate a shared root such
@@ -216,7 +221,28 @@ func ForWorkspace(beadsDir string) (Gate, error) { return forDir(beadsDir) }
 // file's parent along with everything else in it, which is exactly the
 // split-inode hazard the package comment warns against for the guarded
 // root's own parent.
-func ForPhysicalRoot(root string) (Gate, error) { return forDir(root) }
+func ForPhysicalRoot(root string) (Gate, error) {
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return Gate{}, fmt.Errorf("workspacegate: resolving physical root %s: %w", root, err)
+	}
+	abs = filepath.Clean(abs)
+	if fi, lerr := os.Lstat(abs); lerr == nil && fi.Mode()&os.ModeSymlink != 0 {
+		physical, rerr := filepath.EvalSymlinks(abs)
+		if rerr != nil {
+			return Gate{}, fmt.Errorf("workspacegate: resolving physical root symlink %s: %w", abs, rerr)
+		}
+		target, serr := os.Stat(physical)
+		if serr != nil {
+			return Gate{}, fmt.Errorf("workspacegate: inspecting physical root symlink target %s: %w", abs, serr)
+		}
+		if !target.IsDir() {
+			return Gate{}, fmt.Errorf("workspacegate: physical root symlink %s targets %s, which is not a directory", abs, physical)
+		}
+		return forDir(physical)
+	}
+	return forDir(abs)
+}
 
 // Info is the advisory holder-info sidecar written next to the gate file
 // on exclusive acquisition. It is diagnostics only: the flock is the

--- a/internal/workspacegate/gate_test.go
+++ b/internal/workspacegate/gate_test.go
@@ -421,6 +421,75 @@ func TestCanonicalizationAgreesAcrossSymlinkSpellings(t *testing.T) {
 	}
 }
 
+func TestForPhysicalRootResolvesRootSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation needs privileges on windows")
+	}
+	dir := t.TempDir()
+	realRoot := filepath.Join(dir, "real-root")
+	if err := os.Mkdir(realRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linkRoot := filepath.Join(dir, "root-alias")
+	if err := os.Symlink(realRoot, linkRoot); err != nil {
+		t.Skipf("symlink: %v", err)
+	}
+
+	realGate, err := ForPhysicalRoot(realRoot)
+	if err != nil {
+		t.Fatalf("ForPhysicalRoot(real): %v", err)
+	}
+	linkGate, err := ForPhysicalRoot(linkRoot)
+	if err != nil {
+		t.Fatalf("ForPhysicalRoot(symlink): %v", err)
+	}
+	if linkGate.Path() != realGate.Path() {
+		t.Fatalf("same physical root produced two gates: %s vs %s", linkGate.Path(), realGate.Path())
+	}
+
+	h := mustAcquire(t, realGate, Exclusive, Options{})
+	defer h.Release()
+	if _, err := linkGate.Acquire(context.Background(), Shared, Options{}); !errors.Is(err, ErrBusy) {
+		t.Fatalf("symlink spelling did not contend with physical root: err = %v, want ErrBusy", err)
+	}
+}
+
+func TestForPhysicalRootRejectsNonDirectorySymlinkTarget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation needs privileges on windows")
+	}
+	dir := t.TempDir()
+	fileTarget := filepath.Join(dir, "not-a-directory")
+	if err := os.WriteFile(fileTarget, []byte("data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	linkRoot := filepath.Join(dir, "root-alias")
+	if err := os.Symlink(fileTarget, linkRoot); err != nil {
+		t.Skipf("symlink: %v", err)
+	}
+
+	_, err := ForPhysicalRoot(linkRoot)
+	if err == nil || !strings.Contains(err.Error(), "not a directory") {
+		t.Fatalf("ForPhysicalRoot(file symlink) error = %v, want not-a-directory diagnostic", err)
+	}
+}
+
+func TestForPhysicalRootRejectsDanglingSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation needs privileges on windows")
+	}
+	dir := t.TempDir()
+	linkRoot := filepath.Join(dir, "root-alias")
+	if err := os.Symlink(filepath.Join(dir, "missing-root"), linkRoot); err != nil {
+		t.Skipf("symlink: %v", err)
+	}
+
+	_, err := ForPhysicalRoot(linkRoot)
+	if err == nil || !strings.Contains(err.Error(), "resolving physical root symlink") {
+		t.Fatalf("ForPhysicalRoot(dangling symlink) error = %v, want symlink-resolution diagnostic", err)
+	}
+}
+
 // A Wait shorter than the poll interval must come back within (about)
 // Wait, not a full poll interval later.
 func TestWaitBudgetCapsPolling(t *testing.T) {


### PR DESCRIPTION
## Summary

- resolve an existing physical-root symlink before deriving its workspace gate
- make aliases of the same physical storage contend on one lock
- preserve literal workspace-gate identity and nonexistent-root bootstrap behaviour
- reject dangling and non-directory physical-root symlink targets with specific diagnostics

Fixes #5750.

## Why this boundary

ForWorkspace still rejects a workspace directory that is itself a symlink. Only ForPhysicalRoot resolves a root alias, which keeps the existing create/replace identity rule for workspaces while allowing callers to gate the physical storage they actually open.

I reviewed open PR #5310 as required by the repository preflight. It changes destructive init acquisition in cmd/bd; this PR changes the lower-level physical-root constructor in internal/workspacegate and does not replace or alter #5310's tests or intent.

## Test evidence

- The new regression tests failed against the unmodified implementation with the existing "is a symlink; gate the physical directory" error.
- The same tests pass with this commit and prove both equal gate paths and real exclusive/shared contention.
- A locally built bd 1.2.1 dev binary opened the original symlinked HEALTH embedded database with empty stderr and all 1183 issues visible.
- make test
- BD_LINT_NEW_FROM_MERGE_BASE=upstream/main make ci-pr-lint

The unscoped main-branch lint sweep also reports two pre-existing gosec findings in internal/config/permissions_open_nonlinux.go and internal/utils/path_case_darwin.go; the PR-scoped lint lane reports zero issues.

_codex-unknown-model-unknown-reasoning on behalf of James Cherry_
