### PR TITLE
test(cli): cover bd info --json in embedded mode

### DIFF
--- a/cmd/bd/info_embedded_test.go
+++ b/cmd/bd/info_embedded_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -81,9 +82,63 @@ func TestEmbeddedInfo(t *testing.T) {
 		}
 	})
 
-	// Note: --json tests skipped — info's local --json flag shadows the
-	// root persistent flag, causing it to not produce JSON output.
-	// This is an existing bug, not related to embedded mode.
+	// ===== --json =====
+
+	infoJSON := func(t *testing.T, args ...string) map[string]interface{} {
+		t.Helper()
+		out := bdInfo(t, bd, dir, append([]string{"--json"}, args...)...)
+		var got map[string]interface{}
+		if err := json.Unmarshal([]byte(out), &got); err != nil {
+			t.Fatalf("info --json %v did not emit JSON: %v\n%s", args, err, out)
+		}
+		return got
+	}
+
+	t.Run("info_json", func(t *testing.T) {
+		got := infoJSON(t)
+		if got["mode"] != "direct" {
+			t.Errorf("mode = %v, want direct", got["mode"])
+		}
+		if path, ok := got["database_path"].(string); !ok || !strings.Contains(path, ".beads") {
+			t.Errorf("database_path missing or not a .beads path: %v", got["database_path"])
+		}
+		if _, ok := got["issue_count"].(float64); !ok {
+			t.Errorf("issue_count missing or not a number: %v", got["issue_count"])
+		}
+	})
+
+	t.Run("info_schema_json", func(t *testing.T) {
+		got := infoJSON(t, "--schema")
+		schema, ok := got["schema"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("schema block missing: %v", got["schema"])
+		}
+		tables, ok := schema["tables"].([]interface{})
+		if !ok {
+			t.Fatalf("schema tables missing: %v", schema["tables"])
+		}
+		foundIssues := false
+		for _, tbl := range tables {
+			if tbl == "issues" {
+				foundIssues = true
+				break
+			}
+		}
+		if !foundIssues {
+			t.Errorf("expected 'issues' in schema tables: %v", tables)
+		}
+	})
+
+	t.Run("info_whats_new_json", func(t *testing.T) {
+		got := infoJSON(t, "--whats-new")
+		if _, ok := got["current_version"].(string); !ok {
+			t.Errorf("current_version missing or not a string: %v", got["current_version"])
+		}
+		changes, ok := got["recent_changes"].([]interface{})
+		if !ok || len(changes) == 0 {
+			t.Errorf("recent_changes missing or empty: %v", got["recent_changes"])
+		}
+	})
 }
 
 // TestEmbeddedInfoConcurrent exercises info operations concurrently.


### PR DESCRIPTION
## What

Adds `--json`, `--schema --json` and `--whats-new --json` subtests to `TestEmbeddedInfo`, and drops a stale comment saying those variants can't be tested.

## Why

The comment at the end of `TestEmbeddedInfo` said info's local `--json` flag shadowed the root persistent flag so no JSON came out, and skipped every JSON variant on that basis. That local flag registration is gone from `cmd/bd/info.go` and all three paths emit JSON, so the note is wrong and the behavior it describes has no test in embedded mode. Proxied-server mode already covers this end to end in `info_proxied_integration_test.go`; direct mode had nothing.

The new tests assert the output actually parses as JSON rather than just being non-empty, which is the property that matters here. The old failure was silent: the flag was accepted, ignored, and exit 0, so a caller doing `bd info --json | jq` got a parse error that looks like a database problem rather than a flag problem.

Refs #5824, which reported this against v1.2.2. It doesn't reproduce on main.

## Verification

```
BEADS_TEST_EMBEDDED_DOLT=1 ./scripts/test.sh -v -run '^TestEmbeddedInfo$' ./cmd/bd/...
```
All 7 subtests pass.

To confirm the new tests discriminate, add the old registration back to `infoCmd`'s init:
```go
infoCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
```
The three new subtests then fail on plain-text output while the four existing text subtests still pass.

`./scripts/check-cli-docs-drift.sh --base main` passes (no CLI surface touched).

`make ci-pr-lint` reports 2 gosec findings on macOS, in `internal/config/permissions_open_nonlinux.go` and `internal/utils/path_case_darwin.go`. Both are pre-existing and unrelated to this change, confirmed identical with the change stashed. Both files are build-constrained to darwin/non-linux, so CI's Linux runners don't lint them.
