### PR TITLE
fix: bound and retry apt-get calls in CI to avoid unbounded 15-minute job timeout

### DIFF
--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -67,17 +67,29 @@ jobs:
       - name: Install test dependencies
         timeout-minutes: 6
         run: |
+          updated=""
           for attempt in 1 2 3; do
             if sudo timeout 120 apt-get \
                  -o Acquire::Retries=3 \
                  -o Acquire::http::Timeout=30 \
                  -o Acquire::https::Timeout=30 \
                  update; then
+              updated=yes
               break
             fi
-            echo "::warning::apt-get update attempt $attempt failed or timed out; retrying"
-            sleep 10
+            echo "::warning::apt-get update attempt $attempt failed or timed out"
+            # No backoff after the final attempt - there is nothing left to wait for.
+            if [ "$attempt" -lt 3 ]; then
+              sleep 10
+            fi
           done
+          # Deliberate best-effort: a stale index still installs these packages
+          # from the runner image cache far more often than not, and failing the
+          # job here would turn a transient mirror outage into a red build. The
+          # warning is what makes the degraded path visible in the job log.
+          if [ -z "$updated" ]; then
+            echo "::warning::apt-get update failed after 3 attempts; proceeding with cached index"
+          fi
           sudo timeout 180 apt-get install -y jq libicu74
 
       - name: Install Dolt test runtime

--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -65,9 +65,20 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install test dependencies
+        timeout-minutes: 6
         run: |
-          sudo apt-get update
-          sudo apt-get install -y jq libicu74
+          for attempt in 1 2 3; do
+            if sudo timeout 120 apt-get \
+                 -o Acquire::Retries=3 \
+                 -o Acquire::http::Timeout=30 \
+                 -o Acquire::https::Timeout=30 \
+                 update; then
+              break
+            fi
+            echo "::warning::apt-get update attempt $attempt failed or timed out; retrying"
+            sleep 10
+          done
+          sudo timeout 180 apt-get install -y jq libicu74
 
       - name: Install Dolt test runtime
         if: contains(fromJSON('["v0.55.4","v0.56.1","v0.57.0","v0.62.0"]'), matrix.version)

--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -65,7 +65,12 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install test dependencies
-        timeout-minutes: 6
+        # Backstop for a hang that escapes the inner `timeout` calls, so it has
+        # to sit ABOVE what those calls can legitimately consume: 3 update
+        # attempts x 120s + 2 backoffs x 10s + 180s install = 560s worst case.
+        # 11m leaves ~100s of headroom and stays under the job's 15m budget, so
+        # a stuck step fails as a step instead of cancelling the whole job.
+        timeout-minutes: 11
         run: |
           updated=""
           for attempt in 1 2 3; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,9 +123,20 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install cross-compilation toolchains and signing tools
+        timeout-minutes: 8
         run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-mingw-w64-x86-64 gcc-aarch64-linux-gnu osslsigncode
+          for attempt in 1 2 3; do
+            if sudo timeout 120 apt-get \
+                 -o Acquire::Retries=3 \
+                 -o Acquire::http::Timeout=30 \
+                 -o Acquire::https::Timeout=30 \
+                 update; then
+              break
+            fi
+            echo "::warning::apt-get update attempt $attempt failed or timed out; retrying"
+            sleep 10
+          done
+          sudo timeout 300 apt-get install -y gcc-mingw-w64-x86-64 gcc-aarch64-linux-gnu osslsigncode
 
       - name: Install go-winres for Windows PE resource embedding
         run: go install github.com/tc-hib/go-winres@latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,12 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install cross-compilation toolchains and signing tools
-        timeout-minutes: 8
+        # Backstop for a hang that escapes the inner `timeout` calls, so it has
+        # to sit ABOVE what those calls can legitimately consume: 3 update
+        # attempts x 120s + 2 backoffs x 10s + 300s install = 680s worst case.
+        # 13m leaves ~100s of headroom. This job sets no job-level
+        # timeout-minutes, so this cap is the only bound on a stuck apt.
+        timeout-minutes: 13
         run: |
           updated=""
           for attempt in 1 2 3; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,17 +125,29 @@ jobs:
       - name: Install cross-compilation toolchains and signing tools
         timeout-minutes: 8
         run: |
+          updated=""
           for attempt in 1 2 3; do
             if sudo timeout 120 apt-get \
                  -o Acquire::Retries=3 \
                  -o Acquire::http::Timeout=30 \
                  -o Acquire::https::Timeout=30 \
                  update; then
+              updated=yes
               break
             fi
