### PR TITLE
[DO NOT MERGE] probe: stdio-leak bisect instrumentation for #5881

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -454,7 +454,7 @@ jobs:
   # Cross-platform test matrix (Linux/macOS only - Windows uses smoke tests)
   test:
     name: Test (${{ matrix.os }})
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.os }}
     needs: build-artifacts
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,7 @@ name: Main
 on:
   push:
     branches: [ main ]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}

--- a/cmd/bd/aa_stdioprobe_test.go
+++ b/cmd/bd/aa_stdioprobe_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestStdioProbeAA(t *testing.T) {
+	if os.Stdout != realStdout {
+		t.Errorf("probe aa: os.Stdout already polluted (fd=%d name=%q)", os.Stdout.Fd(), os.Stdout.Name())
+	}
+	if os.Stderr != realStderr {
+		t.Errorf("probe aa: os.Stderr already polluted (fd=%d name=%q)", os.Stderr.Fd(), os.Stderr.Name())
+	}
+}

--- a/cmd/bd/ab_stdiochk_test.go
+++ b/cmd/bd/ab_stdiochk_test.go
@@ -1,0 +1,19 @@
+package main
+
+// Probe instrumentation for gastownhall/beads#5881 (DO NOT MERGE).
+//
+// stdioChk prints whether os.Stdout / os.Stderr still point at the objects
+// captured at package var-init (realStdout / realStderr, zz_stdio_leak_guard_test.go).
+// testMainInner calls it at labeled checkpoints so a single CI run bisects
+// WHERE in the TestMain window the swap happens. Output goes to the entry-time
+// genuine stderr so it is visible regardless of the current swap state.
+
+import (
+	"fmt"
+	"os"
+)
+
+func stdioChk(label string) {
+	fmt.Fprintf(realStderr, "STDIOCHK %-22s stdout_ok=%v stderr_ok=%v (stderr fd=%d name=%q)\n",
+		label, os.Stdout == realStdout, os.Stderr == realStderr, os.Stderr.Fd(), os.Stderr.Name())
+}

--- a/cmd/bd/cm_stdioprobe_test.go
+++ b/cmd/bd/cm_stdioprobe_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestStdioProbeCM(t *testing.T) {
+	if os.Stdout != realStdout {
+		t.Errorf("probe cm: os.Stdout already polluted (fd=%d name=%q)", os.Stdout.Fd(), os.Stdout.Name())
+	}
+	if os.Stderr != realStderr {
+		t.Errorf("probe cm: os.Stderr already polluted (fd=%d name=%q)", os.Stderr.Fd(), os.Stderr.Name())
+	}
+}

--- a/cmd/bd/fm_stdioprobe_test.go
+++ b/cmd/bd/fm_stdioprobe_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestStdioProbeFM(t *testing.T) {
+	if os.Stdout != realStdout {
+		t.Errorf("probe fm: os.Stdout already polluted (fd=%d name=%q)", os.Stdout.Fd(), os.Stdout.Name())
+	}
+	if os.Stderr != realStderr {
+		t.Errorf("probe fm: os.Stderr already polluted (fd=%d name=%q)", os.Stderr.Fd(), os.Stderr.Name())
+	}
+}

--- a/cmd/bd/im_stdioprobe_test.go
+++ b/cmd/bd/im_stdioprobe_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestStdioProbeIM(t *testing.T) {
+	if os.Stdout != realStdout {
+		t.Errorf("probe im: os.Stdout already polluted (fd=%d name=%q)", os.Stdout.Fd(), os.Stdout.Name())
+	}
+	if os.Stderr != realStderr {
+		t.Errorf("probe im: os.Stderr already polluted (fd=%d name=%q)", os.Stderr.Fd(), os.Stderr.Name())
+	}
+}

--- a/cmd/bd/lm_stdioprobe_test.go
+++ b/cmd/bd/lm_stdioprobe_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestStdioProbeLM(t *testing.T) {
+	if os.Stdout != realStdout {
+		t.Errorf("probe lm: os.Stdout already polluted (fd=%d name=%q)", os.Stdout.Fd(), os.Stdout.Name())
+	}
+	if os.Stderr != realStderr {
+		t.Errorf("probe lm: os.Stderr already polluted (fd=%d name=%q)", os.Stderr.Fd(), os.Stderr.Name())
+	}
+}

--- a/cmd/bd/om_stdioprobe_test.go
+++ b/cmd/bd/om_stdioprobe_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestStdioProbeOM(t *testing.T) {
+	if os.Stdout != realStdout {
+		t.Errorf("probe om: os.Stdout already polluted (fd=%d name=%q)", os.Stdout.Fd(), os.Stdout.Name())
+	}
+	if os.Stderr != realStderr {
+		t.Errorf("probe om: os.Stderr already polluted (fd=%d name=%q)", os.Stderr.Fd(), os.Stderr.Name())
+	}
+}

