### PR TITLE
fix(doctor): recommend 'bd prune' instead of nonexistent 'bd cleanup'

### DIFF
--- a/cmd/bd/doctor/agent.go
+++ b/cmd/bd/doctor/agent.go
@@ -216,7 +216,7 @@ func enrichLargeDatabase(dc DoctorCheck) agentEnrichment {
 		explanation: fmt.Sprintf("The database has accumulated many closed issues: %s. This may cause performance degradation in list/search operations. Pruning is optional and destructive.", dc.Message),
 		observed:    dc.Message,
 		expected:    "Closed issue count below configured threshold",
-		commands:    []string{"bd cleanup --older-than 90"},
+		commands:    []string{"bd prune --older-than 90d"},
 		sourceFiles: []string{"cmd/bd/doctor/database.go:CheckDatabaseSize"},
 	}
 }
@@ -521,7 +521,7 @@ func enrichStaleClosedIssues(dc DoctorCheck) agentEnrichment {
 		explanation: fmt.Sprintf("Stale closed issues: %s. Old closed issues can be pruned to reduce database size and improve query performance.", dc.Message),
 		observed:    dc.Message + "\n" + dc.Detail,
 		expected:    "Closed issues are within acceptable age/count thresholds",
-		commands:    []string{"bd cleanup --older-than 90"},
+		commands:    []string{"bd prune --older-than 90d"},
 		sourceFiles: []string{"cmd/bd/doctor/maintenance.go:CheckStaleClosedIssues"},
 	}
 }

--- a/cmd/bd/doctor/agent_test.go
+++ b/cmd/bd/doctor/agent_test.go
@@ -37,3 +37,29 @@ func TestEnrichFreshClone_WithSyncRemoteMentionsBootstrapAndFallback(t *testing.
 		t.Fatalf("expected sync.remote fallback command, got %#v", enrichment.commands)
 	}
 }
+
+// TestPruneEnrichmentsRecommendRealCommand pins the agent-facing pruning
+// advice to a command that exists: these enrichments used to suggest
+// 'bd cleanup', which is not a root-level command in this build (cleanup
+// lives under 'bd admin cleanup'). 'bd prune --older-than 90d' previews by
+// default, matching the "optional and destructive" framing.
+func TestPruneEnrichmentsRecommendRealCommand(t *testing.T) {
+	enrichments := map[string]agentEnrichment{
+		"Large Database":      enrichLargeDatabase(DoctorCheck{Message: "6000 closed issues (threshold: 5000)"}),
+		"Stale Closed Issues": enrichStaleClosedIssues(DoctorCheck{Message: "5000 stale closed issues"}),
+	}
+	for name, enrichment := range enrichments {
+		if len(enrichment.commands) == 0 {
+			t.Errorf("%s enrichment has no commands", name)
+			continue
+		}
+		for _, cmd := range enrichment.commands {
+			if strings.Contains(cmd, "bd cleanup") {
+				t.Errorf("%s enrichment recommends nonexistent 'bd cleanup': %q", name, cmd)
+			}
+		}
+		if !strings.HasPrefix(enrichment.commands[0], "bd prune") {
+			t.Errorf("%s enrichment should recommend 'bd prune', got %#v", name, enrichment.commands)
+		}
+	}
+}

--- a/cmd/bd/doctor/database.go
+++ b/cmd/bd/doctor/database.go
@@ -498,7 +498,7 @@ func isNoDbModeConfigured(beadsDir string) bool {
 
 // CheckDatabaseSize warns when the database has accumulated many closed issues.
 // This is purely informational - pruning is NEVER auto-fixed because it
-// permanently deletes data. Users must explicitly run 'bd cleanup' to prune.
+// permanently deletes data. Users must explicitly run 'bd prune' to prune.
 //
 // Config: doctor.suggest_pruning_issue_count (default: 5000, 0 = disabled)
 //
@@ -577,18 +577,26 @@ func checkDatabaseSizeWithStore(store *dolt.DoltStore) DoctorCheck {
 	}
 
 	if stats.ClosedIssues > threshold {
-		return DoctorCheck{
-			Name:    "Large Database",
-			Status:  StatusWarning,
-			Message: fmt.Sprintf("%d closed issues (threshold: %d)", stats.ClosedIssues, threshold),
-			Detail:  "Large number of closed issues may impact performance",
-			Fix:     "Consider running 'bd cleanup --older-than 90' to prune old closed issues",
-		}
+		return largeDatabaseWarning(stats.ClosedIssues, threshold)
 	}
 
 	return DoctorCheck{
 		Name:    "Large Database",
 		Status:  StatusOK,
 		Message: fmt.Sprintf("%d closed issues (threshold: %d)", stats.ClosedIssues, threshold),
+	}
+}
+
+// largeDatabaseWarning builds the over-threshold Large Database check. Split
+// out so tests can pin the recommended remedy to a command that actually
+// exists: 'bd prune' is the root-level lifecycle command ('cleanup' only
+// exists as 'bd admin cleanup').
+func largeDatabaseWarning(closedIssues, threshold int) DoctorCheck {
+	return DoctorCheck{
+		Name:    "Large Database",
+		Status:  StatusWarning,
+		Message: fmt.Sprintf("%d closed issues (threshold: %d)", closedIssues, threshold),
+		Detail:  "Large number of closed issues may impact performance",
+		Fix:     "Consider running 'bd prune --older-than 90d' to prune old closed issues (preview; add --force to delete)",
 	}
 }

