### PR TITLE
feat(stale,blocked): add label filtering to bd stale and bd blocked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   payload is unchanged. Under `--quiet` the audit now skips its queries
   entirely rather than running them to discard the output.
 
+### Added
+
+- **`bd stale` and `bd blocked` gain `--label`, `--label-any` and
+  `--exclude-label`** ([#5822](https://github.com/gastownhall/beads/pull/5822)),
+  with the same meanings and the same flag names they already have on `bd list`
+  and `bd ready`: `--label` is AND (repeatable, must have all), `--label-any` is
+  OR, `--exclude-label` drops anything carrying one. They were the two listing
+  commands with no label-scoped output at all, so a theme-scoped stale sweep had
+  to pull the whole list as JSON and post-filter it on the labels array.
+  Filtering happens in SQL ahead of `LIMIT`, not on the hydrated rows, so
+  `--label x --limit 10` returns ten matching issues rather than whatever
+  survives filtering the first ten. No `--theme` flag: beads has no theme
+  concept, themes are labels here, and `--label theme:x` is the native way to
+  say it.
+
+### Fixed
+
+- **`bd blocked` silently ignored the label filters it already accepted**
+  ([#5822](https://github.com/gastownhall/beads/pull/5822)).
+  `types.WorkFilter` has carried `Labels`, `LabelsAny` and `ExcludeLabels` all
+  along, and `bd blocked` built one, but `GetBlockedIssuesInTx` only ever read
+  `ParentID`. Programmatic callers that set them got unfiltered results back and
+  no error — a full list where a scoped one was asked for.
+
 ### Documentation
 
 - **The heartbeat/re-home invariant and the two states it can strand are now

--- a/cmd/bd/blocked_embedded_test.go
+++ b/cmd/bd/blocked_embedded_test.go
@@ -233,4 +233,38 @@ func TestEmbeddedBlockedLabelFilters(t *testing.T) {
 			}
 		}
 	})
+
+	// blockedFilterFromFlags normalizes, as every sibling label filter does.
+	// Without it an untrimmed value returns nothing and is indistinguishable
+	// from "nothing blocked carries that label".
+	t.Run("leading_space_is_trimmed_like_every_other_label_filter", func(t *testing.T) {
+		ids := idSet(bdBlockedJSON(t, bd, dir, "--label", " theme:alpha"))
+		if !ids[alpha.ID] || !ids[alphaUrgent.ID] {
+			t.Errorf("expected ' theme:alpha' to match theme:alpha, got %v", ids)
+		}
+		if ids[beta.ID] {
+			t.Errorf("' theme:alpha' leaked %s: %v", beta.ID, ids)
+		}
+	})
+
+	t.Run("empty_element_does_not_annihilate_the_filter", func(t *testing.T) {
+		ids := idSet(bdBlockedJSON(t, bd, dir, "--label", "theme:alpha,,urgent"))
+		if !ids[alphaUrgent.ID] {
+			t.Errorf("expected %s to survive an empty label element, got %v", alphaUrgent.ID, ids)
+		}
+	})
+
+	t.Run("normalization_applies_to_label_any_and_exclude_label", func(t *testing.T) {
+		anyIDs := idSet(bdBlockedJSON(t, bd, dir, "--label-any", " theme:beta"))
+		if !anyIDs[beta.ID] {
+			t.Errorf("expected ' theme:beta' to match via --label-any, got %v", anyIDs)
+		}
+		excludeIDs := idSet(bdBlockedJSON(t, bd, dir, "--exclude-label", " theme:alpha"))
+		if excludeIDs[alpha.ID] || excludeIDs[alphaUrgent.ID] {
+			t.Errorf("' theme:alpha' failed to exclude the alpha issues: %v", excludeIDs)
+		}
+		if !excludeIDs[beta.ID] {
+			t.Errorf("exclusion dropped %s, which it should have kept: %v", beta.ID, excludeIDs)
+		}
+	})
 }

--- a/cmd/bd/blocked_embedded_test.go
+++ b/cmd/bd/blocked_embedded_test.go
@@ -123,3 +123,114 @@ func TestEmbeddedBlockedConcurrent(t *testing.T) {
 		}
 	}
 }
