### PR TITLE
test(dbproxy): re-exec the test binary for named force-stop helpers instead of copying sleep

### DIFF
--- a/internal/storage/dbproxy/proxy/force_stop_linux_test.go
+++ b/internal/storage/dbproxy/proxy/force_stop_linux_test.go
@@ -3,6 +3,7 @@
 package proxy
 
 import (
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -154,22 +155,49 @@ func TestForceStopUnverifiedRejectsVerifiableV2Record(t *testing.T) {
 	assert.FileExists(t, pidfile.Path(root, PIDFileName))
 }
 
+// forceStopHelperEnv gates TestForceStopHelperProcess so a normal test run
+// skips the helper body.
+const forceStopHelperEnv = "BEADS_FORCE_STOP_HELPER"
+
+// TestForceStopHelperProcess is the body of the helper processes
+// startNamedForceStopHelper spawns: a re-exec of this test binary that idles
+// until the test (or its Cleanup) kills it.
+func TestForceStopHelperProcess(t *testing.T) {
+	if os.Getenv(forceStopHelperEnv) != "1" {
+		t.Skip("helper-process body; only meaningful under startNamedForceStopHelper")
+	}
+	time.Sleep(30 * time.Second)
+}
+
 // startNamedForceStopHelper starts a long-sleeping process whose executable
 // basename is name and whose command line references dir (the binary lives
 // inside it), matching how a workspace's own bd/dolt processes reference
-// their root path.
+// their root path. The body is this test binary re-executed in helper mode,
+// not a renamed copy of the system sleep: on busybox/uutils-coreutils
+// systems (Ubuntu 25.10+) sleep is a multicall binary dispatching on
+// argv[0], so a renamed copy exits instantly and the fixture silently loses
+// its live process.
 func startNamedForceStopHelper(t *testing.T, dir, name string) helperProcess {
 	t.Helper()
-	sleepPath, err := exec.LookPath("sleep")
+	self, err := os.Executable()
 	require.NoError(t, err)
-	sleepPath, err = filepath.EvalSymlinks(sleepPath)
-	require.NoError(t, err)
-	data, err := os.ReadFile(sleepPath)
+	self, err = filepath.EvalSymlinks(self)
 	require.NoError(t, err)
 	executable := filepath.Join(dir, name)
-	require.NoError(t, os.WriteFile(executable, data, 0o700))
+	// Hard link when dir is on the same filesystem; stream a copy otherwise.
+	if os.Link(self, executable) != nil {
+		src, err := os.Open(self)
+		require.NoError(t, err)
+		dst, err := os.OpenFile(executable, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o700)
+		require.NoError(t, err)
+		_, cpErr := io.Copy(dst, src)
+		require.NoError(t, src.Close())
+		require.NoError(t, dst.Close())
+		require.NoError(t, cpErr)
+	}
 
-	cmd := exec.Command(executable, "30")
+	cmd := exec.Command(executable, "-test.run=^TestForceStopHelperProcess$")
+	cmd.Env = append(os.Environ(), forceStopHelperEnv+"=1")
 	require.NoError(t, cmd.Start())
 	token, err := procid.Capture(cmd.Process.Pid)
 	require.NoError(t, err)


### PR DESCRIPTION
## What

`startNamedForceStopHelper` copies the resolved system `sleep` binary to `dir/{bd,dolt}` and executes it. On hosts where `sleep` resolves to a **multicall binary** that dispatches on `argv[0]` — busybox, or the Rust **uutils coreutils** that Ubuntu ships as `/bin/sleep` since 25.10 — the renamed copy exits instantly:

```
$ cp "$(readlink -f "$(which sleep)")" /tmp/x/dolt && /tmp/x/dolt 30
coreutils: unknown program 'dolt'
$ echo $?
1
```

The fixture then silently loses its live process:

- `TestForceStopUnverifiedHeldLock` turns **intermittent**: the `<-helper.done` goroutine releases the held flock almost immediately, racing `ForceStopUnverified`'s own `TryLock` (`LockWasHeld=false`, `Executable=""`).
- `TestForceStopUnverifiedPairedLegacyRecords` fails **deterministically**: the recovery only finds dead records (`SignalSent=false`, empty `QuarantinedPath`).

GNU-coreutils hosts (Ubuntu 24.04 runners, WSL) never see this because their `sleep` is a standalone binary — which also means current CI stays green **until the runner image moves to uutils coreutils**, at which point these tests fail with no code change.

## Fix

Materialize the helper as a **hard link to this test binary** (streaming-copy fallback across filesystems) and re-exec it in helper mode (`TestForceStopHelperProcess`), so the executable-basename contract holds regardless of how the distro ships `sleep`. Every fixture spawn passes a left- and right-anchored selector (`-test.run='^TestForceStopHelperProcess$'`), so a spawned helper can never re-enter the suite; the helper body is additionally gated on `BEADS_FORCE_STOP_HELPER=1` so normal test runs skip it.

The command line still references the workspace dir through `argv[0]` (the copy lives in `dir`), so `TestForceStopUnverifiedRejectsForeignWorkspaceProcess`'s cmdline-must-reference-workspace contract is exercised unchanged.

## Testing

- Ubuntu 25.10+ host with uutils coreutils (`/bin/sleep -> /usr/lib/cargo/bin/coreutils/sleep`): before = `PairedLegacyRecords` red + `HeldLock` intermittent; after = **7/7 PASS**, repeated **5/5** (the surface was race-prone, so single greens were not trusted).
- GNU coreutils environment (WSL2 Ubuntu, standalone `/usr/bin/sleep`): **7/7 PASS** before and after — no regression where the old fixture worked.
- Repo sweep: this was the only site that renames a copy of `sleep`; all other `exec.Command("sleep", ...)` sites keep `argv[0]` intact and are unaffected.

Test-only change; no production code touched.

Agent-Signature: claude-code-claude-fable-5 on behalf of Marco Del Pin
