### PR TITLE
test(dbproxy): make external_dolt_server_test paths platform-portable

### DIFF
--- a/internal/storage/dbproxy/server/external_dolt_server_test.go
+++ b/internal/storage/dbproxy/server/external_dolt_server_test.go
@@ -3,7 +3,9 @@ package server
 import (
 	"context"
 	"net"
+	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -14,13 +16,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// testPlatformPath makes a POSIX-shaped fixture path absolute on the running
+// platform: Windows filepath.IsAbs rejects a bare leading "/" (no volume), so
+// POSIX literals cannot satisfy ExternalDoltConfig.Validate there. Inputs and
+// the matching DSN expectation both go through it, keeping assertions literal
+// instead of rebuilt from the code under test.
+func testPlatformPath(t testing.TB, p string) string {
+	t.Helper()
+	if runtime.GOOS != "windows" {
+		return p
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("resolve volume for platform path fixture: %v", err)
+	}
+	return filepath.VolumeName(wd) + filepath.FromSlash(p)
+}
+
 func TestExternalDoltConfigValidate(t *testing.T) {
 	t.Run("tcp endpoint with host+port", func(t *testing.T) {
 		require.NoError(t, configfile.ExternalDoltConfig{Host: "db.internal", Port: 3306}.Validate())
 	})
 
 	t.Run("unix socket endpoint", func(t *testing.T) {
-		require.NoError(t, configfile.ExternalDoltConfig{Socket: "/var/run/dolt.sock"}.Validate())
+		require.NoError(t, configfile.ExternalDoltConfig{Socket: testPlatformPath(t, "/var/run/dolt.sock")}.Validate())
 	})
 
 	t.Run("tcp endpoint with tls required and no cert/key", func(t *testing.T) {
@@ -36,8 +55,8 @@ func TestExternalDoltConfigValidate(t *testing.T) {
 			Host:        "hosted-dolt.example.com",
 			Port:        3306,
 			TLSRequired: true,
-			TLSCert:     "/etc/beads/client.pem",
-			TLSKey:      "/etc/beads/client.key",
+			TLSCert:     testPlatformPath(t, "/etc/beads/client.pem"),
+			TLSKey:      testPlatformPath(t, "/etc/beads/client.key"),
 		}.Validate())
 	})
 
@@ -56,13 +75,13 @@ func TestExternalDoltConfigValidate(t *testing.T) {
 	})
 
 	t.Run("socket and host together rejected", func(t *testing.T) {
-		err := configfile.ExternalDoltConfig{Host: "db", Port: 3306, Socket: "/var/run/dolt.sock"}.Validate()
+		err := configfile.ExternalDoltConfig{Host: "db", Port: 3306, Socket: testPlatformPath(t, "/var/run/dolt.sock")}.Validate()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "either Socket OR (Host, Port)")
 	})
 
 	t.Run("socket and port together rejected", func(t *testing.T) {
-		err := configfile.ExternalDoltConfig{Port: 3306, Socket: "/var/run/dolt.sock"}.Validate()
+		err := configfile.ExternalDoltConfig{Port: 3306, Socket: testPlatformPath(t, "/var/run/dolt.sock")}.Validate()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "either Socket OR (Host, Port)")
 	})
@@ -104,13 +123,13 @@ func TestExternalDoltConfigValidate(t *testing.T) {
 	})
 
 	t.Run("tls cert without key rejected", func(t *testing.T) {
-		err := configfile.ExternalDoltConfig{Host: "db", Port: 3306, TLSCert: "/etc/beads/client.pem"}.Validate()
+		err := configfile.ExternalDoltConfig{Host: "db", Port: 3306, TLSCert: testPlatformPath(t, "/etc/beads/client.pem")}.Validate()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "TLSCert set without TLSKey")
 	})
 
 	t.Run("tls key without cert rejected", func(t *testing.T) {
-		err := configfile.ExternalDoltConfig{Host: "db", Port: 3306, TLSKey: "/etc/beads/client.key"}.Validate()
+		err := configfile.ExternalDoltConfig{Host: "db", Port: 3306, TLSKey: testPlatformPath(t, "/etc/beads/client.key")}.Validate()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "TLSKey set without TLSCert")
 	})
