### PR TITLE
fix(storage/dolt): stop the server transaction diverging from embedded on history and IncludeDependencies

### DIFF
--- a/backend/conformance/conformance.go
+++ b/backend/conformance/conformance.go
@@ -265,6 +265,8 @@ func RunAll(t *testing.T, factory Factory) {
 	t.Run("TransactionCallbackAtMostOnce", func(t *testing.T) { testTransactionCallbackAtMostOnce(t, factory) })
 	t.Run("TransactionSnapshotReads", func(t *testing.T) { testTransactionSnapshotReads(t, factory) })
 	t.Run("TransactionReadYourWrites", func(t *testing.T) { testTransactionReadYourWrites(t, factory) })
+	t.Run("TransactionUpdateRecordsHistory", func(t *testing.T) { testTransactionUpdateRecordsHistory(t, factory) })
+	t.Run("TransactionSearchIncludeDependencies", func(t *testing.T) { testTransactionSearchIncludeDependencies(t, factory) })
 }
 
 // RunDeferredReads runs a curated three-case subset — statistics, external-ref

--- a/backend/conformance/transaction_parity.go
+++ b/backend/conformance/transaction_parity.go
@@ -1,0 +1,175 @@
+package conformance
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// This file holds the transaction cases whose whole point is that the two Dolt
+// backends must answer them IDENTICALLY. Both are silent-wrong-answer shapes:
+// nothing errors, nothing logs, and the caller is handed a plausible result
+// that is wrong on one backend and right on the other. A caller cannot tell
+// which backend it has, so a divergence here is a correctness bug in whichever
+// leg deviates, not a documented difference.
+//
+// Each case takes its expectation from an ORACLE the two backends already
+// agree on — the store-level form of the same operation — rather than from the
+// other backend. Making two backends agree on the wrong answer would be worse
+// than the divergence, because the disagreement is the only signal there is.
+
+// testTransactionUpdateRecordsHistory pins Transaction.UpdateIssue to the same
+// history the store-level UpdateIssue records (ga-1huib.7).
+//
+// The oracle is DoltStorage.UpdateIssue on the SAME store: both backends route
+// it through issueops.UpdateIssueInTx, so an "updated" event for a real field
+// change is not a backend opinion. Transaction.UpdateIssue is the same
+// operation with a transaction around it, and storage.Transaction documents no
+// carve-out for it — where event suppression IS intended on that interface it
+// is spelled out (RemoveDependency vs RemoveDependencyWithOptions.EmitEvent).
+//
+// The untouched issue is the control: it proves the assertion is not satisfied
+// trivially by every issue carrying an "updated" event, which would make a
+// green run meaningless.
+func testTransactionUpdateRecordsHistory(t *testing.T, f Factory) {
+	s := f(t)
+	c := ctx()
+
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "txh-store", Title: "Store edit"}), "a"))
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "txh-tx", Title: "Tx edit"}), "a"))
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "txh-untouched", Title: "Never edited"}), "a"))
+
+	// Oracle: the same field change, outside a transaction.
+	must(t, s.UpdateIssue(c, "txh-store", map[string]interface{}{"title": "Store edit, revised"}, "a"))
+
+	// Subject: the same field change, inside a transaction.
+	must(t, s.RunInTransaction(c, "bd: update txh-tx", func(tx storage.Transaction) error {
+		return tx.UpdateIssue(c, "txh-tx", map[string]interface{}{"title": "Tx edit, revised"}, "a")
+	}))
+
+	oracle := countIssueEvents(t, s, "txh-store", types.EventUpdated)
+	if oracle != 1 {
+		t.Fatalf("oracle broken: store-level UpdateIssue recorded %d %q events, want 1", oracle, types.EventUpdated)
+	}
+	if control := countIssueEvents(t, s, "txh-untouched", types.EventUpdated); control != 0 {
+		t.Fatalf("control broken: an issue that was never updated has %d %q events, want 0 — "+
+			"the oracle assertion below cannot distinguish anything", control, types.EventUpdated)
+	}
+
+	if got := countIssueEvents(t, s, "txh-tx", types.EventUpdated); got != oracle {
+		t.Errorf("Transaction.UpdateIssue recorded %d %q events, want %d (what the store-level "+
+			"UpdateIssue records for the same change) — a transactional update must not have a "+
+			"different audit trail from a plain one", got, types.EventUpdated, oracle)
+	}
+}
+
+// testTransactionSearchIncludeDependencies pins Transaction.SearchIssues to
+// honoring IssueFilter.IncludeDependencies (ga-1huib.8).
+//
+// A silently dropped filter field is worse than a missing one: a missing field
+// is a compile error, a dropped one returns plausible wrong data. Two controls
+// keep the positive assertion honest — an issue with NO dependencies must come
+// back in the results with an empty slice (so the fixture cannot pass by having
+// dependencies everywhere), and the same search with the flag OFF must hydrate
+// nothing (so the case cannot pass on a backend that hydrates unconditionally
+// and never reads the flag at all).
+func testTransactionSearchIncludeDependencies(t *testing.T, f Factory) {
+	s := f(t)
+	c := ctx()
+
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "txdep-blocker", Title: "TxDepHydration Blocker"}), "a"))
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "txdep-blocked", Title: "TxDepHydration Blocked"}), "a"))
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "txdep-lone", Title: "TxDepHydration Lone"}), "a"))
+	must(t, s.AddDependency(c, &types.Dependency{
+		IssueID:     "txdep-blocked",
+		DependsOnID: "txdep-blocker",
+		Type:        types.DepBlocks,
+	}, "a"))
+
+	var on, off map[string][]*types.Dependency
+	must(t, s.RunInTransaction(c, "bd: search txdep", func(tx storage.Transaction) error {
+		hydrated, err := tx.SearchIssues(c, "TxDepHydration", types.IssueFilter{IncludeDependencies: true})
+		if err != nil {
+			return err
+		}
+		on = dependenciesByIssue(hydrated)
+
+		plain, err := tx.SearchIssues(c, "TxDepHydration", types.IssueFilter{})
+		if err != nil {
+			return err
+		}
+		off = dependenciesByIssue(plain)
+		return nil
+	}))
+
+	if len(on) != 3 {
+		t.Fatalf("in-tx SearchIssues(IncludeDependencies) returned %d issues %v, want 3", len(on), issueIDsOf(on))
+	}
+
+	deps, ok := on["txdep-blocked"]
+	if !ok {
+		t.Fatalf("in-tx SearchIssues(IncludeDependencies) dropped txdep-blocked entirely")
+	}
+	if len(deps) != 1 {
+		t.Errorf("txdep-blocked came back with %d dependencies, want 1 — IncludeDependencies was "+
+			"accepted and ignored", len(deps))
+	} else if deps[0].DependsOnID != "txdep-blocker" {
+		t.Errorf("txdep-blocked depends on %q, want %q", deps[0].DependsOnID, "txdep-blocker")
+	}
+
+	// Control: a dependency-free issue is still returned, with nothing hydrated.
+	lone, ok := on["txdep-lone"]
+	if !ok {
+		t.Errorf("control broken: txdep-lone (no dependencies) was dropped from the results")
+	} else if len(lone) != 0 {
+		t.Errorf("control broken: txdep-lone has no dependencies but %d were hydrated — the "+
+			"fixture cannot tell a hydrated result from an unhydrated one", len(lone))
+	}
+
+	// Control: the flag is read, not ignored in the other direction.
+	for _, id := range issueIDsOf(off) {
+		if len(off[id]) != 0 {
+			t.Errorf("control broken: %s hydrated %d dependencies without IncludeDependencies",
+				id, len(off[id]))
+		}
+	}
+}
+
+// countIssueEvents counts an issue's history events of one type.
+func countIssueEvents(t *testing.T, s storage.DoltStorage, id string, want types.EventType) int {
+	t.Helper()
+	events, err := s.GetEvents(ctx(), id, 0)
+	if err != nil {
+		t.Fatalf("GetEvents(%s): %v", id, err)
+	}
+	n := 0
+	for _, e := range events {
+		if e.EventType == want {
+			n++
+		}
+	}
+	return n
+}
+
+// dependenciesByIssue keys search results by issue ID so a case can assert on
+// what was hydrated for each one, including the issues that got nothing.
+func dependenciesByIssue(issues []*types.Issue) map[string][]*types.Dependency {
+	byID := make(map[string][]*types.Dependency, len(issues))
+	for _, issue := range issues {
+		byID[issue.ID] = issue.Dependencies
+	}
+	return byID
+}
+
+// issueIDsOf returns the map's issue IDs in a stable order so failure messages
+// name the same issues in the same order on every run.
+func issueIDsOf(byID map[string][]*types.Dependency) []string {
+	ids := make([]string, 0, len(byID))
+	for id := range byID {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -35,7 +35,6 @@ type doltTransaction struct {
 	// role: it deliberately drops wisp_* tables because they are dolt-ignored.
 	wroteRegularDep bool
 	wroteWispDep    bool
-	lifecycle       bool
 	// journalPinned records that ignoredTx IS regularTx because the events
 	// journal collapsed the two planes into one transaction, so the finish path
 	// must not commit or roll it back a second time.
@@ -124,7 +123,7 @@ func (s *DoltStore) runInIssueLifecycleTransaction(
 		var callbackErr error
 		err := run(ctx, func(sqlTx *sql.Tx) error {
 			invoked = true
-			tx := &doltTransaction{regularTx: sqlTx, ignoredTx: sqlTx, store: s, lifecycle: true}
+			tx := &doltTransaction{regularTx: sqlTx, ignoredTx: sqlTx, store: s}
 			if callbackErr = fn(tx); callbackErr != nil {
 				return callbackErr
 			}
@@ -532,7 +531,26 @@ func (t *doltTransaction) SearchIssueIDs(ctx context.Context, query string, filt
 }
 
 // SearchIssues searches for issues within the transaction.
-// Supports the same filter fields as DoltStore.SearchIssues (bd-v6v8).
+//
+// It is a SECOND filter builder, hand-rolled here because issueops' shared one
+// merges issues and wisps over a single *sql.Tx while this transaction splits
+// those tiers across regularTx/ignoredTx (see txFor). Being a second builder is
+// the hazard: a field it does not implement is not refused, it is IGNORED, and
+// the caller gets plausible wrong rows with no error.
+//
+// This builder does NOT honor the following IssueFilter fields, all of which
+// the store-level DoltStore.SearchIssues does (measured against it on one
+// fixture, 2026-08-20): Statuses, ExcludeLabels, LabelPattern, LabelRegex,
+// IsBlocked, StartedAfter/StartedBefore, the AfterID/AfterCreatedAt keyset
+// cursor, SortBy/SortDesc (results are always priority ASC, created_at DESC),
+// and MaxRows/MaxRowsSource (the defensive row cap is not enforced). It also
+// never hydrates Issue.Labels, so SkipLabels=false does not get labels. Callers
+// needing any of those must use the store-level search. Tracked as siblings of
+// ga-1huib.8; the fix that removes the divergence for good is deleting this
+// builder in favor of the shared one, not adding fields to it one at a time.
+//
+// IncludeDependencies IS honored (ga-1huib.8), through the same bulk read
+// issueops uses.
 func (t *doltTransaction) SearchIssues(ctx context.Context, query string, filter types.IssueFilter) ([]*types.Issue, error) {
 	table := "issues"
 	if filter.Ephemeral != nil && *filter.Ephemeral {
@@ -870,9 +888,45 @@ func (t *doltTransaction) SearchIssues(ctx context.Context, query string, filter
 		}
 		issues = append(issues, issue)
 	}
+	if err := t.hydrateSearchDependencies(ctx, depTable, filter, issues); err != nil {
+		return nil, err
+	}
 	return issues, nil
 }
 
+// hydrateSearchDependencies populates Issue.Dependencies when the filter asked
+// for it, using the same bulk read issueops.SearchIssuesInTx uses so the two
+// backends answer IncludeDependencies from one implementation. Issues with no
+// edges keep a nil slice; the map simply has no entry for them.
+func (t *doltTransaction) hydrateSearchDependencies(ctx context.Context, depTable string, filter types.IssueFilter, issues []*types.Issue) error {
+	if !filter.IncludeDependencies || len(issues) == 0 {
+		return nil
+	}
+	ids := make([]string, len(issues))
+	for i, issue := range issues {
+		ids[i] = issue.ID
+	}
+	depsByID, err := issueops.GetDependencyRecordsForIssuesFromTableInTx(ctx, t.txFor(depTable), depTable, ids)
+	if err != nil {
+		return fmt.Errorf("search issues in tx: hydrate dependencies: %w", err)
+	}
+	for _, issue := range issues {
+		if deps, ok := depsByID[issue.ID]; ok {
+			issue.Dependencies = deps
+		}
+	}
+	return nil
+}
+
+// UpdateIssue applies field updates and records the "updated" history event,
+// which is what the store-level DoltStore.UpdateIssue records for the same
+// change and what embeddedTransaction.UpdateIssue records here. Wrapping an
+// update in a transaction must not change its audit trail: a consumer cannot
+// see which backend or which call shape it got, so a transaction-only silence
+// shows up as a user's own edits missing from the history of their own issue.
+// The eventless variant exists for demotion (ephemeral_routing.go), which
+// copies the historical event stream and appends one demotion event of its
+// own; a generic update is not that case.
 func (t *doltTransaction) UpdateIssue(ctx context.Context, id string, updates map[string]interface{}, actor string) error {
 	table := "issues"
 	if t.isActiveWisp(ctx, id) {
@@ -889,11 +943,7 @@ func (t *doltTransaction) UpdateIssue(ctx context.Context, id string, updates ma
 		}
 	}
 
-	update := issueops.UpdateIssueWithoutEventInTx
-	if t.lifecycle {
-		update = issueops.UpdateIssueInTx
-	}
-	result, err := update(ctx, t.txFor(table), id, updates, actor)
+	result, err := issueops.UpdateIssueInTx(ctx, t.txFor(table), id, updates, actor)
 	if err != nil {
 		return wrapExecError("update issue in tx", err)
 	}
@@ -901,10 +951,8 @@ func (t *doltTransaction) UpdateIssue(ctx context.Context, id string, updates ma
 		return nil
 	}
 	t.dirty.MarkDirty(table)
-	if t.lifecycle {
-		_, _, eventTable, _ := issueops.WispTableRouting(table == "wisps")
-		t.dirty.MarkDirty(eventTable)
-	}
+	_, _, eventTable, _ := issueops.WispTableRouting(table == "wisps")
+	t.dirty.MarkDirty(eventTable)
 	return nil
 }
 


### PR DESCRIPTION
Fixes two silent-wrong-answer divergences between the two Dolt backends. Both were found only because both connection-mode gates run: nothing errors and nothing logs, the caller just gets a plausible result that is wrong on the server backend and right on the embedded one — and a caller cannot tell which backend it has.

## ga-1huib.7 — `Transaction.UpdateIssue` recorded no history on the server backend

`doltTransaction.UpdateIssue` called `UpdateIssueWithoutEventInTx` unless the transaction was on the lifecycle lane. So the same field change recorded an `updated` event outside a transaction and **nothing** inside one, on the same backend.

### Which backend was wrong, and how that was established

Not by majority vote — by asking what the operation means. Five update implementations exist in this tree:

| implementation | records `updated`? |
| --- | --- |
| `DoltStore.UpdateIssue` (server, store-level) | yes |
| `EmbeddedDoltStore.UpdateIssue` (embedded, store-level) | yes |
| `embeddedTransaction.UpdateIssue` (embedded, in-tx) | yes |
| `domain/db` update (uow leg) | yes — its comment already names embedded as the parity reference |
| `doltTransaction.UpdateIssue` (server, in-tx) | **no** |

Also: `doltTransaction.CloseIssue` and `ReopenIssueWithResult` record events unconditionally *in this same file* — `UpdateIssue` was the only member of its own type that did not. And `UpdateIssueWithoutEventInTx`'s own godoc names its intended caller: demotion, which copies the historical event stream and then appends a single demotion event. A generic transactional update is not that case. `storage.Transaction` spells out event suppression where it *is* intended (`RemoveDependency` vs `RemoveDependencyWithOptions.EmitEvent`); `UpdateIssue` carries no such carve-out.

The server transaction is the outlier, so it is what changed. Events are now marked dirty so the Dolt commit stages them — exactly as `CloseIssue` already did, so this is not a new code path.

`git log -S` shows the eventless call arrived in a bulk `read optimizations` commit rather than a deliberate decision, and #5191 later added the lifecycle conditional to restore events on one lane. That flag existed only to select the with-event variant, so it is deleted rather than left as write-only state.

## ga-1huib.8 — `Transaction.SearchIssues` accepted `IncludeDependencies` and ignored it

Rows came back, no error, every `Issue.Dependencies` empty. That builder is a *second*, hand-rolled filter implementation — it exists because issueops' shared one merges issues and wisps over one `*sql.Tx` while this transaction splits the tiers across `regularTx`/`ignoredTx` — and it never hydrated dependencies. Three of the four search implementations honour the field (issueops, `domain/db`, and the store-level path); only this one did not.

It now hydrates through `issueops.GetDependencyRecordsForIssuesFromTableInTx`, the same bulk read issueops itself uses, so both backends answer the field from one implementation rather than two.

### Siblings — reported, not fixed

The comment claiming this builder "supports the same filter fields as `DoltStore.SearchIssues`" was false. It is replaced with a measured list. Comparing the in-transaction result against the store-level result on one fixture, these fields are **accepted and silently dropped**:

| field | store-level | in-transaction |
| --- | --- | --- |
| `Statuses` | `[a]` | `[a b c]` — unfiltered |
| `ExcludeLabels` | `[a c]` | `[a b c]` — unfiltered |
| `LabelPattern` | `[a]` | `[a b c]` — unfiltered |
| `IsBlocked` | `[]` | `[a b c]` — unfiltered |
| `AfterID` + `AfterCreatedAt` | `[]` | `[a b c]` — **keyset cursor ignored; a paging loop never advances** |
| `SortBy`+`SortDesc` | `[c b a]` | `[a b c]` — always priority ASC, created_at DESC |
| `MaxRows` | error, cap enforced | `[a b c]`, no error — row cap not enforced |
| labels (`SkipLabels=false`) | populated | **all empty** — labels never hydrated |

`LabelRegex` and `StartedAfter`/`StartedBefore` are dropped by inspection. These are left for follow-up: the fix that ends the divergence for good is deleting this second builder in favour of the shared one, not adding fields to it one at a time.

## Tests

Both are pinned in `backend/conformance`, which already runs against both backends. Each case takes its expectation from an **oracle the two backends already agree on** — the store-level form of the same operation — rather than from the other backend, because making two backends agree on a *wrong* answer would remove the only signal there is.

Each carries a control so it cannot pass trivially:

- `.7` — an issue created and never updated must have **zero** `updated` events, so the assertion is not satisfied by every issue carrying one.
- `.8` — a dependency-free issue must still be returned, with nothing hydrated (an "includes dependencies" assertion is vacuous against a fixture where everything has dependencies), and the same search with the flag **off** must hydrate nothing, so a backend that hydrated unconditionally would not pass either.

Verified red-then-green with build and vet clean in the red state, then each control re-verified by reintroducing **one** divergence at a time — `.7` alone goes red while `.8` stays green, and vice versa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
