### PR TITLE
docs(cli): describe embedded mode in bd dolt help

### DIFF
--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -34,17 +34,21 @@ var doltCmd = &cobra.Command{
 	Short:   "Configure Dolt database settings",
 	Long: `Configure and manage Dolt database settings and server lifecycle.
 
-Beads uses a dolt sql-server for all database operations. The server is
-auto-started transparently when needed. Use these commands for explicit
-control or diagnostics.
+Beads runs Dolt embedded (in-process) by default: there is no sql-server and
+nothing is auto-started. A database only uses a dolt sql-server when it is
+configured for one: shared-server mode, an explicit server mode, or a
+non-localhost dolt_server_host. The server-only commands below fail with
+"not supported in embedded mode (no Dolt server)" on an embedded database.
 
-Server lifecycle:
+Server lifecycle (server mode only):
   bd dolt start        Start the Dolt server for this project
   bd dolt stop         Stop the Dolt server for this project
-  bd dolt status       Show Dolt server status
 
-Configuration:
+Diagnostics (both modes):
+  bd dolt status       Show Dolt engine status (embedded: in-process, data dir)
   bd dolt show         Show current Dolt configuration with connection test
+
+Configuration (server mode only):
   bd dolt set <k> <v>  Set a configuration value
   bd dolt test         Test server connection
 

--- a/cmd/bd/dolt_help_auth_test.go
+++ b/cmd/bd/dolt_help_auth_test.go
@@ -22,3 +22,20 @@ func TestDoltHelpMentionsRemoteAuth(t *testing.T) {
 		t.Error("dolt set help should explain why password is not a set key")
 	}
 }
+
+// GH#5741: the default is embedded Dolt, so the help must not describe a
+// sql-server as the architecture every database uses, and must scope the
+// server-only subcommands.
+func TestDoltHelpDescribesEmbeddedDefault(t *testing.T) {
+	if strings.Contains(doltCmd.Long, "Beads uses a dolt sql-server for all database operations") {
+		t.Error("dolt help still describes a sql-server as the architecture for all databases")
+	}
+	for _, needle := range []string{
+		"embedded (in-process) by default",
+		"server mode only",
+	} {
+		if !strings.Contains(doltCmd.Long, needle) {
+			t.Errorf("dolt help missing %q", needle)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #5741.

## What

Rewrites the architecture paragraph in `bd dolt --help` so it describes embedded Dolt, which is the default, and marks the server-only subcommands as server-only. Help text plus one test. No behavior change.

## Why

The current help opens with:

```
Beads uses a dolt sql-server for all database operations. The server is
auto-started transparently when needed. Use these commands for explicit
control or diagnostics.
```

In embedded mode none of that is true. `usesSQLServer()` in `cmd/bd/store_factory.go` returns false unless the workspace is configured for a server (shared-server mode, an explicit server mode, or a non-localhost `dolt_server_host`), and `bd dolt set`, `test`, `start`, `stop`, `killall` and `clean-databases` all bail with `not supported in embedded mode (no Dolt server)`.

The cost is not cosmetic. The help sends users and agents after a server that cannot exist, usually via `bd dolt start`/`stop`/`status`, which is a dead end on the default configuration. It also lists all three lifecycle commands together as though they behave alike, when `bd dolt status` in fact works in both modes and already reports the in-process engine and its data directory.

The new text states the embedded default, names what puts a database into server mode, quotes the error the server-only commands actually return, and splits the command list into server-only and both-modes so the reader can tell which is which.

## Verification

- `./scripts/test.sh -run '^TestDoltHelp' ./cmd/bd/...` and the full `./scripts/test.sh ./cmd/bd/...`: pass.
- Red/green on the new test: with the `dolt.go` hunk reverted and the test kept, `TestDoltHelpDescribesEmbeddedDefault` fails on all three assertions.
- `make build`, then `bd dolt --help` by hand to read the rendered text.
- `./scripts/check-cli-docs-drift.sh --base main`: `PASS: generated CLI docs are fresh`. `docs/CLI_REFERENCE.md` and `docs/cli-reference/dolt.md` still carry the old paragraph on purpose. They build from the tag in `docs/cli-docs.pin` (currently `v1.2.2`), not from HEAD, so hand-editing them here would create drift rather than fix it.

The test goes next to the existing `TestDoltHelpMentionsRemoteAuth` (GH#5011) and follows its shape: it asserts the false claim is gone and that the embedded default and the server-only scoping are present, so a future edit that quietly restores the old architecture text fails.

One note on the local lint gate: `make ci-pr-lint` reports 2 gosec findings for me, in `internal/config/permissions_open_nonlinux.go` (G304) and `internal/utils/path_case_darwin.go` (G103). Both reproduce identically with this change stashed, and both sit in darwin/non-linux build-constrained files that CI's Linux runners do not lint. Neither file is touched here.