--- a/cmd/bd/doctor/database_test.go
+++ b/cmd/bd/doctor/database_test.go
@@ -210,3 +210,21 @@ func setupDoctorBareParentWorktree(t *testing.T) (string, string) {
 
 	return bareDir, featureWorktreeDir
 }
+
+// TestLargeDatabaseWarningRecommendsRealCommand pins the Large Database
+// remedy to a command that exists: the check used to recommend 'bd cleanup',
+// which is not a root-level command in this build (cleanup lives under
+// 'bd admin cleanup'); the operator-facing lifecycle command is 'bd prune'.
+func TestLargeDatabaseWarningRecommendsRealCommand(t *testing.T) {
+	dc := largeDatabaseWarning(6000, 5000)
+
+	if dc.Status != StatusWarning {
+		t.Fatalf("expected StatusWarning, got %v", dc.Status)
+	}
+	if strings.Contains(dc.Fix, "bd cleanup") {
+		t.Fatalf("Large Database fix recommends nonexistent 'bd cleanup': %q", dc.Fix)
+	}
+	if !strings.Contains(dc.Fix, "bd prune") {
+		t.Fatalf("Large Database fix should recommend 'bd prune': %q", dc.Fix)
+	}
+}

--- a/cmd/bd/doctor/perf_dolt.go
+++ b/cmd/bd/doctor/perf_dolt.go
@@ -361,7 +361,7 @@ func assessDoltPerformance(metrics *DoltPerfMetrics) {
 
 	// Check database size
 	if metrics.TotalIssues > 5000 && metrics.ClosedIssues > 4000 {
-		recommendations = append(recommendations, "Many closed issues. Consider 'bd cleanup' to prune old issues.")
+		recommendations = append(recommendations, "Many closed issues. Consider 'bd prune --older-than 90d' to prune old issues.")
 	}
 
 	if len(warnings) == 0 {

--- a/cmd/bd/doctor_fix.go
+++ b/cmd/bd/doctor_fix.go
@@ -363,7 +363,7 @@ func applyFixList(path string, fixes []doctorCheck) {
 			continue
 		case "Large Database":
 			// No auto-fix: pruning deletes data, must be user-controlled
-			fmt.Printf("  ⚠ Run 'bd cleanup --older-than 90' to prune old closed issues\n")
+			fmt.Printf("  ⚠ Run 'bd prune --older-than 90d' to preview prunable closed issues (add --force to delete)\n")
 			continue
 		case "Legacy MQ Files":
 			err = doctor.FixStaleMQFiles(path)

--- a/engdocs/messaging.md
+++ b/engdocs/messaging.md
@@ -74,13 +74,13 @@ Messages marked `ephemeral: true` are transient - they can be bulk-deleted after
 
 ```bash
 # Clean up closed ephemeral messages
-bd cleanup --ephemeral --force
+bd purge --force
 
 # Preview what would be deleted
-bd cleanup --ephemeral --dry-run
+bd purge --dry-run
 
 # Only delete ephemeral messages older than 7 days
-bd cleanup --ephemeral --older-than 7 --force
+bd purge --older-than 7d --force
 ```
 
 Ephemeral messages are:


### PR DESCRIPTION
## What

Doctor advice that tells users to prune old closed issues now names a command that exists: `bd prune --older-than 90d` instead of `bd cleanup`. Five sites updated — the Large Database check's `Fix` string and its design-note comment, both agent enrichments (Large Database, Stale Closed Issues), the Dolt perf recommendation, and the `doctor --fix` advisory line. The over-threshold branch of the Large Database check is extracted into `largeDatabaseWarning` so a test can pin the remedy string, and the two enrichments' command lists are pinned likewise.

## Why

`bd cleanup` is not a root-level command — cleanup lives under `bd admin cleanup` — so following the doctor's own advice fails with an unknown-command error. The operator-facing lifecycle command is `bd prune`, and it happens to fit this advice better than the admin command would: the Large Database check deliberately has no auto-fix because pruning deletes data, and `bd prune` previews by default (`--force` to actually delete), so an operator or agent that runs the recommended command verbatim gets the safe preview, not a deletion. The advice strings say so explicitly.

## Verification

```
go build -tags gms_pure_go ./...
go test -tags gms_pure_go ./cmd/bd/doctor/ -run 'TestLargeDatabaseWarningRecommendsRealCommand|TestPruneEnrichmentsRecommendRealCommand' -count=1
grep -rn "bd cleanup" cmd/bd/doctor/ cmd/bd/doctor_fix.go   # only the new tests' negative assertions remain
```

Both new tests pass; the full doctor package suite matches main except `TestCheckBeadsRole_NotConfigured`/`_NotGitRepo`, which fail on my machine with or without this change (host role config leaks into the test environment — same known-neutral noted while working #4933).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