+
+// bdBlockedJSON runs "bd blocked --json" and parses the result as a slice.
+func bdBlockedJSON(t *testing.T, bd, dir string, args ...string) []map[string]interface{} {
+	t.Helper()
+	fullArgs := append([]string{"blocked", "--json"}, args...)
+	cmd := exec.Command(bd, fullArgs...)
+	cmd.Dir = dir
+	cmd.Env = bdEnv(dir)
+	stdout, stderr, err := runCommandBuffers(t, cmd)
+	if err != nil {
+		t.Fatalf("bd blocked --json %s failed: %v\nstdout:\n%s\nstderr:\n%s", strings.Join(args, " "), err, stdout.String(), stderr.String())
+	}
+	s := strings.TrimSpace(stdout.String())
+	start := strings.Index(s, "[")
+	if start < 0 {
+		t.Fatalf("no JSON array in blocked output: %s", s)
+	}
+	var entries []map[string]interface{}
+	if err := json.Unmarshal([]byte(s[start:]), &entries); err != nil {
+		t.Fatalf("parse blocked JSON: %v\n%s", err, s)
+	}
+	return entries
+}
+
+// TestEmbeddedBlockedLabelFilters covers --label, --label-any and
+// --exclude-label on bd blocked. The flags filter the blocked issues
+// themselves, never their blockers: a blocked issue stays visible under
+// --label whatever labels the thing blocking it happens to carry.
+func TestEmbeddedBlockedLabelFilters(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "bt")
+
+	blocker := bdCreate(t, bd, dir, "Blocker", "--type", "task", "--labels", "theme:blocker-only")
+	alpha := bdCreate(t, bd, dir, "Blocked alpha", "--type", "task", "--labels", "theme:alpha")
+	beta := bdCreate(t, bd, dir, "Blocked beta", "--type", "task", "--labels", "theme:beta")
+	alphaUrgent := bdCreate(t, bd, dir, "Blocked alpha urgent", "--type", "task", "--labels", "theme:alpha,urgent")
+
+	for _, blocked := range []string{alpha.ID, beta.ID, alphaUrgent.ID} {
+		cmd := exec.Command(bd, "dep", "add", blocked, blocker.ID)
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("dep add %s -> %s failed: %v\n%s", blocked, blocker.ID, err, out)
+		}
+	}
+
+	t.Run("label_scopes_to_one_theme", func(t *testing.T) {
+		ids := idSet(bdBlockedJSON(t, bd, dir, "--label", "theme:alpha"))
+		if !ids[alpha.ID] || !ids[alphaUrgent.ID] {
+			t.Errorf("expected both theme:alpha blocked issues, got %v", ids)
+		}
+		if ids[beta.ID] {
+			t.Errorf("theme:alpha filter leaked %s: %v", beta.ID, ids)
+		}
+	})
+
+	t.Run("repeated_label_is_AND", func(t *testing.T) {
+		ids := idSet(bdBlockedJSON(t, bd, dir, "--label", "theme:alpha", "--label", "urgent"))
+		if !ids[alphaUrgent.ID] {
+			t.Errorf("expected %s carrying both labels, got %v", alphaUrgent.ID, ids)
+		}
+		if ids[alpha.ID] {
+			t.Errorf("%s carries only theme:alpha and must not match an AND of both: %v", alpha.ID, ids)
+		}
+	})
+
+	t.Run("label_any_is_OR", func(t *testing.T) {
+		ids := idSet(bdBlockedJSON(t, bd, dir, "--label-any", "theme:alpha,theme:beta"))
+		for _, id := range []string{alpha.ID, beta.ID, alphaUrgent.ID} {
+			if !ids[id] {
+				t.Errorf("expected %s from --label-any, got %v", id, ids)
+			}
+		}
+	})
+
+	t.Run("exclude_label_drops_matches", func(t *testing.T) {
+		ids := idSet(bdBlockedJSON(t, bd, dir, "--exclude-label", "theme:alpha"))
+		if ids[alpha.ID] || ids[alphaUrgent.ID] {
+			t.Errorf("--exclude-label theme:alpha still returned alpha issues: %v", ids)
+		}
+		if !ids[beta.ID] {
+			t.Errorf("expected %s to survive exclusion, got %v", beta.ID, ids)
+		}
+	})
+
+	t.Run("blocker_labels_do_not_filter_the_blocked", func(t *testing.T) {
+		// theme:blocker-only lives on the blocker, not on anything blocked,
+		// so scoping to it must return nothing rather than the issues it
+		// blocks.
+		ids := idSet(bdBlockedJSON(t, bd, dir, "--label", "theme:blocker-only"))
+		for _, id := range []string{alpha.ID, beta.ID, alphaUrgent.ID} {
+			if ids[id] {
+				t.Errorf("blocked issue %s matched a label carried only by its blocker: %v", id, ids)
+			}
+		}
+	})
+
+	t.Run("no_label_flags_returns_everything", func(t *testing.T) {
+		ids := idSet(bdBlockedJSON(t, bd, dir))
+		for _, id := range []string{alpha.ID, beta.ID, alphaUrgent.ID} {
+			if !ids[id] {
+				t.Errorf("expected %s in unfiltered blocked output, got %v", id, ids)
+			}
+		}
+	})
+}

