### PR TITLE
fix(dolt): hermetic peer-branch naming in TestMergeRecomputesIsBlocked

### DIFF
--- a/internal/storage/dolt/blocked_merge_test.go
+++ b/internal/storage/dolt/blocked_merge_test.go
@@ -241,6 +241,18 @@ func TestMergeRecomputesIsBlocked(t *testing.T) {
 		t.Fatalf("get current branch: %v", err)
 	}
 
+	// The peer branch name is derived from this test's own isolation branch
+	// (already unique per run) instead of a fixed literal: the shared Dolt
+	// server can outlive a single test run in this environment (containers
+	// that leak past TestMain persist their branches), so a fixed name risks
+	// colliding with a stale branch of the same name left by an earlier run.
+	// The "test-" prefix also means the next run's CleanTestBranches sweeps
+	// it even if this t.Cleanup doesn't get to.
+	peerBranch := currentBranch + "-peer"
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(context.Background(), "CALL DOLT_BRANCH('-D', ?)", peerBranch)
+	})
+
 	seedBlockedPair(ctx, t, store, true)
 	if !isBlocked(ctx, t, db, "bm-w") {
 		t.Fatal("precondition: bm-w should be blocked by open bm-x")
@@ -248,21 +260,23 @@ func TestMergeRecomputesIsBlocked(t *testing.T) {
 
 	// Peer branch closes the blocker with raw SQL (a merged-in write: no
 	// local write path, no recompute hook).
-	for _, q := range []string{
-		"CALL DOLT_BRANCH('bmpeer', 'HEAD')",
-		"CALL DOLT_CHECKOUT('bmpeer')",
-		"UPDATE issues SET status = 'closed' WHERE id = 'bm-x'",
-		"CALL DOLT_COMMIT('-am', 'peer closes blocker')",
-	} {
-		if _, err := db.ExecContext(ctx, q); err != nil {
-			t.Fatalf("%q: %v", q, err)
-		}
+	if _, err := db.ExecContext(ctx, "CALL DOLT_BRANCH(?, 'HEAD')", peerBranch); err != nil {
+		t.Fatalf("create peer branch: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, "CALL DOLT_CHECKOUT(?)", peerBranch); err != nil {
+		t.Fatalf("checkout peer branch: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, "UPDATE issues SET status = 'closed' WHERE id = 'bm-x'"); err != nil {
+		t.Fatalf("close blocker on peer branch: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, "CALL DOLT_COMMIT('-am', 'peer closes blocker')"); err != nil {
+		t.Fatalf("commit peer branch: %v", err)
 	}
 	if _, err := db.ExecContext(ctx, "CALL DOLT_CHECKOUT(?)", currentBranch); err != nil {
 		t.Fatalf("checkout test branch: %v", err)
 	}
 
-	conflicts, err := store.Merge(ctx, "bmpeer")
+	conflicts, err := store.Merge(ctx, peerBranch)
 	if err != nil {
 		t.Fatalf("merge peer branch: %v", err)
 	}

--- a/release-gates/be-km2kg-blocked-recompute-guard-gate.md
+++ b/release-gates/be-km2kg-blocked-recompute-guard-gate.md
@@ -1,0 +1,108 @@
+# Release gate: be-km2kg — Blocked-recompute guard fails against real Dolt server
+
+**Deploy bead:** be-km2kg
+**Build bead:** be-mge0b (closed, fix: hermetic peer-branch naming in `TestMergeRecomputesIsBlocked`)
+**Review bead:** be-dbpsx (closed, reason: pass — `=== REVIEWER VERDICT: PASS ===`)
+**Source branch:** `builder/be-mge0b` (provenance only, not a push target)
+**Deploy branch:** `deploy/be-km2kg-gate`
+**Push target:** `headfork` (`quad341/beads-sec003-contrib.git`) — already pushed by the builder's rebase-recovery step; independently confirmed via `git ls-remote` against both `headfork` and `fork` this session
+**Deploy commit:** `3e1a002a35c133115d00496c280d5bb05ac70cf9`
+
+## Provenance note: rebase recovery
+
+The originally reviewed commit (`160deb6011369c182ea24d225475d41afc819da9`) hit a stale-base
+conflict at deploy time against just-merged PR #5836 content in `scripts/ci_workflow_test.go`
+(non-diff-owned to this bead's reviewed scope: `internal/storage/dolt/blocked_merge_test.go`,
+`TestMergeRecomputesIsBlocked` only). The builder rebased `builder/be-mge0b` cleanly onto
+`origin/main`, producing `3e1a002a35c133115d00496c280d5bb05ac70cf9`. `blocked_merge_test.go`
+is verified byte-identical to the reviewed/PASSED `160deb601` content — untouched by the
+conflict resolution, which was entirely in the non-diff-owned CI-wiring file.
+
+## Criteria (0–7, in mandated order)
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 0 | Pre-flight: already merged? | PASS | `git merge-base --is-ancestor 3e1a002a3 origin/main` → not an ancestor. `gh pr list --search` on be-km2kg/be-dbpsx/both SHAs against `gastownhall/beads` → empty. Not merged, no duplicate PR. |
+| 1 | Review PASS present | PASS | be-dbpsx CLOSED, close reason `pass`, notes contain explicit `=== REVIEWER VERDICT: PASS ===`. |
+| 2 | Acceptance criteria met | PASS | Review evidence: real-Dolt-server run on `160deb601`, 12 PASS / 0 FAIL / 0 SKIP, covering all 5 #5848 acceptance-criteria tests (repair/dirty-detect/merge) including the diff-owned `TestMergeRecomputesIsBlocked` (3.43s). |
+| 3 | Tests pass (diff-owned SKIP = FAIL, no self-granted waivers) | **PENDING — real CI requested, not self-graded** | See "Criterion 3" section below. |
+| 3a | Pre-existing-failure attribution | N/A | No failure is being attributed as pre-existing; this is a SKIP-with-real-CI-path situation, not a FAIL-attribution situation. |
+| 3b | Policy/lint lane | PASS | `gc beads-contributor pre-pr-check`: 0 blockers, 0 warnings. No postgres tokens, no `.claude/**` paths, no undefined build tags, changed-file count 1, commit count 1. |
+| 4 | No open HIGH findings | PASS | Review notes: "Security: test-only file, SQL hardened to parameterized calls, no findings." No other HIGH findings on record. |
+| 5 | Branch clean | PASS | `git status --short` empty on `deploy/be-km2kg-gate` @ `3e1a002a3`. |
+| 6 | Diverges cleanly from main | PASS | `assert_deploy_ancestry_scope origin/main 3e1a002a3 be-km2kg be-dbpsx be-mge0b` → rc=0 (no `.claude/**` paths, every commit cites an accepted bead id). pre-pr-check: "branch is 0 commit(s) behind origin/main." |
+| 7 | Single feature theme | PASS | 1 file, 1 commit, entirely the peer-branch-collision hermeticity fix in `TestMergeRecomputesIsBlocked`. |
+
+## Independent verification (this session, fresh on `3e1a002a3`)
+
+```
+gofmt -l internal/storage/dolt/blocked_merge_test.go   → (clean, no output)
+go build ./...                                          → exit 0
+go vet ./...                                             → exit 0
+gc beads-contributor pre-pr-check                        → 0 blockers, 0 warnings
+```
+
+## Criterion 3 — full detail
+
+The diff-owned test (`TestMergeRecomputesIsBlocked`) has a **real, completed PASS** on
+byte-identical content, from the review phase: real-Dolt-server run, 12 PASS / 0 FAIL / 0 SKIP,
+recorded on be-dbpsx. That run predates the rebase; the rebase changed only the parent commit
+(re-parenting onto `origin/main`), not this file's bytes.
+
+Re-attempting that same real-Dolt-server run in this deployer's sandbox, on the current checkout,
+produces SKIP:
+
+```
+$ BEADS_TEST_ENV_RUN_DOLT=1 go test ./internal/storage/dolt/... -run TestMergeRecomputesIsBlocked -v
+WARN: Docker image dolthub/dolt-sql-server:2.2.0 not cached locally, skipping Dolt tests
+=== RUN   TestMergeRecomputesIsBlocked
+    blocked_merge_test.go:231: Test Dolt server not running, skipping test
+--- SKIP: TestMergeRecomputesIsBlocked (0.00s)
+```
+
+Root cause independently reproduced this session (not just cited from a tracked memory): a raw
+`docker pull dolthub/dolt-sql-server:2.2.0` on this host fails with
+`failed to get reader from content store: blob sha256:4f4fb700... not found` — corrupted
+containerd content-store, tracked as `docker-containerd-content-store-corrupted-2026-08-20`.
+This is host-level and commit-independent; it would SKIP identically on `origin/main` or any
+other checkout on this host.
+
+**This SKIP is not being scored as a PASS.** Mayor's explicit ruling on be-vc1m
+(round 42, msg `gm-wisp-5vw1ga`), which addressed the structurally identical situation (a
+diff-owned Dolt-container test unable to produce a real result in a rig sandbox), is general and
+unambiguous: *"hold the gate, a SKIP is not a PASS, nobody is to fix this by loosening the gate,
+no waiver is available."* Citing byte-identical prior-PASS evidence plus an independently-proven
+environmental cause is exactly the kind of "more careful route to the same substitute outcome"
+that ruling rejects (see also be-vc1m's PR #5339 precedent: a conformance-audit substitute scored
+PASS while the actual new test SKIPped — rejected). No waiver is self-granted here.
+
+**Unlike be-vc1m's original blocker, the underlying CI-lane gap is already fixed.** be-vc1m's
+saga stalled because no PR-triggered GitHub Actions lane executed anything beyond
+`^TestConformance$` from this package. PR #5836 (merged into `gastownhall/beads:main`
+2026-08-20T03:39:38Z, mergeCommit `30f30ca95b9d177b84451ba16cf53e208aab4d5b`) fixed exactly this
+gap by adding `test-server-storage-full` to `.github/workflows/pr-risk.yml`. Verified by direct
+inspection of the merged workflow and script (not assumed):
+
+- `full_embedded` tier-detection (`.github/scripts/ci-embedded-tier.sh`) sets `full_embedded=true`
+  whenever the PR diff touches `internal/*` — this diff does (`internal/storage/dolt/blocked_merge_test.go`),
+  so `test-server-storage-full` will run on this PR.
+- `.github/scripts/server-storage-test-shard.sh` discovers **every top-level `Test*` function in
+  `internal/storage/dolt/*_test.go`** (excluding `TestConformance`, which has its own lane) and
+  shards them across 16 real-Docker jobs. `TestMergeRecomputesIsBlocked` lives in that same
+  package/directory, so it will be reached and run against a real `dolt-sql-server` container on
+  GitHub-hosted infrastructure — independent of this host's corrupted containerd store.
+
+**Verdict on criterion 3: PENDING, not FAIL, not PASS.** The PR is being opened specifically to
+obtain the real CI result this criterion requires, per this bead's own prose ("Run the standard
+deploy gate... Open the PR from the isolated branch") and the established be-vc1m/mayor pattern.
+Gate will be finalized (PASS 7/7, or FAIL if CI actually fails/still-skips) once that CI result is
+in hand — tracked in bd notes on be-km2kg, not assumed here.
+
+## Merge authority
+
+`gastownhall/beads` is a contributor-only repo — no rig agent (including mayor) has merge access.
+Per established precedent (be-vc1m, be-gd3v, be-79jh, be-39ss, be-pp7e, be-r3ysh, be-krza3), the
+deployer's job ends at a verified PR; no clearance-status, no merge-request is routed, even though
+this bead's own prose says to route one (deviated from deliberately, matching precedent). This
+gate additionally holds the bead open (not closed) pending the criterion-3 real-CI result before
+even that verified-PR endpoint is reached.


### PR DESCRIPTION
## Summary

Fixes a real-flakiness bug in `TestMergeRecomputesIsBlocked`: the test hardcoded a fixed
peer-branch name (`"bmpeer"`), which is not collision-safe in a shared, leak-prone real-server
test environment. Leaked Dolt containers persist their anonymous storage volumes, and a later
container creation can attach to a volume carrying stale state from an earlier run, including a
pre-existing `"bmpeer"` branch. This derives the peer branch name from the test's own
already-unique isolation branch instead, and cleans it up in `t.Cleanup`.

Root cause confirmed distinct from #5848 (this is a peer-branch anonymous-volume collision, not
connection pinning).

## Review

Reviewed and PASSED by beads/reviewer. Real-Dolt-server run at review time: 12 PASS, 0 FAIL,
0 SKIP, including this diff-owned test (3.43s) and all 4 other #5848 acceptance-criteria tests.
Security: test-only file, parameterized SQL, no findings.

This deploy branch was rebase-recovered onto current `main` after a stale-base conflict in
unrelated CI-wiring content (non-diff-owned); `blocked_merge_test.go` is byte-identical to the
reviewed/PASSED commit.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean on changed file
- [x] Reviewed with a real Dolt server: 12/12 PASS (see review record)
- [ ] This PR's own CI (`test-server-storage-full`, added by #5836) will independently execute
      `TestMergeRecomputesIsBlocked` against a real Docker Dolt server — deploy-gate criterion 3
      is being finalized against that result rather than a local re-run, which SKIPs in the
      deploy sandbox due to an unrelated, independently-tracked host Docker/containerd defect.

Full release-gate evidence: `release-gates/be-km2kg-blocked-recompute-guard-gate.md` in this
branch.