### PR TITLE
fix: cmd/bd no-workspace tests depend on temp-dir ancestry and a stale git cache

### DIFF
--- a/cmd/bd/bootstrap_embedded_test.go
+++ b/cmd/bd/bootstrap_embedded_test.go
@@ -42,6 +42,7 @@ func TestBootstrapNoWorkspace(t *testing.T) {
 
 	bd := buildEmbeddedBD(t)
 	dir := t.TempDir()
+	initGitRepoAt(t, dir)
 
 	t.Run("default_output", func(t *testing.T) {
 		out, err := bdBootstrapAllowError(t, bd, dir)

--- a/cmd/bd/init_embedded_test.go
+++ b/cmd/bd/init_embedded_test.go
@@ -63,23 +63,6 @@ func buildEmbeddedBD(t *testing.T) string {
 	return embeddedBD
 }
 
-func initGitRepoAt(t *testing.T, dir string) {
-	t.Helper()
-	for _, args := range [][]string{
-		{"init"},
-		{"config", "user.email", "test@test.com"},
-		{"config", "user.name", "Test"},
-		// Force repo-local hooks so tests ignore any global hooksPath override.
-		{"config", "core.hooksPath", ".git/hooks"},
-	} {
-		cmd := exec.Command("git", args...)
-		cmd.Dir = dir
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %s failed: %v\n%s", args[0], err, out)
-		}
-	}
-}
-
 func bdEnv(dir string) []string {
 	var env []string
 	for _, e := range os.Environ() {

--- a/cmd/bd/test_helpers_pure_test.go
+++ b/cmd/bd/test_helpers_pure_test.go
@@ -354,3 +354,28 @@ func runGitForBootstrapTest(t *testing.T, dir string, args ...string) {
 		t.Fatalf("git %v failed: %v\n%s", args, err, string(output))
 	}
 }
+
+// initGitRepoAt turns dir into a git repository with a test identity, giving
+// the no-workspace tests a walk boundary so FindBeadsDir cannot climb out of
+// the temp dir into a real .beads above it.
+//
+// This lives in the pure-Go helper file, not alongside the embedded-Dolt
+// helpers: cmd/bd/where_test.go carries no build tag, so it compiles under
+// CGO_ENABLED=0 where every `//go:build cgo` file is excluded. Keep this
+// helper stdlib-only and keep it here.
+func initGitRepoAt(t *testing.T, dir string) {
+	t.Helper()
+	for _, args := range [][]string{
+		{"init"},
+		{"config", "user.email", "test@test.com"},
+		{"config", "user.name", "Test"},
+		// Force repo-local hooks so tests ignore any global hooksPath override.
+		{"config", "core.hooksPath", ".git/hooks"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %s failed: %v\n%s", args[0], err, out)
+		}
+	}
+}

--- a/cmd/bd/where_embedded_test.go
+++ b/cmd/bd/where_embedded_test.go
@@ -41,6 +41,7 @@ func TestWhereNoWorkspace(t *testing.T) {
 
 	bd := buildEmbeddedBD(t)
 	dir := t.TempDir()
+	initGitRepoAt(t, dir)
 
 	t.Run("default_output", func(t *testing.T) {
 		out, err := bdWhereAllowError(t, bd, dir)

--- a/cmd/bd/where_test.go
+++ b/cmd/bd/where_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/git"
 	"github.com/steveyegge/beads/internal/utils"
 )
 
@@ -41,8 +42,10 @@ func TestResolveWhereBeadsDir_FallsBackToFindBeadsDir(t *testing.T) {
 	if err := os.Chdir(repoDir); err != nil {
 		t.Fatalf("chdir(%q): %v", repoDir, err)
 	}
+	git.ResetCaches()
 	t.Cleanup(func() {
 		_ = os.Chdir(originalWD)
+		git.ResetCaches()
 	})
 
 	t.Setenv("BEADS_DIR", "")
@@ -79,6 +82,7 @@ func TestResolveWhereBeadsDir_ReturnsEmptyWithoutWorkspace(t *testing.T) {
 	resetCommandContext()
 
 	workspace := t.TempDir()
+	initGitRepoAt(t, workspace)
 	originalWD, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("getwd: %v", err)
@@ -86,8 +90,10 @@ func TestResolveWhereBeadsDir_ReturnsEmptyWithoutWorkspace(t *testing.T) {
 	if err := os.Chdir(workspace); err != nil {
 		t.Fatalf("chdir(%q): %v", workspace, err)
 	}
+	git.ResetCaches()
 	t.Cleanup(func() {
 		_ = os.Chdir(originalWD)
+		git.ResetCaches()
 	})
 
 	t.Setenv("BEADS_DIR", "")
@@ -146,8 +152,10 @@ func TestResolveWhereBeadsDir_UsesInitializedDBPath(t *testing.T) {
 	if err := os.Chdir(cwd); err != nil {
 		t.Fatalf("chdir: %v", err)
 	}
+	git.ResetCaches()
 	t.Cleanup(func() {
 		_ = os.Chdir(originalWD)
+		git.ResetCaches()
 	})
 
 	t.Setenv("BEADS_DIR", "")


### PR DESCRIPTION
## Summary

Two of the "no workspace" tests in `cmd/bd` (`TestWhereNoWorkspace`, `TestBootstrapNoWorkspace`, `TestResolveWhereBeadsDir_ReturnsEmptyWithoutWorkspace`) placed their scratch workspace in `t.TempDir()` without giving it a walk boundary. `beads.FindBeadsDir()` walks up from the current directory looking for a `.beads/` ancestor, and when the OS temp dir happens to live under a directory tree that contains a real `.beads` (e.g. `GOTMPDIR` resolving under `$HOME`), the walk finds it — so the tests intermittently observed a real workspace instead of "no workspace," depending entirely on where the OS temp dir was rooted.

A second, independent issue affected `TestResolveWhereBeadsDir_ReturnsEmptyWithoutWorkspace` specifically: it `os.Chdir`s during the test but never resets the package-level memoized git context (`internal/git` caches the git root via `sync.Once`), so a stale cached root from an earlier test in the same binary could leak in after the chdir.

## Fix

- Give each no-workspace test its own git-init'd temp dir, so the ancestor walk has an explicit boundary and can't escape into a real `.beads` higher up the tree.
- Call the existing `git.ResetCaches()` seam after `os.Chdir`ing (and again after chdiring back in cleanup) in the `TestResolveWhereBeadsDir_*` tests, matching the pattern already used elsewhere in this package.

Test-only change — no production code touched.

## Test plan

- [x] Target tests pass with `GOTMPDIR` resolving under a directory tree containing a real `.beads` (the previously-failing condition)
- [x] Same tests also pass with `GOTMPDIR` pointing at a clean tree, confirming the fix isn't just swapping which environment happens to work
- [x] `go vet ./cmd/bd/...` clean
- [x] Full test suite (`scripts/ci/pr-core.sh`) green, no regressions