### PR TITLE
chore(release): forward-port v1.2.2 to main (version record, retracts, recovery guide, gate record)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "beads",
       "source": "./plugins/beads",
       "description": "AI-supervised issue tracker for coding workflows",
-      "version": "1.2.1"
+      "version": "1.2.2"
     }
   ]
 }

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v1.2.1 ---
+# --- BEGIN BEADS INTEGRATION v1.2.2 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -56,4 +56,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ "$_bd_exit" -ne 0 ]; then exit "$_bd_exit"; fi
 fi
-# --- END BEADS INTEGRATION v1.2.1 ---
+# --- END BEADS INTEGRATION v1.2.2 ---

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v1.2.1 ---
+# --- BEGIN BEADS INTEGRATION v1.2.2 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -56,4 +56,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ "$_bd_exit" -ne 0 ]; then exit "$_bd_exit"; fi
 fi
-# --- END BEADS INTEGRATION v1.2.1 ---
+# --- END BEADS INTEGRATION v1.2.2 ---

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -40,7 +40,7 @@ if [ -n "$staged_go_files" ]; then
     echo "$staged_go_files" | xargs git add
 fi
 
-# --- BEGIN BEADS INTEGRATION v1.2.1 ---
+# --- BEGIN BEADS INTEGRATION v1.2.2 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -97,4 +97,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ "$_bd_exit" -ne 0 ]; then exit "$_bd_exit"; fi
 fi
-# --- END BEADS INTEGRATION v1.2.1 ---
+# --- END BEADS INTEGRATION v1.2.2 ---

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -39,7 +39,7 @@ fi
 
 exec < <(printf '%s\n' "$push_refs")
 
-# --- BEGIN BEADS INTEGRATION v1.2.1 ---
+# --- BEGIN BEADS INTEGRATION v1.2.2 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -96,4 +96,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ "$_bd_exit" -ne 0 ]; then exit "$_bd_exit"; fi
 fi
-# --- END BEADS INTEGRATION v1.2.1 ---
+# --- END BEADS INTEGRATION v1.2.2 ---

--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v1.2.1 ---
+# --- BEGIN BEADS INTEGRATION v1.2.2 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -56,4 +56,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ "$_bd_exit" -ne 0 ]; then exit "$_bd_exit"; fi
 fi
-# --- END BEADS INTEGRATION v1.2.1 ---
+# --- END BEADS INTEGRATION v1.2.2 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `HeartbeatIssueInTx`, `docs/multi-agent/federation.md`, and
   `bd reclaim --help`.
 
