### PR TITLE
schema: keep the primary migration error leading when lock release also fails

### DIFF
--- a/internal/storage/schema/lock.go
+++ b/internal/storage/schema/lock.go
@@ -187,7 +187,13 @@ func MigrateUpWithLock(ctx context.Context, conn *sql.Conn, databaseName string,
 	}
 	defer func() {
 		if releaseErr := ReleaseMigrationLock(conn, lockName); releaseErr != nil {
-			err = errors.Join(err, releaseErr)
+			if err != nil {
+				// Two %w verbs keep errors.Is/As working for both errors
+				// without errors.Join's separator newline, primary first.
+				err = fmt.Errorf("%w (lock release also failed: %w)", err, releaseErr)
+			} else {
+				err = errors.Join(err, releaseErr)
+			}
 		}
 	}()
 	if o.lockedPreparation != nil && o.lockedPreparation.fn != nil {

--- a/internal/storage/schema/lock_test.go
+++ b/internal/storage/schema/lock_test.go
@@ -141,6 +141,80 @@ func TestMigrateUpWithLockPreparationErrorReleasesAndJoinsReleaseFailure(t *test
 	}
 }
 
+// TestMigrateUpWithLockMigrationErrorNotMaskedByReleaseFailure covers the
+// sibling failure shape of the preparation-error case above: MigrateUp itself
+// fails AND the deferred lock release also fails. The combiner must not
+// introduce a separator newline between the two errors (for single-line
+// constituent errors like these fixtures the whole message stays on one
+// line), and the primary migration failure must lead, so a last-line-only
+// capture (`tail -1` in a triage script) cannot see only the generic release
+// wrapper. Classification is unchanged from the case above.
+func TestMigrateUpWithLockMigrationErrorNotMaskedByReleaseFailure(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("create sql mock: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("pin mock connection: %v", err)
+	}
+	defer conn.Close()
+
+	lockName := MigrationLockName("testdb")
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT GET_LOCK(?, ?)")).
+		WithArgs(lockName, migrationLockAcquireTimeoutSeconds).
+		WillReturnRows(sqlmock.NewRows([]string{"locked"}).AddRow(1))
+	// MigrateUp's first statement fails with a structural error, standing in
+	// for a migration hard-failing on a malformed clone.
+	migrationCause := errors.New("column 'is_blocked' could not be found in any table in scope")
+	releaseCause := errors.New("driver: bad connection")
+	mock.ExpectExec(regexp.QuoteMeta("INSERT IGNORE INTO dolt_ignore VALUES (?, true)")).
+		WillReturnError(migrationCause)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT RELEASE_LOCK(?)")).
+		WithArgs(lockName).
+		WillReturnError(releaseCause)
+
+	applied, err := MigrateUpWithLock(ctx, conn, "testdb")
+	if applied != 0 {
+		t.Fatalf("MigrateUpWithLock() applied = %d, want 0", applied)
+	}
+	if err == nil {
+		t.Fatal("MigrateUpWithLock() error = nil, want the migration failure")
+	}
+
+	msg := err.Error()
+	if strings.Contains(msg, "\n") {
+		t.Fatalf("MigrateUpWithLock() error is multi-line, want one line so a last-line-only capture cannot drop the primary error: %q", msg)
+	}
+	primaryIdx := strings.Index(msg, "is_blocked")
+	releaseIdx := strings.Index(msg, "release migration lock")
+	if primaryIdx < 0 {
+		t.Fatalf("MigrateUpWithLock() error = %q, want the primary migration diagnostic present", msg)
+	}
+	if releaseIdx < 0 {
+		t.Fatalf("MigrateUpWithLock() error = %q, want the lock-release diagnostic present too", msg)
+	}
+	if primaryIdx > releaseIdx {
+		t.Fatalf("MigrateUpWithLock() error = %q, want the primary migration error printed before the lock-release error", msg)
+	}
+
+	if !errors.Is(err, migrationCause) {
+		t.Fatalf("MigrateUpWithLock() error = %v, want errors.Is against the original migration cause", err)
+	}
+	if !errors.Is(err, releaseCause) {
+		t.Fatalf("MigrateUpWithLock() error = %v, want errors.Is against the original release cause", err)
+	}
+	if !errors.Is(err, ErrMigrationLockRelease) || !IsMigrationLockError(err) {
+		t.Fatalf("MigrateUpWithLock() error = %v, want classifiable release failure", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
 // TestMigrateUpSeedsIgnorePatternsWhenNoWorkNeeded is the regression guard for
 // out-of-band-materialized databases: one whose migration cursors arrived
 // at-latest WITHOUT executing the seeding migrations (out-of-band table


### PR DESCRIPTION
## Problem

When `MigrateUp` fails and the deferred `ReleaseMigrationLock` also fails, `MigrateUpWithLock` combines the two with `errors.Join`, which renders them on **two lines** — migration failure first, release failure second. An operational capture that keeps only the last line of the printed error (a `tail -1` in a triage script) then records only the generic `release migration lock ... driver: bad connection` wrapper and loses the structural cause it masks. We hit exactly this: a repair campaign misclassified two databases with a structural migration failure as transient-connection failures for a full retry pass.

## Fix

Combine the two errors with `fmt.Errorf` and two `%w` verbs: no separator newline is introduced (for single-line constituent errors the whole message stays on one line), the primary error leads, and `errors.Is`/`errors.As` keep resolving both wrapped errors (`Unwrap() []error`, Go 1.20+). The success-path release failure keeps `errors.Join`, so its wrapper topology is unchanged.

Scope notes, measured before opening:
- Production consumers of `MigrateUpWithLock`'s error (`internal/storage/dolt/store.go`, `internal/storage/uow/dolt_sql_provider.go`, the `schema.go` wrapper) classify via `errors.Is`/`errors.As` or substring matching; none parses the joined-message structure.
- This does not make every combined failure single-line: a constituent error that itself contains a newline keeps it. The change only stops the combiner from *introducing* one.

## Test

`TestMigrateUpWithLockMigrationErrorNotMaskedByReleaseFailure` (sqlmock, same pattern as the neighboring preparation-error test): asserts both diagnostics present, primary first, no separator newline, and `errors.Is` against both original causes plus `ErrMigrationLockRelease`/`IsMigrationLockError`. It fails on current `main` (two-line message) and passes with this change. The pre-existing `TestMigrateUpWithLockPreparationErrorReleasesAndJoinsReleaseFailure` passes unmodified.

_claude-code-claude-fable-5 on behalf of Marco Del Pin_