-            echo "::warning::apt-get update attempt $attempt failed or timed out; retrying"
-            sleep 10
+            echo "::warning::apt-get update attempt $attempt failed or timed out"
+            # No backoff after the final attempt - there is nothing left to wait for.
+            if [ "$attempt" -lt 3 ]; then
+              sleep 10
+            fi
           done
+          # Deliberate best-effort: a stale index still installs these packages
+          # from the runner image cache far more often than not, and failing the
+          # job here would turn a transient mirror outage into a red build. The
+          # warning is what makes the degraded path visible in the job log.
+          if [ -z "$updated" ]; then
+            echo "::warning::apt-get update failed after 3 attempts; proceeding with cached index"
+          fi
           sudo timeout 300 apt-get install -y gcc-mingw-w64-x86-64 gcc-aarch64-linux-gnu osslsigncode
 
       - name: Install go-winres for Windows PE resource embedding

--- a/scripts/ci_workflow_apt_get_timeout_test.go
+++ b/scripts/ci_workflow_apt_get_timeout_test.go
@@ -19,6 +19,8 @@ func TestMigrationTestInstallDependenciesIsBoundedAndRetried(t *testing.T) {
 		"-o Acquire::http::Timeout=30",
 		"-o Acquire::https::Timeout=30",
 		"for attempt in 1 2 3",
+		`if [ "$attempt" -lt 3 ]; then`,
+		`echo "::warning::apt-get update failed after 3 attempts; proceeding with cached index"`,
 		"sudo timeout 180 apt-get install -y jq libicu74",
 	} {
 		if !strings.Contains(step.Run, required) {
@@ -41,6 +43,8 @@ func TestReleaseInstallCrossCompilationToolchainsIsBoundedAndRetried(t *testing.
 		"-o Acquire::http::Timeout=30",
 		"-o Acquire::https::Timeout=30",
 		"for attempt in 1 2 3",
+		`if [ "$attempt" -lt 3 ]; then`,
+		`echo "::warning::apt-get update failed after 3 attempts; proceeding with cached index"`,
 		"sudo timeout 300 apt-get install -y gcc-mingw-w64-x86-64 gcc-aarch64-linux-gnu osslsigncode",
 	} {
 		if !strings.Contains(step.Run, required) {

--- a/scripts/ci_workflow_apt_get_timeout_test.go
+++ b/scripts/ci_workflow_apt_get_timeout_test.go
@@ -1,54 +1,143 @@
 package scripts_test
 
 import (
+	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 )
 
-func TestMigrationTestInstallDependenciesIsBoundedAndRetried(t *testing.T) {
-	job := readCIWorkflow(t, "migration-test.yml").job(t, "historical-upgrades")
-	step := job.step(t, "Install test dependencies")
+// aptStepBudget describes one bounded `apt-get` step: how long its own inner
+// `timeout` calls may run, and the step-level `timeout-minutes` that backstops
+// them.
+//
+// The components are declared here rather than only pinning the final minute
+// count so that the two halves are checked against each other. A cap that
+// lands below the step's own worst case reproduces exactly the undiagnosable
+// mid-flight kill this hardening exists to remove, just at a smaller number --
+// and that is invisible if the test only asserts the cap's literal value.
+type aptStepBudget struct {
+	workflow string
+	job      string
+	step     string
 
-	if step.TimeoutMinutes != 6 {
-		t.Errorf("Install test dependencies timeout-minutes = %d, want 6", step.TimeoutMinutes)
+	updateAttempts int // iterations of the `for attempt in ...` loop
+	updateTimeout  int // seconds allowed per `apt-get update` attempt
+	backoff        int // seconds slept between attempts (never after the last)
+	installTimeout int // seconds allowed for `apt-get install`
+	installPkgs    string
+
+	capMinutes int // the step's `timeout-minutes`
+}
+
+// worstCaseSeconds is the longest the step's own bounds permit it to run.
+func (b aptStepBudget) worstCaseSeconds() int {
+	return b.updateAttempts*b.updateTimeout +
+		(b.updateAttempts-1)*b.backoff +
+		b.installTimeout
+}
+
+// loopHeader is the `for` header the declared attempt count implies.
+func (b aptStepBudget) loopHeader() string {
+	attempts := make([]string, 0, b.updateAttempts)
+	for i := 1; i <= b.updateAttempts; i++ {
+		attempts = append(attempts, strconv.Itoa(i))
 	}
+	return "for attempt in " + strings.Join(attempts, " ")
+}
 
-	for _, required := range []string{
-		"sudo timeout 120 apt-get",
-		"-o Acquire::Retries=3",
-		"-o Acquire::http::Timeout=30",
-		"-o Acquire::https::Timeout=30",
-		"for attempt in 1 2 3",
-		`if [ "$attempt" -lt 3 ]; then`,
-		`echo "::warning::apt-get update failed after 3 attempts; proceeding with cached index"`,
-		"sudo timeout 180 apt-get install -y jq libicu74",
-	} {
-		if !strings.Contains(step.Run, required) {
-			t.Errorf("Install test dependencies command does not contain %q:\n%s", required, step.Run)
-		}
+func aptStepBudgets() []aptStepBudget {
+	return []aptStepBudget{
+		{
+			workflow:       "migration-test.yml",
+			job:            "historical-upgrades",
+			step:           "Install test dependencies",
+			updateAttempts: 3,
+			updateTimeout:  120,
+			backoff:        10,
+			installTimeout: 180,
+			installPkgs:    "jq libicu74",
+			capMinutes:     11,
+		},
+		{
+			workflow:       "release.yml",
+			job:            "goreleaser",
+			step:           "Install cross-compilation toolchains and signing tools",
+			updateAttempts: 3,
+			updateTimeout:  120,
+			backoff:        10,
+			installTimeout: 300,
+			installPkgs:    "gcc-mingw-w64-x86-64 gcc-aarch64-linux-gnu osslsigncode",
+			capMinutes:     13,
+		},
 	}
 }
 
-func TestReleaseInstallCrossCompilationToolchainsIsBoundedAndRetried(t *testing.T) {
-	job := readCIWorkflow(t, "release.yml").job(t, "goreleaser")
-	step := job.step(t, "Install cross-compilation toolchains and signing tools")
+// TestAptGetStepsAreBoundedAndRetried pins the bounded/retried invocations, so
+// a revert to a bare `apt-get update` -- the unbounded shape that burned whole
+// job budgets on a stalled mirror -- goes red.
+func TestAptGetStepsAreBoundedAndRetried(t *testing.T) {
+	for _, b := range aptStepBudgets() {
+		t.Run(b.workflow+"/"+b.step, func(t *testing.T) {
+			step := readCIWorkflow(t, b.workflow).job(t, b.job).step(t, b.step)
 
-	if step.TimeoutMinutes != 8 {
-		t.Errorf("Install cross-compilation toolchains timeout-minutes = %d, want 8", step.TimeoutMinutes)
+			for _, required := range []string{
+				fmt.Sprintf("sudo timeout %d apt-get", b.updateTimeout),
+				"-o Acquire::Retries=3",
+				"-o Acquire::http::Timeout=30",
+				"-o Acquire::https::Timeout=30",
+				b.loopHeader(),
+				// Backoff between attempts, but not after the final one.
+				fmt.Sprintf("if [ \"$attempt\" -lt %d ]; then", b.updateAttempts),
+				fmt.Sprintf("sleep %d", b.backoff),
+				// Exhausting the retries proceeds best-effort against the
+				// cached index; the warning is what keeps that visible in the
+				// job log instead of a silent fall-through.
+				fmt.Sprintf("echo \"::warning::apt-get update failed after %d attempts; proceeding with cached index\"", b.updateAttempts),
+				fmt.Sprintf("sudo timeout %d apt-get install -y %s", b.installTimeout, b.installPkgs),
+			} {
+				if !strings.Contains(step.Run, required) {
+					t.Errorf("%s command does not contain %q:\n%s", b.step, required, step.Run)
+				}
+			}
+		})
 	}
+}
 
-	for _, required := range []string{
-		"sudo timeout 120 apt-get",
-		"-o Acquire::Retries=3",
-		"-o Acquire::http::Timeout=30",
-		"-o Acquire::https::Timeout=30",
-		"for attempt in 1 2 3",
-		`if [ "$attempt" -lt 3 ]; then`,
-		`echo "::warning::apt-get update failed after 3 attempts; proceeding with cached index"`,
-		"sudo timeout 300 apt-get install -y gcc-mingw-w64-x86-64 gcc-aarch64-linux-gnu osslsigncode",
-	} {
-		if !strings.Contains(step.Run, required) {
-			t.Errorf("Install cross-compilation toolchains command does not contain %q:\n%s", required, step.Run)
-		}
+// TestAptGetStepTimeoutsExceedTheirOwnBudget is the relation the first round of
+// this hardening got backwards: the step-level cap was set *tighter* than the
+// inner `timeout` calls it was meant to backstop.
+func TestAptGetStepTimeoutsExceedTheirOwnBudget(t *testing.T) {
+	for _, b := range aptStepBudgets() {
+		t.Run(b.workflow+"/"+b.step, func(t *testing.T) {
+			workflow := readCIWorkflow(t, b.workflow)
+			job := workflow.job(t, b.job)
+			step := job.step(t, b.step)
+
+			if step.TimeoutMinutes != b.capMinutes {
+				t.Errorf("%s timeout-minutes = %d, want %d", b.step, step.TimeoutMinutes, b.capMinutes)
+			}
+
+			// Read the relations off the workflow itself, never off capMinutes:
+			// checking a declared constant against the budget it was derived
+			// from is self-satisfying, and would stay green while the YAML
+			// drifted underneath it.
+			capSeconds := step.TimeoutMinutes * 60
+			if capSeconds <= b.worstCaseSeconds() {
+				t.Errorf("%s timeout-minutes = %d (%ds) does not exceed its own worst case of %ds "+
+					"(%d update attempts x %ds + %d backoffs x %ds + %ds install); "+
+					"raise the cap or shrink the inner budgets",
+					b.step, step.TimeoutMinutes, capSeconds, b.worstCaseSeconds(),
+					b.updateAttempts, b.updateTimeout, b.updateAttempts-1, b.backoff, b.installTimeout)
+			}
+
+			// Where the job carries its own cap, the step must fail first --
+			// otherwise the whole job is cancelled and the log gives no hint
+			// that apt was the thing that stalled.
+			if job.TimeoutMinutes > 0 && step.TimeoutMinutes >= job.TimeoutMinutes {
+				t.Errorf("%s timeout-minutes = %d is not below job %q timeout-minutes = %d",
+					b.step, step.TimeoutMinutes, b.job, job.TimeoutMinutes)
+			}
+		})
 	}
 }

--- a/scripts/ci_workflow_apt_get_timeout_test.go
+++ b/scripts/ci_workflow_apt_get_timeout_test.go
@@ -1,0 +1,50 @@
+package scripts_test
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMigrationTestInstallDependenciesIsBoundedAndRetried(t *testing.T) {
+	job := readCIWorkflow(t, "migration-test.yml").job(t, "historical-upgrades")
+	step := job.step(t, "Install test dependencies")
+
+	if step.TimeoutMinutes != 6 {
+		t.Errorf("Install test dependencies timeout-minutes = %d, want 6", step.TimeoutMinutes)
+	}
+
+	for _, required := range []string{
+		"sudo timeout 120 apt-get",
+		"-o Acquire::Retries=3",
+		"-o Acquire::http::Timeout=30",
+		"-o Acquire::https::Timeout=30",
+		"for attempt in 1 2 3",
+		"sudo timeout 180 apt-get install -y jq libicu74",
+	} {
+		if !strings.Contains(step.Run, required) {
+			t.Errorf("Install test dependencies command does not contain %q:\n%s", required, step.Run)
+		}
+	}
+}
+
+func TestReleaseInstallCrossCompilationToolchainsIsBoundedAndRetried(t *testing.T) {
+	job := readCIWorkflow(t, "release.yml").job(t, "goreleaser")
+	step := job.step(t, "Install cross-compilation toolchains and signing tools")
+
+	if step.TimeoutMinutes != 8 {
+		t.Errorf("Install cross-compilation toolchains timeout-minutes = %d, want 8", step.TimeoutMinutes)
+	}
+
+	for _, required := range []string{
+		"sudo timeout 120 apt-get",
+		"-o Acquire::Retries=3",
+		"-o Acquire::http::Timeout=30",
+		"-o Acquire::https::Timeout=30",
+		"for attempt in 1 2 3",
+		"sudo timeout 300 apt-get install -y gcc-mingw-w64-x86-64 gcc-aarch64-linux-gnu osslsigncode",
+	} {
+		if !strings.Contains(step.Run, required) {
+			t.Errorf("Install cross-compilation toolchains command does not contain %q:\n%s", required, step.Run)
+		}
+	}
+}

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -950,6 +950,7 @@ type ciWorkflowStep struct {
 	Run             string            `yaml:"run"`
 	Shell           string            `yaml:"shell"`
 	ContinueOnError any               `yaml:"continue-on-error"`
+	TimeoutMinutes  int               `yaml:"timeout-minutes"`
 	Env             map[string]string `yaml:"env"`
 	With            map[string]string `yaml:"with"`
 }


### PR DESCRIPTION
## Problem

`Install test dependencies` (migration-test.yml) and `Install cross-compilation
toolchains and signing tools` (release.yml) both run a bare `sudo apt-get
update && sudo apt-get install -y ...` with no timeout of their own. When the
apt mirror is slow or flaky, these steps can hang for the entire remaining CI
job budget — for jobs on a 15-minute job-level timeout, a stuck `apt-get
update` can burn the whole budget before the job is killed, without ever
reaching the actual test/build step, and without leaving a signal that
distinguishes "apt hung" from "the tests are slow."

This is not hypothetical: it killed two clusters of `historical-upgrades` legs
on 2026-08-19 (07:59–08:15Z and 15:30–16:59Z), every one at start+15m15s with
the log ending mid-`apt-get update` fetching `noble-security InRelease`.
Context: #5864 (leaving that issue open — it tracks the incident and the
mirror behaviour, which is broader than this hardening).

### Repro

Before fix:

```
sudo apt-get update
sudo apt-get install -y jq libicu74
```

Force `apt-get update` to stall (e.g. block `archive.ubuntu.com` /
`security.ubuntu.com` at the runner's network layer, or point
`/etc/apt/sources.list` at an unreachable host), then run either affected job.

- **Before:** the job runs until the 15-minute job-level timeout cancels it,
  with no apt-specific error, no retry, and no indication that zero lines of
  project code ever ran.
- **After:** each `apt-get update` attempt is killed at 120s and retried up to
  3 times, each failure is a `::warning::` in the job log, and — if all three
  fail — the step says so and continues against the runner's cached index.
  A genuine hang is now bounded at ~9.5 min by the step's own cap rather than
  eating the job.

## Fix

- Wrap `apt-get update` in a bounded retry loop (3 attempts, `timeout 120`,
  `Acquire::Retries=3`, `Acquire::http::Timeout=30`,
  `Acquire::https::Timeout=30`), emitting `::warning::` on each failed attempt
  so a flaky-mirror run is visible in the job log instead of reading as a
  generic hang. The 10s backoff is skipped after the final attempt.
- **On retry exhaustion, proceed best-effort and say so.** After three failed
  `update` attempts the step emits
  `::warning::apt-get update failed after 3 attempts; proceeding with cached
  index` and goes on to `apt-get install`. This is deliberate: the runner
  image's cached index installs these packages far more often than not, and
  failing the job here would convert a transient mirror outage into a red
  build — the 2026-08-19 incident would most likely have gone green under it.
  The warning is what keeps the degraded path visible rather than silent.
- Wrap `apt-get install` in its own `timeout` (180s for the small `jq
  libicu74` install in migration-test.yml, 300s for the larger toolchain
  install in release.yml).
- Add a `timeout-minutes` cap on the step itself as a backstop for a hang that
  escapes the inner `timeout` calls. It has to sit **above** what those calls
  can legitimately consume, or it just reproduces the same undiagnosable
  mid-flight kill at a smaller number:

  | workflow | worst case | cap |
  |---|---|---|
  | migration-test.yml | 3×120s + 2×10s + 180s = **560s** | **11 min** (660s) |
  | release.yml | 3×120s + 2×10s + 300s = **680s** | **13 min** (780s) |

  11 min also stays under the `historical-upgrades` job's own 15-minute
  budget, so a stuck step fails *as a step* instead of cancelling the job.
  The `goreleaser` job sets no job-level `timeout-minutes` at all, so its step
  cap is the only bound on a stuck apt there.

No change to what gets installed — only how long a stuck apt call may run, and
whether a degraded run is legible in the log.

## Test plan

- `scripts/ci_workflow_apt_get_timeout_test.go` asserts, for both steps:
  - the bounded/retried invocations, the guarded backoff, and the
    retry-exhaustion warning are present — so a revert to a bare `apt-get
    update`, or back to a silent fall-through, goes red;
  - the step's `timeout-minutes` **exceeds its own worst-case budget**,
    computed from the attempt count, per-attempt timeout, backoff and install
    timeout that the same table pins against the YAML;
  - the step's `timeout-minutes` stays **below the job's**, where the job sets
    one.

  Both relations read the value off the workflow rather than off the test's
  own constant, so they stay honest if the YAML drifts. Verified red against
  the previous 6/8 caps and against an over-corrected 15.
- `go test ./scripts/`, `go vet ./scripts/`, `gofmt` clean.
- `actionlint` (which runs shellcheck over the `run:` blocks) clean on both
  changed workflow files.
- The end-to-end fork run referenced earlier in review covered the original
  bounding commit; the two follow-up commits change only the warning text,
  the backoff guard and the `timeout-minutes` values, with no change to the
  installed packages.
