### PR TITLE
schema: repair missing wisps.is_blocked before ignored recomputes (0007/0015)

### DIFF
--- a/internal/storage/schema/migration_repairs.go
+++ b/internal/storage/schema/migration_repairs.go
@@ -31,11 +31,13 @@ type repairKey struct {
 // migration whose frozen body cannot replay on its own (0040/0041, which write
 // dolt_nonlocal_tables and self-commit) has a repair registered here.
 var preMigrationRepairs = map[repairKey]func(context.Context, DBConn) error{
-	{"schema_migrations", 40}: repairPartial0040NonlocalInsert,
-	{"schema_migrations", 41}: repairPartial0041NonlocalDelete,
-	{"schema_migrations", 47}: ensureWispTablesForMixedBlockedRecompute,
-	{"schema_migrations", 53}: repairV53RigAndSplitTargets,
-	{"schema_migrations", 58}: repairWispDependenciesForwardShape,
+	{"schema_migrations", 40}:         repairPartial0040NonlocalInsert,
+	{"schema_migrations", 41}:         repairPartial0041NonlocalDelete,
+	{"schema_migrations", 47}:         ensureWispTablesForMixedBlockedRecompute,
+	{"schema_migrations", 53}:         repairV53RigAndSplitTargets,
+	{"schema_migrations", 58}:         repairWispDependenciesForwardShape,
+	{"ignored_schema_migrations", 7}:  ensureWispIsBlockedForRecompute,
+	{"ignored_schema_migrations", 15}: ensureWispIsBlockedForRecompute,
 }
 
 // preMigrationRepair dispatches any repair registered for (source, version).
@@ -217,6 +219,84 @@ func ensureWispTablesForMixedBlockedRecompute(ctx context.Context, db DBConn) er
 	}
 
 	return ensureWispDependenciesSplitTargets(ctx, db)