+## [1.2.2] - 2026-08-15
+
+Recovery release, cut from the v1.1.2 tree on branch `release/v1.2.2` (not
+from main). v1.2.0 and v1.2.1 were published by accident on 2026-08-11
+without release testing (v1.2.0's tag burned pre-publish; only v1.2.1
+reached users). This release supersedes them by re-releasing the **tested
+1.1 line**: it is the v1.1.2 code under a higher version number, so every
+install channel (Homebrew, npm, the install script,
+`go install ...@latest`) moves forward onto tested code. The 1.2.x-only
+features listed under [1.2.1] below are **not** in this release; they
+remain on main for a properly tested future release.
+
+**If v1.2.1 migrated your database** (running any command once was enough),
+v1.2.2 stops with `schema version mismatch: database is at v65, binary
+knows up to v53`. See the recovery guide
+([site](https://beads.gascity.com/recovery/accidental-1-2-1-release),
+[repo copy at the tag](https://github.com/gastownhall/beads/blob/v1.2.2/docs/RECOVERY-1.2.1.md))
+for the two-minute fix (roll the schema cursor back to v53) and a verified
+stopgap (`BD_IGNORE_SCHEMA_SKEW=1`).
+
+### Changed
+
+- **The forward-skew error recognizes the accidental-release window** (on
+  the release branch): a v53 binary opening a database at schema v54–v65
+  points at the recovery guide instead of advising "install the latest
+  release" (which would loop back to that binary).
+- **`go.mod` retracts v1.2.1, v1.2.0, and v1.1.1** so
+  `go install github.com/steveyegge/beads/cmd/bd@latest` resolves to this
+  release instead of the accidental one. (The retract block is also
+  carried on main so future tags keep the retractions.)
+
 ## [1.2.1] - 2026-08-11
 
 (Released as 1.2.1: the v1.2.0 tag burned pre-publish on a freebsd

--- a/cmd/bd/info.go
+++ b/cmd/bd/info.go
@@ -221,6 +221,15 @@ type VersionChange struct {
 // versionChanges contains agent-actionable changes for recent versions
 var versionChanges = []VersionChange{
 	{
+		Version: "1.2.2",
+		Date:    "2026-08-15",
+		Changes: []string{
+			"RELEASE: v1.2.2 re-releases the tested 1.1 line (identical code to v1.1.2) to supersede the accidental, untested v1.2.0/v1.2.1; 1.2.x-only features (leases, events journal, sync federation, HTTP API server, provenance) are not included.",
+			"RECOVERY: if v1.2.1 already migrated a database to schema v65, the v1.2.2 binary refuses with a schema version mismatch; see https://beads.gascity.com/recovery/accidental-1-2-1-release — recommended fix is rolling the schema_migrations cursor back to v53, stopgap is BD_IGNORE_SCHEMA_SKEW=1.",
+			"GO: go.mod retracts v1.2.1/v1.2.0/v1.1.1 so 'go install ...@latest' resolves to v1.2.2.",
+		},
+	},
+	{
 		Version: "1.2.1",
 		Date:    "2026-08-11",
 		Changes: []string{

--- a/cmd/bd/version.go
+++ b/cmd/bd/version.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	// Version is the current version of bd (overridden by ldflags at build time)
-	Version = "1.2.1"
+	Version = "1.2.2"
 	// Build can be set via ldflags at compile time
 	Build = "dev"
 	// Commit and branch the git revision the binary was built from (optional ldflag)

--- a/cmd/bd/winres/manifest.xml
+++ b/cmd/bd/winres/manifest.xml
@@ -3,7 +3,7 @@
   <assemblyIdentity
     type="win32"
     name="beads.bd"
-    version="1.2.1.0"
+    version="1.2.2.0"
     processorArchitecture="*"/>
   <description>beads - AI-supervised issue tracker</description>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">

--- a/cmd/bd/winres/winres.json
+++ b/cmd/bd/winres/winres.json
@@ -9,8 +9,8 @@
     "#1": {
       "0000": {
         "fixed": {
-          "file_version": "1.2.1",
-          "product_version": "1.2.1",
+          "file_version": "1.2.2",
+          "product_version": "1.2.2",
           "type": "App"
         },
         "info": {
@@ -18,12 +18,12 @@
             "Comments": "AI-supervised issue tracker for coding workflows",
             "CompanyName": "Steve Yegge",
             "FileDescription": "beads - AI-supervised issue tracker",
-            "FileVersion": "1.2.1",
+            "FileVersion": "1.2.2",
             "InternalName": "bd",
             "LegalCopyright": "Copyright (c) 2024-2026 Steve Yegge. MIT License.",
             "OriginalFilename": "bd.exe",
             "ProductName": "beads",
-            "ProductVersion": "1.2.1"
+            "ProductVersion": "1.2.2"
           }
         }
       }

--- a/default.nix
+++ b/default.nix
@@ -7,7 +7,7 @@
 }:
 buildGoModule {
   pname = "beads";
-  version = "1.2.1";
+  version = "1.2.2";
 
   src = self;
 

--- a/docs/cli-docs.pin
+++ b/docs/cli-docs.pin
@@ -9,4 +9,4 @@
 #
 # Set to HEAD to track the current checkout's source instead (the pre-pin
 # behavior).
-v1.1.0
+v1.2.2

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -269,6 +269,7 @@
         "group": "Recovery",
         "pages": [
           "recovery/index",
+          "recovery/accidental-1-2-1-release",
           "recovery/init-safety",
           "recovery/database-corruption",
           "recovery/merge-conflicts",

--- a/docs/recovery/accidental-1-2-1-release.md
+++ b/docs/recovery/accidental-1-2-1-release.md
@@ -1,0 +1,120 @@
+---
+title: Accidental v1.2.1 Release
+description: Recover a database migrated by the accidental, untested v1.2.1 release
+---
+
+v1.2.0 and v1.2.1 were published by accident on 2026-08-11, without release
+testing. v1.2.2 superseded them by re-releasing the tested 1.1 line — it is
+the v1.1.2 code under a higher version number, so every install channel
+(Homebrew, npm, the install script, `go install`) moves forward onto tested
+code. The 1.2.x-only features (work leases, the events journal, sync
+federation, the HTTP API server, provenance events) are not in v1.2.2; they
+will return in a properly tested release.
+
+The catch: running the v1.2.1 binary even once (any command, including
+`bd list`) migrated your local database schema from v53 to v65. The v1.2.2
+binary speaks schema v53, so on such a database it stops with:
+
+```
+schema version mismatch: database is at v65, binary knows up to v53 (12 migrations ahead)
+```
+
+This guide fixes that. The v1.2.x schema changes are strictly additive —
+nothing the 1.1 line reads or writes was dropped, renamed, or narrowed — so
+recovery is a two-minute metadata fix, not a data migration.
+
+## Am I affected?
+
+Only if you both ran v1.2.1 at least once **and** see the schema-mismatch
+error above with v1.2.2 (or any 1.1.x binary). Users who upgraded but never
+ran `bd`, and users whose workspace has a Dolt remote configured (the
+remote-migrate gate blocked silent migration), are typically not affected.
+
+## Recommended fix: roll the schema cursor back
+
+The v1.2.x migrations were written to be replay-safe after a cursor
+rollback, so this is reversible and a later, properly tested 1.2.x upgrade
+will work normally afterwards.
+
+1. **Upgrade every machine and clone to v1.2.2 first.** A leftover v1.2.1
+   binary that touches the database will silently re-migrate it.
+2. Stop anything using the database: close running `bd` processes; in
+   server mode also run `bd dolt stop`.
+3. Take a backup copy of the workspace database:
+
+   ```sh
+   cp -a .beads .beads.backup-pre-recovery
+   ```
+
+4. Roll the cursor back with the [Dolt CLI](https://docs.dolthub.com/cli-reference/cli)
+   (any recent `dolt` release works; no `dolt config` setup is needed —
+   the command carries its own author). The database directory is
+   `.beads/embeddeddolt/<db>` (embedded mode, the default) or
+   `.beads/dolt/<db>` (server mode):
+
+   ```sh
+   cd .beads/embeddeddolt/<db>
+   dolt sql -q "DELETE FROM schema_migrations WHERE version > 53; CALL DOLT_ADD('schema_migrations'); CALL DOLT_COMMIT('-m', 'recovery: roll schema cursor back to v53 (accidental v1.2.1)', '--author', 'bd recovery <recovery@beads.invalid>')"
+   ```
+
+   (If this reports there is nothing to commit, the step was already
+   done — safe to continue.)
+
+5. Run any `bd` command from the workspace. It should work with no
+   warnings and no `BD_IGNORE_SCHEMA_SKEW` needed.
+
+This also works for databases **created** by v1.2.1 (not just upgraded
+ones): the v65 schema is a superset of everything the 1.1 line needs.
+
+If you push/pull issue data with teammates, note that the migrated cursor
+replicates: either recover every clone, or recover one and push, then have
+the others pull.
+
+### Optional: restore audit-event versioning
+
+One v1.2.x migration moved the `events` audit table off Dolt's versioned
+plane, and after the cursor rollback the 1.1 line keeps writing audit
+events without versioning or syncing them (everything else syncs
+normally). If you rely on the versioned audit trail, re-track the table
+from the same database directory:
+
+```sh
+dolt sql -q "DELETE FROM dolt_ignore WHERE pattern = 'events'; CALL DOLT_ADD('-f', 'events'); CALL DOLT_COMMIT('-m', 'recovery: re-track events table', '--author', 'bd recovery <recovery@beads.invalid>')"
+```
+
+## Stopgap: keep working before you recover
+
+If you need `bd` this minute, the skew guard has an escape hatch:
+
+```sh
+BD_IGNORE_SCHEMA_SKEW=1 bd <command>
+```
+
+This has been verified against the exact v53-binary/v65-database
+combination: reads are identical and writes work, because the v1.2.x
+schema additions are invisible to the 1.1 line. Audit-event versioning is
+paused (see above) until you do the cursor rollback, so treat this as a
+stopgap, not a destination.
+
+## What recovery leaves behind
+
+Data the accidental release wrote into 1.2.x-only structures stays in the
+database but is unused by the 1.1 line: work-lease state (ephemeral,
+5-minute horizon), events-journal rows (feature was off by default),
+provenance rows (only written by an explicit new command), and
+`storage_class` markers. None of it blocks a future 1.2.x upgrade, which
+will simply resume using it.
+
+## Alternative: full rollback via Dolt history
+
+If you want the database history itself restored to its pre-migration
+state (the cursor rollback keeps the migration commits in history), the
+v1.2.1 migrator made one labeled Dolt commit per migration
+(`schema: apply migration 0054_...` through `0065_...`), so the
+pre-migration commit is easy to find. The safe sequence is: export with
+the v1.2.1 binary (`bd export --all -o backup.jsonl`), stop everything and
+copy `.beads` aside, `dolt reset --hard <pre-migration-commit>` in the
+database directory, install v1.2.2, then `bd import backup.jsonl`.
+Caveats: issues deleted after the upgrade come back (import cannot
+re-delete), and audit events recorded while on v1.2.1 are lost. Most users
+should prefer the cursor rollback above.

--- a/go.mod
+++ b/go.mod
@@ -283,3 +283,13 @@ require (
 )
 
 tool github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen
+
+// v1.2.0 and v1.2.1 were published accidentally without release testing and
+// auto-migrated local databases to an unsupported schema (v54..v65); v1.1.1
+// was a burned tag that never shipped. v1.2.2 re-releases the tested 1.1
+// line — retracting these keeps `go install ...@latest` off the bad versions.
+retract (
+	v1.2.1 // accidental untested release; superseded by v1.2.2
+	v1.2.0 // burned tag for the accidental 1.2 release, never published
+	v1.1.1 // burned tag, never published; superseded by v1.1.2
+)

--- a/integrations/beads-mcp/pyproject.toml
+++ b/integrations/beads-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "beads-mcp"
-version = "1.2.1"
+version = "1.2.2"
 description = "MCP server for beads issue tracker."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/beads-mcp/src/beads_mcp/__init__.py
+++ b/integrations/beads-mcp/src/beads_mcp/__init__.py
@@ -4,4 +4,4 @@ This package provides an MCP (Model Context Protocol) server that exposes
 beads (bd) issue tracker functionality to MCP Clients.
 """
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"

--- a/integrations/beads-mcp/uv.lock
+++ b/integrations/beads-mcp/uv.lock
@@ -125,7 +125,7 @@ wheels = [
 
 [[package]]
 name = "beads-mcp"
-version = "1.2.1"
+version = "1.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beads/bd",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Beads issue tracker - lightweight memory system for coding agents with native binary support",
   "main": "bin/bd.js",
   "bin": {

--- a/plugins/beads/.claude-plugin/plugin.json
+++ b/plugins/beads/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beads",
   "description": "AI-supervised issue tracker for coding workflows. Manage tasks, discover work, and maintain context with simple CLI commands.",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": {
     "name": "Steve Yegge",
     "url": "https://github.com/steveyegge"

--- a/plugins/beads/.codex-plugin/plugin.json
+++ b/plugins/beads/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "beads",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "AI-supervised issue tracking for coding workflows with agent skills.",
   "author": {
     "name": "Steve Yegge",

--- a/plugins/beads/.copilot-plugin/plugin.json
+++ b/plugins/beads/.copilot-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beads",
   "description": "AI-supervised issue tracker for coding workflows. Manage tasks, discover work, and maintain context with simple CLI commands.",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": {
     "name": "Steve Yegge",
     "url": "https://github.com/steveyegge"

--- a/release-gates/v1.2.2-recovery-release-gate.md
+++ b/release-gates/v1.2.2-recovery-release-gate.md
@@ -1,0 +1,43 @@
+# Release gate — v1.2.2 (recovery re-release of the tested 1.1 line)
+
+**Date:** 2026-08-15
+**Releaser:** Julian Knutsen (staged and gate-run by Claude)
+**Tag:** `v1.2.2` @ `6c124203e` on `release/v1.2.2` (4 content commits + rc/promotion bumps on top of `v1.1.2`; NOT cut from main)
+**Review:** PR #5773 (diff vs a base branch pinned at v1.1.2), approved 2026-08-15
+**RC:** `v1.2.2-rc.1` @ `bb6be669f` — full pipeline dry-run, green
+**Context:** v1.2.0/v1.2.1 were published accidentally on 2026-08-11 without release testing; running v1.2.1 once auto-migrated local DBs to schema v65. v1.2.2 = the v1.1.2 tree + incident-aware skew message + `docs/RECOVERY-1.2.1.md` + go.mod retracts + release-verification tooling.
+
+## Verdict: PASS
+
+## Pre-tag gates (all on `release/v1.2.2`, host: linux dev box)
+
+| Gate | Result |
+|---|---|
+| `scripts/test.sh` full suite | PASS — 63 pkgs ok; `cmd/bd` (249s) and `internal/doltserver` (360s) exceed the 3m local default and pass at CI's canonical `-timeout=30m` |
+| `npm run test:all` | PASS (unit, against candidate binary); `test:integration` unrunnable pre-publish by design (postinstall fetches the versioned release asset) — covered by the pipeline npm gate + post-publish smoke |
+| Stability Gate `upgrade-smoke-test.sh` | PASS — `v1.1.2 → candidate` and `v1.1.0 → candidate`, all scenarios. Argless default resolves to v1.2.0 (burned tag, no binary). The `v1.2.1 →` leg is deliberately refused (forward skew); evidence: verification legs L4–L8 below |
+| `make test-regression` (baseline v0.49.6) | PASS (183 tests, 896s) |
+| `make ci-package-mcp` / `ci-package-npm` / `ci-website` (local) | PASS / PASS / PASS |
+| `scripts/release-verification-1.2.2.sh` (with a v1.2.1 binary) | PASS — 21/21: v53 round-trip; 1.2.1 migrates to v65; candidate refuses with incident message (no `@latest` loop); `BD_IGNORE_SCHEMA_SKEW=1` reads byte-identical + writes land; runbook cursor rollback → clean guard-free open; events re-track; 1.2.1 re-migration after recovery idempotent with data intact |
+| `check-versions.sh` strict tag-simulated | PASS |
+| vendorHash | unchanged by inspection: go.mod delta is retract-only, go.sum untouched (nix unavailable on the gate host) |
+
+## Pipeline evidence (tag-triggered, v1.1.2-era workflow from the tag tree)
+
+- `v1.2.2-rc.1`: Release workflow **success** (publish jobs correctly skipped for prerelease); published rc linux binary download-verified (`bd version 1.2.2-rc.1 @ bb6be669f`); release marked Pre-release, `latest` unchanged.
+- `v1.2.2`: Release workflow **success**; release auto-marked **Latest**; full asset matrix (linux/darwin/windows ×2, android, freebsd, checksums, SBOM, attestations); published linux binary download-verified (`bd version 1.2.2 @ 6c124203e`).
+- Cross-version smoke on `v1.2.2`: **30 green / 1 red**, the red being `v1.2.1 → candidate` — the deliberately refused forward-skew (pre-declared expected signature).
+- Migration Test Harness on `v1.2.2`: **success**.
+
+## Post-publish channel state (2026-08-15)
+
+- GitHub `releases/latest` → v1.2.2; v1.2.1 flagged Pre-release with a caution banner pointing at the recovery guide.
+- npm `@beads/bd` dist-tag `latest` = 1.2.2 (deprecation of 1.2.1 pending, needs org credentials).
+- PyPI `beads-mcp` 1.2.2 live (yank of 1.2.1 pending, maintainer web UI).
+- Go proxy `@latest` → v1.2.2; retracts active.
+- homebrew-core bump to 1.2.2 pending (formula is autobump-eligible; open `brew bump-formula-pr` only if BrewTestBot doesn't).
+
+## Notes
+
+- Local gate logs were lost to the host tmp cleaner after the fact; results are recorded here and independently reproduced by the two tag pipelines. `scripts/release-verification-1.2.2.sh` lives on the release branch/tag and is rerunnable.
+- The incident-aware skew message is NOT ported to main: its guard (`BinaryVersion == 53`) is dead code on the 1.2.x-line schema (main's ceiling is v65).


### PR DESCRIPTION
v1.2.2 (the recovery re-release of the tested 1.1 line, superseding the accidental v1.2.0/v1.2.1) shipped from branch `release/v1.2.2`, not from main. This PR is the selective forward-port — a literal merge would drag the v1.1.2 tree into main, so each piece is ported by hand:

1. **`chore(release): sync main to released v1.2.2`** — main's version metadata (version.go, plugins, marketplace, MCP + uv.lock, npm, nix, winres, `.githooks` markers) moves 1.2.1 → 1.2.2, matching the published release; `docs/cli-docs.pin` v1.1.0 → v1.2.2 (regeneration produced **zero content changes** — the CLI surface is identical); `info.go` versionChanges entry for 1.2.2.
2. **`chore(go.mod): carry the v1.2.x retractions`** — critical: Go resolves retractions from the *highest* release's go.mod, so the first tag cut from a retract-free main would silently un-retract v1.2.1.
3. **`docs: publish the accidental-v1.2.1 recovery guide`** — `docs/recovery/accidental-1-2-1-release.md` in the Mintlify Recovery nav (this is what puts the runbook on beads.gascity.com; the binaries' tag-pinned GitHub URL keeps working regardless), plus the CHANGELOG `[1.2.2]` entry.
4. **`docs(release-gates): record the v1.2.2 release gate`** — durable PASS record: all pre-tag gates, the rc.1 pipeline dry-run, tag pipeline evidence, and the expected cross-version-smoke signature (only `v1.2.1 → candidate` red, by design).

**Deliberately not ported:** the incident-aware schema-skew message from the release branch — its guard (`BinaryVersion == 53`) is dead code on main's v65-ceiling schema line.

**Verified locally:** `go build ./...`, `go vet`, gofmt, golangci-lint (0 issues), docsync guard, `check-versions.sh` green for 1.2.2. vendorHash unchanged by inspection (go.mod delta is retract-only; go.sum untouched; nix unavailable on this host — `nix-build` CI will confirm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)