### PR TITLE
test(dolt): green — five dolt tests fail on stale test scaffolding, not product defects (be-s8zbv, build be-s7dh)

### DIFF
--- a/internal/storage/dolt/federation_test.go
+++ b/internal/storage/dolt/federation_test.go
@@ -433,8 +433,20 @@ func TestFederationSyncCommitsPendingPeerMetadataBeforeFetch(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected sync to fail for nonexistent file remote")
 	}
-	if federationStatusHasTable(t, ctx, store, "federation_peers") {
-		t.Fatal("sync should commit pending federation_peers metadata before fetch/merge")
+
+	// Sync's own post-fetch bookkeeping (e.g. last-sync metadata) can leave
+	// federation_peers dirty again after the fetch fails, so checking
+	// dolt_status here would be a false signal either way. Instead read the
+	// pre-existing pending write straight from HEAD: it must have been
+	// committed before fetch/merge ran, regardless of what Sync dirties after.
+	var sovereignty string
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT sovereignty FROM federation_peers AS OF 'HEAD' WHERE name = ?", peer.Name,
+	).Scan(&sovereignty); err != nil {
+		t.Fatalf("query federation_peers AS OF HEAD: %v", err)
+	}
+	if sovereignty != "T3" {
+		t.Fatalf("federation_peers.sovereignty AS OF HEAD = %q, want T3 (pending metadata should be committed before fetch/merge)", sovereignty)
 	}
 }
 

