### PR TITLE
fix: TestMain teardown was dead code after os.Exit — 101 dolt containers leaked over 6 days

### DIFF
--- a/beads_test.go
+++ b/beads_test.go
@@ -18,6 +18,13 @@ import (
 var testServerPort int
 
 func TestMain(m *testing.M) {
+	os.Exit(testMainInner(m))
+}
+
+// testMainInner holds TestMain's body so its defers run before the process
+// exits — os.Exit skips deferred calls, so TestMain itself must never defer
+// anything (be-5kkk6).
+func testMainInner(m *testing.M) int {
 	os.Setenv("BEADS_TEST_MODE", "1")
 	// AD-01 (be-c5p): allow root tests to connect to the test container.
 	os.Setenv("BEADS_TEST_SERVER", "1")
@@ -32,7 +39,7 @@ func TestMain(m *testing.M) {
 
 	os.Unsetenv("BEADS_DOLT_PORT")
 	os.Unsetenv("BEADS_TEST_MODE")
-	os.Exit(code)
+	return code
 }
 
 func skipIfNoDolt(t *testing.T) {

--- a/cmd/bd/doctor/fix/testmain_cgo_test.go
+++ b/cmd/bd/doctor/fix/testmain_cgo_test.go
@@ -14,6 +14,13 @@ import (
 // TestMain starts an isolated Dolt server so fix tests don't hit the
 // production server on port 3307.
 func TestMain(m *testing.M) {
+	os.Exit(testMainInner(m))
+}
+
+// testMainInner holds TestMain's body so its defer runs before the process
+// exits — os.Exit skips deferred calls, so TestMain itself must never defer
+// anything (be-5kkk6).
+func testMainInner(m *testing.M) int {
 	os.Setenv("BEADS_TEST_MODE", "1")
 	// AD-01 (be-c5p): allow doctor/fix tests through the dolt.New
 	// database-name firewall when they connect to the spawned test server.
@@ -45,5 +52,5 @@ func TestMain(m *testing.M) {
 	os.Unsetenv("BEADS_DOLT_PORT")
 	os.Unsetenv("BEADS_TEST_MODE")
 	os.Unsetenv("BEADS_TEST_SERVER")
-	os.Exit(code)
+	return code
 }

--- a/release-gates/be-r3ysh-testmain-dead-teardown-gate.md
+++ b/release-gates/be-r3ysh-testmain-dead-teardown-gate.md
@@ -1,0 +1,88 @@
+# Release gate — TestMain teardown was dead code after `os.Exit` (be-r3ysh)
+
+- **Deploy bead:** be-r3ysh (needs-deploy, routed beads/deployer)
+- **Build bead:** be-5kkk6 — tdd_red `85e9093599629a7262e613e8e223b04c564a5cf8`, tdd_green `9e4037916a9a0adae423e5a807c8f22c946e90f1`
+- **Review bead:** be-43oyc — verdict **PASS**, closed 2026-08-20T06:12:56Z
+- **Commit deployed:** `9e4037916a9a0adae423e5a807c8f22c946e90f1` (deploy source; branch cut from exactly this SHA)
+- **Source branch:** `builder/be-5kkk6` — provenance only, never a push target
+- **Deploy branch:** `deploy/be-r3ysh-gate`, derived mechanically via `resolve_deploy_branch_target` (the bead's own prose named `deploy/be-cqmfa-gate`, a stale/mismatched id from a different bead — not used)
+- **Push target:** `headfork` (`quad341/beads-sec003-contrib.git`) — `origin` push is disabled by design on this rig (`DISABLED-upstream-is-fetch-only-push-to-fork-and-PR`)
+- **PR:** https://github.com/gastownhall/beads/pull/5876 (OPEN, base `main`, head `quad341:deploy/be-r3ysh-gate`, mergeable=MERGEABLE)
+- **Evaluated:** 2026-08-20 by beads/deployer
+
+## Scope
+
+Three `TestMain` functions (`beads_test.go`, `cmd/bd/doctor/fix/testmain_cgo_test.go`,
+`tests/regression/regression_test.go`) called `os.Exit(N)` directly inside
+their own body, after `defer TerminateDoltContainer(...)`. A deferred call
+never runs when the enclosing function exits via `os.Exit`, so container
+teardown was dead code on every exit path. Over 6 days this leaked 101 dolt
+containers and exhausted swap (be-43oyc).
+
+Fix introduces a `testMainInner` pattern in all three files: every
+`os.Exit(N)` call site (all 4 in `regression_test.go`, not just the ones on
+the leak path) becomes `return N` inside `testMainInner`; the outer
+`TestMain` calls `os.Exit(testMainInner(m))`, so `defer` registered before
+`m.Run()` now executes on every path. No behavior change beyond the function
+split (env vars, error messages, exit codes, control-flow order preserved —
+confirmed by diff read).
+
+Adds a new regression guard, `test/testmainconvention/testmain_convention_test.go`:
+an AST walk that fails if any `TestMain` calls `TerminateDoltContainer` via
+`defer` and then exits the same function without routing through an inner
+function. Matches by method name (alias-proof); correctly excludes nested
+closures so an unrelated defer/exit can't false-positive.
+
+Single feature theme, single build bead (be-5kkk6) — both commits in the
+deploy range cite it, confirmed by `assert_deploy_ancestry_scope`.
+
+## Gate criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 0 | Already merged? (pre-flight) | **NO** | `git merge-base --is-ancestor 9e40379 origin/main` → not an ancestor; `gh pr list --search "be-r3ysh OR be-43oyc OR 9e4037916"` → no existing PR. Proceeded. |
+| 1 | Review PASS present | **PASS** | be-43oyc, `verdict: pass`, closed 2026-08-20T06:12:56Z, close_reason `pass`. |
+| 2 | Acceptance criteria met | **PASS** | All 3 exit_contract criteria from be-5kkk6 independently verified in be-43oyc: (1) pattern applied correctly across all 3 files including all 4 exit sites in `regression_test.go`; (2) no behavior change beyond the split, confirmed by diff read; (3) RED commit independently checked out to a throwaway worktree and confirmed to fail citing exactly the 3 affected files with no false positives on 8 other pre-existing-correct `TestMain` files. |
+| 3 | Tests pass (diff-owned-SKIP=FAIL rule) | **PASS** | 259 PASS / 0 FAIL / 18 SKIP across all 4 diff-owned files, executed on real Dolt-container infrastructure (rootless podman, container lifecycle create→start→stop→terminate logged cleanly — direct behavioral proof the defer now runs). All 18 SKIPs are pre-existing and individually attributed: named by test, cited with a GH#/bd- issue ref or explicit "intentional change" rationale, confirmed unrelated to `TestMain`/defer/`os.Exit`, confirmed present before this diff. Zero diff-owned SKIPs. Independently re-verified by deployer on the cut branch: `gofmt -l` (4 diff-owned files) clean, `go build ./...` clean, `go vet ./...` clean, `go vet -tags=regression ./tests/regression/...` clean, `go vet -tags=cgo ./cmd/bd/doctor/fix/...` clean. |
+| 4 | Policy / lint lane | **PASS** | `golangci-lint run --new-from-merge-base=origin/main` clean (default tags, `regression` tag, `cgo` tag) — 0 issues across all 3 scopes, per be-43oyc. |
+| 5 | No open HIGH findings | **PASS** | be-43oyc: zero security findings (explicit OWASP Top 10 walk — test-only diff, zero production files touched, no injection/auth/data-exposure/config surface). Zero style findings; nothing blocking. |
+| 6 | Clean branch status / clean divergence from main | **PASS** | `git merge-tree --write-tree origin/main 9e40379` exits 0 with a single resulting tree, no conflict markers — clean merge despite the reviewed SHA's base sitting 14 commits behind current `origin/main` tip (2 commits ahead of merge-base). No self-rebase needed; bounded self-rebase exception not invoked. `assert_deploy_ancestry_scope origin/main 9e40379 be-r3ysh be-5kkk6` → rc=0 (no `.claude/**` paths introduced; both commits in range cite `be-5kkk6`). `assert_safe_push_target deploy/be-r3ysh-gate` → rc=0 (not a shared worktree branch). |
+| 7 | Single feature theme | **PASS** | One coherent fix (TestMain dead-teardown bug) across 3 files + 1 new guard test; both commits (red/green) cite the same build bead be-5kkk6; ancestry-scope check found no stray commits. |
+
+## Tests run by deployer on the cut branch (independent of review)
+
+| Check | Result |
+|---|---|
+| `gofmt -l beads_test.go cmd/bd/doctor/fix/testmain_cgo_test.go tests/regression/regression_test.go test/testmainconvention/testmain_convention_test.go` | clean (no output) |
+| `go build ./...` | clean, exit 0 |
+| `go vet ./...` | clean, exit 0 |
+| `go vet -tags=regression ./tests/regression/...` | clean, exit 0 |
+| `go vet -tags=cgo ./cmd/bd/doctor/fix/...` | clean, exit 0 |
+
+Full container-backed test execution (259 PASS / 0 FAIL / 18 pre-existing
+SKIP) was not re-run by the deployer — already performed by the reviewer
+with real CI-equivalent commands and logged evidence (be-43oyc); PR CI on
+#5876 provides the additional independent real-world confirmation.
+
+## Push target
+
+`origin` (`gastownhall/beads`) denies push (`DISABLED-upstream-is-fetch-only-push-to-fork-and-PR`
+sentinel); `headfork` (`quad341/beads-sec003-contrib.git`) accepts, per
+established precedent on this rig. PR opens cross-repo against
+`gastownhall/beads:main` with head `quad341:deploy/be-r3ysh-gate`.
+
+## Merge authority
+
+`gastownhall/beads` is a contributor-only repo for this rig — no rig agent
+has merge access. Per established precedent (be-vc1m, be-gd3v, be-79jh,
+be-39ss, be-pp7e), the deployer's job ends at the open, verified PR. No
+merge-request is routed to mayor/mpr.
+
+## Verdict
+
+**PASS 7/7** — branch cut, build verified independently, PR opened and
+confirmed OPEN/MERGEABLE. Standing down; PR CI will provide further
+real-world confirmation but is not a precondition for this gate (unlike
+be-vc1m, this bead carries no hard-precondition blocking criterion 3 on a
+fresh CI result — the review's evidence was obtained by real execution, not
+a SKIP).

--- a/test/testmainconvention/testmain_convention_test.go
+++ b/test/testmainconvention/testmain_convention_test.go
@@ -1,0 +1,163 @@
+// Package testmainconvention enforces a structural rule discovered by
+// be-5kkk6: a TestMain that both defers testutil.TerminateDoltContainer and
+// calls os.Exit in its own function body never runs that cleanup, because
+// os.Exit terminates the process immediately and skips every deferred call.
+// Three TestMain functions had this shape and leaked 101 containers over six
+// days before anything caught it. The fix used elsewhere in this repo is the
+// testMainInner pattern: TestMain shrinks to `os.Exit(testMainInner(m))`,
+// and testMainInner — not TestMain — holds the defer and returns an int on
+// every path, so deferred cleanup runs before the outer os.Exit.
+package testmainconvention
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func repoRoot() string {
+	_, filename, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(filename), "..", "..")
+}
+
+// isTestMain reports whether decl is `func TestMain(m *testing.M)`.
+func isTestMain(decl *ast.FuncDecl) bool {
+	if decl.Name.Name != "TestMain" || decl.Recv != nil || decl.Body == nil {
+		return false
+	}
+	params := decl.Type.Params
+	if params == nil || len(params.List) != 1 {
+		return false
+	}
+	star, ok := params.List[0].Type.(*ast.StarExpr)
+	if !ok {
+		return false
+	}
+	sel, ok := star.X.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	pkgIdent, ok := sel.X.(*ast.Ident)
+	return ok && pkgIdent.Name == "testing" && sel.Sel.Name == "M"
+}
+
+// isOsExitCall reports whether expr is a call to os.Exit.
+func isOsExitCall(expr ast.Expr) bool {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	pkgIdent, ok := sel.X.(*ast.Ident)
+	return ok && pkgIdent.Name == "os" && sel.Sel.Name == "Exit"
+}
+
+// isTerminateDoltContainerCall reports whether expr calls a method or
+// function named TerminateDoltContainer, independent of the receiver/package
+// identifier so an import alias can't hide a match.
+func isTerminateDoltContainerCall(expr ast.Expr) bool {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	return ok && sel.Sel.Name == "TerminateDoltContainer"
+}
+
+// bodyHasDefer reports whether a defer statement anywhere in body's own
+// scope (not inside a nested func literal) defers a call matching match.
+func bodyHasDefer(body *ast.BlockStmt, match func(ast.Expr) bool) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		if _, isLit := n.(*ast.FuncLit); isLit {
+			return false
+		}
+		if d, ok := n.(*ast.DeferStmt); ok && match(d.Call) {
+			found = true
+		}
+		return true
+	})
+	return found
+}
+
+// bodyHasCall reports whether a call matching match appears anywhere in
+// body's own scope (not inside a nested func literal), whether as a bare
+// statement or nested inside another statement such as an if-block.
+func bodyHasCall(body *ast.BlockStmt, match func(ast.Expr) bool) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		if _, isLit := n.(*ast.FuncLit); isLit {
+			return false
+		}
+		if call, ok := n.(*ast.CallExpr); ok && match(call) {
+			found = true
+		}
+		return true
+	})
+	return found
+}
+
+// TestNoTestMainDefersTerminateDoltContainerBeforeOsExit is a repo-wide
+// structural regression test for be-5kkk6. See the package doc for the bug.
+func TestNoTestMainDefersTerminateDoltContainerBeforeOsExit(t *testing.T) {
+	root := repoRoot()
+	var violations []string
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "testdata":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			t.Fatalf("relativize %s: %v", path, err)
+		}
+
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || !isTestMain(fn) {
+				continue
+			}
+			hasDefer := bodyHasDefer(fn.Body, isTerminateDoltContainerCall)
+			hasExit := bodyHasCall(fn.Body, isOsExitCall)
+			if hasDefer && hasExit {
+				violations = append(violations, rel)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+
+	if len(violations) > 0 {
+		sort.Strings(violations)
+		t.Errorf("TestMain defers TerminateDoltContainer and also calls os.Exit in the same function body — os.Exit skips deferred calls, so the container is never cleaned up. Convert to the testMainInner pattern (TestMain reduces to os.Exit(testMainInner(m)); the defer and every os.Exit call site move inside testMainInner as returns). Violations:\n  %s",
+			strings.Join(violations, "\n  "))
+	}
+}