+}
+
+// ensureWispIsBlockedForRecompute repairs a drift shape in ignored/0006's own
+// guard: it no-ops (SELECT 1) when wisps does not exist yet at the moment it
+// runs, and once the ignored cursor advances past 6 that migration is never
+// pending again (pending = version > MAX(cursor); a missing low-numbered row
+// does not lower the high-water mark). wisps can be materialized without
+// is_blocked several ways -- ignored/0001's own CREATE-then-RENAME leaves an
+// existing wisps table untouched, and the main-side 0047 repair above
+// creates wisps at the wispsTableDDLForMigration0047 shape, which has no
+// is_blocked column, whenever the main pass reaches version 47 with wisps
+// entirely missing. Whichever path, a clone that ends up there permanently
+// lacks the column, and BOTH ignored/0007 and ignored/0015's frozen
+// recomputes (each an UPDATE against wisps.is_blocked) hard-fail with
+// "column 'is_blocked' could not be found in any table in scope", masking
+// the real defect behind a generic-looking SQL error.
+//
+// A cursor-6 clone is the sharper case: it reaches 0007 first, and 0007's
+// hard-fail aborts the pass before any later file -- including 0015 -- ever
+// runs. Registering this repair only at {ignored_schema_migrations, 15}
+// left such a clone permanently unrecoverable: every pass re-hits 0007's
+// hard-fail before it can advance far enough to reach the version-15 entry
+// at all. Both 0007 and 0015's shipped bodies are frozen and content-hashed
+// like the repairs above, so neither can be fixed forward with a new
+// migration either. Registering this same function at BOTH
+// {ignored_schema_migrations, 7} and {ignored_schema_migrations, 15} runs it
+// immediately before either frozen file's own SQL, self-healing a clone
+// stuck at either cursor position. The repair is idempotent -- each of its
+// two steps re-probes the live schema and no-ops once its target already
+// exists -- so hitting it twice in one pass (once before 0007, again before
+// 0015) or on a later already-healed pass merely re-confirms the column and
+// index are present rather than re-adding them. It mirrors ignored/0006's
+// own two statements so a clone that never ran 0006 to completion still
+// ends up in the shape 0006 would have produced.
+func ensureWispIsBlockedForRecompute(ctx context.Context, db DBConn) error {
+	hasWisps, err := schemaTableExists(ctx, db, "wisps")
+	if err != nil {
+		return fmt.Errorf("checking wisps table: %w", err)
+	}
+	if !hasWisps {
+		return nil
+	}
+	if err := ensureWispIsBlockedColumn(ctx, db); err != nil {
+		return err
+	}
+	return ensureWispIsBlockedIndex(ctx, db)
+}
+
+// ensureWispIsBlockedColumn is ignored/0006's ADD COLUMN statement,
+// translated to Go for a clone that reached this repair without it.
+func ensureWispIsBlockedColumn(ctx context.Context, db DBConn) error {
+	hasColumn, err := schemaColumnExists(ctx, db, "wisps", "is_blocked")
+	if err != nil {
+		return fmt.Errorf("checking wisps.is_blocked column: %w", err)
+	}
+	if hasColumn {
+		return nil
+	}
+	if _, err := db.ExecContext(ctx, "ALTER TABLE wisps ADD COLUMN is_blocked TINYINT(1) NOT NULL DEFAULT 0"); err != nil {
+		return fmt.Errorf("adding wisps.is_blocked: %w", err)
+	}
+	return nil
+}
+
+// ensureWispIsBlockedIndex is ignored/0006's CREATE INDEX statement,
+// translated to Go alongside ensureWispIsBlockedColumn above.
+func ensureWispIsBlockedIndex(ctx context.Context, db DBConn) error {
+	hasIndex, err := schemaIndexExists(ctx, db, "wisps", "idx_wisps_is_blocked")
+	if err != nil {
+		return fmt.Errorf("checking idx_wisps_is_blocked index: %w", err)
+	}
+	if hasIndex {
+		return nil
+	}
+	if _, err := db.ExecContext(ctx, "CREATE INDEX idx_wisps_is_blocked ON wisps(is_blocked, status)"); err != nil {
+		return fmt.Errorf("creating idx_wisps_is_blocked: %w", err)
+	}
+	return nil
 }
 
 // wispsTableDDLForMigration0047 is 0020_create_wisps.up.sql's shape plus every

--- a/internal/storage/schema/schema_test.go
+++ b/internal/storage/schema/schema_test.go
@@ -581,6 +581,342 @@ func TestEnsureWispTablesForMigration0047DelegatesSplitTargetRepairWhenWispDepen
 	}
 }
 