--- a/internal/storage/dolt/lease_test.go
+++ b/internal/storage/dolt/lease_test.go
@@ -345,7 +345,14 @@ func TestReclaimRevertsExpiredOnly(t *testing.T) {
 	seedClaimedIssue(t, ctx, store, "lease-dead", "dead-worker", time.Second)
 	seedClaimedIssue(t, ctx, store, "lease-live", "live-worker", time.Hour)
 
-	time.Sleep(1500 * time.Millisecond) // let dead's lease expire
+	// Force "dead"'s lease into the past directly rather than sleeping for it
+	// to expire: lease_expires_at is DATETIME(0) (second resolution, rounds
+	// up), so a short sleep is not a deterministic way to cross the boundary.
+	if _, err := store.db.ExecContext(ctx,
+		"UPDATE leases SET lease_expires_at = ? WHERE issue_id = ?",
+		time.Now().UTC().Add(-10*time.Second), "lease-dead"); err != nil {
+		t.Fatalf("force lease-dead expiry: %v", err)
+	}
 
 	// Grace window larger than how long the lease has been expired: nothing yet.
 	reclaimed, err := store.ReclaimExpiredLeases(ctx, time.Hour, types.ReclaimFilter{}, "reaper")

--- a/internal/storage/dolt/queries_test.go
+++ b/internal/storage/dolt/queries_test.go
@@ -37,6 +37,10 @@ func TestRigIssueIsPersistentButHiddenFromReady(t *testing.T) {
 	ctx, cancel := testContext(t)
 	defer cancel()
 
+	if err := store.SetConfig(ctx, "types.custom", "rig"); err != nil {
+		t.Fatalf("SetConfig types.custom: %v", err)
+	}
+
 	rig := &types.Issue{
 		ID:        "rw-rig-durable",
 		Title:     "Rig identity",

--- a/internal/storage/dolt/schema_migration_dirty_test.go
+++ b/internal/storage/dolt/schema_migration_dirty_test.go
@@ -294,7 +294,8 @@ func TestSchemaMigrationRejectsChangedPreExistingDirtyTable(t *testing.T) {
 		t.Fatalf("commit cleared custom_statuses: %v", err)
 	}
 
-	// Leave an UNCOMMITTED user write on custom_statuses: the pass's backfill
+	// Seed and commit a scratch row so the table has pre-existing committed
+	// content, then dirty it with an UNCOMMITTED delete: the pass's backfill
 	// (re-inserting 'review' from config) then changes a pre-existing dirty
 	// table mid-pass, which the changed-signature guard must reject.
 	// (Historically this test dirtied dolt_ignore and relied on the pass's
@@ -303,6 +304,12 @@ func TestSchemaMigrationRejectsChangedPreExistingDirtyTable(t *testing.T) {
 	if _, err := store.db.ExecContext(ctx,
 		"INSERT INTO custom_statuses (name, category) VALUES ('scratch', 'wip')",
 	); err != nil {
+		t.Fatalf("seed scratch custom_statuses: %v", err)
+	}
+	if err := store.doltAddAndCommit(ctx, []string{"custom_statuses"}, "test: seed scratch custom status"); err != nil {
+		t.Fatalf("commit scratch custom_statuses: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, "DELETE FROM custom_statuses"); err != nil {
 		t.Fatalf("dirty custom_statuses: %v", err)
 	}
 

--- a/internal/storage/dolt/schema_version_test.go
+++ b/internal/storage/dolt/schema_version_test.go
@@ -253,7 +253,7 @@ func TestMigration0053RepairsIssuesMissingRigColumns(t *testing.T) {
 		t.Fatalf("commit legacy fixture: %v", err)
 	}
 
-	if _, err := store.db.ExecContext(ctx, "DELETE FROM schema_migrations WHERE version = ?", schema.LatestVersion()); err != nil {
+	if _, err := store.db.ExecContext(ctx, "DELETE FROM schema_migrations WHERE version >= ?", rigRepairVersion); err != nil {
 		t.Fatalf("mark 0053 pending: %v", err)
 	}
 	if _, err := schema.MigrateUp(ctx, store.db); err != nil {
@@ -270,6 +270,9 @@ func TestMigration0053RepairsIssuesMissingRigColumns(t *testing.T) {
 		t.Fatalf("promoted rig issue rows = %d, want 1 with rig columns restored and copied", promoted)
 	}
 }
+
+// rigRepairVersion is the 0053 rig-columns repair migration under test above.
+const rigRepairVersion = 53
 
 // orphanCleanupIgnoredVersion is migrations/ignored/0011_cleanup_orphaned_
 // child_counters.up.sql — the migration under test below.


### PR DESCRIPTION
## Summary

Fixes five Dolt tests (`internal/storage/dolt`) that fail — or pass only by
timing luck — due to stale test scaffolding, not product defects. Each of the
five was root-caused against a live Dolt container and confirmed to be a
test-side issue: a version constant that rotted as migrations were added past
it, a dirtying write that accidentally suppressed the backfill under test, a
sub-second sleep racing a whole-second-resolution DATETIME column, a custom
issue type never registered before use, and an end-state proxy assertion that
broke when an unrelated writer started touching the same table after the
property it names had already been established. All five fixes are confined
to the affected `_test.go` files — `store.go` and `internal/types` are
untouched.

## Beads

- Deploy bead: be-s8zbv
- Review bead: be-rcxeg (beads/reviewer, verdict: pass, round 1)
- Build bead: be-s7dh (closed, shipped), from investigator handoff be-bwk1
  (items 2, 4, 5, 6, 7)

## Release gate — 7/7 PASS

1. Review PASS present — be-rcxeg, verdict: pass (round 1), no security
   findings
2. Build matches spec — diff scope is exactly the 5 `_test.go` files
   be-s7dh's investigator handoff prescribed (38 insertions/5 deletions),
   `store.go` and `internal/types` untouched, each fix matches the
   prescribed approach exactly
3. Tests pass — all 5 diff-owned tests independently reproduced by the
   deployer: 4/5 clean on first run (4.13s-6.05s); `TestReclaimRevertsExpiredOnly`
   failed once with an infra-contention signature (`context deadline
   exceeded` at a suspiciously round 45.00s), then passed 5/5 on an isolated
   `-count=5` re-run (11.56s-18.42s), confirming transient infra flakiness,
   not a regression — consistent with the reviewer's own earlier `-count=5`
   determinism check on the same test
3a. A broader full-package sweep hit shared-box resource contention (multiple
    long-lived Dolt servers plus concurrent unrelated agent load on this
    host) and exceeded the default 25-minute test timeout twice. All 13
    failures it did produce carry the same context-deadline-exceeded infra
    signature at round-number durations, none overlap this diff's own tests,
    and the 2 SKIPs present are pre-existing and unrelated (an opt-in
    upstream-repro test gated on `BEADS_RUN_DOLT_UPSTREAM_REPRO`; a
    Dolt-version-dependent `dolt_conflicts` schema test). Filed separately as
    be-hgw22 to track the shared-host timeout/contention finding itself
3b. Policy gate clean — `ci-pr-policy` and `ci-pr-lint` both pass cleanly,
    re-verified fresh at the current `origin/main` tip
4. No regressions — reviewer's record: no style/security findings;
   deployer's independent re-run corroborates
5. Clean git status at the deploy SHA (modulo pre-existing untracked files
   unrelated to this diff)
6. Diverges cleanly from `origin/main` — branch was re-cut against a newer
   `origin/main` tip after a sibling PR (be-p7dzx) landed mid-evaluation;
   re-verified 0 commits behind / 1 ahead, diff content confirmed
   byte-identical to the original cherry-pick
7. Single feature theme — one test-scaffolding fix, 5 files, all
   `internal/storage/dolt/*_test.go`, 38 insertions / 5 deletions

## Coverage

Automated patch-coverage check reports `internal/storage/dolt` package
coverage at 26.5%, below the usual 50% bar. That figure is whole-package line
coverage, not coverage of the changed lines: this PR touches only test
scaffolding in 5 of the package's `_test.go` files (38 insertions/5
deletions) and adds no new production code paths to cover. The pre-existing
package coverage number is unrelated to this diff.

## Merge authority

This repo is upstream-contributor-only for this rig; the deployer's job ends
at this open PR. Merge authority rests with the repo's own maintainers.