--- a/tests/regression/regression_test.go
+++ b/tests/regression/regression_test.go
@@ -43,9 +43,16 @@ var candidateBin string
 var testDoltServerPort int
 
 func TestMain(m *testing.M) {
+	os.Exit(testMainInner(m))
+}
+
+// testMainInner holds TestMain's body so its defer runs before the process
+// exits — os.Exit skips deferred calls, so TestMain itself must never defer
+// anything (be-5kkk6).
+func testMainInner(m *testing.M) int {
 	if runtime.GOOS == "windows" {
 		fmt.Fprintln(os.Stderr, "regression tests not yet supported on Windows (zip extraction needed)")
-		os.Exit(0)
+		return 0
 	}
 
 	// Start an isolated Dolt server so regression tests don't pollute
@@ -53,10 +60,10 @@ func TestMain(m *testing.M) {
 	if _, err := exec.LookPath("dolt"); err != nil {
 		if os.Getenv("GITHUB_ACTIONS") == "true" {
 			fmt.Fprintln(os.Stderr, "FAIL: dolt missing under GITHUB_ACTIONS — CI workflow must install dolt")
-			os.Exit(1)
+			return 1
 		}
 		fmt.Fprintln(os.Stderr, "SKIP: dolt not found in PATH; regression tests require dolt")
-		os.Exit(0)
+		return 0
 	}
 	os.Setenv("BEADS_TEST_MODE", "1")
 	// AD-01 (be-c5p): allow regression tests to connect to the test container.
@@ -72,7 +79,7 @@ func TestMain(m *testing.M) {
 	tmpDir, err := os.MkdirTemp("", "bd-regression-bin-*")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "creating temp dir: %v\n", err)
-		os.Exit(1)
+		return 1
 	}
 
 	// Build candidate from current worktree
@@ -81,7 +88,7 @@ func TestMain(m *testing.M) {
 	if err := buildCandidate(candidateBin); err != nil {
 		fmt.Fprintf(os.Stderr, "building candidate: %v\n", err)
 		os.RemoveAll(tmpDir)
-		os.Exit(1)
+		return 1
 	}
 
 	// Get baseline (env override > cache > download)
@@ -90,13 +97,13 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "getting baseline: %v\n", err)
 		os.RemoveAll(tmpDir)
-		os.Exit(1)
+		return 1
 	}
 
 	fmt.Fprintf(os.Stderr, "Baseline:  %s\nCandidate: %s\n\n", baselineBin, candidateBin)
 	code := m.Run()
 	os.RemoveAll(tmpDir)
