### PR TITLE
fix(metrics): prune eventsData even when telemetry is disabled (GH#5712)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   payload is unchanged. Under `--quiet` the audit now skips its queries
   entirely rather than running them to discard the output.
 
+### Fixed
+
+- **Disabling telemetry no longer strands the queued eventsData backlog
+  forever** (GH#5712). `bd send-metrics` early-returned on disabled metrics
+  *before* its prune step, and the spawn gate refused to schedule the child at
+  all when disabled — so the one machine whose queue can never again drain by
+  upload (the one that just opted out) kept every queued batch and orphaned
+  emitter temp indefinitely (2M+ files / 15.8GB observed on one control VM).
+  With metrics disabled, bd now still spawns the detached child under the same
+  marker-first throttle, and the child prunes by the normal TTL/cap policy and
+  exits without POSTing anything. Once the backlog has decayed empty, spawns
+  stop entirely; a machine that never enabled telemetry has no queue directory
+  and never forks.
+
 ### Documentation
 
 - **The heartbeat/re-home invariant and the two states it can strand are now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   emitter temp indefinitely (2M+ files / 15.8GB observed on one control VM).
   With metrics disabled, bd now still spawns the detached child under the same
   marker-first throttle, and the child prunes by the normal TTL/cap policy and
-  exits without POSTing anything. Once the backlog has decayed empty, spawns
-  stop entirely; a machine that never enabled telemetry has no queue directory
-  and never forks.
+  exits without POSTing anything. Until that pre-existing backlog ages out, a
+  host that just opted out while its queue still holds batches younger than the
+  7-day TTL (and under the file/size caps) keeps forking the throttled,
+  detached, network-free prune child every flush interval — reclaiming nothing
+  until those batches age past the TTL — so new prune-only `bd send-metrics`
+  processes on a freshly disabled host are expected during that bounded window
+  and never POST. Once the backlog has decayed empty, spawns stop entirely; a
+  machine that never enabled telemetry has no queue directory and never forks.
 
 ### Documentation
 

--- a/internal/metrics/flusher.go
+++ b/internal/metrics/flusher.go
@@ -17,10 +17,6 @@ const (
 )
 
 func RunSendMetrics() int {
-	if !Enabled() {
-		return 0
-	}
-
 	dir, err := DataDir()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "send-metrics: %v\n", err)
@@ -34,6 +30,15 @@ func RunSendMetrics() int {
 	if dropped, freed := PruneQueue(dir, time.Now()); dropped > 0 {
 		fmt.Fprintf(os.Stderr, "send-metrics: pruned %d queued event file(s), freed %.1f MB\n",
 			dropped, float64(freed)/(1<<20))
+	}
+
+	// With telemetry disabled this child exists only for the prune above:
+	// nothing may be POSTed, but the backlog an earlier enabled configuration
+	// queued still has to decay. The old ordering (enabled check first)
+	// stranded eventsData forever on exactly the machine that just opted out —
+	// 2M+ files / 15.8GB observed on one control VM (GH#5712).
+	if !Enabled() {
+		return 0
 	}
 
 	ga, err := ga4tx.New(ga4tx.Config{Endpoint: Endpoint()})

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -110,8 +110,11 @@ const closeFlushTimeout = 500 * time.Millisecond
 // reachable os.Exit guards (CheckReadonly and the pre-run gates in main), so
 // events already queued earlier in this run are still written to disk and
 // scheduled for upload even when a command exits without returning through the
-// RunE/ExecuteC path. It is a no-op when metrics are disabled or uninitialized,
-// and the BD_IS_FLUSHER guard in MaybeSpawnFlusher keeps it from recursing.
+// RunE/ExecuteC path. When metrics are disabled the collector half is inert
+// (NullEmitter), but the spawn half still runs: a leftover queue from a
+// previously-enabled configuration is drained by prune-only send-metrics
+// children (GH#5712). The BD_IS_FLUSHER guard in MaybeSpawnFlusher keeps it
+// from recursing.
 func CloseAndFlush() {
 	if c := Global(); c != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), closeFlushTimeout)

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestInitDisabledKeepsEnabledFalse(t *testing.T) {
@@ -72,23 +73,92 @@ func TestInitEnabledFlipsEnabledTrue(t *testing.T) {
 	}
 }
 
-func TestRunSendMetricsNoOpWhenDisabled(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	_, err := Init("0.0.0-test", false, "")
-	if err != nil {
+// TestRunSendMetricsDisabledPrunesWithoutUploading is the regression for
+// GH#5712: RunSendMetrics used to early-return on !Enabled() BEFORE PruneQueue,
+// so the machine that just opted out of telemetry — the one whose queue can
+// never again drain by upload — kept its eventsData backlog forever (2M+ files
+// / 15.8GB observed on one control VM). Disabled mode must prune by the normal
+// policy and must not upload.
+func TestRunSendMetricsDisabledPrunesWithoutUploading(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := filepath.Join(home, ".beads", "eventsData")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("mkdir eventsData: %v", err)
+	}
+	stale := filepath.Join(dir, "stale"+queuedEventExt)
+	orphan := filepath.Join(dir, writeTempPrefix+"orphan")
+	fresh := filepath.Join(dir, "fresh"+queuedEventExt)
+	for _, p := range []string{stale, orphan, fresh} {
+		if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+	old := time.Now().Add(-pruneTTL - time.Hour)
+	for _, p := range []string{stale, orphan} {
+		if err := os.Chtimes(p, old, old); err != nil {
+			t.Fatalf("chtimes %s: %v", p, err)
+		}
+	}
+
+	// The endpoint is unreachable by construction: if the disabled path ever
+	// fell through to the upload half, Flush would fail on fresh.evtq and
+	// RunSendMetrics would return nonzero.
+	if _, err := Init("0.0.0-test", false, "http://127.0.0.1:1/collect"); err != nil {
 		t.Fatalf("Init: %v", err)
 	}
 	if code := RunSendMetrics(); code != 0 {
-		t.Errorf("RunSendMetrics() = %d, want 0", code)
+		t.Fatalf("RunSendMetrics() = %d, want 0 (disabled mode must prune and skip the upload)", code)
+	}
+
+	for _, p := range []string{stale, orphan} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Errorf("%s survived a disabled-mode prune (stat err %v)", filepath.Base(p), err)
+		}
+	}
+	if _, err := os.Stat(fresh); err != nil {
+		t.Errorf("fresh batch did not survive: %v (disabled mode prunes by the same TTL/cap policy, it does not purge)", err)
 	}
 }
 
-func TestMaybeSpawnFlusherNoOpWhenDisabled(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	_, err := Init("0.0.0-test", false, "")
-	if err != nil {
+// TestSpawnGateIgnoresDisabledMetrics pins the spawn-side half of the GH#5712
+// fix: the env half of the spawn gate must NOT require Enabled(), or the
+// disable path could never schedule the prune-only child that drains a
+// leftover queue. The stateful half still applies — with no queued backlog
+// nothing is due, so a machine that never enabled telemetry never forks.
+func TestSpawnGateIgnoresDisabledMetrics(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Hermetically clear the two env suppressors (the repo's own runner exports
+	// BEADS_TEST_MODE=1, and CI exports BD_DISABLE_EVENT_FLUSH=1 workflow-wide)
+	// so the assertion below is gated on Enabled() alone. shouldSpawnFlusher is
+	// a pure decision — nothing forks here.
+	t.Setenv(EnvTestMode, "")
+	os.Unsetenv(EnvTestMode)
+	t.Setenv(EnvDisableEventFlush, "")
+	os.Unsetenv(EnvDisableEventFlush)
+
+	if _, err := Init("0.0.0-test", false, ""); err != nil {
 		t.Fatalf("Init: %v", err)
 	}
+	if Enabled() {
+		t.Fatalf("Enabled() = true, want false")
+	}
+	if !shouldSpawnFlusher() {
+		t.Errorf("shouldSpawnFlusher() = false with metrics disabled, want true (prune-only child, GH#5712)")
+	}
+
+	// Stateful half: Init(disabled) never creates eventsData, so nothing is
+	// due. MaybeSpawnFlusher is exercised only with the test-mode guard
+	// restored, so a regression in flusherDue cannot fork a real child.
+	dir, err := DataDir()
+	if err != nil {
+		t.Fatalf("DataDir: %v", err)
+	}
+	if flusherDue(dir, time.Now()) {
+		t.Errorf("flusherDue(no queue dir) = true, want false")
+	}
+	t.Setenv(EnvTestMode, "1")
 	MaybeSpawnFlusher()
 }
 

--- a/internal/metrics/spawn.go
+++ b/internal/metrics/spawn.go
@@ -33,8 +33,17 @@ func inTestMode() bool {
 // shouldSpawnFlusher is the env/config half of the spawn gate, extracted so
 // tests can assert the decision without forking a real detached child. The
 // stateful half (pending events + throttle) is flusherDue.
+//
+// Enabled() is deliberately NOT part of this gate (GH#5712): with telemetry
+// disabled the detached child still has one job — pruning the queued backlog
+// a previously-enabled configuration left behind. RunSendMetrics exits after
+// the prune, before any upload, when disabled; and flusherDue's marker-first
+// throttle keeps the disabled path exactly as cheap as the enabled one (one
+// marker stat inside the interval, and no spawn at all once the queue has
+// decayed empty — a never-enabled machine has no queue dir, so its scan is a
+// single failed open).
 func shouldSpawnFlusher() bool {
-	return os.Getenv(EnvIsFlusher) != "1" && Enabled() && !flushDisabledByEnv() && !inTestMode()
+	return os.Getenv(EnvIsFlusher) != "1" && !flushDisabledByEnv() && !inTestMode()
 }
 
 // flushInterval is the minimum spacing between detached send-metrics spawns.

--- a/internal/metrics/spawn.go
+++ b/internal/metrics/spawn.go
@@ -62,16 +62,17 @@ const flushInterval = 5 * time.Minute
 const flushMarkerName = ".last-flush"
 
 // flusherDue reports whether a detached flush is worth spawning: the last
-// spawn attempt is at least flushInterval old, and at least one queued event
-// batch exists. The marker stat runs FIRST so the throttled path — the common
-// case, every invocation inside the interval — costs one stat and never scans
-// the queue: when uploads keep failing the queue backs up without bound
-// (148k entries / 1.1GB observed on one dev machine), and a scan of a
-// directory that size costs ~250ms. A marker mtime more than one interval in
-// the future (clock stepped back) reads as due rather than suppressing
-// uploads until the wall clock catches up; smaller negative ages are ordinary
-// timestamp skew (e.g. the caller sampled now just before the marker was
-// written) and stay throttled.
+// spawn attempt is at least flushInterval old, and the queue holds work — a
+// queued event batch, or an orphaned emitter temp already past its prune TTL.
+// The marker stat runs FIRST so the throttled path — the common case, every
+// invocation inside the interval — costs one stat and never scans the queue:
+// when uploads keep failing the queue backs up without bound (148k entries /
+// 1.1GB observed on one dev machine), and a scan of a directory that size
+// costs ~250ms. A marker mtime more than one interval in the future (clock
+// stepped back) reads as due rather than suppressing uploads until the wall
+// clock catches up; smaller negative ages are ordinary timestamp skew (e.g.
+// the caller sampled now just before the marker was written) and stay
+// throttled.
 func flusherDue(dir string, now time.Time) bool {
 	if fi, err := os.Stat(filepath.Join(dir, flushMarkerName)); err == nil {
 		age := now.Sub(fi.ModTime())
@@ -79,7 +80,7 @@ func flusherDue(dir string, now time.Time) bool {
 			return false
 		}
 	}
-	return scanQueue(dir)
+	return scanQueue(dir, now)
 }
 
 // scanQueue is hasQueuedEvents behind a seam so tests can assert the
@@ -87,29 +88,52 @@ func flusherDue(dir string, now time.Time) bool {
 // ordering exists for.
 var scanQueue = hasQueuedEvents
 
-// hasQueuedEvents reports whether dir holds at least one queued event batch.
-// It reads the directory in small unsorted chunks and returns at the first
-// match, instead of os.ReadDir, which reads and sorts EVERY entry before the
-// caller sees one — on a backed-up queue that is the whole cost flusherDue
-// exists to avoid paying per invocation.
-func hasQueuedEvents(dir string) bool {
+// hasQueuedEvents reports whether dir holds work a detached child should act
+// on: a queued event batch, or a prune-eligible (past-pruneTTL) orphaned
+// emitter temp. It reads the directory in small unsorted chunks and returns at
+// the first match, instead of os.ReadDir, which reads and sorts EVERY entry
+// before the caller sees one — on a backed-up queue that is the whole cost
+// flusherDue exists to avoid paying per invocation.
+//
+// A batch matches by name alone (no stat), so the backed-up-queue hot path is
+// unchanged. Orphaned .write-* temps (a FileEmitter killed between CreateTemp
+// and Rename) are reclaimed ONLY by the prune child and only once past
+// pruneTTL; a dir holding just those, with no batch, must still become due or
+// the prune child never spawns and the temp outlives its TTL forever on a
+// disabled machine (the GH#5712 orphan-only follow-up). A stale temp is
+// stat-gated on the same pruneTTL threshold pruneQueue uses, so the predicate
+// fires exactly when the prune would actually remove it — a still-fresh temp
+// is not yet due.
+func hasQueuedEvents(dir string, now time.Time) bool {
 	f, err := os.Open(dir) // #nosec G304 -- dir is the metrics DataDir, not user input
 	if err != nil {
 		// Unreadable/missing queue dir: the emitter never wrote, so there is
-		// nothing a flusher child could upload.
+		// nothing a flusher child could upload or prune.
 		return false
 	}
 	defer f.Close()
 	for {
 		entries, err := f.ReadDir(64)
 		for _, e := range entries {
-			if !e.IsDir() && filepath.Ext(e.Name()) == queuedEventExt {
+			if e.IsDir() {
+				continue
+			}
+			name := e.Name()
+			if filepath.Ext(name) == queuedEventExt {
 				return true
+			}
+			if strings.HasPrefix(name, writeTempPrefix) {
+				// Stat only the temp candidates (rare on a disabled machine,
+				// which emits nothing new); a batch already returned above, so
+				// the hot path never reaches this stat.
+				if fi, err := e.Info(); err == nil && now.Sub(fi.ModTime()) > pruneTTL {
+					return true
+				}
 			}
 		}
 		if err != nil {
 			// io.EOF (scanned everything) or a read error mid-listing: either
-			// way no queued batch was seen.
+			// way no batch and no prune-eligible temp was seen.
 			return false
 		}
 	}
@@ -118,6 +142,15 @@ func hasQueuedEvents(dir string) bool {
 // touchFlushMarker stamps the throttle marker with the current time. Failures
 // are ignored: the marker is a rate limiter, and on a filesystem where it
 // cannot be written the worst case is the old always-spawn behavior.
+//
+// The marker is per-eventsData-dir. On a shared $HOME where enabled and
+// disabled bd invocations target one dir, a disabled prune-only spawn also
+// stamps it, so it can make a post-throttle window prune-only and delay (worst
+// case, if disabled traffic dominates, starve) the enabled stream's uploads.
+// This is design-tolerated latency, not a data-safety issue: enabled and
+// disabled children run the identical PruneQueue(dir, now), so a disabled prune
+// deletes exactly what an enabled one would; only upload cadence is affected,
+// which the 7d TTL / 5-min batching budget already absorbs.
 func touchFlushMarker(dir string) {
 	path := filepath.Join(dir, flushMarkerName)
 	now := time.Now()

--- a/internal/metrics/spawn_throttle_test.go
+++ b/internal/metrics/spawn_throttle_test.go
@@ -55,6 +55,37 @@ func TestFlusherDueRequiresPendingEvents(t *testing.T) {
 	}
 }
 
+// TestFlusherDueOrphanTempsWithoutBatch pins the GH#5712 orphan-only follow-up:
+// an eventsData dir holding only orphaned .write-* emitter temps and no .evtq
+// batch must still become due once a temp is past pruneTTL, so the prune-only
+// child spawns and reclaims it. Before the fix the due predicate matched only
+// .evtq batches, so such a dir never scheduled a prune and the temp outlived
+// its TTL forever on a disabled machine — the exact leak the review caught. A
+// still-fresh temp is NOT yet due, matching pruneQueue's own TTL gate.
+func TestFlusherDueOrphanTempsWithoutBatch(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	orphan := filepath.Join(dir, writeTempPrefix+"orphan")
+	if err := os.WriteFile(orphan, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write orphan temp: %v", err)
+	}
+
+	// Fresh orphan temp, no batch: nothing is prune-eligible yet, so not due.
+	if flusherDue(dir, now) {
+		t.Errorf("flusherDue(fresh orphan temp only) = true, want false")
+	}
+
+	// Age it past the prune TTL: now the prune child would reclaim it, so the
+	// due predicate must fire even though there is still no .evtq batch.
+	stale := now.Add(-pruneTTL - time.Hour)
+	if err := os.Chtimes(orphan, stale, stale); err != nil {
+		t.Fatalf("chtimes orphan temp: %v", err)
+	}
+	if !flusherDue(dir, now) {
+		t.Errorf("flusherDue(stale orphan temp only) = false, want true (prune-only child, GH#5712)")
+	}
+}
+
 func TestFlusherDueMissingDirIsNotDue(t *testing.T) {
 	if flusherDue(filepath.Join(t.TempDir(), "never-created"), time.Now()) {
 		t.Errorf("flusherDue(missing dir) = true, want false")
@@ -122,7 +153,7 @@ func TestHasQueuedEventsAcrossChunks(t *testing.T) {
 			t.Fatalf("write litter: %v", err)
 		}
 	}
-	if hasQueuedEvents(dir) {
+	if hasQueuedEvents(dir, time.Now()) {
 		t.Errorf("hasQueuedEvents(200 litter files) = true, want false")
 	}
 	// The all-litter pass above is the deterministic pin on the loop: 200
@@ -131,7 +162,7 @@ func TestHasQueuedEventsAcrossChunks(t *testing.T) {
 	// enumeration is sorted (e.g. NTFS, which CI exercises); elsewhere the
 	// batch may surface in any chunk, and the assertion is just "found".
 	writeQueuedEventNamed(t, dir, "zz-last")
-	if !hasQueuedEvents(dir) {
+	if !hasQueuedEvents(dir, time.Now()) {
 		t.Errorf("hasQueuedEvents(batch among 200 litter files) = false, want true")
 	}
 }
@@ -147,7 +178,7 @@ func TestFlusherDueFreshMarkerSkipsQueueScan(t *testing.T) {
 	touchFlushMarker(dir)
 
 	orig := scanQueue
-	scanQueue = func(string) bool {
+	scanQueue = func(string, time.Time) bool {
 		t.Error("flusherDue scanned the queue despite a fresh marker")
 		return true
 	}


### PR DESCRIPTION
Fixes #5712 (follow-up to #5660; tracked internally as bd-eomat).

## The bug

`RunSendMetrics` early-returned on `!Enabled()` **before** its `PruneQueue` step, and `shouldSpawnFlusher` required `Enabled()` — so once `BD_DISABLE_METRICS=1` / `bd metrics off` was set, nothing in bd ever revisited eventsData. The standard remediation for a runaway queue (turn telemetry off) was also the thing that made the existing backlog permanently unreclaimable: queued batches AND the orphaned `.write-*` temps #5660 set out to reclaim stayed forever (reporter's control VM: 2M+ `.evtq` / 15.8GB, root fs 61%→85%).

## The fix

Two sides, matching the shape proposed on the issue:

- **Child side** (`flusher.go`): the prune runs before the enabled check; a disabled `send-metrics` child prunes and exits without POSTing anything.
- **Spawn side** (`spawn.go`): `shouldSpawnFlusher` drops the `Enabled()` requirement so the prune-only child still gets scheduled. The stateful half is untouched: the marker-first throttle (bd-p6o3y discipline) means the disabled path costs exactly what the enabled path costs — one marker stat per invocation inside the interval, no full scan on any interactive invocation.

## Deliberate choices

- **Prune, don't purge.** Disabled mode uses the same TTL/cap policy as enabled mode rather than deleting the whole queue. On a shared $HOME where some processes run with `DO_NOT_TRACK=1` and others don't, a transiently-disabled invocation therefore only ever deletes what an enabled child would also have deleted — no fight between the two modes. Consequence for the 15.8GB case: the first prune drops everything past the 10k/64MiB caps immediately (~99.6% reclaimed), and the remainder ages out via the 7-day TTL.
- **Spawns self-extinguish.** Once the backlog decays empty, `flusherDue`'s chunked scan finds no `.evtq` and nothing spawns. A machine that never enabled telemetry has no queue dir at all — its cost is one failed stat + one failed open past each throttle interval.
- `BD_DISABLE_EVENT_FLUSH` and `BEADS_TEST_MODE` still suppress the child entirely (unchanged).

## Known residual

If the queue decays to only orphaned `.write-*` temps (no `.evtq`), the due-check won't schedule a child to reclaim them until the next `.evtq` appears. That asymmetry predates this PR and exists in enabled mode too; left as-is to keep the scan predicate shared.

## Tests

- `TestRunSendMetricsDisabledPrunesWithoutUploading`: stale batch + orphan temp pruned, fresh batch survives, and the endpoint is unreachable-by-construction so any fall-through to the upload half fails the test with a nonzero exit.
- `TestSpawnGateIgnoresDisabledMetrics`: env-half decision is true with metrics disabled (hermetic wrt the runner's `BEADS_TEST_MODE`/CI's `BD_DISABLE_EVENT_FLUSH` exports); stateful half stays no-spawn with no backlog; `MaybeSpawnFlusher` only exercised with the test-mode guard restored so a regression can't fork under `go test`.
- Replaces the two tests that pinned the old (buggy) disabled-mode behavior.
- `go test ./internal/metrics/` and the metrics-adjacent `cmd/bd` tests (`-run 'Metrics|Flusher|SendMetrics'`) green; `gofmt`/`go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)