### PR TITLE
test(ready): cover --label-any at the bd ready CLI surface

### DIFF
--- a/cmd/bd/ready_embedded_test.go
+++ b/cmd/bd/ready_embedded_test.go
@@ -203,6 +203,77 @@ func TestEmbeddedReady(t *testing.T) {
 		}
 	})
 
+	// ===== Label Any =====
+
+	readyIDs := func(t *testing.T, args ...string) ([]string, string) {
+		t.Helper()
+		cmd := exec.Command(bd, args...)
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		stdout, stderr, err := runCommandBuffers(t, cmd)
+		if err != nil {
+			t.Fatalf("bd %s failed: %v\nstdout:\n%s\nstderr:\n%s",
+				strings.Join(args, " "), err, stdout.String(), stderr.String())
+		}
+		var issues []types.IssueWithCounts
+		if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &issues); err != nil {
+			t.Fatalf("parse JSON: %v\n%s", err, stdout.String())
+		}
+		ids := make([]string, 0, len(issues))
+		for _, issue := range issues {
+			ids = append(ids, issue.ID)
+		}
+		return ids, stdout.String()
+	}
+
+	t.Run("ready_label_any", func(t *testing.T) {
+		laneA := bdCreate(t, bd, dir, "Lane A work", "--type", "task", "--label", "lany:lane-a")
+		bdCreate(t, bd, dir, "Lane B work", "--type", "task", "--label", "lany:lane-b")
+		laneC := bdCreate(t, bd, dir, "Lane C work", "--type", "task", "--label", "lany:lane-c")
+
+		ids, raw := readyIDs(t, "ready", "--json", "--label-any", "lany:lane-a,lany:lane-c")
+
+		want := map[string]bool{laneA.ID: true, laneC.ID: true}
+		if len(ids) != len(want) {
+			t.Fatalf("--label-any returned %d issues, want %d — an unfiltered ready set means the OR-set clause was dropped: %s",
+				len(ids), len(want), raw)
+		}
+		for _, id := range ids {
+			if !want[id] {
+				t.Fatalf("--label-any returned %s, which carries neither requested label: %s", id, raw)
+			}
+		}
+	})
+
+	t.Run("ready_label_any_intersects_with_label", func(t *testing.T) {
+		both := bdCreate(t, bd, dir, "Tiered lane A work", "--type", "task",
+			"--label", "lmix:tier", "--label", "lmix:lane-a")
+		bdCreate(t, bd, dir, "Untiered lane A work", "--type", "task", "--label", "lmix:lane-a")
+		bdCreate(t, bd, dir, "Tiered lane B work", "--type", "task",
+			"--label", "lmix:tier", "--label", "lmix:lane-b")
+
+		ids, raw := readyIDs(t, "ready", "--json",
+			"--label", "lmix:tier", "--label-any", "lmix:lane-a,lmix:lane-c")
+
+		if len(ids) != 1 || ids[0] != both.ID {
+			t.Fatalf("--label with --label-any returned %v, want only %s (AND-set and OR-set must both apply): %s",
+				ids, both.ID, raw)
+		}
+	})
+
+	t.Run("ready_claim_label_any_fences_to_its_lane", func(t *testing.T) {
+		// An exhausted lane must claim nothing. If --label-any is dropped here
+		// the claim silently takes unfenced work while the caller believes it
+		// is fenced to its own lane.
+		bdCreate(t, bd, dir, "Fence lane B work", "--type", "task", "--label", "lfence:lane-b")
+
+		ids, raw := readyIDs(t, "ready", "--claim", "--json", "--label-any", "lfence:lane-a")
+
+		if len(ids) != 0 {
+			t.Fatalf("--claim --label-any on an empty lane claimed %v, want nothing: %s", ids, raw)
+		}
+	})
+
 	// ===== -C flag =====
 
 	t.Run("ready_with_C_flag", func(t *testing.T) {


### PR DESCRIPTION
## What

Three subtests in `cmd/bd/ready_embedded_test.go` asserting `--label-any`
through the `bd` binary on the ready and claim paths. Test-only; no
production code touched.

## Why

`67ccdbfd4` fixed `--label-any` being silently dropped by `bd ready` and
`bd ready --claim`. That fix is guarded at two seams — `sqlbuild`
(`TestBuildReadyWorkWhereLabelsAny`) and backend conformance
(`testClaimReadyIssueLabelFilters`) — but **nothing asserts it through the
CLI**. Every `--label-any` CLI test targets `list`, `search`, `count`, or
`orphans`; none targets `bd ready`. That gap is precisely how the drop
shipped unnoticed in the first place, and #5358 is a user who upgraded
specifically to check whether it had landed.

The three cases mirror the fix's own claims:

| Subtest | Asserts |
|---|---|
| `ready_label_any` | an OR-set of two lanes returns exactly those two, not the unfiltered ready set |
| `ready_label_any_intersects_with_label` | `--label` (AND) and `--label-any` (OR) both apply, as the flag help promises |
| `ready_claim_label_any_fences_to_its_lane` | claiming against an exhausted lane claims **nothing** |

The third is the one that matters. A dropped filter there is not merely wrong
— it hands the caller another lane's issue while it believes it is fenced.

## Verification

Built with the repo's canonical flags (`source .buildflags`,
`BEADS_TEST_EMBEDDED_DOLT=1`).

**Green on current main** (`7505e173f`) — full `TestEmbeddedReady`, 19/19 subtests:

```
--- PASS: TestEmbeddedReady/ready_label_any (2.41s)
--- PASS: TestEmbeddedReady/ready_label_any_intersects_with_label (1.77s)
--- PASS: TestEmbeddedReady/ready_claim_label_any_fences_to_its_lane (0.58s)
ok  github.com/steveyegge/beads/cmd/bd  36.447s
```

**Red without the fix** — reverting only the `LabelsAny` clause in
`internal/storage/sqlbuild/ready.go` fails all three:

```
--- FAIL: TestEmbeddedReady/ready_label_any (2.45s)
    --label-any returned 4 issues, want 2 — an unfiltered ready set means the OR-set clause was dropped
--- FAIL: TestEmbeddedReady/ready_label_any_intersects_with_label (1.84s)
    --label with --label-any returned [rd-cxb rd-dsb], want only rd-cxb
--- FAIL: TestEmbeddedReady/ready_claim_label_any_fences_to_its_lane (0.76s)
    --claim --label-any on an empty lane claimed [rd-kaq], want nothing
```

In the reverted claim run the issue it took carries none of the requested
labels — the fencing hazard reproduced at the CLI surface.

**Lint:** `make ci-pr-lint` — gofmt clean; golangci-lint reports the same 2
pre-existing gosec findings with and without this change
(`internal/config/permissions_open_nonlinux.go`,
`internal/utils/path_case_darwin.go` — both darwin/non-linux files, so they
are outside CI's linux lint). Verified by running the gate on a stashed tree.

No `.beads/` paths in the diff.