--- a/cmd/bd/ready.go
+++ b/cmd/bd/ready.go
@@ -282,6 +282,21 @@ This is useful for agents executing molecules to see which steps can run next.`,
 		return nil
 	},
 }
+
+// blockedFilterFromFlags builds the blocked-issue filter from blockedCmd's
+// flags. Both the direct and the proxied-server path call it, so the two
+// cannot drift as filtering flags are added.
+func blockedFilterFromFlags(cmd *cobra.Command) types.WorkFilter {
+	var filter types.WorkFilter
+	if parentID, _ := cmd.Flags().GetString("parent"); parentID != "" {
+		filter.ParentID = &parentID
+	}
+	filter.Labels, _ = cmd.Flags().GetStringSlice("label")
+	filter.LabelsAny, _ = cmd.Flags().GetStringSlice("label-any")
+	filter.ExcludeLabels, _ = cmd.Flags().GetStringSlice("exclude-label")
+	return filter
+}
+
 var blockedCmd = &cobra.Command{
 	Use:           "blocked",
 	Short:         "Show blocked issues",
@@ -301,11 +316,7 @@ var blockedCmd = &cobra.Command{
 		// Use global jsonOutput set by PersistentPreRun (respects config.yaml + env vars)
 		// Use factory to respect backend configuration (bd-m2jr: SQLite fallback fix)
 		ctx := rootCtx
-		parentID, _ := cmd.Flags().GetString("parent")
-		var blockedFilter types.WorkFilter
-		if parentID != "" {
-			blockedFilter.ParentID = &parentID
-		}
+		blockedFilter := blockedFilterFromFlags(cmd)
 		blocked, err := store.GetBlockedIssues(ctx, blockedFilter)
 		if err != nil {
 			return HandleErrorRespectJSON("%v", err)
@@ -731,5 +742,8 @@ func init() {
 	addMaxRowsFlag(readyCmd)
 	rootCmd.AddCommand(readyCmd)
 	blockedCmd.Flags().String("parent", "", "Filter to descendants of this bead/epic")
+	blockedCmd.Flags().StringSliceP("label", "l", []string{}, "Filter by labels (AND: must have ALL). Can combine with --label-any")
+	blockedCmd.Flags().StringSlice("label-any", []string{}, "Filter by labels (OR: must have AT LEAST ONE). Can combine with --label")
+	blockedCmd.Flags().StringSlice("exclude-label", []string{}, "Exclude issues that have ANY of these labels")
 	rootCmd.AddCommand(blockedCmd)
 }

--- a/cmd/bd/ready.go
+++ b/cmd/bd/ready.go
@@ -291,9 +291,20 @@ func blockedFilterFromFlags(cmd *cobra.Command) types.WorkFilter {
 	if parentID, _ := cmd.Flags().GetString("parent"); parentID != "" {
 		filter.ParentID = &parentID
 	}
-	filter.Labels, _ = cmd.Flags().GetStringSlice("label")
-	filter.LabelsAny, _ = cmd.Flags().GetStringSlice("label-any")
-	filter.ExcludeLabels, _ = cmd.Flags().GetStringSlice("exclude-label")
+	// Normalize as every other label filter does (list_input.go:293-295,
+	// search.go:106, orphans.go:56, workapi/ready.go:56-58). These clauses
+	// match a label EXACTLY, so an untrimmed value silently under-reports:
+	// pflag's CSV split leaves the leading space in the everyday
+	// `--label 'a, b'` form, and `--label 'a,,b'` would AND in a `label = ''`
+	// clause that matches nothing at all. Without this, `--label` would not
+	// mean the same thing here as on the commands next to it -- which is the
+	// promise LabelSetClauses is documented to keep.
+	labels, _ := cmd.Flags().GetStringSlice("label")
+	labelsAny, _ := cmd.Flags().GetStringSlice("label-any")
+	excludeLabels, _ := cmd.Flags().GetStringSlice("exclude-label")
+	filter.Labels = utils.NormalizeLabels(labels)
+	filter.LabelsAny = utils.NormalizeLabels(labelsAny)
+	filter.ExcludeLabels = utils.NormalizeLabels(excludeLabels)
 	return filter
 }
 

--- a/cmd/bd/ready_proxied_server.go
+++ b/cmd/bd/ready_proxied_server.go
@@ -79,10 +79,7 @@ func runBlockedProxiedServer(cmd *cobra.Command, ctx context.Context) error {
 	}
 	defer uw.Close(ctx)
 
-	var filter types.WorkFilter
-	if parentID, _ := cmd.Flags().GetString("parent"); parentID != "" {
-		filter.ParentID = &parentID
-	}
+	filter := blockedFilterFromFlags(cmd)
 
 	blocked, err := uw.IssueUseCase().GetBlockedIssues(ctx, filter)
 	if err != nil {

--- a/cmd/bd/stale.go
+++ b/cmd/bd/stale.go
@@ -32,6 +32,9 @@ This helps identify:
 		days, _ := cmd.Flags().GetInt("days")
 		status, _ := cmd.Flags().GetString("status")
 		limit, _ := cmd.Flags().GetInt("limit")
+		labels, _ := cmd.Flags().GetStringSlice("label")
+		labelsAny, _ := cmd.Flags().GetStringSlice("label-any")
+		excludeLabels, _ := cmd.Flags().GetStringSlice("exclude-label")
 		if days < 1 {
 			return HandleErrorRespectJSON("--days must be at least 1")
 		}
@@ -39,9 +42,12 @@ This helps identify:
 			return HandleErrorRespectJSON("invalid status '%s'. Valid values: open, in_progress, blocked, deferred", status)
 		}
 		filter := types.StaleFilter{
-			Days:   days,
-			Status: status,
-			Limit:  limit,
+			Days:          days,
+			Status:        status,
+			Limit:         limit,
+			Labels:        labels,
+			LabelsAny:     labelsAny,
+			ExcludeLabels: excludeLabels,
 		}
 
 		if usesProxiedServer() {
@@ -88,6 +94,9 @@ func init() {
 	staleCmd.Flags().IntP("days", "d", 30, "Issues not updated in this many days")
 	staleCmd.Flags().StringP("status", "s", "", "Filter by status (open|in_progress|blocked|deferred)")
 	staleCmd.Flags().IntP("limit", "n", 50, "Maximum issues to show")
+	staleCmd.Flags().StringSliceP("label", "l", []string{}, "Filter by labels (AND: must have ALL). Can combine with --label-any")
+	staleCmd.Flags().StringSlice("label-any", []string{}, "Filter by labels (OR: must have AT LEAST ONE). Can combine with --label")
+	staleCmd.Flags().StringSlice("exclude-label", []string{}, "Exclude issues that have ANY of these labels")
 	// Note: --json flag is defined as a persistent flag in main.go, not here
 	rootCmd.AddCommand(staleCmd)
 }

--- a/cmd/bd/stale.go
+++ b/cmd/bd/stale.go
@@ -8,6 +8,7 @@ import (
 	"github.com/steveyegge/beads/internal/metrics"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
+	"github.com/steveyegge/beads/internal/utils"
 )
 
 var staleCmd = &cobra.Command{
@@ -32,9 +33,15 @@ This helps identify:
 		days, _ := cmd.Flags().GetInt("days")
 		status, _ := cmd.Flags().GetString("status")
 		limit, _ := cmd.Flags().GetInt("limit")
-		labels, _ := cmd.Flags().GetStringSlice("label")
-		labelsAny, _ := cmd.Flags().GetStringSlice("label-any")
-		excludeLabels, _ := cmd.Flags().GetStringSlice("exclude-label")
+		// Normalized for the reason blockedFilterFromFlags gives: these are
+		// exact-match clauses, and every sibling label filter trims its input
+		// before building them.
+		rawLabels, _ := cmd.Flags().GetStringSlice("label")
+		rawLabelsAny, _ := cmd.Flags().GetStringSlice("label-any")
+		rawExcludeLabels, _ := cmd.Flags().GetStringSlice("exclude-label")
+		labels := utils.NormalizeLabels(rawLabels)
+		labelsAny := utils.NormalizeLabels(rawLabelsAny)
+		excludeLabels := utils.NormalizeLabels(rawExcludeLabels)
 		if days < 1 {
 			return HandleErrorRespectJSON("--days must be at least 1")
 		}

--- a/cmd/bd/stale_embedded_test.go
+++ b/cmd/bd/stale_embedded_test.go
@@ -332,3 +332,100 @@ func TestEmbeddedStaleConcurrent(t *testing.T) {
 		}
 	}
 }
+
+// idSet reduces bd's JSON rows to the set of issue IDs they name, so a filter
+// assertion can talk about membership rather than ordering or row counts.
+func idSet(entries []map[string]interface{}) map[string]bool {
+	ids := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		if id, ok := e["id"].(string); ok {
+			ids[id] = true
+		}
+	}
+	return ids
+}
+
+// TestEmbeddedStaleLabelFilters covers --label, --label-any and
+// --exclude-label on bd stale. Before these flags a theme-scoped stale sweep
+// had to pull every stale issue and post-filter the JSON, which also silently
+// broke --limit: the limit applied to the unfiltered query, so a caller asking
+// for N issues in one theme could get none.
+func TestEmbeddedStaleLabelFilters(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, beadsDir, _ := bdInit(t, bd, "--prefix", "sl")
+
+	alpha := bdCreate(t, bd, dir, "Stale alpha", "--type", "task", "--labels", "theme:alpha")
+	beta := bdCreate(t, bd, dir, "Stale beta", "--type", "task", "--labels", "theme:beta")
+	alphaUrgent := bdCreate(t, bd, dir, "Stale alpha urgent", "--type", "task", "--labels", "theme:alpha,urgent")
+	bare := bdCreate(t, bd, dir, "Stale unlabelled", "--type", "task")
+
+	makeIssuesStale(t, beadsDir, "sl", []string{alpha.ID, beta.ID, alphaUrgent.ID, bare.ID})
+
+	t.Run("label_scopes_to_one_theme", func(t *testing.T) {
+		ids := idSet(bdStaleJSON(t, bd, dir, "--label", "theme:alpha"))
+		if !ids[alpha.ID] || !ids[alphaUrgent.ID] {
+			t.Errorf("expected both theme:alpha issues, got %v", ids)
+		}
+		if ids[beta.ID] || ids[bare.ID] {
+			t.Errorf("theme:alpha filter leaked other issues: %v", ids)
+		}
+	})
+
+	t.Run("repeated_label_is_AND", func(t *testing.T) {
+		ids := idSet(bdStaleJSON(t, bd, dir, "--label", "theme:alpha", "--label", "urgent"))
+		if !ids[alphaUrgent.ID] {
+			t.Errorf("expected %s carrying both labels, got %v", alphaUrgent.ID, ids)
+		}
+		if ids[alpha.ID] {
+			t.Errorf("%s carries only theme:alpha and must not match an AND of both: %v", alpha.ID, ids)
+		}
+	})
+
+	t.Run("label_any_is_OR", func(t *testing.T) {
+		ids := idSet(bdStaleJSON(t, bd, dir, "--label-any", "theme:alpha,theme:beta"))
+		if !ids[alpha.ID] || !ids[beta.ID] || !ids[alphaUrgent.ID] {
+			t.Errorf("expected all three themed issues, got %v", ids)
+		}
+		if ids[bare.ID] {
+			t.Errorf("unlabelled issue %s must not match --label-any: %v", bare.ID, ids)
+		}
+	})
+
+	t.Run("exclude_label_drops_matches", func(t *testing.T) {
+		ids := idSet(bdStaleJSON(t, bd, dir, "--exclude-label", "theme:alpha"))
+		if ids[alpha.ID] || ids[alphaUrgent.ID] {
+			t.Errorf("--exclude-label theme:alpha still returned alpha issues: %v", ids)
+		}
+		if !ids[beta.ID] || !ids[bare.ID] {
+			t.Errorf("expected beta and unlabelled issues to survive exclusion, got %v", ids)
+		}
+	})
+
+	t.Run("no_label_flags_returns_everything", func(t *testing.T) {
+		ids := idSet(bdStaleJSON(t, bd, dir))
+		for _, id := range []string{alpha.ID, beta.ID, alphaUrgent.ID, bare.ID} {
+			if !ids[id] {
+				t.Errorf("expected %s in unfiltered stale output, got %v", id, ids)
+			}
+		}
+	})
+
+	t.Run("limit_applies_after_the_label_filter", func(t *testing.T) {
+		// The regression this pins: if labels were applied to the hydrated
+		// results instead of in SQL, LIMIT 1 would take the stalest issue
+		// overall and then drop it for not matching, returning nothing.
+		entries := bdStaleJSON(t, bd, dir, "--label", "theme:alpha", "--limit", "1")
+		if len(entries) != 1 {
+			t.Fatalf("expected exactly 1 result for --label theme:alpha --limit 1, got %d: %v", len(entries), entries)
+		}
+		ids := idSet(entries)
+		if !ids[alpha.ID] && !ids[alphaUrgent.ID] {
+			t.Errorf("the single result should be a theme:alpha issue, got %v", ids)
+		}
+	})
+}

--- a/cmd/bd/stale_embedded_test.go
+++ b/cmd/bd/stale_embedded_test.go
@@ -428,4 +428,44 @@ func TestEmbeddedStaleLabelFilters(t *testing.T) {
 			t.Errorf("the single result should be a theme:alpha issue, got %v", ids)
 		}
 	})
+
+	// These clauses match a label EXACTLY, so an untrimmed flag value returns
+	// nothing and looks exactly like "no stale issues carry that label". Every
+	// sibling filter (list, search, ready, orphans) normalizes its input; these
+	// pin that --label means the same thing here.
+	t.Run("leading_space_is_trimmed_like_every_other_label_filter", func(t *testing.T) {
+		// The everyday form: pflag's CSV split leaves the space on the second
+		// value, so `--label 'theme:beta, theme:alpha'` arrives as
+		// {"theme:beta", " theme:alpha"}.
+		ids := idSet(bdStaleJSON(t, bd, dir, "--label", " theme:alpha"))
+		if !ids[alpha.ID] || !ids[alphaUrgent.ID] {
+			t.Errorf("expected ' theme:alpha' to match theme:alpha, got %v", ids)
+		}
+		if ids[beta.ID] || ids[bare.ID] {
+			t.Errorf("' theme:alpha' matched issues outside the theme: %v", ids)
+		}
+	})
+
+	t.Run("empty_element_does_not_annihilate_the_filter", func(t *testing.T) {
+		// A doubled comma used to AND in a `label = ''` clause, which no row
+		// can satisfy, turning a valid filter into a silent empty result.
+		ids := idSet(bdStaleJSON(t, bd, dir, "--label", "theme:alpha,,urgent"))
+		if !ids[alphaUrgent.ID] {
+			t.Errorf("expected %s to survive an empty label element, got %v", alphaUrgent.ID, ids)
+		}
+	})
+
+	t.Run("normalization_applies_to_label_any_and_exclude_label", func(t *testing.T) {
+		anyIDs := idSet(bdStaleJSON(t, bd, dir, "--label-any", " theme:beta"))
+		if !anyIDs[beta.ID] {
+			t.Errorf("expected ' theme:beta' to match via --label-any, got %v", anyIDs)
+		}
+		excludeIDs := idSet(bdStaleJSON(t, bd, dir, "--exclude-label", " theme:alpha"))
+		if excludeIDs[alpha.ID] || excludeIDs[alphaUrgent.ID] {
+			t.Errorf("' theme:alpha' failed to exclude the alpha issues: %v", excludeIDs)
+		}
+		if !excludeIDs[beta.ID] {
+			t.Errorf("exclusion dropped issues it should have kept: %v", excludeIDs)
+		}
+	})
 }

--- a/internal/storage/issueops/blocked.go
+++ b/internal/storage/issueops/blocked.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/steveyegge/beads/internal/storage/sqlbuild"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -240,12 +241,22 @@ func GetDescendantIDsInTx(ctx context.Context, tx DBTX, rootID string, maxDepth 
 func GetBlockedIssuesInTx(ctx context.Context, tx DBTX, filter types.WorkFilter) ([]*types.BlockedIssue, error) {
 	var blockedIDList []string
 	blockedSet := make(map[string]bool)
-	for _, table := range []string{"issues", "wisps"} {
-		//nolint:gosec // G201: table is one of two hardcoded values.
+	// Label predicates are applied here, in the per-table scan, rather than to
+	// the assembled results: issues and wisps keep their labels in different
+	// tables, and filtering at the source also spares the blocker-dependency
+	// and hydration passes below any work on rows that cannot survive.
+	for _, tables := range []sqlbuild.FilterTables{IssuesFilterTables, WispsFilterTables} {
+		table := tables.Main
+		labelWhere, labelArgs := sqlbuild.LabelSetClauses("id", tables, filter.Labels, filter.LabelsAny, filter.ExcludeLabels)
+		labelClause := ""
+		if len(labelWhere) > 0 {
+			labelClause = " AND " + strings.Join(labelWhere, " AND ")
+		}
+		//nolint:gosec // G201: table is one of two hardcoded values; labelClause is literal SQL plus ? placeholders.
 		rows, err := tx.QueryContext(ctx, fmt.Sprintf(`
 			SELECT id FROM %s