+func TestPreMigrationRepairScopedToIgnored15(t *testing.T) {
+	// The repair must not fire for other versions or for the main source
+	// (whose cursor table differs); nil DB proves no queries are attempted.
+	if err := ignoredSource.preMigrationRepair(context.Background(), nil, 14); err != nil {
+		t.Fatalf("ignored v14 repair = %v, want nil no-op", err)
+	}
+	if err := mainSource.preMigrationRepair(context.Background(), nil, 15); err != nil {
+		t.Fatalf("main v15 repair = %v, want nil no-op", err)
+	}
+}
+
+func TestPreMigrationRepairDispatchesIgnored15ToWispIsBlockedRepair(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	tableQuery := `(?s)SELECT COUNT\(\*\) FROM INFORMATION_SCHEMA\.TABLES.*TABLE_NAME = \?`
+	columnQuery := `(?s)SELECT COUNT\(\*\) FROM INFORMATION_SCHEMA\.COLUMNS.*TABLE_NAME = \? AND COLUMN_NAME = \?`
+	indexQuery := `(?s)SELECT COUNT\(\*\) FROM INFORMATION_SCHEMA\.STATISTICS.*TABLE_NAME = \? AND INDEX_NAME = \?`
+
+	// wisps exists (id/status present) but is_blocked never landed, and its
+	// index is missing too.
+	mock.ExpectQuery(tableQuery).WithArgs("wisps").
+		WillReturnRows(sqlmock.NewRows([]string{"c"}).AddRow(1))
+	mock.ExpectQuery(columnQuery).WithArgs("wisps", "is_blocked").
+		WillReturnRows(sqlmock.NewRows([]string{"c"}).AddRow(0))
+	mock.ExpectExec(`ALTER TABLE wisps ADD COLUMN is_blocked TINYINT\(1\) NOT NULL DEFAULT 0`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(indexQuery).WithArgs("wisps", "idx_wisps_is_blocked").
+		WillReturnRows(sqlmock.NewRows([]string{"c"}).AddRow(0))
+	mock.ExpectExec(`CREATE INDEX idx_wisps_is_blocked ON wisps\(is_blocked, status\)`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	if err := ignoredSource.preMigrationRepair(context.Background(), db, 15); err != nil {
+		t.Fatalf("ignored v15 repair: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestEnsureWispIsBlockedForRecomputeNoopsWhenWispsAbsent(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	// A clone whose ignored/0001 has not yet materialized wisps in this
+	// pass: the repair takes its early no-op branch rather than attempt to
+	// ALTER a table that does not exist. That is NOT because an absent wisps
+	// table is harmless to the pending recompute -- ignored/0007 and 0015's
+	// own unguarded "UPDATE wisps SET is_blocked = ..." both fail outright
+	// with a table-not-found error if wisps is genuinely missing when they
+	// run. The no-op is safe here only because it is never reached with
+	// wisps absent in a real pass: ignored/0001 (or the cursor-reality
+	// repair, cursorContradictedBySchema, when the cursor and schema
+	// disagree) always materializes wisps before the pass advances this far.
+	// This test exercises the repair function in isolation and is not a
+	// claim that 0007/0015 tolerate a missing wisps table.
+	tableQuery := `(?s)SELECT COUNT\(\*\) FROM INFORMATION_SCHEMA\.TABLES.*TABLE_NAME = \?`
+	mock.ExpectQuery(tableQuery).WithArgs("wisps").
+		WillReturnRows(sqlmock.NewRows([]string{"c"}).AddRow(0))
+
+	if err := ensureWispIsBlockedForRecompute(context.Background(), db); err != nil {
+		t.Fatalf("ensureWispIsBlockedForRecompute: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestEnsureWispIsBlockedForRecomputeNoopsWhenAlreadyPresent(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	// The common (non-drifted) path: a clone that ran ignored/0006 normally
+	// already has both the column and its index, so the repair issues no
+	// ALTER or CREATE INDEX -- matching ignored/0006's own guard being a
+	// no-op here.
+	tableQuery := `(?s)SELECT COUNT\(\*\) FROM INFORMATION_SCHEMA\.TABLES.*TABLE_NAME = \?`
+	columnQuery := `(?s)SELECT COUNT\(\*\) FROM INFORMATION_SCHEMA\.COLUMNS.*TABLE_NAME = \? AND COLUMN_NAME = \?`
+	indexQuery := `(?s)SELECT COUNT\(\*\) FROM INFORMATION_SCHEMA\.STATISTICS.*TABLE_NAME = \? AND INDEX_NAME = \?`
+	mock.ExpectQuery(tableQuery).WithArgs("wisps").
+		WillReturnRows(sqlmock.NewRows([]string{"c"}).AddRow(1))
+	mock.ExpectQuery(columnQuery).WithArgs("wisps", "is_blocked").
+		WillReturnRows(sqlmock.NewRows([]string{"c"}).AddRow(1))
+	mock.ExpectQuery(indexQuery).WithArgs("wisps", "idx_wisps_is_blocked").
+		WillReturnRows(sqlmock.NewRows([]string{"c"}).AddRow(1))
+
+	if err := ensureWispIsBlockedForRecompute(context.Background(), db); err != nil {
+		t.Fatalf("ensureWispIsBlockedForRecompute: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+// wispIsBlockedDriftDB models the drift shape ensureWispIsBlockedForRecompute
+// repairs: a wisps table that exists but is missing is_blocked. Unlike a
+// loose fake that accepts any statement merely mentioning "is_blocked", this
+// one verifies every ExecContext call it receives byte-for-byte against what
+// the repair and the pending migration are actually supposed to send: the
+// two guarded DDL statements must match ignored/0006's own SQL exactly (the
+// same literal strings ensureWispIsBlockedColumn/ensureWispIsBlockedIndex
+// issue), the migration body must match the pending file's real embedded
+// bytes (read via IgnoredMigrationSQL, so a change to the shipped file
+// changes what this test expects too, rather than silently going stale), and
+// the cursor-row INSERT must record the exact version this test bounds
+// runMigrations to. Anything else reaching ExecContext fails the test
+// immediately via t.Fatalf instead of silently succeeding -- unrecognized
+// SQL and a wrong cursor version are exactly the two failure modes a
+// rubber-stamp fake would hide. QueryRowContext delegates to a real *sql.DB
+// (backed by sqlmock, purely for genuine *sql.Row Scan semantics) so
+// schemaTableExists/schemaColumnExists/schemaIndexExists behave exactly as
+// they would against a live engine; see wispsAbsentDB above for the same
+// technique.
+type wispIsBlockedDriftDB struct {
+	t                 *testing.T
+	real              *sql.DB
+	mock              sqlmock.Sqlmock
+	cursorTable       string
+	migrationBody     string
+	wantCursorVersion int
+
+	hasIsBlockedColumn bool
+	hasIsBlockedIndex  bool
+	bodyExecuted       bool
+	cursorInserted     bool
+}
+
+// wispIsBlockedColumnDDL / wispIsBlockedIndexDDL are the exact statements
+// ensureWispIsBlockedColumn / ensureWispIsBlockedIndex issue -- ignored/0006's
+// own ADD COLUMN and CREATE INDEX, translated to Go. wispIsBlockedDriftDB's
+// ExecContext matches against these literal strings, so a future drift
+// between the repair's SQL and 0006's shipped SQL fails this test byte-for-
+// byte instead of passing under a substring check.
+const (
+	wispIsBlockedColumnDDL = "ALTER TABLE wisps ADD COLUMN is_blocked TINYINT(1) NOT NULL DEFAULT 0"
+	wispIsBlockedIndexDDL  = "CREATE INDEX idx_wisps_is_blocked ON wisps(is_blocked, status)"
+)
+
+// newWispIsBlockedDriftDB builds a drift DB bounded to one pending ignored
+// migration file (migrationFile, e.g.
+// "0015_recompute_null_gate_wisp_is_blocked.up.sql") at wantCursorVersion
+// (its numeric version). TestIgnored15RecomputeHardFailsWithoutIsBlockedRepair
+// and TestIgnored7RecomputeHardFailsWithoutIsBlockedRepair below share this
+// helper for the {ignored_schema_migrations, 15} and {..., 7} registrations
+// respectively; only the pending file and version differ between them. The
+// returned sqlmock.Sqlmock is exposed via (*wispIsBlockedDriftDB).
+// expectationsWereMet so callers can assert it was fully consumed -- but
+// only after confirming runMigrations itself succeeded, since an
+// unregistered repair never issues the three INFORMATION_SCHEMA probes
+// below and would otherwise report a second, unrelated "unmet
+// expectations" failure on top of the real one.
+func newWispIsBlockedDriftDB(t *testing.T, migrationFile string, wantCursorVersion int) *wispIsBlockedDriftDB {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	tableQuery := `(?s)SELECT COUNT\(\*\) FROM INFORMATION_SCHEMA\.TABLES.*TABLE_NAME = \?`
+	columnQuery := `(?s)SELECT COUNT\(\*\) FROM INFORMATION_SCHEMA\.COLUMNS.*TABLE_NAME = \? AND COLUMN_NAME = \?`
+	indexQuery := `(?s)SELECT COUNT\(\*\) FROM INFORMATION_SCHEMA\.STATISTICS.*TABLE_NAME = \? AND INDEX_NAME = \?`
+	mock.ExpectQuery(tableQuery).WithArgs("wisps").
+		WillReturnRows(sqlmock.NewRows([]string{"c"}).AddRow(1))
+	mock.ExpectQuery(columnQuery).WithArgs("wisps", "is_blocked").
+		WillReturnRows(sqlmock.NewRows([]string{"c"}).AddRow(0))
+	mock.ExpectQuery(indexQuery).WithArgs("wisps", "idx_wisps_is_blocked").
+		WillReturnRows(sqlmock.NewRows([]string{"c"}).AddRow(0))
+
+	body, err := IgnoredMigrationSQL(migrationFile)
+	if err != nil {
+		t.Fatalf("IgnoredMigrationSQL(%s): %v", migrationFile, err)
+	}
+
+	return &wispIsBlockedDriftDB{
+		t:                 t,
+		real:              db,
+		mock:              mock,
+		cursorTable:       ignoredSource.cursorTable,
+		migrationBody:     body,
+		wantCursorVersion: wantCursorVersion,
+	}
+}
+
+func (d *wispIsBlockedDriftDB) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	return d.real.QueryRowContext(ctx, query, args...)
+}
+
+func (d *wispIsBlockedDriftDB) QueryContext(context.Context, string, ...any) (*sql.Rows, error) {
+	panic("wispIsBlockedDriftDB: QueryContext not expected on the ignored pre-repair path")
+}
+
+func (d *wispIsBlockedDriftDB) ExecContext(_ context.Context, query string, args ...any) (sql.Result, error) {
+	d.t.Helper()
+	switch query {
+	case wispIsBlockedColumnDDL:
+		d.hasIsBlockedColumn = true
+		return execOK{}, nil
+	case wispIsBlockedIndexDDL:
+		d.hasIsBlockedIndex = true
+		return execOK{}, nil
+	case d.migrationBody:
+		// The pending migration's real embedded body, byte-for-byte. A wisps
+		// table still missing is_blocked fails on its first statement with
+		// the same error a real engine gives; once the column exists (the
+		// repair ran first) it succeeds -- matching runMigrations' real
+		// ordering (preMigrationRepair before execMigrationBody).
+		if !d.hasIsBlockedColumn {
+			return nil, errors.New("column 'is_blocked' could not be found in any table in scope")
+		}
+		d.bodyExecuted = true
+		return execOK{}, nil
+	case "INSERT IGNORE INTO " + d.cursorTable + " (version, content_hash) VALUES (?, ?)":
+		if len(args) == 0 {
+			d.t.Fatalf("wispIsBlockedDriftDB: cursor INSERT with no version arg")
+		}
+		gotVersion, ok := args[0].(int)
+		if !ok {
+			d.t.Fatalf("wispIsBlockedDriftDB: cursor INSERT version arg is %T, want int", args[0])
+		}
+		if gotVersion != d.wantCursorVersion {
+			d.t.Fatalf("wispIsBlockedDriftDB: cursor INSERT recorded version %d, want %d", gotVersion, d.wantCursorVersion)
+		}
+		d.cursorInserted = true
+		return execOK{}, nil
+	default:
+		d.t.Fatalf("wispIsBlockedDriftDB: unexpected ExecContext query:\n%s", query)
+		return nil, nil // unreachable: t.Fatalf stops this goroutine
+	}
+}
+
+// expectationsWereMet asserts the three INFORMATION_SCHEMA probe expectations
+// registered in newWispIsBlockedDriftDB were consumed. Callers check this
+// only once runMigrations has already returned nil: an unregistered repair
+// (the RED half of the red-green proof below) never issues those probes at
+// all, and asserting this unconditionally would report a second, unrelated
+// failure alongside the real one.
+func (d *wispIsBlockedDriftDB) expectationsWereMet() error {
+	return d.mock.ExpectationsWereMet()
+}
+
+// execOK is a trivial sql.Result for wispIsBlockedDriftDB's successful exec
+// paths above.
+type execOK struct{}
+
+func (execOK) LastInsertId() (int64, error) { return 0, nil }
+func (execOK) RowsAffected() (int64, error) { return 0, nil }
+
+// TestIgnored15RecomputeHardFailsWithoutIsBlockedRepair is the red-green
+// proof for ensureWispIsBlockedForRecompute at the {ignored_schema_migrations,
+// 15} registration: it exercises the real runMigrations/preMigrationRepair
+// dispatch against the literal embedded ignored/0015 SQL bytes, using
+// wispIsBlockedDriftDB to reproduce the exact error a wisps table missing
+// is_blocked gets from 0015's frozen UPDATE. With the
+// {ignored_schema_migrations, 15} entry in preMigrationRepairs this test
+// passes: the column and index are restored before 0015 runs, 0015's own
+// embedded body then executes for real, and the version-15 cursor row is
+// recorded. With that entry removed it fails with the same "column
+// 'is_blocked' could not be found" error a real affected clone hits.
+func TestIgnored15RecomputeHardFailsWithoutIsBlockedRepair(t *testing.T) {
+	orig := stderr
+	stderr = &bytes.Buffer{}
+	defer func() { stderr = orig }()
+
+	db := newWispIsBlockedDriftDB(t, "0015_recompute_null_gate_wisp_is_blocked.up.sql", 15)
+
+	// Bounded to exactly version 15: minVersion=14 skips 1..14 (irrelevant to
+	// this probe of 0015 alone), upTo=15 stops right after it.
+	if _, err := runMigrations(context.Background(), db, ignoredSource, 14, 15, false); err != nil {
+		t.Fatalf("runMigrations(ignoredSource, v15) = %v, want nil: a clone whose wisps table lacks is_blocked must have it restored before 0015's frozen recompute runs", err)
+	}
+	if err := db.expectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+	if !db.hasIsBlockedColumn {
+		t.Error("ignored/0015 ran without ever restoring wisps.is_blocked")
+	}
+	if !db.hasIsBlockedIndex {
+		t.Error("ignored/0015 ran without ever restoring idx_wisps_is_blocked")
+	}
+	if !db.bodyExecuted {
+		t.Error("ignored/0015's own embedded recompute body never executed")
+	}
+	if !db.cursorInserted {
+		t.Error("ignored/0015's cursor row (version 15) was never recorded")
+	}
+}
+
+// TestIgnored7RecomputeHardFailsWithoutIsBlockedRepair is
+// TestIgnored15RecomputeHardFailsWithoutIsBlockedRepair's twin for the
+// {ignored_schema_migrations, 7} registration: a clone stuck at ignored
+// cursor 6 (one that never completed 0006) reaches 0007 -- not 0015 -- first,
+// and 0007's frozen recompute is the same shape of unguarded UPDATE against
+// wisps.is_blocked ignored/0015 carries. Without the
+// {ignored_schema_migrations, 7} entry, such a clone hard-fails on every
+// single pass at 0007 and can never advance far enough to reach the
+// version-15 entry at all: the unrecoverable case
+// ensureWispIsBlockedForRecompute's doc comment describes.
+func TestIgnored7RecomputeHardFailsWithoutIsBlockedRepair(t *testing.T) {
+	orig := stderr
+	stderr = &bytes.Buffer{}
+	defer func() { stderr = orig }()
+
+	db := newWispIsBlockedDriftDB(t, "0007_recompute_wisp_is_blocked.up.sql", 7)
+
+	// Bounded to exactly version 7: minVersion=6 (the stuck cursor position)
+	// skips 1..6, upTo=7 stops right after it.
+	if _, err := runMigrations(context.Background(), db, ignoredSource, 6, 7, false); err != nil {
+		t.Fatalf("runMigrations(ignoredSource, v7) = %v, want nil: a cursor-6 clone whose wisps table lacks is_blocked must have it restored before 0007's frozen recompute runs", err)
+	}
+	if err := db.expectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+	if !db.hasIsBlockedColumn {
+		t.Error("ignored/0007 ran without ever restoring wisps.is_blocked")
+	}
+	if !db.hasIsBlockedIndex {
+		t.Error("ignored/0007 ran without ever restoring idx_wisps_is_blocked")
+	}
+	if !db.bodyExecuted {
+		t.Error("ignored/0007's own embedded recompute body never executed")
+	}
+	if !db.cursorInserted {
+		t.Error("ignored/0007's cursor row (version 7) was never recorded")
+	}
+}
+
 func TestEnsureDependenciesIDColumnNoopWhenAlreadyFullyBackfilledAndKeyed(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -1920,6 +2256,49 @@ func (m *mockDB) QueryRowContext(_ context.Context, _ string, _ ...any) *sql.Row
 	panic("not called")
 }
 
+// wispsAbsentDB extends mockDB's blind-success ExecContext / panicking
+// QueryContext with TWO answerable QueryRowContext queries, same pattern:
+// the ignored/7 and ignored/15 pre-migration repairs (both dispatch to
+// ensureWispIsBlockedForRecompute) each probe whether wisps exists before
+// touching it, and *sql.Row has no public constructor outside a real
+// database/sql driver -- mockDB itself cannot fake a scan result. A small
+// embedded sqlmock answers exactly those two queries with "table absent"
+// (0), so the repair takes its early no-op branch on both firings; any
+// OTHER QueryRowContext this pass might issue still surfaces loudly, via
+// sqlmock's own unmet/unexpected-call error rather than a silent success.
+type wispsAbsentDB struct {
+	mockDB
+	real *sql.DB
+}
+
+func newWispsAbsentDB(t *testing.T) *wispsAbsentDB {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	// Registered twice, once per firing of the {ignored_schema_migrations, 7}
+	// and {ignored_schema_migrations, 15} repairs; go-sqlmock v1.5.2 predates
+	// ExpectedQuery.Times, so the same expectation is set up twice instead of
+	// asking for a repeat count.
+	for i := 0; i < 2; i++ {
+		mock.ExpectQuery(`(?s)SELECT COUNT\(\*\) FROM INFORMATION_SCHEMA\.TABLES.*TABLE_NAME = \?`).
+			WithArgs("wisps").
+			WillReturnRows(sqlmock.NewRows([]string{"c"}).AddRow(0))
+	}
+	t.Cleanup(func() {
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Errorf("wispsAbsentDB: unmet sql expectations: %v", err)
+		}
+	})
+	return &wispsAbsentDB{real: db}
+}
+
+func (w *wispsAbsentDB) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	return w.real.QueryRowContext(ctx, query, args...)
+}
+
 func TestRunMigrationsStderrOutput(t *testing.T) {
 	var buf bytes.Buffer
 	orig := stderr
@@ -1989,8 +2368,15 @@ func TestRunMigrationsUsesProvidedSource(t *testing.T) {
 	// Same upTo cap as the mainSource call: the source-threading regression
 	// this test guards (hardcoding mainSource) is only detectable when both
 	// calls share a bound, so their counts collapse to equal under the bug.
-	// ignoredSource has 16 migrations, so 39 is a no-op on correct behavior.
-	ignored, err := runMigrations(context.Background(), &mockDB{}, ignoredSource, 0, 39, false)
+	// ignoredSource has 24 migrations, so 39 is a no-op on correct behavior.
+	// A shared bound below 15 would dodge the ignored/15 repair too, but main
+	// and ignored both number their first 14 files contiguously (1..14, no
+	// gaps in either series), so any bound < 15 gives main==ignored and would
+	// fail this test's own regression check for an unrelated reason.
+	// wispsAbsentDB answers both the {ignored_schema_migrations, 7} and
+	// {..., 15} repairs' probes (ensureWispIsBlockedForRecompute dispatches
+	// at both) instead of dodging them.
+	ignored, err := runMigrations(context.Background(), newWispsAbsentDB(t), ignoredSource, 0, 39, false)
 	if err != nil {
 		t.Fatalf("runMigrations(ignoredSource): %v", err)
 	}
@@ -2031,7 +2417,11 @@ func TestRunMigrationsLargeRigNoticeOnlyOnMainSource(t *testing.T) {
 
 	var ignoredBuf bytes.Buffer
 	stderr = &ignoredBuf
-	_, err := runMigrations(context.Background(), &mockDB{}, ignoredSource, 0, 39, false)
+	// This assertion (no large-rig notice on the ignored-source pass) does
+	// not depend on applying every ignored migration, so bound below the
+	// {ignored_schema_migrations, 7} repair rather than answering it (7, not
+	// 15: ensureWispIsBlockedForRecompute now dispatches at both versions).
+	_, err := runMigrations(context.Background(), &mockDB{}, ignoredSource, 0, 6, false)
 	stderr = orig
 	if err != nil {
 		t.Fatalf("runMigrations(ignoredSource): %v", err)


### PR DESCRIPTION
## Problem

`preMigrationRepairs` currently has main-source entries only. A clone whose `wisps` table exists **without** `is_blocked` — one way to get there: the main-side 0047 repair's sentinel DDL materializes `wisps` without that column while the ignored cursor lags — hard-fails deterministically on the frozen recomputes that require the column: `ignored/0007` (cursor 6) or `ignored/0015` (cursor 7–14):

```
migration 0015_recompute_null_gate_wisp_is_blocked.up.sql: column 'is_blocked' could not be found in any table in scope
```

Since 0015's body is frozen by migration hygiene and pending migrations abort the pass on first error, such a clone has no in-tool self-heal.

## Fix

Add the first ignored-source repair entries: `{"ignored_schema_migrations", 7}` and `{"ignored_schema_migrations", 15}` → `ensureWispIsBlockedForRecompute`, which restores the column and its index with guarded DDL byte-equivalent to `ignored/0006` (`ADD COLUMN` + `CREATE INDEX` through the existing `schemaTableExists`/`schemaColumnExists`/`schemaIndexExists` helpers). Idempotent: when the shape is already present it is three probe queries and no DDL; the probes only run while 7 or 15 is pending.

Scope, stated precisely:
- Clones whose pending ignored migration is 7 or 15 self-heal on the next migration pass. A clone already at cursor ≥ 15 never reaches these hooks (a missing column there would surface at the first wisp write — different surface, out of scope here).
- If `wisps` is absent entirely the repair no-ops; the normal cursor-reality/earlier-migration path materializes the table.
- The probes check presence only: a same-name index with a different shape, or a column-type drift, is left as-is.

## Tests

Two regression tests drive the real `runMigrations` + the real embedded `0007`/`0015` bytes over a drift-modeling `DBConn` that byte-matches the repair's DDL statements, asserts the migration body and the cursor `INSERT` actually executed, and rejects any unexpected SQL. Both fail on current `main` with the production error text above, and pass with this change. `TestPreMigrationRepairScopedToIgnored15` pins the registry dispatch; two pre-existing bounded-pass tests were adapted for the new v7 firing. Full `internal/storage/schema` package green.

Opened as **draft** to let CI run first; I'll mark it ready when the checks are green.

_claude-code-claude-fable-5 on behalf of Marco Del Pin_