@@ -120,7 +139,7 @@ func TestExternalDoltConfigValidate(t *testing.T) {
 			Host:    "db",
 			Port:    3306,
 			TLSCert: "client.pem",
-			TLSKey:  "/etc/beads/client.key",
+			TLSKey:  testPlatformPath(t, "/etc/beads/client.key"),
 		}.Validate()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "TLSCert")
@@ -131,7 +150,7 @@ func TestExternalDoltConfigValidate(t *testing.T) {
 		err := configfile.ExternalDoltConfig{
 			Host:    "db",
 			Port:    3306,
-			TLSCert: "/etc/beads/client.pem",
+			TLSCert: testPlatformPath(t, "/etc/beads/client.pem"),
 			TLSKey:  "client.key",
 		}.Validate()
 		require.Error(t, err)
@@ -180,7 +199,7 @@ func TestExternalDoltServer_ID(t *testing.T) {
 	t.Run("socket and tcp produce different ids even when notation overlaps", func(t *testing.T) {
 		a, err := NewExternalDoltServer(configfile.ExternalDoltConfig{Host: "db", Port: 3306})
 		require.NoError(t, err)
-		b, err := NewExternalDoltServer(configfile.ExternalDoltConfig{Socket: "/var/run/dolt.sock"})
+		b, err := NewExternalDoltServer(configfile.ExternalDoltConfig{Socket: testPlatformPath(t, "/var/run/dolt.sock")})
 		require.NoError(t, err)
 		assert.NotEqual(t, a.ID(context.Background()), b.ID(context.Background()))
 	})
@@ -198,8 +217,8 @@ func TestExternalDoltServerID_AuthFieldsDoNotChangeID(t *testing.T) {
 	withAuth := base
 	withAuth.User = "beads"
 	withAuth.TLSRequired = true
-	withAuth.TLSCert = "/etc/beads/client.pem"
-	withAuth.TLSKey = "/etc/beads/client.key"
+	withAuth.TLSCert = testPlatformPath(t, "/etc/beads/client.pem")
+	withAuth.TLSKey = testPlatformPath(t, "/etc/beads/client.key")
 	assert.Equal(t, ExternalDoltServerID(base), ExternalDoltServerID(withAuth))
 }
 
@@ -221,10 +240,10 @@ func TestExternalDoltServer_DSN(t *testing.T) {
 	})
 
 	t.Run("unix socket", func(t *testing.T) {
-		s, err := NewExternalDoltServer(configfile.ExternalDoltConfig{Socket: "/var/run/dolt.sock"})
+		s, err := NewExternalDoltServer(configfile.ExternalDoltConfig{Socket: testPlatformPath(t, "/var/run/dolt.sock")})
 		require.NoError(t, err)
 		dsn := s.DSN(context.Background(), "beads", "root", "")
-		assert.Contains(t, dsn, "unix(/var/run/dolt.sock)")
+		assert.Contains(t, dsn, "unix("+testPlatformPath(t, "/var/run/dolt.sock")+")")
 		assert.NotContains(t, dsn, "tcp(")
 	})
 


### PR DESCRIPTION
## Problem

`internal/storage/dbproxy/server/external_dolt_server_test.go` hardcodes 13 POSIX-absolute config-field path literals (`Socket`, `TLSCert`, `TLSKey`) plus one matching `unix(...)` DSN expectation. On Windows, `filepath.IsAbs` rejects a bare leading slash, so `ExternalDoltConfig.Validate` refuses the fixtures that reach it and five test cases in the package fail. (Same portability family as #4809, which covered the cmd/bd and storage suites.)

## Fix

Route the 14 occurrences through a small test helper that prefixes the working directory's volume on Windows and returns the path unchanged elsewhere. The helper takes `testing.TB` and fails the test on setup error instead of silently returning a still-relative path. Both the inputs and the matching DSN expectation go through it, so assertions stay literal rather than being rebuilt from the code under test. The one `"/beads"` suffix check is deliberately untouched: it is the DSN database name, not a filesystem path. The two deliberately-relative negative fixtures are also untouched.

## Verification

Manually verified on windows/amd64 (go1.26.5), fresh shallow clones: the package fails on current `main` and passes with this change; on Linux the package stays green.

CI note, flagged per the portability intent: no PR-time CI lane currently runs this package on Windows (the existing Windows jobs cover other focused targets), so this regression guard will not execute in PR CI as-is. Happy to add a minimal Windows lane for the package in this PR or as a follow-up, whichever you prefer.

_claude-code-claude-fable-5 on behalf of Marco Del Pin_
