### PR TITLE
fix(dolt): pin recompute connections to the store's actual branch

### DIFF
--- a/internal/storage/dolt/federation.go
+++ b/internal/storage/dolt/federation.go
@@ -463,6 +463,13 @@ func (s *DoltStore) filteredPushToPeer(ctx context.Context, peer string, exclude
 	// Pin a single long-timeout connection for the session-scoped staging
 	// operation. RecomputeAllIsBlockedInTx can exceed the shared pool's
 	// 10-second I/O deadline, and branch state is connection-scoped.
+	//
+	// Audited for be-b0am's fresh-connection branch hazard: safe. Unlike
+	// recomputeAllBlocked/recomputeBlockedTx, this never depends on the
+	// fresh connection's default checkout — it explicitly creates
+	// stagingBranch FROM sourceBranch (CALL DOLT_BRANCH(stagingBranch,
+	// sourceBranch) in stageFilteredBranch) and checks that out by name, so
+	// the source ref is named, not inherited.
 	db, err := s.openLongTimeoutConn()
 	if err != nil {
 		return fmt.Errorf("federation filter: open long-timeout connection: %w", err)

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -3984,14 +3984,27 @@ func (s *DoltStore) pullWithAutoResolve(ctx context.Context, remote string, quer
 }
 
 func (s *DoltStore) pullWithAutoResolveUnchecked(ctx context.Context, remote string, query string, args ...any) error {
-	// Audited for be-b0am's fresh-connection branch hazard: store.go's two
-	// callers pass s.branch explicitly as a CALL DOLT_PULL(...) arg, so this
-	// fresh connection's default checkout never matters for them. But
-	// federation.go's peer-pull route calls this with no branch arg at all
-	// (CALL DOLT_PULL(?) with only the remote), which merges into whatever
-	// branch the connection defaults to — the same root cause be-b0am fixed
-	// for the recompute paths, on a call site out of that bead's scope
-	// (needs its own regression test). Tracked as be-5ybd.
+	// Audited for be-b0am's fresh-connection branch hazard: NOT safe, and all
+	// three callers share it. Passing a branch argument does not avoid it.
+	//
+	// DOLT_PULL's second positional arg names the remote ref to merge FROM
+	// (dolt's doDoltPull binds it to remoteRefName); the merge TARGET is
+	// always the session's current working branch (CWBHeadRef), which on this
+	// fresh openLongTimeoutConn connection is the database's default branch,
+	// never s.branch. So store.go's two callers, which pass s.branch to
+	// CALL DOLT_PULL(...), pin only the source and still merge into the
+	// default branch; federation.go's peer-pull route (CALL DOLT_PULL(?),
+	// remote only) derives both source and target from that same default
+	// branch. The GH#3144 fallback below has the same shape — DOLT_FETCH
+	// names the remote ref, but CALL DOLT_MERGE(trackingRef) merges into the
+	// current branch too.
+	//
+	// Left unfixed here deliberately: this is be-b0am's root cause on a
+	// pull/merge path, and a merge landing on the wrong branch has a much
+	// larger blast radius than a stale is_blocked flag, so it needs its own
+	// regression test asserting the merge target rather than riding an
+	// unrelated TDD cycle. Tracked as be-5ybd, which covers all three call
+	// sites. The fix is s.pinStoreBranch(ctx, db) before BeginTx below.
 	db, err := s.openLongTimeoutConn()
 	if err != nil {
 		return err

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1046,6 +1046,21 @@ type execer interface {
 // read or write runs on it. Every caller that opens its own connection
 // instead of using the shared pool (s.db) must call this before issuing any
 // branch-sensitive query — see openLongTimeoutConn's callers.
+//
+// Caveat: the SELECT active_branch() read below is only well-defined when the
+// pool behind s.db is effectively single-connection. Checkout() leases one
+// connection from that pool (s.db.Conn), runs DOLT_CHECKOUT on it and returns
+// it — the branch stays with that physical connection, because checkout is
+// per-connection session state. The pool defaults to defaultMaxOpenConns (10,
+// overridable by BEADS_DOLT_MAX_CONNS or dolt.max-conns), so on a genuinely
+// multi-connection pool this read may be served by a sibling connection that
+// never saw that checkout and still reports the branch it was opened with.
+// The paths that rely on this pin run effectively single-connection —
+// server-mode stores are pinned to MaxOpenConns=1 precisely because branch
+// isolation is session-level (see iter_issues.go) — so the read is reliable
+// in practice rather than by construction. The s.branch fallback does not
+// close the gap either: it fires only when the query errors, not when it
+// succeeds with another connection's answer.
 func (s *DoltStore) pinStoreBranch(ctx context.Context, conn execer) error {
 	var branch string
 	if scanErr := s.db.QueryRowContext(ctx, "SELECT active_branch()").Scan(&branch); scanErr == nil {

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1027,6 +1027,43 @@ func (s *DoltStore) withReadTx(ctx context.Context, fn func(tx *sql.Tx) error) e
 	})
 }
 
+// execer is satisfied by both *sql.DB and *sql.Conn, letting pinStoreBranch
+// share one implementation between withReadTxLongTimeout's one-shot *sql.DB
+// and a single pinned *sql.Conn (see recomputeAllBlocked/recomputeBlockedTx).
+type execer interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
+
+// pinStoreBranch reproduces the store's real active branch on conn. Branch
+// checkout is Dolt session state, scoped to one physical connection — a
+// fresh connection (from openLongTimeoutConn or db.Conn) defaults to the
+// database's default branch rather than inheriting whatever branch the
+// store's pooled session (s.db) is actually checked out to. Query s.db for
+// its live active_branch() (preferred over the possibly-stale s.branch
+// field, which is only ever set inside Checkout() and left behind by any
+// checkout run directly against s.db, e.g. the test harness's
+// per-test-branch isolation) and reproduce that checkout on conn before any
+// read or write runs on it. Every caller that opens its own connection
+// instead of using the shared pool (s.db) must call this before issuing any
+// branch-sensitive query — see openLongTimeoutConn's callers.
+func (s *DoltStore) pinStoreBranch(ctx context.Context, conn execer) error {
+	var branch string
+	if scanErr := s.db.QueryRowContext(ctx, "SELECT active_branch()").Scan(&branch); scanErr == nil {
+		if branch != "" {
+			if _, err := conn.ExecContext(ctx, "CALL DOLT_CHECKOUT(?)", branch); err != nil {
+				return fmt.Errorf("checkout active branch %q: %w", branch, err)
+			}
+		}
+	} else if s.branch != "" {
+		// Fall back to the store's recorded branch rather than failing the
+		// whole call outright.
+		if _, err := conn.ExecContext(ctx, "CALL DOLT_CHECKOUT(?)", s.branch); err != nil {
+			return fmt.Errorf("checkout fallback branch %q: %w", s.branch, err)
+		}
+	}
+	return nil
+}
+
 // withReadTxLongTimeout is like withReadTx but runs fn against a dedicated
 // one-shot connection with a 5-minute read timeout (see openLongTimeoutConn)
 // instead of the shared pool's 10s ReadTimeout (see buildServerDSN). Use for
@@ -1053,26 +1090,9 @@ func (s *DoltStore) withReadTxLongTimeout(ctx context.Context, fn func(tx *sql.T
 		defer db.Close()
 		// The fresh one-shot connection defaults to the default branch, not
 		// whatever branch the store's pooled session (s.db) is actually
-		// checked out to. The pool is branch-isolated (MaxOpenConns(1)
-		// semantics — see the comment on MaxOpenConns above), so ask it for
-		// its real active branch and reproduce that checkout here before
-		// starting the read tx; otherwise a query like dolt_history_* would
-		// silently read the wrong branch after any in-process checkout,
-		// including a test-harness CALL DOLT_CHECKOUT run directly against
-		// s.db, which bypasses Store.Checkout and leaves s.branch stale.
-		var branch string
-		if scanErr := s.db.QueryRowContext(ctx, "SELECT active_branch()").Scan(&branch); scanErr == nil {
-			if branch != "" {
-				if _, err := db.ExecContext(ctx, "CALL DOLT_CHECKOUT(?)", branch); err != nil {
-					return fmt.Errorf("checkout active branch %q on long-timeout connection: %w", branch, err)
-				}
-			}
-		} else if s.branch != "" {
-			// Fall back to the store's recorded branch rather than failing
-			// the whole call outright.
-			if _, err := db.ExecContext(ctx, "CALL DOLT_CHECKOUT(?)", s.branch); err != nil {
-				return fmt.Errorf("checkout fallback branch %q on long-timeout connection: %w", s.branch, err)
-			}
+		// checked out to — reproduce it before starting the read tx.
+		if err := s.pinStoreBranch(ctx, db); err != nil {
+			return err
 		}
 		tx, err := db.BeginTx(ctx, nil)
 		if err != nil {
@@ -2164,6 +2184,11 @@ func buildServerDSN(cfg *Config, database string) string {
 // DOLT_PULL merge operations succeed even when the server runs with
 // autocommit=1. Without this, Dolt rejects merges under autocommit because
 // it cannot expose conflict-resolution tables to the caller.
+//
+// Audited for be-b0am's fresh-connection branch hazard: safe. Every caller
+// (DOLT_PUSH, DOLT_FETCH) passes its target branch/ref explicitly as a query
+// arg rather than relying on the connection's implicit active_branch(), so
+// this fresh connection's default checkout never matters.
 func (s *DoltStore) execWithLongTimeout(ctx context.Context, query string, args ...any) error {
 	cfg, err := mysql.ParseDSN(s.connStr)
 	if err != nil {
@@ -2191,6 +2216,10 @@ func (s *DoltStore) execWithLongTimeout(ctx context.Context, query string, args 
 // an explicit transaction. Push operations do not need the pull/merge conflict
 // handling above, and DOLT_PUSH has diverged from direct `dolt push` behavior
 // when wrapped in a SQL transaction.
+//
+// Audited for be-b0am's fresh-connection branch hazard: safe. Every caller
+// passes s.branch explicitly as a CALL DOLT_PUSH(...) arg, so this fresh
+// connection's default checkout never matters.
 func (s *DoltStore) execWithLongTimeoutNoTx(ctx context.Context, query string, args ...any) error {
 	db, err := s.oneShotConn(5 * time.Minute)
 	if err != nil {
@@ -3955,6 +3984,14 @@ func (s *DoltStore) pullWithAutoResolve(ctx context.Context, remote string, quer
 }
 
 func (s *DoltStore) pullWithAutoResolveUnchecked(ctx context.Context, remote string, query string, args ...any) error {
+	// Audited for be-b0am's fresh-connection branch hazard: store.go's two
+	// callers pass s.branch explicitly as a CALL DOLT_PULL(...) arg, so this
+	// fresh connection's default checkout never matters for them. But
+	// federation.go's peer-pull route calls this with no branch arg at all
+	// (CALL DOLT_PULL(?) with only the remote), which merges into whatever
+	// branch the connection defaults to — the same root cause be-b0am fixed
+	// for the recompute paths, on a call site out of that bead's scope
+	// (needs its own regression test). Tracked as be-5ybd.
 	db, err := s.openLongTimeoutConn()
 	if err != nil {
 		return err
@@ -4137,10 +4174,34 @@ func (s *DoltStore) recomputeAllBlocked(ctx context.Context) (int, error) {
 		return 0, err
 	}
 	defer db.Close()
-	return s.recomputeAllBlockedWithDB(ctx, db)
+	// Pin a single physical connection for the whole operation (same
+	// pattern as federation.go's filteredPushToPeer — branch state is
+	// connection-scoped, so BeginTx must run on the exact connection that
+	// was just checked out, not whatever the pool hands out next) and
+	// reproduce the store's real active branch on it before the recompute
+	// reads or writes anything; otherwise this fresh connection defaults to
+	// Dolt's default branch instead of whatever the store is actually
+	// checked out to (be-b0am).
+	db.SetMaxIdleConns(0)
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("acquire long-timeout connection: %w", err)
+	}
+	defer conn.Close()
+	if err := s.pinStoreBranch(ctx, conn); err != nil {
+		return 0, err
+	}
+	return s.recomputeAllBlockedWithDB(ctx, conn)
 }
 
-func (s *DoltStore) recomputeAllBlockedWithDB(ctx context.Context, db *sql.DB) (int, error) {
+// txBeginner is satisfied by both *sql.DB and *sql.Conn, letting
+// recomputeAllBlockedWithDB run either against a caller-owned pinned
+// *sql.Conn (recomputeAllBlocked) or directly against a *sql.DB (tests).
+type txBeginner interface {
+	BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)
+}
+
+func (s *DoltStore) recomputeAllBlockedWithDB(ctx context.Context, db txBeginner) (int, error) {
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return 0, fmt.Errorf("begin is_blocked recompute: %w", err)
@@ -4192,10 +4253,22 @@ func (s *DoltStore) recomputeBlockedTx(ctx context.Context, fromCommit string) e
 		return err
 	}
 	defer db.Close()
-	return s.recomputeBlockedTxWithDB(ctx, db, fromCommit)
+	// See recomputeAllBlocked: pin a single physical connection and
+	// reproduce the store's real active branch on it before the recompute
+	// runs (be-b0am).
+	db.SetMaxIdleConns(0)
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("acquire long-timeout connection: %w", err)
+	}
+	defer conn.Close()
+	if err := s.pinStoreBranch(ctx, conn); err != nil {
+		return err
+	}
+	return s.recomputeBlockedTxWithDB(ctx, conn, fromCommit)
 }
 
-func (s *DoltStore) recomputeBlockedTxWithDB(ctx context.Context, db *sql.DB, fromCommit string) error {
+func (s *DoltStore) recomputeBlockedTxWithDB(ctx context.Context, db txBeginner, fromCommit string) error {
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin is_blocked recompute: %w", err)

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -2185,10 +2185,14 @@ func buildServerDSN(cfg *Config, database string) string {
 // autocommit=1. Without this, Dolt rejects merges under autocommit because
 // it cannot expose conflict-resolution tables to the caller.
 //
-// Audited for be-b0am's fresh-connection branch hazard: safe. Every caller
-// (DOLT_PUSH, DOLT_FETCH) passes its target branch/ref explicitly as a query
-// arg rather than relying on the connection's implicit active_branch(), so
-// this fresh connection's default checkout never matters.
+// Audited for be-b0am's fresh-connection branch hazard: safe — but the two
+// callers are safe for different reasons, so the annotation names both.
+// federation.go's CALL DOLT_PUSH(?, ?) names the refspec explicitly. Its
+// CALL DOLT_FETCH(?) passes only the remote: with no refspec argument dolt
+// falls back to the remote's configured refspecs (ParseRefSpecs ->
+// GetRefSpecs), which are remote config rather than session state, and a
+// fetch writes only remote-tracking refs, never the working branch. Neither
+// depends on this fresh connection's default checkout.
 func (s *DoltStore) execWithLongTimeout(ctx context.Context, query string, args ...any) error {
 	cfg, err := mysql.ParseDSN(s.connStr)
 	if err != nil {

--- a/internal/storage/dolt/store_branch_pin_test.go
+++ b/internal/storage/dolt/store_branch_pin_test.go
@@ -1,0 +1,60 @@
+package dolt
+
+import (
+	"testing"
+)
+
+// TestPinStoreBranch_ReproducesStoreActiveBranch is the be-b0am regression
+// test: pinStoreBranch is the single implementation withReadTxLongTimeout,
+// recomputeAllBlocked, and recomputeBlockedTx all depend on to avoid running
+// on a fresh connection's default branch instead of the store's real branch.
+// Branch checkout is connection-scoped session state in Dolt, so a fresh
+// *sql.DB from openLongTimeoutConn defaults away from whatever the pooled
+// store connection (s.db) is actually checked out to — this is exactly the
+// production bug reported against recomputeAllBlocked/recomputeBlockedTx.
+//
+// This asserts the invariant directly on the connection's active_branch(),
+// not on a downstream symptom (row counts, commit contents). A symptom-only
+// test would pass again the moment someone reintroduces the split with
+// different pool timing — see federation.go's SetMaxIdleConns(0)+Conn(ctx)
+// pattern for why that hazard is not hypothetical.
+func TestPinStoreBranch_ReproducesStoreActiveBranch(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	var storeBranch string
+	if err := store.db.QueryRowContext(ctx, "SELECT active_branch()").Scan(&storeBranch); err != nil {
+		t.Fatalf("query store active_branch: %v", err)
+	}
+	if storeBranch == "" || storeBranch == "main" {
+		t.Fatalf("precondition: setupTestStore must isolate the pooled connection onto a non-default branch, got %q", storeBranch)
+	}
+
+	db, err := store.openLongTimeoutConn()
+	if err != nil {
+		t.Fatalf("openLongTimeoutConn: %v", err)
+	}
+	defer db.Close()
+
+	var freshBranch string
+	if err := db.QueryRowContext(ctx, "SELECT active_branch()").Scan(&freshBranch); err != nil {
+		t.Fatalf("query fresh connection active_branch: %v", err)
+	}
+	if freshBranch == storeBranch {
+		t.Fatalf("precondition: a brand-new connection must NOT already report the store's branch (got %q) — otherwise this test cannot distinguish a pinned connection from an accidentally-matching default", storeBranch)
+	}
+
+	if err := store.pinStoreBranch(ctx, db); err != nil {
+		t.Fatalf("pinStoreBranch: %v", err)
+	}
+
+	var pinnedBranch string
+	if err := db.QueryRowContext(ctx, "SELECT active_branch()").Scan(&pinnedBranch); err != nil {
+		t.Fatalf("query pinned connection active_branch: %v", err)
+	}
+	if pinnedBranch != storeBranch {
+		t.Fatalf("connection must report the store's active branch %q after pinStoreBranch, got %q", storeBranch, pinnedBranch)
+	}
+}

--- a/release-gates/be-a8g61-recompute-branch-pin-gate.md
+++ b/release-gates/be-a8g61-recompute-branch-pin-gate.md
@@ -1,0 +1,48 @@
+# Release Gate: be-a8g61 — recomputeAllBlocked/recomputeBlockedTx repaired the wrong branch on a fresh connection
+
+- **Deploy bead:** be-a8g61
+- **Review bead:** be-ahog (closed, verdict: pass)
+- **Build bead:** be-b0am
+- **Repo:** gastownhall/beads
+- **Deploy commit:** `929a5c347e2a730835bfb790e00f151f2a81b0dd`
+- **Deploy branch:** `deploy/be-a8g61-gate` (cut from the commit above, pushed to `headfork` = quad341/beads-sec003-contrib)
+- **Base:** origin/main @ `ed382cbdb89cf7ba42b020e4927575dbf27e102e`
+
+## Pre-flight: already-merged check
+
+`gh api repos/gastownhall/beads/commits/929a5c347.../pulls` — no PR references this commit. Clean.
+
+## Ancestry scope (assert_deploy_ancestry_scope)
+
+Base→deploy range: 2 commits, both cite be-b0am, neither touches `.claude/**`. rc=0.
+
+## Gate criteria
+
+1. **Review PASS present** — PASS. be-ahog status=closed, close_reason=pass, verdict:pass in notes; deploy_bead/deploy_commit metadata match be-a8g61 exactly.
+2. **Acceptance criteria met** — PASS. All 6 of be-b0am's Done-when items individually cross-checked by the reviewer against the diff; no uncovered criteria recorded.
+3. **Tests pass** — PASS. Reviewer's documented command, independently re-run by me on a detached checkout of the reviewed SHA (fresh testcontainers lifecycle, distinct container/session id from the reviewer's run):
+
+   ```
+   DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true \
+   go test -tags=integration,gms_pure_go -run '^(TestMergeRecomputesIsBlocked|TestRecomputeAllBlocked_RefusesDirtyIssues|TestRecomputeAllBlocked_RefusesDirtyDependencies|TestRecomputeAllBlocked_AllowsDirtyWisps|TestRecomputeAllBlocked_RepairsAndCommitsWhenClean|TestPinStoreBranch_ReproducesStoreActiveBranch)$' \
+   -v ./internal/storage/dolt/...
+   ```
+   Result: 6 PASS, 0 FAIL, 0 SKIP in 18.919s. Diff-owned test (`TestPinStoreBranch_ReproducesStoreActiveBranch`, the only test file touched by this diff) confirmed genuinely red pre-fix (compile-red) by the reviewer. `waiver_ref: none`.
+3a. **Pre-existing-failure attribution** — N/A for the test lane (no failures to attribute); used for 3b below.
+3b. **Policy/lint lane** — PASS, with one attributed pre-existing failure.
+    - `make ci-pr-policy` on the reviewed SHA as checked out initially failed:
+      `.githooks/commit-msg: no 'BEGIN/END BEADS INTEGRATION' marker found` + a resulting version-mismatch report from `scripts/check-versions.sh`.
+    - Attribution, all 4 clauses of `non-diff-owned-gate-failure`:
+      - *Not diff-owned*: `git diff --name-only origin/main...929a5c347e2a730835bfb790e00f151f2a81b0dd -- .githooks/` is empty — the diff never touches this path.
+      - *No path overlap*: `.githooks/` vs. the diff's `internal/storage/dolt/**` — disjoint.
+      - *Tracked bead id*: be-jygq (closed) root-caused this: `.githooks/commit-msg` is not tracked in git anywhere (`git log --all -- .githooks/commit-msg` and `git ls-tree origin/main -- .githooks/commit-msg` both empty) and is listed in this worktree's `.git/info/exclude`. It is a local gc-rig session shim rewritten by `worktree-setup.sh` on every session start; `scripts/check-versions.sh` globs `.githooks/*` on the raw filesystem rather than via `git ls-tree`, so it only surfaces inside a gc-managed worktree. Independently re-confirmed this round (`git log --all` / `git ls-tree` / `.git/info/exclude` all checked directly, not just cited from the bead). be-2q84 (open) and be-jy56 (open) are later duplicate filings of the same symptom that predate/don't incorporate be-jygq's correction.
+      - *Proven pre-existing at BASE_REF*: stronger than the usual case — this artifact isn't part of any commit's tree at all, so it reproduces identically regardless of which SHA is checked out in a gc-managed worktree. Verified directly: moved the untracked shim aside (reversible; git-ignored, so this is not a working-tree mutation of anything tracked) and re-ran `make ci-pr-policy` end-to-end — exit 0, every one of the 10 sub-checks (build-tag policy, go-install guidance, version consistency, docs binary build, doc-flags, doc-freshness, testing.Short boundaries, workapi frontend boundary, no-beads-jsonl-changes, openapi spec gate) passed cleanly. Shim restored immediately after.
+    - `BD_LINT_NEW_FROM_MERGE_BASE=origin/main make ci-pr-lint`: gofmt clean, golangci-lint 0 issues, golangci-lint (windows) 0 issues.
+4. **No open HIGH findings** — PASS. be-ahog's security_findings and style_findings are both "none" — zero findings of any severity, not just zero HIGH.
+5. **Clean working tree** — PASS. `git status --porcelain=v1` on the deploy branch shows only pre-existing, already-triaged harmless untracked leftovers from unrelated closed beads (release-gates/be-hi97, be-k9js, be-uoat gate files; scripts/rebase-resolve-lib.sh — see memory `deployer-worktree-stray-rebase-lib-copy`), none of which this deploy branch's commits touch.
+6. **Clean divergence from base** (checked first) — PASS. `git log origin/main..929a5c347e2a730835bfb790e00f151f2a81b0dd --oneline`: exactly 2 commits. `git log 929a5c347e2a730835bfb790e00f151f2a81b0dd..origin/main --oneline`: 0 commits. origin/main is a direct ancestor; clean fast-forward extension, no rebase needed.
+7. **Single-feature theme** — PASS. Two commits (red test, green fix), two files (`internal/storage/dolt/federation.go` +7, `internal/storage/dolt/store.go` +104/-24), one coherent fix: a `pinStoreBranch` helper shared by `recomputeAllBlocked`/`recomputeBlockedTx`/the original caller, so all three reproduce the store's actual branch checkout instead of silently repairing whichever branch a fresh connection happens to default to. The build bead audited other fresh-connection call sites, found one further latent hazard (`pullWithAutoResolveUnchecked`, federation.go:126), and correctly deferred it to its own bead (be-5ybd) rather than bundling it in.
+
+## Result: PASS
+
+Merge authority: gastownhall/beads is a contributor-only repo (we do not maintain it). Deployer's job ends at the opened PR; no merge-request routed to mayor. Upstream maintainers own the merge.


### PR DESCRIPTION
## What changed

`recomputeAllBlocked` and `recomputeBlockedTx` opened a fresh database
connection to repair blocked-issue state, but a fresh connection defaults to
Dolt's HEAD branch rather than reproducing whichever branch the calling
store actually had checked out. On a store pinned to a non-default branch,
this silently repaired the wrong branch instead of the one the caller was
working on.

The fix factors the existing branch-reproduction logic (already used by a
read-transaction helper) into a shared `pinStoreBranch` helper, and applies
it at both recompute call sites plus the original caller. All three now
reproduce the store's real active branch before doing any repair work.

## Why

Silently repairing the wrong branch corrupts blocked-issue state on a branch
nobody asked to touch, while leaving the intended branch's state stale.
That's a data-correctness bug, not a cosmetic one.

## Audit of the other fresh-connection call sites

Every other `openLongTimeoutConn` caller was audited for the same hazard and
annotated in place. **This section was corrected after review** — the original
version of it was wrong, and the wrong version is what the annotations said
too, so both were fixed in `2cd47d7`:

- **`pullWithAutoResolveUnchecked` — NOT safe, and all three of its callers
  share the hazard.** The first draft claimed store.go's two callers were safe
  because they pass `s.branch` to `CALL DOLT_PULL(...)`. That is wrong.
  DOLT_PULL's second positional argument names the remote ref to merge
  **from** (dolt binds it to `remoteRefName`); the merge **target** is always
  the session's current working branch (`CWBHeadRef`) — on this fresh
  connection, the database's default branch. So passing a branch argument pins
  only the source. federation.go's single-argument route derives both source
  and target from that same default branch, and the GH#3144
  `DOLT_FETCH`+`DOLT_MERGE(trackingRef)` fallback merges into it as well.
  Left unfixed here deliberately: a merge landing on the wrong branch has a
  much larger blast radius than a stale `is_blocked` flag and needs its own
  regression test asserting the merge target, rather than riding this bead's
  TDD cycle. Tracked as **be-5ybd**, which has been widened from
  federation-only to all three call sites and corrected to record
  `pinStoreBranch` before `BeginTx` as the actual fix.

- **`execWithLongTimeout` — safe, for two different reasons** (`b5b209e`).
  federation.go's `CALL DOLT_PUSH(?, ?)` names the refspec explicitly. Its
  `CALL DOLT_FETCH(?)` passes only the remote, so it has no ref argument to
  point at — but with no refspec argument dolt resolves the remote's
  configured fetch specs (`ParseRefSpecs` falls through to `GetRefSpecs`,
  reading `remote.FetchSpecs`), which is remote config rather than session
  state, and the resulting refspecs write remote-tracking refs only, never the
  working branch.

- **`filteredPushToPeer` — safe.** It creates its staging branch explicitly
  `FROM` the source branch and checks it out by name, so the source ref is
  named rather than inherited.

## What to review

- `internal/storage/dolt/store.go`: the new `pinStoreBranch` helper and its
  three call sites (`recomputeAllBlocked`, `recomputeBlockedTx`, and the
  existing read-transaction path it was factored out of).
- `internal/storage/dolt/federation.go`: **comment-only** — 7 lines of audit
  annotation recording why `filteredPushToPeer`'s fresh connection is safe.
  (An earlier version of this section described it as a call site needing an
  interface change to keep compiling. That was stale draft language: the
  `txBeginner` interface change did not reach this file.)
- Whether `txBeginner` (satisfied by both `*sql.DB` and `*sql.Conn`) is the
  right minimal interface for the two recompute entry points, or whether a
  narrower one would do.
- `86d04ca` documents a known limitation rather than fixing it:
  `pinStoreBranch` reads the store's live branch with `SELECT active_branch()`
  on the pooled `s.db`, which is only well-defined when that pool is
  effectively single-connection. Worth a look at whether documenting it is the
  right call here — see the commit message for why fixing it properly belongs
  with be-5ybd.

## Test plan

New regression test `TestPinStoreBranch_ReproducesStoreActiveBranch`
(reproduces the bug on a fresh connection pinned to a non-default branch;
red before the fix). Full targeted suite, run against a fresh testcontainers
Dolt instance:

```
go test -tags=integration,gms_pure_go -run '^(TestMergeRecomputesIsBlocked|TestRecomputeAllBlocked_RefusesDirtyIssues|TestRecomputeAllBlocked_RefusesDirtyDependencies|TestRecomputeAllBlocked_AllowsDirtyWisps|TestRecomputeAllBlocked_RepairsAndCommitsWhenClean|TestPinStoreBranch_ReproducesStoreActiveBranch)$' -v ./internal/storage/dolt/...
```

6/6 passing. `make ci-pr-policy` and `make ci-pr-lint` both clean on this
branch.

Review additionally established stronger evidence than this section originally
claimed: the **pre-existing** `TestRecomputeAllBlocked_RepairsAndCommitsWhenClean`
is RED at main under a real Dolt server ("want 1 row repaired, got 0") and
green with this diff — so the change is behaviourally red-before/green-after,
not merely compile-red. That failure was independently observed against main
back on 2026-08-07 and recorded in bd-7xtsq, which asked whether it was
env-specific or a real main red masked by CI; it was a real main red, and
bd-7xtsq has been updated with the answer.

The reason it stayed hidden is filed separately as **be-erbgk**: a server-mode
test in `internal/storage/dolt` runs in CI only if it is named
`TestConformance`. Every general integration lane sets `BEADS_TEST_SKIP=dolt`,
and the one real-server lane (`test-server-storage` in `pr-risk.yml`) filters
to `-test.run '^TestConformance$'`. That also means the new guard added here
will land green and then never be executed by CI again until be-erbgk is
resolved.