-	os.Exit(code)
+	return code
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three `TestMain` functions called `os.Exit(N)` directly inside their own body, after `defer TerminateDoltContainer(...)`. A deferred call never runs when the enclosing function exits via `os.Exit` — so container teardown was dead code on every path. Over 6 days this leaked 101 dolt containers and exhausted swap (be-43oyc).

Fix: introduce a `testMainInner` pattern in all three affected files (`beads_test.go`, `cmd/bd/doctor/fix/testmain_cgo_test.go`, `tests/regression/regression_test.go`). Every `os.Exit(N)` call site becomes `return N` inside `testMainInner`; the outer `TestMain` calls `os.Exit(testMainInner(m))`, so `defer` registered before `m.Run()` now actually executes on every path. No behavior change beyond the function split (env vars, error messages, exit codes, control-flow order all preserved).

Adds a new regression guard (`test/testmainconvention/testmain_convention_test.go`): an AST walk that fails if any `TestMain` calls `TerminateDoltContainer` via `defer` and then exits from the same function without routing through an inner function — matching by method name (alias-proof), correctly excluding nested closures.

## Review

Independently reviewed and verified PASS (be-43oyc, deploy bead be-r3ysh):
- gofmt / go vet (default, `regression`, `cgo` tags) / golangci-lint: all clean, 0 issues
- Zero security findings (test-only diff, zero production files touched, no injection/auth/data-exposure surface)
- RED commit independently checked out and confirmed to fail citing exactly the 3 affected files, with no false positives on 8 other pre-existing-correct `TestMain` files
- All 3 fixed suites + the new guard test run to completion in a real Dolt-container-backed environment (rootless podman): 259 PASS / 0 FAIL / 18 SKIP total, every SKIP individually verified pre-existing and unrelated to this diff (cited by name/issue), zero diff-owned SKIPs
- Container lifecycle (create→start→stop→terminate) confirmed logged cleanly on all 3 suites — direct behavioral proof the defer now executes, which was impossible under the old bug

## Test plan

- [x] `gofmt -l` on all 4 diff-owned files: clean
- [x] `go build ./...`, `go vet ./...`: clean
- [x] `go vet -tags=regression ./tests/regression/...`, `go vet -tags=cgo ./cmd/bd/doctor/fix/...`: clean
- [x] Full review test evidence (259 PASS / 0 FAIL / 18 pre-existing SKIP) — see be-43oyc
- [ ] PR CI (this PR)

refs be-r3ysh, be-43oyc, be-5kkk6