### PR TITLE
fix(storage): stop reporting a broken wisp plane as an empty one in search

### DIFF
--- a/internal/storage/domain/db/issue_search.go
+++ b/internal/storage/domain/db/issue_search.go
@@ -26,10 +26,20 @@ var (
 	wispsFilterTables  = sqlbuild.WispsFilterTables
 )
 
+// missingOptionalWispTable reports whether err is the absence of a wisp-plane
+// table a database may legitimately not have. A wisp search touches more than
+// that: its FROM clause carries sqlbuild.LeaseJoin and its hydration reads
+// wisp_labels, so a blanket table-not-exist check reports a broken database as
+// an empty wisp plane and silently drops live rows from the result.
+func missingOptionalWispTable(err error) bool {
+	name, ok := dberrors.MissingTableName(err)
+	return ok && sqlbuild.OptionalWispTable(name)
+}
+
 func (r *issueSQLRepositoryImpl) searchAcrossIssuesAndWisps(ctx context.Context, query string, filter types.IssueFilter) (domain.SearchPage, error) {
 	if filter.Ephemeral != nil && *filter.Ephemeral {
 		page, err := r.searchTable(ctx, query, filter, wispsFilterTables)
-		if err != nil && !dberrors.IsTableNotExist(err) {
+		if err != nil && !missingOptionalWispTable(err) {
 			return domain.SearchPage{}, fmt.Errorf("search wisps (ephemeral filter): %w", err)
 		}
 		if len(page.Items) > 0 {
@@ -105,7 +115,7 @@ func (r *issueSQLRepositoryImpl) searchUnion(ctx context.Context, query string, 
 		return domain.SearchPage{}, fmt.Errorf("search union (hydrate issues): %w", err)
 	}
 	wispsByID, err := r.fetchIssuesByIDs(ctx, page.wispIDs, wispsFilterTables, filter)
-	if err != nil && !dberrors.IsTableNotExist(err) {
+	if err != nil && !missingOptionalWispTable(err) {
 		return domain.SearchPage{}, fmt.Errorf("search union (hydrate wisps): %w", err)
 	}
 

--- a/internal/storage/domain/db/issue_search_missing_table_test.go
+++ b/internal/storage/domain/db/issue_search_missing_table_test.go
@@ -1,0 +1,75 @@
+package db
+
+import (
+	"errors"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	mysql "github.com/go-sql-driver/mysql"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func missingTable(table string) error {
+	return &mysql.MySQLError{Number: 1146, Message: "table not found: " + table}
+}
+
+func ephemeralFilter() types.IssueFilter {
+	on := true
+	return types.IssueFilter{Ephemeral: &on}
+}
+
+func newMockRepo(t *testing.T) (sqlmock.Sqlmock, *issueSQLRepositoryImpl) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return mock, &issueSQLRepositoryImpl{runner: db}
+}
+
+// TestSearchAcrossEphemeralBrokenWispPlaneIsAnError mirrors the issueops guard
+// on the domain/db stack: the two must agree on what a missing table means, or
+// the same query answers differently depending on which stack served it.
+func TestSearchAcrossEphemeralBrokenWispPlaneIsAnError(t *testing.T) {
+	for _, missing := range []string{"wisp_labels", "leases"} {
+		t.Run(missing, func(t *testing.T) {
+			mock, repo := newMockRepo(t)
+			gone := missingTable(missing)
+			mock.ExpectQuery("FROM wisps").WillReturnError(gone)
+			mock.ExpectQuery("SELECT 1 FROM wisps").WillReturnError(missingTable("wisps"))
+			mock.ExpectQuery("FROM issues").WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+			_, err := repo.searchAcrossIssuesAndWisps(t.Context(), "", ephemeralFilter())
+			if !errors.Is(err, gone) {
+				t.Fatalf("search hid a broken wisp plane: %v", err)
+			}
+		})
+	}
+}
+
+// TestSearchAcrossEphemeralMissingWispPlaneIsEmpty is the control: a
+// pre-migration database has no wisp plane, and searching it for wisps
+// really does match nothing.
+func TestSearchAcrossEphemeralMissingWispPlaneIsEmpty(t *testing.T) {
+	for _, table := range []string{"wisps", "wisp_dependencies"} {
+		t.Run(table, func(t *testing.T) {
+			mock, repo := newMockRepo(t)
+			mock.ExpectQuery("FROM wisps").WillReturnError(missingTable(table))
+			mock.ExpectQuery("SELECT 1 FROM wisps").WillReturnError(missingTable("wisps"))
+			mock.ExpectQuery("FROM issues").WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+			page, err := repo.searchAcrossIssuesAndWisps(t.Context(), "", ephemeralFilter())
+			if err != nil {
+				t.Fatalf("search errored on a database with no wisp plane: %v", err)
+			}
+			if len(page.Items) != 0 {
+				t.Fatalf("got %d rows, want 0", len(page.Items))
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatalf("unmet sql expectations: %v", err)
+			}
+		})
+	}
+}

--- a/internal/storage/embeddeddolt/search_missing_table_test.go
+++ b/internal/storage/embeddeddolt/search_missing_table_test.go
@@ -1,0 +1,105 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func ephemeralOnly() *bool { b := true; return &b }
+
+func searchIDs(t *testing.T, te *testEnv, filter types.IssueFilter) ([]string, error) {
+	t.Helper()
+	got, err := te.store.SearchIssues(t.Context(), "", filter)
+	ids := make([]string, 0, len(got))
+	for _, issue := range got {
+		ids = append(ids, issue.ID)
+	}
+	return ids, err
+}
+
+// TestSearchWithMissingWispPlaneTables pins which missing tables a wisp search
+// may treat as "no wisps" and which it must report. The wisp query and its
+// label hydration span more tables than the wisp plane owns, and folding all
+// of them into an empty result set drops live rows from an ordinary list with
+// no error to show for it.
+func TestSearchWithMissingWispPlaneTables(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	seed := func(t *testing.T, te *testEnv, prefix string) {
+		t.Helper()
+		wisp := &types.Issue{
+			ID: prefix + "-wisp", Title: "ephemeral bead", Status: types.StatusOpen,
+			Priority: 2, IssueType: types.TypeTask, Ephemeral: true,
+		}
+		if err := te.store.CreateIssue(t.Context(), wisp, "tester"); err != nil {
+			t.Fatalf("CreateIssue wisp: %v", err)
+		}
+		durable := &types.Issue{
+			ID: prefix + "-issue", Title: "durable bead", Status: types.StatusOpen,
+			Priority: 2, IssueType: types.TypeTask,
+		}
+		if err := te.store.CreateIssue(t.Context(), durable, "tester"); err != nil {
+			t.Fatalf("CreateIssue durable: %v", err)
+		}
+	}
+
+	// A missing wisp_labels is not the wisp plane being absent, it is the wisp
+	// plane being broken. assertRowExists is the control: the wisp is present
+	// while the search is answering that there is nothing there.
+	t.Run("missing_wisp_labels_is_an_error_not_an_empty_result", func(t *testing.T) {
+		te := newTestEnv(t, "wl2")
+		seed(t, te, "wl2")
+		te.exec(t, t.Context(), "RENAME TABLE wisp_labels TO wisp_labels_renamed_away")
+		te.assertRowExists(t, t.Context(), "wisps", "wl2-wisp")
+
+		if ids, err := searchIDs(t, te, types.IssueFilter{Ephemeral: ephemeralOnly()}); err == nil {
+			t.Fatalf("ephemeral search returned %v with no error and no wisp_labels table", ids)
+		}
+		if ids, err := searchIDs(t, te, types.IssueFilter{}); err == nil {
+			t.Fatalf("merged search returned %v with no error and no wisp_labels table", ids)
+		}
+	})
+
+	// The control the tolerance exists for: a pre-migration database has no
+	// wisp plane at all, and a search of it really does match no wisps.
+	t.Run("missing_wisps_table_is_an_empty_result", func(t *testing.T) {
+		te := newTestEnv(t, "wt2")
+		seed(t, te, "wt2")
+		te.exec(t, t.Context(), "RENAME TABLE wisps TO wisps_renamed_away")
+
+		ids, err := searchIDs(t, te, types.IssueFilter{Ephemeral: ephemeralOnly()})
+		if err != nil {
+			t.Fatalf("ephemeral search on a database with no wisp plane: %v", err)
+		}
+		if len(ids) != 0 {
+			t.Fatalf("ephemeral search returned %v, want none", ids)
+		}
+
+		ids, err = searchIDs(t, te, types.IssueFilter{})
+		if err != nil {
+			t.Fatalf("merged search on a database with no wisp plane: %v", err)
+		}
+		if len(ids) != 1 || ids[0] != "wt2-issue" {
+			t.Fatalf("merged search returned %v, want just the durable issue", ids)
+		}
+	})
+
+	// The second control: wisp_dependencies is genuinely optional and its
+	// absence must stay invisible to a plain search.
+	t.Run("missing_wisp_dependencies_is_invisible", func(t *testing.T) {
+		te := newTestEnv(t, "wd2")
+		seed(t, te, "wd2")
+		te.exec(t, t.Context(), "RENAME TABLE wisp_dependencies TO wisp_dependencies_renamed_away")
+
+		ids, err := searchIDs(t, te, types.IssueFilter{Ephemeral: ephemeralOnly()})
+		if err != nil {
+			t.Fatalf("ephemeral search with no wisp_dependencies: %v", err)
+		}
+		if len(ids) != 1 || ids[0] != "wd2-wisp" {
+			t.Fatalf("ephemeral search returned %v, want just the wisp", ids)
+		}
+	})
+}

--- a/internal/storage/issueops/blocked.go
+++ b/internal/storage/issueops/blocked.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/steveyegge/beads/internal/storage/sqlbuild"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -16,7 +17,7 @@ type blockingDepRecord struct {
 }
 
 func optionalBlockedTable(table string) bool {
-	return table == "wisps" || table == "wisp_dependencies"
+	return sqlbuild.OptionalWispTable(table)
 }
 
 func loadBlockingDepsForIssueIDsInTx(ctx context.Context, tx DBTX, depTables []string, issueIDs []string) ([]blockingDepRecord, error) {

--- a/internal/storage/issueops/search.go
+++ b/internal/storage/issueops/search.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/steveyegge/beads/internal/storage/dberrors"
 	"github.com/steveyegge/beads/internal/storage/sqlbuild"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -155,6 +156,16 @@ func hydrateIssueLabelsAndDeps(ctx context.Context, tx DBTX, tables FilterTables
 	return nil
 }
 
+// missingOptionalWispTable reports whether err is the absence of a wisp-plane
+// table a database may legitimately not have. A wisp search touches more than
+// that: its FROM clause carries sqlbuild.LeaseJoin and its hydration reads
+// wisp_labels, so a blanket table-not-exist check reports a broken database as
+// an empty wisp plane and silently drops live rows from the result.
+func missingOptionalWispTable(err error) bool {
+	name, ok := dberrors.MissingTableName(err)
+	return ok && sqlbuild.OptionalWispTable(name)
+}
+
 // searchInTx is the shared wisp-merge wrapper. Ephemeral routing, the
 // empty-wisps probe, the issues+wisps queries, and overlap detection live
 // here once. Both SearchIssuesInTx and SearchIssueIDsInTx use this body —
@@ -163,7 +174,7 @@ func searchInTx[T any](ctx context.Context, tx DBTX, query string, filter types.
 	// Route ephemeral-only queries to wisps table.
 	if filter.Ephemeral != nil && *filter.Ephemeral {
 		results, err := searchTableInTxT(ctx, tx, query, filter, WispsFilterTables, proj)
-		if err != nil && !isTableNotExistError(err) {
+		if err != nil && !missingOptionalWispTable(err) {
 			return nil, fmt.Errorf("search wisps (ephemeral filter): %w", err)
 		}
 		if len(results) > 0 {
@@ -218,7 +229,7 @@ func searchInTx[T any](ctx context.Context, tx DBTX, query string, filter types.
 			return results, nil
 		}
 		wispResults, wispErr := searchTableInTxT(ctx, tx, query, filter, WispsFilterTables, proj)
-		if wispErr != nil && !isTableNotExistError(wispErr) {
+		if wispErr != nil && !missingOptionalWispTable(wispErr) {
 			return nil, fmt.Errorf("search wisps (merge): %w", wispErr)
 		}
 		if len(wispResults) > 0 {

--- a/internal/storage/issueops/search_missing_table_test.go
+++ b/internal/storage/issueops/search_missing_table_test.go
@@ -1,0 +1,128 @@
+package issueops
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	mysql "github.com/go-sql-driver/mysql"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func tableNotFound(table string) error {
+	return &mysql.MySQLError{Number: 1146, Message: "table not found: " + table}
+}
+
+type searchEntryPoint struct {
+	name string
+	run  func(context.Context, DBTX, string, types.IssueFilter) (int, error)
+}
+
+var searchEntryPoints = []searchEntryPoint{
+	{
+		name: "SearchIssuesInTx",
+		run: func(ctx context.Context, tx DBTX, q string, f types.IssueFilter) (int, error) {
+			out, err := SearchIssuesInTx(ctx, tx, q, f)
+			return len(out), err
+		},
+	},
+	{
+		name: "SearchIssueIDsInTx",
+		run: func(ctx context.Context, tx DBTX, q string, f types.IssueFilter) (int, error) {
+			out, err := SearchIssueIDsInTx(ctx, tx, q, f)
+			return len(out), err
+		},
+	},
+}
+
+// TestSearchInTxEphemeralBrokenWispPlaneIsAnError pins the tolerance to the
+// wisp-plane tables a database may legitimately not have. The ephemeral branch
+// runs the wisps query as its only query, so its table-not-exist check is the
+// last word on what the caller is told: a table the wisp query reads but the
+// wisp plane does not own -- wisp_labels during hydration, leases through
+// sqlbuild.LeaseJoin -- was answered as "there are no wisps".
+//
+// The assertion is errors.Is against the primed driver error, not a substring
+// of the message: the query text names the joined tables, so a substring check
+// passes on any error that merely echoes the query.
+func TestSearchInTxEphemeralBrokenWispPlaneIsAnError(t *testing.T) {
+	for _, missing := range []string{"wisp_labels", "leases"} {
+		for _, tc := range searchEntryPoints {
+			t.Run(missing+"/"+tc.name, func(t *testing.T) {
+				_, mock, tx := beginMockTx(t)
+				gone := tableNotFound(missing)
+				mock.ExpectQuery("FROM wisps").WillReturnError(gone)
+				// Only the tolerating path reaches the issues plane. Priming it
+				// makes the untightened behaviour a clean "0 rows, nil error"
+				// rather than an unexpected-query error that reads like a pass.
+				mock.ExpectQuery("FROM issues").WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+				n, err := tc.run(context.Background(), tx, "", types.IssueFilter{Ephemeral: boolPtr(true)})
+				if err == nil {
+					t.Fatalf("search succeeded with no %s table, returning %d rows", missing, n)
+				}
+				if !errors.Is(err, gone) {
+					t.Fatalf("error is not the missing-%s failure: %v", missing, err)
+				}
+			})
+		}
+	}
+}
+
+// TestSearchInTxEphemeralMissingWispPlaneIsEmpty is the control the tightened
+// guard must keep: a pre-migration database has no wisp plane, and a search of
+// it really does match no wisps. Over-tightening to "never tolerate" passes
+// every must-error assertion above and fails here.
+func TestSearchInTxEphemeralMissingWispPlaneIsEmpty(t *testing.T) {
+	for _, table := range []string{"wisps", "wisp_dependencies"} {
+		t.Run(table, func(t *testing.T) {
+			_, mock, tx := beginMockTx(t)
+			mock.ExpectQuery("FROM wisps").WillReturnError(tableNotFound(table))
+			mock.ExpectQuery("FROM issues").WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+			out, err := SearchIssueIDsInTx(context.Background(), tx, "", types.IssueFilter{Ephemeral: boolPtr(true)})
+			if err != nil {
+				t.Fatalf("search errored on a database with no wisp plane: %v", err)
+			}
+			if len(out) != 0 {
+				t.Fatalf("got %d rows, want 0", len(out))
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatalf("unmet sql expectations: %v", err)
+			}
+		})
+	}
+}
+
+// TestSearchInTxEphemeralUnrelatedErrorPropagates is the second control: the
+// tolerance must not be a blanket catch in either direction.
+func TestSearchInTxEphemeralUnrelatedErrorPropagates(t *testing.T) {
+	_, mock, tx := beginMockTx(t)
+	boom := errors.New("connection refused")
+	mock.ExpectQuery("FROM wisps").WillReturnError(boom)
+
+	_, err := SearchIssueIDsInTx(context.Background(), tx, "", types.IssueFilter{Ephemeral: boolPtr(true)})
+	if !errors.Is(err, boom) {
+		t.Fatalf("search did not propagate a failed wisps query: %v", err)
+	}
+}
+
+// TestSearchInTxMergeBrokenWispPlaneIsAnError covers the merge branch: the
+// issues leg has already succeeded there, so the swallowed wisp failure is not
+// re-raised by anything downstream and the caller gets a short list.
+func TestSearchInTxMergeBrokenWispPlaneIsAnError(t *testing.T) {
+	_, mock, tx := beginMockTx(t)
+	gone := tableNotFound("wisp_labels")
+	mock.ExpectQuery("FROM issues").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("bd-1"))
+	mock.ExpectQuery("SELECT 1 FROM wisps").WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+	mock.ExpectQuery("FROM wisps").WillReturnError(gone)
+
+	_, err := SearchIssueIDsInTx(context.Background(), tx, "", types.IssueFilter{})
+	if !errors.Is(err, gone) {
+		t.Fatalf("merged search hid a broken wisp plane: %v", err)
+	}
+}

--- a/internal/storage/sqlbuild/sqlbuild.go
+++ b/internal/storage/sqlbuild/sqlbuild.go
@@ -27,6 +27,14 @@ var (
 	WispsFilterTables  = FilterTables{Main: "wisps", Labels: "wisp_labels", Dependencies: "wisp_dependencies", Comments: "wisp_comments"}
 )
 
+// OptionalWispTable reports whether name is a wisp-plane table a database may
+// legitimately not have, which is the set a wisp query may treat as "no wisps"
+// rather than a failure. Both stacks read it so the two cannot disagree about
+// what a missing table means.
+func OptionalWispTable(name string) bool {
+	return strings.EqualFold(name, "wisps") || strings.EqualFold(name, "wisp_dependencies")
+}
+
 // DepTargetExpr resolves a dependency row's target across the three
 // mutually-exclusive target columns.
 const DepTargetExpr = "COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external)"

--- a/internal/storage/sqlbuild/sqlbuild_test.go
+++ b/internal/storage/sqlbuild/sqlbuild_test.go
@@ -433,3 +433,22 @@ func TestBuildReadyWorkWhereStatusFilter(t *testing.T) {
 		})
 	}
 }
+
+// TestOptionalWispTable pins the set a wisp query may treat as "no wisps".
+// leases and wisp_labels are joined or hydrated by that query but are not the
+// wisp plane being absent, so tolerating them turns a broken database into an
+// empty result.
+func TestOptionalWispTable(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"wisps", "wisp_dependencies", "WISPS"} {
+		if !OptionalWispTable(name) {
+			t.Errorf("OptionalWispTable(%q) = false, want true", name)
+		}
+	}
+	for _, name := range []string{"leases", "wisp_labels", "issues", "labels", "", "wisp"} {
+		if OptionalWispTable(name) {
+			t.Errorf("OptionalWispTable(%q) = true, want false", name)
+		}
+	}
+}


### PR DESCRIPTION
Stacked on #5804 — it needs `dberrors.MissingTableName` from that PR. Review that one
first; this branch is based on it and rebases cleanly once it lands.

## The bug

A wisp search folds any table-not-exist error into "there are no wisps":

```go
results, err := searchTableInTxT(ctx, tx, query, filter, WispsFilterTables, proj)
if err != nil && !isTableNotExistError(err) {
    return nil, fmt.Errorf("search wisps (ephemeral filter): %w", err)
}
```

The tolerance is there for pre-migration databases, which have no wisp plane at all. But
the wisp query reads more tables than the wisp plane owns: its `FROM` clause carries
`sqlbuild.LeaseJoin`, and `hydrateIssueLabelsAndDeps` reads `wisp_labels`. So a database
that **has** wisps and has lost `wisp_labels` is reported as having none — with a nil
error, from an ordinary list.

`GetIssueInTx` already surfaces a missing `wisp_labels` as an error; the existing
embedded-Dolt case `TestGetIssue/wisp_label_table_error_propagates` pins that. So the two
read paths disagreed about whether such a database is broken or merely empty.

## Reproducing it, with a control

Against real embedded Dolt, one durable issue and one wisp seeded, the row present in the
same transaction that is told it is not:

```
RENAME TABLE wisp_labels TO wisp_labels_renamed_away
assertRowExists(wisps, wl2-wisp)              <- the control

SearchIssues(ephemeral)   healthy: [wl2-wisp]              broken: [] err=<nil>
SearchIssues(no filter)   healthy: [wl2-issue wl2-wisp]    broken: [wl2-issue] err=<nil>
```

The merged case is the one that stings: a plain list silently omits every wisp.

The same probe over the other tables is what bounds the fix — these are the controls that
must keep their current answers:

```
RENAME TABLE wisps ...              ephemeral: [] err=<nil>   merged: [issue] err=<nil>   (correct: pre-migration)
RENAME TABLE wisp_dependencies ...  ephemeral: [wisp]         merged: [issue wisp]        (correct: unaffected)
```

## The fix

Narrow the tolerance to the tables the wisp plane may legitimately not have.
`sqlbuild.OptionalWispTable` becomes the one place that set is written down, and
`issueops.optionalBlockedTable` now reads it — so the classic and `domain/db` stacks
cannot drift on what a missing table means, for the same reason the query text itself
already lives in `sqlbuild`.

```go
func missingOptionalWispTable(err error) bool {
	name, ok := dberrors.MissingTableName(err)
	return ok && sqlbuild.OptionalWispTable(name)
}
```

`MissingTableName` is gated on the existing `IsTableNotExist` classification, so nothing
that is an error today becomes tolerated.

Four call sites, two per stack: the ephemeral-only branch and the wisp-merge branch in
`issueops/search.go`, and their counterparts in `domain/db/issue_search.go`. Both stacks
move together because the parity suite requires them to answer identically.

## On the `leases` half

The same over-broad check also spans `leases`, and that half is included — but on its own
it is **not** a reachable wrong answer today, and I would rather say so than imply a repro
I do not have. The ephemeral branch falls through to an issues-plane query over the same
join, which re-raises the missing table, so the caller does get an error:

```
RENAME TABLE leases ...   SearchIssues(ephemeral) -> search issues: search issues: Error 1146: table not found: leases
```

That was measured, not assumed. The `leases` cases in this PR therefore assert the guard's
scope at the guard, and the user-visible claim rests entirely on `wisp_labels`.

## Tests

Red first. Unit, both stacks (sqlmock), and end-to-end (embedded Dolt):

```
--- FAIL: TestSearchWithMissingWispPlaneTables/missing_wisp_labels_is_an_error_not_an_empty_result
    ephemeral search returned [] with no error and no wisp_labels table
--- FAIL: TestSearchInTxEphemeralBrokenWispPlaneIsAnError/wisp_labels/SearchIssuesInTx
    search succeeded with no wisp_labels table, returning 0 rows
--- FAIL: TestSearchInTxMergeBrokenWispPlaneIsAnError
    merged search hid a broken wisp plane: <nil>
--- FAIL: TestSearchAcrossEphemeralBrokenWispPlaneIsAnError/wisp_labels
    search hid a broken wisp plane: <nil>
```

The must-error assertions use `errors.Is` against the primed driver error rather than a
substring of the message: both projections name the joined tables in the query text, so a
substring check passes on any error that merely echoes the query. That version of the test
did pass vacuously before it was tightened.

Over-tightening to "never tolerate" passes every assertion above, so the controls are what
make the guard non-vacuous in the other direction, and they fail as they should:

```
--- FAIL: TestSearchInTxEphemeralMissingWispPlaneIsEmpty/wisps
    search errored on a database with no wisp plane: ... table not found: wisps
--- FAIL: TestSearchWithMissingWispPlaneTables/missing_wisps_table_is_an_empty_result
    ephemeral search on a database with no wisp plane: ... table not found: wisps
```

plus `missing_wisp_dependencies_is_invisible` and an unrelated-error control
(`connection refused` must still propagate).

## Local gates, with actual results

| gate | result |
| --- | --- |
| `make ci-pr-core` (`go test -p 4 -parallel 4 -race -short -skip '^TestEmbedded' ./...`) | **pass**, exit 0, `pr-core go test succeeded in 524s` |
| `./scripts/ci/fmt-check.sh` | **pass** — all Go files properly formatted |
| `go vet ./internal/storage/...` | **clean** |
| `BEADS_TEST_EMBEDDED_DOLT=1 go test ./internal/storage/embeddeddolt/ -run TestSearchWithMissingWispPlaneTables` | **ok 4.98s** — run separately, since ci-pr-core's hermetic env skips the Dolt-backed tests |

Not run, and why: a plain `go test ./internal/storage/...` is not a usable local gate on
this machine. `cross_project_test.go` and `concurrent_test.go` need a live
`dolt sql-server` and fail with `connect: connection refused` /
`context deadline exceeded` before any assertion, and the package then exceeds a 40-minute
timeout. `ci-pr-core`'s test environment skips exactly those, which is why it is the gate
reported above. The `domain/db` suite that needs a Dolt container likewise skips here; the
new `domain/db` coverage is sqlmock, which needs none.
