### PR TITLE
fix(storage): stop reporting a live issue absent when the leases table is missing

### DIFF
--- a/internal/storage/dberrors/errors.go
+++ b/internal/storage/dberrors/errors.go
@@ -41,6 +41,50 @@ func IsTableNotExist(err error) bool {
 		unquotedTableMissingPattern.MatchString(s)
 }
 
+var missingTableNamePatterns = []*regexp.Regexp{
+	// go-mysql-server (embedded Dolt and sql-server alike): "table not found: x".
+	regexp.MustCompile("(?i)table not found:\\s*`?([^\\s'`,;]+)`?"),
+	// Stock MySQL: "Table 'schema.x' doesn't exist".
+	regexp.MustCompile(`(?i)\btable\s+'([^']+)'\s+(?:doesn't exist|does not exist)\b`),
+	// Same, unquoted or backticked.
+	regexp.MustCompile("(?i)\\btable\\s+`?([^\\s'`]+)`?\\s+(?:doesn't exist|does not exist)\\b"),
+}
+
+// MissingTableName returns the table named by a table-not-exist error, with any
+// schema qualifier stripped. It reports false when err is not a table-not-exist
+// error (as IsTableNotExist classifies it) or when the message names no table,
+// so callers that tolerate one specific optional table cannot accidentally
+// tolerate a different missing one.
+func MissingTableName(err error) (string, bool) {
+	if !IsTableNotExist(err) {
+		return "", false
+	}
+	for _, pattern := range missingTableNamePatterns {
+		m := pattern.FindStringSubmatch(err.Error())
+		if m == nil {
+			continue
+		}
+		name := strings.Trim(m[1], "`'\"")
+		if i := strings.LastIndex(name, "."); i >= 0 {
+			name = name[i+1:]
+		}
+		if name != "" {
+			return name, true
+		}
+	}
+	return "", false
+}
+
+// IsMissingTable reports whether err is a table-not-exist error naming exactly
+// the given table. Use it instead of IsTableNotExist wherever a query's FROM
+// clause spans more than one table and only one of them is optional: a blanket
+// table-not-exist check over a joined FROM tolerates the absence of tables the
+// tolerance was never written for.
+func IsMissingTable(err error, table string) bool {
+	name, ok := MissingTableName(err)
+	return ok && strings.EqualFold(name, table)
+}
+
 // IsAccessDenied reports whether err is a MySQL/Dolt privilege refusal: the
 // connected user lacks the right to run the statement. Covers 1044
 // (ER_DBACCESS_DENIED_ERROR), 1045 (ER_ACCESS_DENIED_ERROR), 1142

