### PR TITLE
docs(troubleshooting): document the two native-Windows integration traps

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -266,6 +266,8 @@ Move-Item bd.exe $env:USERPROFILE\AppData\Local\Microsoft\WindowsApps\
 **Windows notes:**
 - The Dolt server listens on a loopback TCP endpoint
 - Allow `bd.exe` loopback traffic through any host firewall
+- Installed from npm, `bd` is a `bd.cmd` shim — Node's `execFile`/`spawn`
+  need `shell: true` to run it ([details](/reference/troubleshooting#platform-specific-issues))
 
 ## IDE and Editor Integrations
 

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -279,7 +279,7 @@ Yes, three ways: `bd query` for the built-in query language (compound filters, b
 
 Yes — native Windows support, no MSYS or MinGW required. A PowerShell script installs prebuilt releases, and everything works with Windows paths. See [Installation](/getting-started/installation#windows-11).
 
-Because `bd.exe` is a native binary, two integration details catch people out: Node programs cannot spawn the npm `bd.cmd` shim without a shell, and `/tmp` from Git Bash is not the directory `bd` writes to. Both are covered under [Platform-Specific Issues](/reference/troubleshooting#platform-specific-issues).
+Because `bd.exe` is a native binary, two integration details catch people out: Node programs cannot spawn the npm `bd.cmd` shim without a shell, and `/tmp` paths that reach `bd` unconverted — from Node, scripts, or config values — resolve to the drive root, not Git Bash's `/tmp`. Both are covered under [Platform-Specific Issues](/reference/troubleshooting#platform-specific-issues).
 
 ### Can I use beads with git worktrees?
 

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -279,6 +279,8 @@ Yes, three ways: `bd query` for the built-in query language (compound filters, b
 
 Yes — native Windows support, no MSYS or MinGW required. A PowerShell script installs prebuilt releases, and everything works with Windows paths. See [Installation](/getting-started/installation#windows-11).
 
+Because `bd.exe` is a native binary, two integration details catch people out: Node programs cannot spawn the npm `bd.cmd` shim without a shell, and `/tmp` from Git Bash is not the directory `bd` writes to. Both are covered under [Platform-Specific Issues](/reference/troubleshooting#platform-specific-issues).
+
 ### Can I use beads with git worktrees?
 
 Yes — beads works from normal git worktrees with no special setup. All worktrees in a repository share the same `.beads` workspace; `bd` discovers it from linked worktrees automatically.

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -751,6 +751,59 @@ protection → Ransomware protection → Controlled folder access → "Allow an
 app through Controlled folder access" → browse to `bd.exe` (typically
 `%USERPROFILE%\go\bin\bd.exe`). Then retry `bd init`.
 
+### Windows: `ENOENT` when a Node program spawns `bd`
+
+**Symptom:** An editor extension, MCP server, or script that shells out to
+`bd` fails on Windows with `spawn bd ENOENT`, even though `bd` runs fine in
+the same terminal.
+
+The npm package installs `bd` as a generated `bd.cmd` shim, not as an
+executable named `bd`. Node's `execFile()` and `spawn()` run their target
+directly instead of through a shell, so they never apply the `PATHEXT`
+resolution that finds `bd.cmd` — and a batch file is not directly executable
+in the first place.
+
+**Solution:** Name the shim explicitly and give it a shell:
+
+```js
+const { execFile } = require('node:child_process');
+
+const isWindows = process.platform === 'win32';
+
+execFile(
+  isWindows ? 'bd.cmd' : 'bd',
+  ['ready', '--json'],
+  { shell: isWindows },
+  (err, stdout) => { /* ... */ },
+);
+```
+
+To avoid a shell — and the argument quoting that comes with it — spawn the
+native binary the shim wraps, at `node_modules/@beads/bd/bin/bd.exe`.
+
+### Windows: `/tmp` paths from Git Bash
+
+**Symptom:** A `bd` command that writes to `/tmp` from Git Bash reports
+success, but the file is not there afterwards.
+
+`bd.exe` is a native Windows binary and does not share Git Bash's emulated
+POSIX filesystem. Git Bash resolves `/tmp` to its own temp directory, while a
+native program resolves it against the current drive root — `C:\tmp`. One
+path string, two directories, no error from either side.
+
+```bash
+bd export -o /tmp/issues.jsonl   # bd writes C:\tmp\issues.jsonl
+ls /tmp/issues.jsonl             # No such file or directory
+```
+
+**Solution:** Hand `bd` a Windows path:
+
+```bash
+bd export -o "$(cygpath -w /tmp)\issues.jsonl"
+```
+
+The same applies to any path argument, including `--db` and config values.
+
 ### macOS: Gatekeeper blocking execution
 
 1. Verify the downloaded binary checksum matches the release `checksums.txt`.

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -781,28 +781,34 @@ execFile(
 To avoid a shell — and the argument quoting that comes with it — spawn the
 native binary the shim wraps, at `node_modules/@beads/bd/bin/bd.exe`.
 
-### Windows: `/tmp` paths from Git Bash
+### Windows: `/tmp` paths silently land in the drive root
 
-**Symptom:** A `bd` command that writes to `/tmp` from Git Bash reports
-success, but the file is not there afterwards.
+**Symptom:** A `bd` command given a `/tmp/...` path reports success, but
+the file is not where you look for it — it was written to `C:\tmp\...`.
 
 `bd.exe` is a native Windows binary and does not share Git Bash's emulated
-POSIX filesystem. Git Bash resolves `/tmp` to its own temp directory, while a
-native program resolves it against the current drive root — `C:\tmp`. One
-path string, two directories, no error from either side.
+POSIX filesystem. When a literal `/tmp/...` string reaches `bd`, it resolves
+against the current drive root.
 
-```bash
-bd export -o /tmp/issues.jsonl   # bd writes C:\tmp\issues.jsonl
-ls /tmp/issues.jsonl             # No such file or directory
+In a default interactive Git Bash this usually does *not* happen — Git for
+Windows converts standalone POSIX-path arguments to Windows paths before
+`bd.exe` sees them. The trap appears when that conversion is out of play:
+
+- `MSYS_NO_PATHCONV=1` or `MSYS2_ARG_CONV_EXCL` is set (common in
+  Docker-heavy environments)
+- the path comes from a config value or a file, not a command-line argument
+- `bd` is spawned by a non-MSYS parent — a Node script, editor extension,
+  or MCP server — which passes the string through verbatim:
+
+```js
+// From Node on Windows: no path conversion happens
+execFile('bd.cmd', ['export', '-o', '/tmp/issues.jsonl'], { shell: true }, ...);
+// bd writes C:\tmp\issues.jsonl — and exits 0
 ```
 
-**Solution:** Hand `bd` a Windows path:
-
-```bash
-bd export -o "$(cygpath -w /tmp)\issues.jsonl"
-```
-
-The same applies to any path argument, including `--db` and config values.
+**Solution:** Hand `bd` a Windows path — `os.tmpdir()` from Node,
+`"$(cygpath -w /tmp)\issues.jsonl"` from Git Bash scripts. This applies to
+any path argument, including `--db` and config values.
 
 ### macOS: Gatekeeper blocking execution
 


### PR DESCRIPTION
## What

Adds two subsections under **Platform-Specific Issues** in
`docs/reference/troubleshooting.md`, plus cross-links from the FAQ Windows
entry and the installation Windows notes:

- **`ENOENT` when a Node program spawns `bd`** — the npm `bd.cmd` shim.
- **`/tmp` paths from Git Bash** — `bd.exe` is native, so `/tmp` is not the
  shell's `/tmp`.

Docs only. No nav change (both pages are already in `docs.json`).

## Why

`bd.exe` is a native Windows binary — the docs say so up front
("native Windows support, no MSYS or MinGW required"). Two consequences of
that are undocumented, and neither fails in a way that points at its cause:

**1. The npm shim.** `npm-package/package.json` declares `"bin": {"bd": "bin/bd.js"}`,
so on Windows npm generates a `bd.cmd` shim rather than an executable named
`bd`. Node's `execFile()`/`spawn()` run their target directly without a shell,
so they apply no `PATHEXT` resolution and a batch file is not directly
executable anyway. An extension or MCP server that shells out to `bd` gets
`spawn bd ENOENT` while `bd` runs fine in the same terminal — the failure
looks like a PATH problem, which is the one thing it is not. Node's own docs
cover the general case (spawn `cmd.exe /c`, or use a shell); nothing tells a
beads integrator that `bd` *is* one of those files. The repo already knows the
shim exists — `npm-package/test/integration.test.js` probes for `bd.cmd` — it
is just never written down for consumers.

**2. `/tmp` from Git Bash.** Git Bash presents an emulated POSIX filesystem
and resolves `/tmp` to its own temp directory. `bd.exe` does not share it and
resolves `/tmp` against the current drive root. `bd export -o /tmp/issues.jsonl`
therefore exits 0 having written `C:\tmp\issues.jsonl`, and the follow-up
`ls /tmp/issues.jsonl` says the file does not exist. Silent on both sides.

I hit both building a VS Code extension against `bd --json`
(https://github.com/cuongbphv/beads-ui-vscode-ext); the ENOENT one cost the
most time precisely because `bd` worked interactively.

Neither is documented anywhere today: `ENOENT`, `execFile`, `shell: true`,
and `git-bash` return no hits across `docs/`, `engdocs/`, `npm-package/*.md`,
or the root `*.md` files. The existing Windows subsections (Path issues,
Firewall, Controlled Folder Access) are the right home and already use the
symptom/solution shape these follow.

## Verification

- `go test ./test/docsync` — ok (nav↔file sync, link conventions)
- `./scripts/generate-cli-docs.sh --check` — `PASS: generated CLI docs are fresh`
  (no generated page touched; all three edited pages are hand-written)
- `./scripts/check-doc-freshness.sh` — `PASSED`
- `git diff --name-only` carries no `.beads/` paths
- Node behavior cross-checked against the child_process docs ("Spawning .bat
  and .cmd files on Windows"); the `bd export -o` flag used in the example is
  in the committed CLI reference