### PR TITLE
docs(changelog): file the --label-any ready fix under the release that has it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -513,6 +513,18 @@ never reused, per the v1.1.1 precedent.)
 
 ### Fixed
 
+- **`--label-any` is no longer silently dropped by `bd ready` and
+  `bd ready --claim`.** The ready-work WHERE builder emitted clauses for
+  `--label` and `--exclude-label` but none for `--label-any`, so the OR-set
+  filter was ignored on the ready/claim path (with or without `--parent`) on
+  every backend — while `bd list`/`bd search` honored it. On an *atomic claim*
+  this was dangerous rather than merely wrong: a worker fencing itself to its
+  own lane (`bd ready --claim --label-any lane-a --parent epic-1`) would
+  happily claim another lane's issue and believe it was fenced. `--label-any`
+  now emits an OR-set membership clause that AND-combines with `--label`,
+  `--exclude-label`, and `--parent`, exactly as the flag help promises; an
+  exhausted lane now claims nothing instead of falling back to unfenced work.
+
 - **FreeBSD builds compile again** (#5661). The dbproxy process-identity arc
   (procid, unverified-process) shipped linux/darwin/windows implementations
   with no fallback, breaking `GOOS=freebsd` compilation — caught only by the
@@ -2344,18 +2356,6 @@ remote-migrate gate from a blunt block into a state-aware one.
   ([#4516](https://github.com/gastownhall/beads/issues/4516)).
 
 ### Fixed
-
-- **`--label-any` is no longer silently dropped by `bd ready` and
-  `bd ready --claim`.** The ready-work WHERE builder emitted clauses for
-  `--label` and `--exclude-label` but none for `--label-any`, so the OR-set
-  filter was ignored on the ready/claim path (with or without `--parent`) on
-  every backend — while `bd list`/`bd search` honored it. On an *atomic claim*
-  this was dangerous rather than merely wrong: a worker fencing itself to its
-  own lane (`bd ready --claim --label-any lane-a --parent epic-1`) would
-  happily claim another lane's issue and believe it was fenced. `--label-any`
-  now emits an OR-set membership clause that AND-combines with `--label`,
-  `--exclude-label`, and `--parent`, exactly as the flag help promises; an
-  exhausted lane now claims nothing instead of falling back to unfenced work.
 
 - **A failed v53 migration no longer traps the database, and the v53 repair
   now covers `wisp_dependencies` split-column drift.** rc.2 repaired the


### PR DESCRIPTION
## What

Moves one CHANGELOG entry — "`--label-any` is no longer silently dropped by
`bd ready` and `bd ready --claim`" — from `[1.1.0]` to `[1.2.1]`. The text is
unchanged; the diff is a pure move (12 lines out, the same 12 in).

## Why

`[1.1.0]` does not contain that fix. v1.1.0 was tagged 2026-07-04; the fix
(`67ccdbfd4`) landed 2026-07-12. The entry was filed into an already-released
section, so the changelog asserts to every 1.1.x reader that the fix is in
their binary.

That is not hypothetical. #5358 is a reporter who upgraded 1.1.0 → 1.1.2
"specifically to check whether this had already shipped", found it still
broken, and root-caused it themselves. The changelog is what sent them
looking.

Verified per tag with `git merge-base --is-ancestor 67ccdbfd4 <tag>`:

| Tag | Contains the fix |
|---|---|
| v1.1.0 | no |
| v1.1.1 | no |
| v1.1.2 | no |
| v1.2.0 | **yes** |
| v1.2.1 | **yes** |
| v1.2.2 | no |

`[1.2.1]` is the release that first shipped it, and is already the section
`[1.2.2]` points readers to for 1.2.x work that is not in the current release
("The 1.2.x-only features listed under [1.2.1] below are **not** in this
release; they remain on main for a properly tested future release"). So the
entry lands where the existing convention puts it, and the `[1.2.2]` note
above it already explains why a v1.2.2 user does not have it.

`[Unreleased]` would be the wrong home for the same reason `[1.1.0]` is: the
change has been released, just not in the current one.

Secondary signal that it was misfiled rather than deliberately placed: every
other item in `[1.1.0]`'s `Fixed` list is a migration fix, matching that
section's stated theme ("a safe schema-migration and upgrade path"). The
label-any entry is the only one that is not.

## Verification

- `git diff --check` — clean
- The moved text is byte-identical (visible in the diff as an exact
  removal/insertion pair)
- The phrase occurs exactly once in the file after the move
- `[1.1.0]`'s `### Fixed` still opens correctly on the v53 migration entry
- Docs-only; no `.beads/` paths in the diff

Related: #5358. A CLI-level regression test for the same fix is in #5839.