-			WHERE is_blocked = 1 AND status <> 'closed' AND status <> 'pinned'
-		`, table))
+			WHERE is_blocked = 1 AND status <> 'closed' AND status <> 'pinned'%s
+		`, table, labelClause), labelArgs...)
 		if err != nil {
 			if optionalBlockedTable(table) && isTableNotExistError(err) {
 				continue

--- a/internal/storage/issueops/stale.go
+++ b/internal/storage/issueops/stale.go
@@ -3,8 +3,10 @@ package issueops
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
+	"github.com/steveyegge/beads/internal/storage/sqlbuild"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -13,13 +15,24 @@ import (
 // filter.Status is empty, open and in_progress issues are returned.
 // Results are ordered by updated_at ascending (stalest first).
 //
-// nolint:gosec // G201: statusClause contains only literal SQL or a single ? placeholder
+// Label predicates are applied in SQL rather than to the hydrated results
+// because filter.Limit is a LIMIT on this query: post-filtering would return
+// fewer than the requested number of stale issues whenever the cut-off page
+// contained a non-matching row.
+//
+// nolint:gosec // G201: statusClause and labelClause contain only literal SQL or ? placeholders
 func GetStaleIssuesInTx(ctx context.Context, tx DBTX, filter types.StaleFilter) ([]*types.Issue, error) {
 	cutoff := time.Now().UTC().AddDate(0, 0, -filter.Days)
 
 	statusClause := "status IN ('open', 'in_progress')"
 	if filter.Status != "" {
 		statusClause = "status = ?"
+	}
+
+	labelWhere, labelArgs := sqlbuild.LabelSetClauses("id", IssuesFilterTables, filter.Labels, filter.LabelsAny, filter.ExcludeLabels)
+	labelClause := ""
+	if len(labelWhere) > 0 {
+		labelClause = "\n\t\t  AND " + strings.Join(labelWhere, "\n\t\t  AND ")
 	}
 
 	// Heartbeats live in the ephemeral leases table and no longer stamp
@@ -32,14 +45,17 @@ func GetStaleIssuesInTx(ctx context.Context, tx DBTX, filter types.StaleFilter) 
 		  AND (ephemeral = 0 OR ephemeral IS NULL)
 		  AND NOT EXISTS (
 			SELECT 1 FROM leases WHERE leases.issue_id = issues.id AND leases.heartbeat_at >= ?
-		  )
+		  )%s
 		ORDER BY updated_at ASC
-	`, statusClause)
+	`, statusClause, labelClause)
 	args := []interface{}{cutoff}
 	if filter.Status != "" {
 		args = append(args, filter.Status)
 	}
 	args = append(args, cutoff) // NOT EXISTS heartbeat cutoff, after any status arg
+	// Label placeholders sit after the NOT EXISTS in the query text, so their
+	// args go last.
+	args = append(args, labelArgs...)
 
 	if filter.Limit > 0 {
 		query += fmt.Sprintf(" LIMIT %d", filter.Limit)

--- a/internal/storage/sqlbuild/labels.go
+++ b/internal/storage/sqlbuild/labels.go
@@ -73,3 +73,44 @@ func BuildLabelDrivenSearch(filter types.IssueFilter, tables FilterTables) Label
 		Filter:   filterForClauses,
 	}
 }
+
+// LabelSetClauses builds the AND / OR / NOT label predicates as IN-subqueries
+// against tables.Labels, keyed on idExpr. Semantics are the ones users already
+// know from bd list and bd ready: labels is AND (carry all of them), labelsAny
+// is OR (carry at least one), exclude drops an issue carrying any. Clause and
+// arg ordering, and the treatment of empty entries, mirror the equivalent
+// blocks in BuildIssueFilterClauses so every listing command filters labels
+// identically.
+//
+// BuildLabelDrivenSearch rewrites the AND/OR pair into JOINs for the search
+// path, which the optimizer prefers on large corpora. This is the subquery
+// form, for callers whose FROM clause is fixed and cannot take a join.
+func LabelSetClauses(idExpr string, tables FilterTables, labels, labelsAny, exclude []string) ([]string, []any) {
+	var where []string
+	var args []any
+
+	for _, label := range labels {
+		where = append(where, fmt.Sprintf("%s IN (SELECT issue_id FROM %s WHERE label = ?)", idExpr, tables.Labels))
+		args = append(args, label)
+	}
+	if len(labelsAny) > 0 {
+		placeholders := make([]string, len(labelsAny))
+		for i, label := range labelsAny {
+			placeholders[i] = "?"
+			args = append(args, label)
+		}
+		where = append(where, fmt.Sprintf("%s IN (SELECT issue_id FROM %s WHERE label IN (%s))",
+			idExpr, tables.Labels, strings.Join(placeholders, ", ")))
+	}
+	if len(exclude) > 0 {
+		placeholders := make([]string, len(exclude))
+		for i, label := range exclude {
+			placeholders[i] = "?"
+			args = append(args, label)
+		}
+		where = append(where, fmt.Sprintf("%s NOT IN (SELECT issue_id FROM %s WHERE label IN (%s))",
+			idExpr, tables.Labels, strings.Join(placeholders, ", ")))
+	}
+
+	return where, args
+}

--- a/internal/storage/sqlbuild/labels_test.go
+++ b/internal/storage/sqlbuild/labels_test.go
@@ -1,0 +1,177 @@
+package sqlbuild
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestLabelSetClauses pins the SQL and arg ordering shared by the listing
+// commands that cannot take a label JOIN (bd stale, bd blocked). The clauses
+// must stay interchangeable with the equivalent blocks in
+// BuildIssueFilterClauses — see TestLabelSetClausesMatchesFilterClauses.
+func TestLabelSetClauses(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		idExpr    string
+		tables    FilterTables
+		labels    []string
+		labelsAny []string
+		exclude   []string
+		wantWhere []string
+		wantArgs  []any
+	}{
+		{
+			name:   "no labels yields no clauses",
+			idExpr: "id",
+			tables: IssuesFilterTables,
+		},
+		{
+			name:      "single AND label",
+			idExpr:    "id",
+			tables:    IssuesFilterTables,
+			labels:    []string{"theme:personal"},
+			wantWhere: []string{"id IN (SELECT issue_id FROM labels WHERE label = ?)"},
+			wantArgs:  []any{"theme:personal"},
+		},
+		{
+			name:   "AND labels emit one clause each, in order",
+			idExpr: "id",
+			tables: IssuesFilterTables,
+			labels: []string{"theme:personal", "actor:robin"},
+			wantWhere: []string{
+				"id IN (SELECT issue_id FROM labels WHERE label = ?)",
+				"id IN (SELECT issue_id FROM labels WHERE label = ?)",
+			},
+			wantArgs: []any{"theme:personal", "actor:robin"},
+		},
+		{
+			name:      "OR labels collapse into one IN clause",
+			idExpr:    "id",
+			tables:    IssuesFilterTables,
+			labelsAny: []string{"p0", "p1"},
+			wantWhere: []string{"id IN (SELECT issue_id FROM labels WHERE label IN (?, ?))"},
+			wantArgs:  []any{"p0", "p1"},
+		},
+		{
+			name:      "exclude labels emit a NOT IN clause",
+			idExpr:    "id",
+			tables:    IssuesFilterTables,
+			exclude:   []string{"monitor"},
+			wantWhere: []string{"id NOT IN (SELECT issue_id FROM labels WHERE label IN (?))"},
+			wantArgs:  []any{"monitor"},
+		},
+		{
+			name:      "all three combine, AND then OR then NOT",
+			idExpr:    "id",
+			tables:    IssuesFilterTables,
+			labels:    []string{"theme:personal"},
+			labelsAny: []string{"p0", "p1"},
+			exclude:   []string{"monitor"},
+			wantWhere: []string{
+				"id IN (SELECT issue_id FROM labels WHERE label = ?)",
+				"id IN (SELECT issue_id FROM labels WHERE label IN (?, ?))",
+				"id NOT IN (SELECT issue_id FROM labels WHERE label IN (?))",
+			},
+			wantArgs: []any{"theme:personal", "p0", "p1", "monitor"},
+		},
+		{
+			name:      "wisps use their own label table",
+			idExpr:    "id",
+			tables:    WispsFilterTables,
+			labels:    []string{"theme:personal"},
+			wantWhere: []string{"id IN (SELECT issue_id FROM wisp_labels WHERE label = ?)"},
+			wantArgs:  []any{"theme:personal"},
+		},
+		{
+			name:      "qualified id expression is used verbatim",
+			idExpr:    "issues.id",
+			tables:    IssuesFilterTables,
+			labels:    []string{"theme:personal"},
+			wantWhere: []string{"issues.id IN (SELECT issue_id FROM labels WHERE label = ?)"},
+			wantArgs:  []any{"theme:personal"},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			where, args := LabelSetClauses(tc.idExpr, tc.tables, tc.labels, tc.labelsAny, tc.exclude)
+			if len(where) != len(tc.wantWhere) {
+				t.Fatalf("got %d clauses %v, want %d %v", len(where), where, len(tc.wantWhere), tc.wantWhere)
+			}
+			for i := range where {
+				if where[i] != tc.wantWhere[i] {
+					t.Errorf("clause %d = %q, want %q", i, where[i], tc.wantWhere[i])
+				}
+			}
+			if len(args) != len(tc.wantArgs) {
+				t.Fatalf("got %d args %v, want %d %v", len(args), args, len(tc.wantArgs), tc.wantArgs)
+			}
+			for i := range args {
+				if args[i] != tc.wantArgs[i] {
+					t.Errorf("arg %d = %v, want %v", i, args[i], tc.wantArgs[i])
+				}
+			}
+		})
+	}
+}
+
+// TestLabelSetClausesPlaceholderArgAgreement guards the failure mode that
+// actually bites at runtime: a clause carrying more ? than the args beside it,
+// which the driver reports far from the code that built it.
+func TestLabelSetClausesPlaceholderArgAgreement(t *testing.T) {
+	t.Parallel()
+
+	where, args := LabelSetClauses("id", IssuesFilterTables,
+		[]string{"a", "b"}, []string{"c", "d", "e"}, []string{"f", "g"})
+
+	placeholders := 0
+	for _, clause := range where {
+		placeholders += strings.Count(clause, "?")
+	}
+	if placeholders != len(args) {
+		t.Errorf("clauses carry %d placeholders but %d args were returned: %v / %v",
+			placeholders, len(args), where, args)
+	}
+}
+
+// TestLabelSetClausesMatchesFilterClauses pins the helper against the inline
+// label handling in BuildIssueFilterClauses. The two must agree: bd stale and
+// bd blocked filter through the helper while bd list filters through
+// BuildIssueFilterClauses, and a user is entitled to the same answer from
+// --label whichever command they reach for.
+func TestLabelSetClausesMatchesFilterClauses(t *testing.T) {
+	t.Parallel()
+
+	labels := []string{"theme:personal", "actor:robin"}
+	labelsAny := []string{"p0", "p1"}
+	exclude := []string{"monitor"}
+
+	helperWhere, helperArgs := LabelSetClauses("id", IssuesFilterTables, labels, labelsAny, exclude)
+
+	filterWhere, filterArgs, err := BuildIssueFilterClauses("", types.IssueFilter{
+		Labels:        labels,
+		LabelsAny:     labelsAny,
+		ExcludeLabels: exclude,
+	}, IssuesFilterTables)
+	if err != nil {
+		t.Fatalf("BuildIssueFilterClauses: %v", err)
+	}
+
+	if strings.Join(helperWhere, " AND ") != strings.Join(filterWhere, " AND ") {
+		t.Errorf("clause mismatch:\n helper: %v\n filter: %v", helperWhere, filterWhere)
+	}
+	if len(helperArgs) != len(filterArgs) {
+		t.Fatalf("arg count mismatch: helper %v, filter %v", helperArgs, filterArgs)
+	}
+	for i := range helperArgs {
+		if helperArgs[i] != filterArgs[i] {
+			t.Errorf("arg %d: helper %v, filter %v", i, helperArgs[i], filterArgs[i])
+		}
+	}
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -2174,6 +2174,10 @@ type StaleFilter struct {
 	Days   int    // Issues not updated in this many days
 	Status string // Filter by status (open|in_progress|blocked), empty = all non-closed
 	Limit  int    // Maximum issues to return
+
+	Labels        []string // AND semantics: issue must have ALL these labels
+	LabelsAny     []string // OR semantics: issue must have AT LEAST ONE of these labels
+	ExcludeLabels []string // Exclusion: issue must NOT have ANY of these labels
 }
 
 // WispFilter is used to filter ListWisps queries.


### PR DESCRIPTION
## What

`bd stale` and `bd blocked` are the last two issue-listing commands with no way to scope their output by label. `bd list`, `bd ready`, `bd orphans`, `bd count` and `bd search` all have it. This adds the three set-based flags to both, reusing the semantics and the help text already in use elsewhere:

- `-l, --label` — AND: must carry all of them
- `--label-any` — OR: must carry at least one
- `--exclude-label` — drops an issue carrying any

`--label-pattern` and `--label-regex` are deliberately left out; say the word and I'll add them.

## Why

Scoping a listing to one label set is the normal way to work a multi-project database, and these two commands force the caller to pull every project's rows and post-filter the JSON instead.

Two things surfaced while implementing it that are worth calling out on their own:

**`bd blocked` was silently dropping label filters it already accepted.** `types.WorkFilter` has carried `Labels`, `LabelsAny` and `ExcludeLabels` for a long time, and `bd blocked` builds a `WorkFilter` — but `GetBlockedIssuesInTx` only ever read `ParentID`. A programmatic caller setting the label fields got unfiltered results back and no error to say why.

**On `bd stale` the filter has to run in SQL, not on the results.** `filter.Limit` becomes this query's `LIMIT`, so filtering the hydrated rows afterwards would make `--label x --limit 10` return fewer than ten matching issues — possibly zero, if the stalest ten happened to be in another project. There's a regression test pinning that specific case.

## How

- **`sqlbuild.LabelSetClauses`** (new) — the IN-subquery form of the three predicates, for callers whose `FROM` clause is fixed and cannot take the JOIN that `BuildLabelDrivenSearch` builds for the search path. A test pins it against the equivalent blocks in `BuildIssueFilterClauses` so the two cannot drift: a user is entitled to the same answer from `--label` whichever command they reach for.
- **`StaleFilter`** gains the three fields; `GetStaleIssuesInTx` applies them in the WHERE clause, before `LIMIT`.
- **`GetBlockedIssuesInTx`** applies them in the per-table scan, so `issues` filters against `labels` and `wisps` against `wisp_labels`. Doing it at the source also spares the blocker-dependency and hydration passes any work on rows that cannot survive. The filter applies to the blocked issues themselves, never to their blockers — there's a test for that, since it is the reading someone might otherwise assume.
- **`blockedFilterFromFlags`** (new, `cmd/bd/ready.go`) is shared by the direct and the proxied-server paths, which previously built the same filter twice.

Every backend — embedded, dolt, and `domain/db` — delegates to those two `...InTx` functions, so there is a single change point per command and no per-backend divergence.

## Testing

- `internal/storage/sqlbuild`: unit coverage for clause and arg construction (including the wisps table and a qualified id expression), placeholder/arg agreement, and equivalence with `BuildIssueFilterClauses`.
- `cmd/bd`: end-to-end tests for both commands against the embedded engine — AND, OR, exclusion, the unfiltered baseline, the blocker-labels case, and the `--limit`-after-filter regression. 12 subtests, run with `BEADS_TEST_EMBEDDED_DOLT=1`, all passing locally.
- `make ci-pr-core` and `gofmt` clean.
- Generated CLI docs are unchanged by design: `docs/cli-docs.pin` pins them to v1.2.2 rather than the checkout, and `check-doc-flags.sh` reports "generated CLI docs are fresh".

Two local gate caveats, both environmental rather than about this change. `golangci-lint` isn't installed on my machine, so lint runs for the first time in CI; `go vet ./cmd/bd/... ./internal/storage/...` is clean as a substitute. `check-build-tags.sh` uses `mapfile` and can't run on macOS's bash 3.2 — it scans `scripts/`, hooks, `.github/` and the Makefile for `go` invocations, none of which this change touches. The other `ci-pr-policy` sub-scripts pass.

## Two things worth your call

1. `BuildIssueFilterClauses` still carries its own inline copies of these three predicates. I kept this change off that hot path deliberately, but if you'd rather have one implementation I'm happy to fold them into `LabelSetClauses` — the ordering is identical, so it should be a mechanical substitution.
2. I have not exercised the proxied-server route; I don't have a server to hand. Both routes now share `blockedFilterFromFlags` and the same `GetBlockedIssuesInTx`, so the embedded coverage should carry over, but it deserves a maintainer's eye rather than my assumption.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