--- a/cmd/bd/rm_stdioprobe_test.go
+++ b/cmd/bd/rm_stdioprobe_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestStdioProbeRM(t *testing.T) {
+	if os.Stdout != realStdout {
+		t.Errorf("probe rm: os.Stdout already polluted (fd=%d name=%q)", os.Stdout.Fd(), os.Stdout.Name())
+	}
+	if os.Stderr != realStderr {
+		t.Errorf("probe rm: os.Stderr already polluted (fd=%d name=%q)", os.Stderr.Fd(), os.Stderr.Name())
+	}
+}

--- a/cmd/bd/test_repo_beads_guard_test.go
+++ b/cmd/bd/test_repo_beads_guard_test.go
@@ -49,6 +49,7 @@ type testRunner interface {
 }
 
 func runTestsAndSweep(m testRunner) int {
+	stdioChk("pre-m.Run")
 	code := m.Run()
 	doltserver.SweepOrphanedTestServers(testTempRoot)
 	return code
@@ -63,6 +64,7 @@ func TestMain(m *testing.M) {
 
 func testMainInner(m *testing.M) int {
 	origWD, _ := os.Getwd()
+	stdioChk("entry")
 
 	// Isolate config discovery from the repo's tracked `.beads/config.yaml`.
 	// Many tests expect default config values; running from within this repo would
@@ -105,7 +107,9 @@ func testMainInner(m *testing.M) int {
 	// (~/.docker/config.json); resolve it into DOCKER_HOST now or every
 	// container-gated test skips "Docker not available" on context-routed
 	// daemons like OrbStack (bd-84kos).
+	stdioChk("pre-docker-pin")
 	testutil.PinDockerHostFromContext()
+	stdioChk("post-docker-pin")
 
 	_ = os.Setenv("HOME", tmp)
 	_ = os.Setenv("USERPROFILE", tmp) // Windows compatibility
@@ -192,8 +196,10 @@ func testMainInner(m *testing.M) int {
 
 	// Start shared test Dolt server if the hook is registered (CGO builds).
 	// This must happen after HOME is changed so dolt config goes to the temp dir.
+	stdioChk("pre-beforeTestsHook")
 	if beforeTestsHook != nil {
 		cleanup := beforeTestsHook()
+		stdioChk("post-beforeTestsHook")
 		defer cleanup()
 	}
 

--- a/cmd/bd/um_stdioprobe_test.go
+++ b/cmd/bd/um_stdioprobe_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestStdioProbeUM(t *testing.T) {
+	if os.Stdout != realStdout {
+		t.Errorf("probe um: os.Stdout already polluted (fd=%d name=%q)", os.Stdout.Fd(), os.Stdout.Name())
+	}
+	if os.Stderr != realStderr {
+		t.Errorf("probe um: os.Stderr already polluted (fd=%d name=%q)", os.Stderr.Fd(), os.Stderr.Name())
+	}
+}

--- a/cmd/bd/xm_stdioprobe_test.go
+++ b/cmd/bd/xm_stdioprobe_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestStdioProbeXM(t *testing.T) {
+	if os.Stdout != realStdout {
+		t.Errorf("probe xm: os.Stdout already polluted (fd=%d name=%q)", os.Stdout.Fd(), os.Stdout.Name())
+	}
+	if os.Stderr != realStderr {
+		t.Errorf("probe xm: os.Stderr already polluted (fd=%d name=%q)", os.Stderr.Fd(), os.Stderr.Name())
+	}
+}


### PR DESCRIPTION
Diagnostic-only draft to bracket the #5881 stdio leak where it actually reproduces (CI full-order runs; it does NOT reproduce locally — a completed 54-min local full run has TestZZStdioNotLeaked and all nine probes green).

Nine sequential probe tests at alphabetical file positions across cmd/bd (positions 1/66/326/395/500/584/698/853/925 of the package file list). Each asserts os.Stdout/os.Stderr still equal the package-init baselines from zz_stdio_leak_guard_test.go. The first failing probe in this PR's CI run brackets the culprit — the test that leaves os.Stderr = os.Stdout (the ZZ red on main shows fd=1 name="/dev/stdout", i.e. the genuine os.Stdout object, so the leak is a crosswise or merged-stream restore, not a dropped pipe).

Will read the bracket, post it to #5881, then close this PR and delete the branch. Caveat noted for reading the bracket: t.Parallel() tests run after the sequential phase of their declaration point, so the bracket is authoritative for sequential culprits only.