--- a/internal/storage/dberrors/errors_test.go
+++ b/internal/storage/dberrors/errors_test.go
@@ -1,0 +1,99 @@
+package dberrors
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	mysql "github.com/go-sql-driver/mysql"
+)
+
+func TestMissingTableName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		err      error
+		wantName string
+		wantOK   bool
+	}{
+		{name: "nil", err: nil},
+		{
+			name:     "go-mysql-server wording",
+			err:      &mysql.MySQLError{Number: 1146, Message: "table not found: leases"},
+			wantName: "leases",
+			wantOK:   true,
+		},
+		{
+			name:     "mysql wording strips the schema qualifier",
+			err:      &mysql.MySQLError{Number: 1146, Message: "Table 'beads.leases' doesn't exist"},
+			wantName: "leases",
+			wantOK:   true,
+		},
+		{
+			name:     "backticked",
+			err:      errors.New("Error 1146 (42S02): Table `wisps` does not exist"),
+			wantName: "wisps",
+			wantOK:   true,
+		},
+		{
+			name:     "wrapped",
+			err:      fmt.Errorf("get issue: %w", &mysql.MySQLError{Number: 1146, Message: "table not found: wisp_labels"}),
+			wantName: "wisp_labels",
+			wantOK:   true,
+		},
+		{
+			// A different failure must never be read as a missing table, or the
+			// narrowed tolerance would be as blind as the blanket one.
+			name: "unrelated mysql error",
+			err:  &mysql.MySQLError{Number: 1213, Message: "Deadlock found when trying to get lock"},
+		},
+		{
+			name: "connection failure",
+			err:  errors.New("dial tcp 127.0.0.1:3306: connect: connection refused"),
+		},
+		{
+			name: "missing column is not a missing table",
+			err:  &mysql.MySQLError{Number: 1054, Message: "Unknown column 'leases.granted_node' in 'field list'"},
+		},
+		{
+			// The IsTableNotExist gate is what makes this a tightening rather
+			// than a widening: prose that merely reads like a missing table,
+			// without the classification, must stay untolerated. Drop the gate
+			// and this case starts returning ("leases", true).
+			name: "table-not-exist wording alone is not a classification",
+			err:  errors.New("table not found: leases"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := MissingTableName(tc.err)
+			if ok != tc.wantOK || got != tc.wantName {
+				t.Fatalf("MissingTableName(%v) = (%q, %v), want (%q, %v)", tc.err, got, ok, tc.wantName, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestIsMissingTable(t *testing.T) {
+	t.Parallel()
+
+	leasesGone := &mysql.MySQLError{Number: 1146, Message: "table not found: leases"}
+
+	if !IsMissingTable(leasesGone, "leases") {
+		t.Error("IsMissingTable(leases error, \"leases\") = false, want true")
+	}
+	// The whole point of the helper: the table the caller is willing to do
+	// without is not the table that actually went missing.
+	if IsMissingTable(leasesGone, "wisps") {
+		t.Error("IsMissingTable(leases error, \"wisps\") = true, want false")
+	}
+	if IsMissingTable(nil, "leases") {
+		t.Error("IsMissingTable(nil, \"leases\") = true, want false")
+	}
+	if !IsMissingTable(&mysql.MySQLError{Number: 1146, Message: "Table 'beads.WISPS' doesn't exist"}, "wisps") {
+		t.Error("IsMissingTable should match table names case-insensitively")
+	}
+}

--- a/internal/storage/embeddeddolt/get_issue_test.go
+++ b/internal/storage/embeddeddolt/get_issue_test.go
@@ -105,6 +105,52 @@ func TestGetIssue(t *testing.T) {
 		}
 	})
 
+	// The hydration FROM clause joins the leases table, so a database missing it
+	// must fail loudly: reporting the row absent is a wrong answer no client can
+	// tell apart from a deletion. assertRowExists is the control — the row is
+	// demonstrably present while GetIssue is being asked about it.
+	t.Run("missing_leases_table_is_an_error_not_absent", func(t *testing.T) {
+		te := newTestEnv(t, "lg")
+		ctx := t.Context()
+
+		issue := &types.Issue{
+			ID:        "lg-live",
+			Title:     "Live issue on a database missing leases",
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+		}
+		if err := te.store.CreateIssue(ctx, issue, "tester"); err != nil {
+			t.Fatalf("CreateIssue: %v", err)
+		}
+		te.exec(t, ctx, "RENAME TABLE leases TO leases_renamed_away")
+		te.assertRowExists(t, ctx, "issues", "lg-live")
+
+		_, err := te.store.GetIssue(ctx, "lg-live")
+		if err == nil {
+			t.Fatal("GetIssue succeeded with no leases table")
+		}
+		if errors.Is(err, storage.ErrNotFound) {
+			t.Fatalf("GetIssue reported a present row absent: %v", err)
+		}
+		if !strings.Contains(err.Error(), "leases") {
+			t.Fatalf("expected the error to name leases, got: %v", err)
+		}
+
+		// The mutation path reads the pre-update row through the same query, so
+		// it inherited the same wrong answer: "no such issue" for a live write.
+		updErr := te.store.UpdateIssue(ctx, "lg-live", map[string]interface{}{"title": "renamed"}, "tester")
+		if updErr == nil {
+			t.Fatal("UpdateIssue succeeded with no leases table")
+		}
+		if errors.Is(updErr, storage.ErrNotFound) {
+			t.Fatalf("UpdateIssue reported a present row absent: %v", updErr)
+		}
+		if !strings.Contains(updErr.Error(), "leases") {
+			t.Fatalf("expected the update error to name leases, got: %v", updErr)
+		}
+	})
+
 	t.Run("wisp_label_table_error_propagates", func(t *testing.T) {
 		te := newTestEnv(t, "wl")
 		ctx := t.Context()

--- a/internal/storage/issueops/get_issue.go
+++ b/internal/storage/issueops/get_issue.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/dberrors"
 	"github.com/steveyegge/beads/internal/storage/sqlbuild"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -34,12 +35,20 @@ func GetIssueInTx(ctx context.Context, tx DBTX, id string) (*types.Issue, error)
 	return nil, err
 }
 
+// missingOptionalIssueTable reports whether err is the absence of the optional
+// issue plane the hydration query just read. The hydration FROM clause also
+// carries sqlbuild.LeaseJoin, so a blanket table-not-exist check here folds a
+// missing leases table into "row absent" — a wrong answer, not an empty one.
+func missingOptionalIssueTable(err error, issueTable string) bool {
+	return optionalBlockedTable(issueTable) && dberrors.IsMissingTable(err, issueTable)
+}
+
 func getIssueFromTableInTx(ctx context.Context, tx DBTX, issueTable, labelTable, id string) (*types.Issue, error) {
 	//nolint:gosec // G201: issueTable is a hardcoded literal supplied by GetIssueInTx ("issues" or "wisps")
 	row := tx.QueryRowContext(ctx, fmt.Sprintf(`SELECT %s FROM %s %s WHERE id = ?`,
 		IssueSelectColumns, issueTable, sqlbuild.LeaseJoin(issueTable)), id)
 	issue, err := ScanIssueFrom(row)
-	if err == sql.ErrNoRows || isTableNotExistError(err) {
+	if err == sql.ErrNoRows || missingOptionalIssueTable(err, issueTable) {
 		return nil, storage.ErrNotFound
 	}
 	if err != nil {

--- a/internal/storage/issueops/get_issue_test.go
+++ b/internal/storage/issueops/get_issue_test.go
@@ -1,0 +1,136 @@
+package issueops
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	mysql "github.com/go-sql-driver/mysql"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/sqlbuild"
+)
+
+// missingTableError builds the driver error a Dolt query returns when its FROM
+// clause names a table that does not exist. Both the embedded driver
+// (dolthub/driver/v2 translateError) and the sql-server wire protocol surface
+// it as a *mysql.MySQLError carrying 1146 and go-mysql-server's
+// "table not found: %s" text.
+func missingTableError(table string) error {
+	return &mysql.MySQLError{Number: 1146, Message: "table not found: " + table}
+}
+
+// missingTableErrorMySQLText is the same condition worded the way stock MySQL
+// (and Dolt's MySQL-compatible error mode) words it.
+func missingTableErrorMySQLText(schema, table string) error {
+	return &mysql.MySQLError{Number: 1146, Message: "Table '" + schema + "." + table + "' doesn't exist"}
+}
+
+func expectHydrationQuery(mock sqlmock.Sqlmock, table, id string, err error) {
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT " + IssueSelectColumns + " FROM " + table + " " + sqlbuild.LeaseJoin(table) + " WHERE id = ?")).
+		WithArgs(id).
+		WillReturnError(err)
+}
+
+// TestGetIssueInTxMissingLeasesTableIsAnError pins the narrowed tolerance. The
+// hydration FROM clause carries sqlbuild.LeaseJoin, so a database missing the
+// leases table fails the query for a row that is demonstrably present. The
+// table-not-exist tolerance exists for the optional wisps plane only; folding
+// a missing leases table into "row absent" hands the caller a 404 it cannot
+// tell apart from a deletion.
+func TestGetIssueInTxMissingLeasesTableIsAnError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "dolt wording", err: missingTableError("leases")},
+		{name: "mysql wording", err: missingTableErrorMySQLText("beads", "leases")},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, mock, tx := beginMockTx(t)
+
+			// Both planes are primed: before the fix the issues query is
+			// swallowed and the wisps query runs too, so ExpectationsWereMet
+			// is deliberately not asserted here — the returned error is the
+			// assertion.
+			expectHydrationQuery(mock, "issues", "bd-1", tc.err)
+			expectHydrationQuery(mock, "wisps", "bd-1", tc.err)
+
+			_, err := GetIssueInTx(context.Background(), tx, "bd-1")
+			if err == nil {
+				t.Fatal("GetIssueInTx succeeded with no leases table")
+			}
+			if errors.Is(err, storage.ErrNotFound) {
+				t.Fatalf("GetIssueInTx reported the row absent for a broken lease join: %v", err)
+			}
+			if !strings.Contains(err.Error(), "leases") {
+				t.Fatalf("error does not name the missing table: %v", err)
+			}
+		})
+	}
+}
+
+// TestGetIssueInTxMissingWispsTableIsNotFound is the control: the tolerance
+// the narrowed guard must keep. A pre-migration database has no wisps table,
+// and an ID on neither plane is genuinely absent.
+func TestGetIssueInTxMissingWispsTableIsNotFound(t *testing.T) {
+	_, mock, tx := beginMockTx(t)
+
+	expectHydrationQuery(mock, "issues", "bd-1", sql.ErrNoRows)
+	expectHydrationQuery(mock, "wisps", "bd-1", missingTableError("wisps"))
+
+	_, err := GetIssueInTx(context.Background(), tx, "bd-1")
+	if !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("GetIssueInTx = %v, want ErrNotFound for a pre-migration database", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+// TestGetIssueInTxAbsentRowIsNotFound is the second control: an ID on neither
+// plane of a healthy database still answers not-found.
+func TestGetIssueInTxAbsentRowIsNotFound(t *testing.T) {
+	_, mock, tx := beginMockTx(t)
+
+	expectHydrationQuery(mock, "issues", "bd-1", sql.ErrNoRows)
+	expectHydrationQuery(mock, "wisps", "bd-1", sql.ErrNoRows)
+
+	_, err := GetIssueInTx(context.Background(), tx, "bd-1")
+	if !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("GetIssueInTx = %v, want ErrNotFound", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+// TestUpdateIssueInTxMissingLeasesTableIsAnError covers the mutation path.
+// updateIssueInTx reads the pre-update row through the same hydration query,
+// so the same swallowed error told a writer its live issue did not exist.
+func TestUpdateIssueInTxMissingLeasesTableIsAnError(t *testing.T) {
+	_, mock, tx := beginMockTx(t)
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT 1 FROM wisps WHERE id = ? LIMIT 1")).
+		WithArgs("bd-1").
+		WillReturnError(sql.ErrNoRows)
+	expectHydrationQuery(mock, "issues", "bd-1", missingTableError("leases"))
+	expectHydrationQuery(mock, "wisps", "bd-1", missingTableError("leases"))
+
+	_, err := UpdateIssueInTx(context.Background(), tx, "bd-1", map[string]interface{}{"title": "new"}, "tester")
+	if err == nil {
+		t.Fatal("UpdateIssueInTx succeeded with no leases table")
+	}
+	if errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("UpdateIssueInTx reported the row absent for a broken lease join: %v", err)
+	}
+	if !strings.Contains(err.Error(), "leases") {
+		t.Fatalf("error does not name the missing table: %v", err)
+	}
+}


### PR DESCRIPTION
## The bug

`getIssueFromTableInTx` folds any table-not-exist error into `storage.ErrNotFound`:

```go
issue, err := ScanIssueFrom(row)
if err == sql.ErrNoRows || isTableNotExistError(err) {
    return nil, storage.ErrNotFound
}
```

That tolerance is there for the optional `wisps` plane, which pre-migration databases do
not have. But lease state lives in its own table now and `sqlbuild.LeaseJoin` is
unconditionally in the same `FROM` clause, so the check also swallows a missing `leases`.
A database that has the row and has lost `leases` is told the row does not exist.

It reaches the mutation path too — `updateIssueInTx` reads the pre-update row through the
same query, so **updating a live issue reports it gone**. A caller cannot tell that apart
from a deletion, which is the part that does damage: a sync or reconciler that treats "not
found" as "deleted" will recreate or tombstone live work.

The sibling reads already behave correctly on the identical condition, which is what makes
this a bug rather than a design choice: `SearchIssues` and `GetReadyWorkWithCounts` both
surface `Error 1146 (HY000): table not found: leases`. `getIssue` is the outlier.

## Reproducing it, with a control

End-to-end against real embedded Dolt, in `internal/storage/embeddeddolt/get_issue_test.go`:

```
CreateIssue(lg-live)
RENAME TABLE leases TO leases_renamed_away
assertRowExists(issues, lg-live)      <- the control: the row is demonstrably present
GetIssue(lg-live)                     -> "not found: issue lg-live"
UpdateIssue(lg-live, ...)             -> "not found: issue lg-live"
```

The raw-SQL existence check is what separates "the issue is missing" from "the join is
missing"; without it the 404 is indistinguishable from a correct answer.

## The fix

Narrow the tolerance to the table it was written for. It now fires only when the error
names the optional plane the query just read:

```go
func missingOptionalIssueTable(err error, issueTable string) bool {
	return optionalBlockedTable(issueTable) && dberrors.IsMissingTable(err, issueTable)
}
```

`optionalBlockedTable` is the pre-existing single source of truth for which planes are
optional, so no second predicate is introduced.

`dberrors` gains `MissingTableName` / `IsMissingTable`. Both are **gated on the existing
`IsTableNotExist` classification** before any name matching happens, so nothing that
`IsTableNotExist` rejects today becomes newly tolerated on any backend — this is a pure
tightening, not a reclassification. Name matching without that gate would have widened
embedded-Dolt behaviour (go-mysql-server's bare `table not found: x` text is not itself a
1146 classification), so the gate is load-bearing and has its own test case.

The parser covers both wordings that actually occur: go-mysql-server's
`table not found: x` (embedded Dolt via `dolthub/driver/v2` and `dolt sql-server` alike)
and stock MySQL's `Table 'schema.x' doesn't exist`, with the schema qualifier stripped.

## Tests

Red first, against the unfixed code:

```
--- FAIL: TestGetIssueInTxMissingLeasesTableIsAnError/dolt_wording
    GetIssueInTx reported the row absent for a broken lease join: not found: issue bd-1
--- FAIL: TestGetIssueInTxMissingLeasesTableIsAnError/mysql_wording
    GetIssueInTx reported the row absent for a broken lease join: not found: issue bd-1
--- FAIL: TestUpdateIssueInTxMissingLeasesTableIsAnError
    UpdateIssueInTx reported the row absent for a broken lease join: failed to get issue for update: not found: issue bd-1
```

and end-to-end on the real engine:

```
--- FAIL: TestGetIssue/missing_leases_table_is_an_error_not_absent
    GetIssue reported a present row absent: not found: issue lg-live
```

Both directions are covered, because "never tolerate" also passes every must-error
assertion above:

- `TestGetIssueInTxMissingWispsTableIsNotFound` — a pre-migration database missing `wisps`
  must still answer not-found. Removing the tolerance entirely fails exactly this one:
  `GetIssueInTx = get issue: Error 1146: table not found: wisps, want ErrNotFound`.
- `TestGetIssueInTxAbsentRowIsNotFound` — an id on neither plane still answers not-found.
- `TestMissingTableName` — a deadlock, a connection failure, and a missing *column* must
  not read as a missing table; and `table not found: leases` with no 1146 classification
  must stay untolerated. Dropping the `IsTableNotExist` gate fails that last case:
  `MissingTableName(table not found: leases) = ("leases", true), want ("", false)`.

## Impact

Latent on an up-to-date database, where `leases` exists everywhere. It arms on any schema
skew — a binary ahead of a database — which is exactly the window in which an operator is
least able to tell a wrong answer from a real one.

## Local gates, with actual results

| gate | result |
| --- | --- |
| `make ci-pr-core` (`go test -p 4 -parallel 4 -race -short -skip '^TestEmbedded' ./...`) | **pass**, exit 0, `pr-core go test succeeded in 721s` |
| `./scripts/ci/fmt-check.sh` | **pass** — all Go files properly formatted |
| `go vet ./internal/storage/...` | **clean** |
| `BEADS_TEST_EMBEDDED_DOLT=1 go test ./internal/storage/embeddeddolt/ -run 'TestGetIssue$'` | **ok 4.9s** — run separately, since ci-pr-core's hermetic env skips the Dolt-backed tests |

Not run, and why: a plain `go test ./internal/storage/...` is not a usable local gate on
this machine. `cross_project_test.go` and `concurrent_test.go` need a live
`dolt sql-server` and fail with `connect: connection refused` /
`context deadline exceeded` before any assertion, and the package then exceeds a 40-minute
timeout. `ci-pr-core`'s test environment skips exactly those, which is why it is the gate
reported above.
