### PR TITLE
fix(dolt): git-remote tests need a sql-server that shares their filesystem (4 of the 6 stalled full-suite shards)

### DIFF
--- a/internal/storage/dolt/git_remote_test.go
+++ b/internal/storage/dolt/git_remote_test.go
@@ -12,11 +12,13 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/steveyegge/beads/internal/doltserver"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/doltutil"
 	"github.com/steveyegge/beads/internal/storage/schema"
@@ -45,10 +47,55 @@ import (
 
 // gitRemoteSetup holds resources for a git-remote test scenario.
 type gitRemoteSetup struct {
-	baseDir   string // root temp dir
-	remoteDir string // bare git repo path
-	remoteURL string // file:// URL for the bare repo
-	sourceDir string // dolt source repo directory
+	baseDir    string // root temp dir
+	remoteDir  string // bare git repo path
+	remoteURL  string // file:// URL for the bare repo
+	sourceDir  string // dolt source repo directory
+	serverPort int    // local dolt sql-server port (0 for CLI-only setups)
+}
+
+// startLocalDoltServer starts a `dolt sql-server` rooted at dataDir and
+// returns its port and an idempotent stop function.
+//
+// The suite's shared Dolt server (testmain_test.go) runs inside a Docker
+// container: its only mount is the image's own /var/lib/dolt volume, so it
+// can reach neither a host file:// git remote nor the store's own Path.
+// Tests that push to a local bare git repo, or that inspect the engine's
+// on-disk state, need a server that shares this process's filesystem.
+// TestGitRemoteExternalServerRouting, TestSQLRemotePersistsAcrossExternalServerRestart
+// and TestCredentialCLIRoutingE2E use the same arrangement.
+//
+// The server is spawned with doltserver.ServerSpawnEnv(), the same environment
+// bd gives the sql-server it starts. That is load-bearing, not cosmetic: a
+// `dolt` CLI command run against a directory a sql-server is already serving
+// is proxied to that server, so the git subprocess is spawned by the server,
+// not by the CLI — env guards applied to the CLI process (git tracing,
+// core.hooksPath) only take effect if the server carries them too.
+func startLocalDoltServer(t *testing.T, dataDir string) (int, func()) {
+	t.Helper()
+	port, err := testutil.FindFreePort()
+	if err != nil {
+		t.Fatalf("failed to find free port: %v", err)
+	}
+	cmd := exec.Command("dolt", "sql-server", "-H", "127.0.0.1", "-P", strconv.Itoa(port))
+	cmd.Dir = dataDir
+	cmd.Env = doltserver.ServerSpawnEnv()
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start dolt sql-server in %s: %v", dataDir, err)
+	}
+	var once sync.Once
+	stop := func() {
+		once.Do(func() {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		})
+	}
+	t.Cleanup(stop)
+	if !testutil.WaitForServer(port, 15*time.Second) {
+		stop()
+		t.Fatalf("dolt sql-server in %s did not become ready within timeout", dataDir)
+	}
+	return port, stop
 }
 
 // setupGitRemote creates a bare git repo (seeded with an initial commit)
@@ -588,18 +635,23 @@ func TestGitRemoteSpecialCharacters(t *testing.T) {
 	}
 }
 
-// --- Embedded driver git remote tests ---
+// --- SQL-driver git remote tests ---
 //
 // These tests verify that Dolt's git remote support works through the
 // SQL driver, not just the CLI. This is the critical question for the
 // Dolt-in-Git spike: can we use store.Push() and store.Pull() with a
 // bare git repo as the remote?
+//
+// CALL DOLT_PUSH runs inside the sql-server process, so the server must be
+// able to see the bare repo and the store's own data directory. These tests
+// therefore run against their own local sql-server (startLocalDoltServer),
+// not the suite's containerized shared server.
 
 // setupEmbeddedGitRemote creates a bare git repo and returns a DoltStore
 // connected with the bare repo configured as "origin".
 func setupEmbeddedGitRemote(t *testing.T) (*DoltStore, *gitRemoteSetup, func()) {
 	t.Helper()
-	skipIfNoDolt(t)
+	testutil.RequireDoltBinary(t)
 	skipIfNoGit(t)
 	acquireTestSlot()
 	t.Cleanup(releaseTestSlot)
@@ -625,47 +677,89 @@ func setupEmbeddedGitRemote(t *testing.T) (*DoltStore, *gitRemoteSetup, func()) 
 
 	remoteURL := "file://" + remoteDir
 
-	// Create embedded DoltStore
+	// Serve the store's own data directory from a local sql-server so the
+	// engine, the bare git repo and this test process all share one
+	// filesystem.
 	doltDir := filepath.Join(baseDir, "embedded-dolt")
+	if err := os.MkdirAll(doltDir, 0o755); err != nil {
+		os.RemoveAll(baseDir)
+		t.Fatalf("failed to create dolt dir: %v", err)
+	}
+	serverPort, stopServer := startLocalDoltServer(t, doltDir)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	dbName := uniqueTestDBName(t)
 	store, err := New(ctx, &Config{
 		Path:            doltDir,
+		ServerHost:      "127.0.0.1",
+		ServerPort:      serverPort,
+		ServerUser:      "root",
+		AutoStart:       false,
 		CommitterName:   "test",
 		CommitterEmail:  "test@example.com",
 		Database:        dbName,
 		CreateIfMissing: true, // test creates a fresh database
 	})
 	if err != nil {
+		stopServer()
 		os.RemoveAll(baseDir)
-		t.Fatalf("failed to create embedded DoltStore: %v", err)
+		t.Fatalf("failed to create DoltStore: %v", err)
+	}
+
+	// The whole point of the local server: the database it just created must
+	// be on this process's filesystem, under the store's own Path. Tests here
+	// push to a host bare repo and read the engine's git-remote cache mirror,
+	// and both silently stop being meaningful if the store ever drifts back
+	// onto a containerized server.
+	if _, statErr := os.Stat(filepath.Join(doltDir, dbName, ".dolt")); statErr != nil {
+		store.Close()
+		stopServer()
+		os.RemoveAll(baseDir)
+		t.Fatalf("store did not materialize %s/.dolt on this filesystem — the engine is not local to the test: %v", filepath.Join(doltDir, dbName), statErr)
 	}
 
 	// Set issue prefix (required for CreateIssue)
 	if err := store.SetConfig(ctx, "issue_prefix", "test"); err != nil {
 		store.Close()
+		stopServer()
 		os.RemoveAll(baseDir)
 		t.Fatalf("failed to set prefix: %v", err)
 	}
 
-	// Add git remote via embedded SQL
+	// Add git remote via SQL
 	if err := store.AddRemote(ctx, "origin", remoteURL); err != nil {
 		store.Close()
+		stopServer()
 		os.RemoveAll(baseDir)
 		t.Fatalf("failed to add remote: %v", err)
 	}
 
+	// Genesis commit, sweeping config too — the CLI sibling setupGitRemote
+	// does the same with DOLT_COMMIT('-Am', 'Genesis: schema and config').
+	// Commit() deliberately skips config (GH#2455), so without this
+	// issue_prefix stays dirty forever: Pull() then refuses to auto-commit a
+	// dirty internal config key, and a peer cloning this database gets no
+	// prefix at all.
+	if _, err := store.CommitAll(ctx, "Genesis: schema and config"); err != nil {
+		store.Close()
+		stopServer()
+		os.RemoveAll(baseDir)
+		t.Fatalf("failed to commit genesis config: %v", err)
+	}
+
 	setup := &gitRemoteSetup{
-		baseDir:   baseDir,
-		remoteDir: remoteDir,
-		remoteURL: remoteURL,
-		sourceDir: doltDir,
+		baseDir:    baseDir,
+		remoteDir:  remoteDir,
+		remoteURL:  remoteURL,
+		sourceDir:  doltDir,
+		serverPort: serverPort,
 	}
 
 	cleanup := func() {
 		store.Close()
+		stopServer()
 		os.RemoveAll(baseDir)
 	}
 
@@ -940,8 +1034,15 @@ func TestGitRemoteSyncRoundTrip(t *testing.T) {
 		t.Fatal("expected bootstrap to occur (no existing dolt dir)")
 	}
 
+	// The clone is a second peer with its own data directory, so it needs its
+	// own local server for the same reason the source does.
+	clonePort, _ := startLocalDoltServer(t, cloneDoltDir)
 	cloneStore, err := New(ctx, &Config{
 		Path:            cloneDoltDir,
+		ServerHost:      "127.0.0.1",
+		ServerPort:      clonePort,
+		ServerUser:      "root",
+		AutoStart:       false,
 		CommitterName:   "clone-user",
 		CommitterEmail:  "clone@example.com",
 		Database:        cloneDBName,
@@ -992,6 +1093,10 @@ func TestGitRemoteSyncRoundTrip(t *testing.T) {
 	// Step 4: Re-open source and pull — verify bidirectional sync
 	sourceStore2, err := New(ctx, &Config{
 		Path:            filepath.Join(setup.baseDir, "embedded-dolt"),
+		ServerHost:      "127.0.0.1",
+		ServerPort:      setup.serverPort,
+		ServerUser:      "root",
+		AutoStart:       false,
 		CommitterName:   "test",
 		CommitterEmail:  "test@example.com",
 		Database:        findClonedDBName(t, filepath.Join(setup.baseDir, "embedded-dolt")),

--- a/internal/storage/dolt/git_remote_test.go
+++ b/internal/storage/dolt/git_remote_test.go
@@ -1183,6 +1183,14 @@ func TestCreateIssueAfterPull(t *testing.T) {
 		t.Fatalf("Pull failed: %v", err)
 	}
 
+	// Pin what the pull itself delivered, before any further write. Pull()
+	// reporting success while the peer's row never arrived, and Pull()
+	// delivering the row only for a later write to drop it, are different
+	// bugs; asserting only at the end of the test cannot tell them apart.
+	if pulled, pulledErr := store.GetIssue(ctx, "ai-clone-001"); pulledErr != nil || pulled == nil {
+		t.Fatalf("Pull reported success but the peer's ai-clone-001 is not in the source store (err=%v)", pulledErr)
+	}
+
 	postPullIssue := &types.Issue{
 		ID:        "ai-src-002",
 		Title:     "Source issue after pull",


### PR DESCRIPTION
## What is stalling the pipeline

Nothing has merged to `main` since #5802 at 2026-08-20T15:11Z. Every PR pushed
after ~14:37Z fails 5-6 of the 16 `Test (Server Dolt Full Suite N/16)` shards
plus the `CI Gate / Required` aggregator, regardless of what the PR changes
(#5883, #5885 and #5886 are three unrelated controls).

This is not a regression from any PR. #5836 (30f30ca95, merged 03:39Z) added the
`test-server-storage-full` matrix **and put it in `CI_GATE_REQUIRED`**. The lane
does exactly what it says on the tin — it un-strands ~1125 `internal/storage/dolt`
tests that no PR-triggered lane had ever executed — and it has never been green.
The earliest run on the new lane (run 32352135077, 09:05Z) already failed shards
1, 3, 9 and 15, and shards 1, 3 and 9 have failed on every full-suite run since.
The older PRs that "pass" (#5866, #5859, #5854) have **zero** full-suite checks:
their last CI predates the lane.

The tests here are not newly broken. They are newly *run*.

## Root cause of 4 of the 6 shards

| shard | test |
|---|---|
| 1 | `TestCreateIssueAfterPull` |
| 9 | `TestGitRemoteEmbeddedPushPull` |
| 10 | `TestGitRemotePushSkipsUserPrePushHook` |
| 15 | `TestGitRemoteSyncRoundTrip` |

All four share one cause:

```
failed to push to origin/main: Error 1105 (HY000): failed to get remote db;
the remote: origin 'git+file:///tmp/embedded-git-remote-test-*/remote.git' could not be
accessed; fatal: '/tmp/embedded-git-remote-test-*/remote.git' does not appear to be a
git repository
```

`setupEmbeddedGitRemote` dates from when this package had an in-process embedded
engine. `store.go` now hardcodes `serverMode: true` (`// TODO: update when embedded
mode returns`), so `New()` connects to the suite's shared Dolt server — which
`TestMain` runs in a Docker container. `docker inspect` on that container shows a
single mount, the image's own `/var/lib/dolt` volume. `CALL DOLT_PUSH` executes
*inside* the container, so:

- the host bare repo the test just created does not exist for it — hence the error above;
- the store's own `Path` does not exist for it either, which is why
  `TestGitRemotePushSkipsUserPrePushHook` cannot find its cache mirror and
  `TestGitRemoteSyncRoundTrip`'s clone comes up empty.

The four `hint: dolt does not support interactive credential prompts` lines in the
CI log are dolt's generic advice appended to any remote failure. **Nothing here needs
a credential**, and no credential was added.

## The fix

Give these tests their own local `dolt sql-server` rooted at the store's data
directory — the arrangement `TestGitRemoteExternalServerRouting`,
`TestSQLRemotePersistsAcrossExternalServerRestart` and `TestCredentialCLIRoutingE2E`
in the same file already use, and the one bd actually ships (bd's server is a local
process, not a container). Engine, bare repo and test process then share one
filesystem, which is the premise these tests were written against. No skips: a skip
would have quietly dropped five real tests, and this repo has enough of that already.

Two consequences fall out and are fixed here:

- **The server is spawned with `doltserver.ServerSpawnEnv()`**, the same environment
  bd gives the server it starts. Load-bearing, not cosmetic: a `dolt` CLI command run
  against a directory a sql-server already serves is *proxied to that server*, so the
  git subprocess is spawned by the server and `applyNoGitHooksToCmd`'s
  `core.hooksPath=/dev/null` on the CLI process (GH#3724) never reaches it. Verified
  by hand on a scratch repo: with a sql-server up and `GIT_CONFIG_PARAMETERS` set on
  the CLI, the pre-push hook still fires; with the server carrying it, it does not.

- **A genesis `CommitAll` in setup.** `Commit()` deliberately skips config (GH#2455),
  so `issue_prefix` stayed dirty forever: `Pull()` refuses to auto-commit a dirty
  internal config key, and a peer cloning the database got no prefix at all. The CLI
  sibling `setupGitRemote` has always done this with
  `DOLT_COMMIT('-Am', 'Genesis: schema and config')`.

The gate becomes `testutil.RequireDoltBinary` rather than `skipIfNoDolt`: these tests
need only `dolt` and `git` now, so demanding the shared container would be a skip for
no reason.

Setup asserts `<Path>/<db>/.dolt` exists on this filesystem, so if the store ever
drifts back onto a containerized server these tests fail loudly instead of quietly
testing nothing.

No test function was added, removed or renamed, so
`.github/scripts/server-storage-test-shards.txt` and the hash fallback are untouched.

## Verification

Run against a live Dolt server with `BEADS_TEST_ENV_RUN_DOLT=1`, using the real
`.github/scripts/server-storage-test-shard.sh` and a `go test -c
-tags=integration,gms_pure_go` binary built from each branch — the same shard
partitions CI runs:

| shard | `origin/main` | this branch |
|---|---|---|
| 1 | FAIL — `TestCreateIssueAfterPull` | **exit 0, 74 tests, 0 failures** |
| 9 | FAIL — `TestGitRemoteEmbeddedPushPull` | **exit 0, 0 failures** |
| 10 | FAIL — `TestGitRemotePushSkipsUserPrePushHook` | **exit 0, 0 failures** |
| 15 | FAIL — `TestGitRemoteSyncRoundTrip` | **exit 0, 0 failures** |

Each control reproduces CI's failure set on that shard exactly — same test names,
nothing extra — so the delta is attributable.

`go vet` clean; `golangci-lint v2.10.1 run --new-from-rev` clean;
`go test ./scripts/...`, `./internal/githooksenv/...`, `./internal/doltserver/...` pass.

## What this does NOT fix

Two shards fail for unrelated reasons and this PR does not touch them:

- **shard 3** — `TestMultiProcessSchemaInit` (`acquire migration lock: schema migration
  lock unavailable: timeout` under 10-way contention, with 10 stray
  `dolt sql-server` processes in the diagnostics dump; related to the intent of #5880)
  and `TestFederationListRemotes` (`context deadline exceeded`, 0.5s, immediately after
  it, likely collateral). Fails on every full-suite run.
- **shard 12** — `TestFreshBootstrapHealIncarnation/exact_creator_heals_its_interrupted_bootstrap`
  (`pending schema migrations alter pre-existing dirty tables: issues`). Intermittent.

So this takes #5883 from 5 failing shards to 1, and #5885 / #5886 from 6 to 2. Those
two shards need their own fixes before the gate goes green.

`Test (storage domain + uow)` is *not* part of the stall: it passed on 12 of the last
13 PR runs and failed once on #5886 with `internal/tracker` reusing a terminated
per-test dolt container's port (`127.0.0.1:32772` refused).

## Process note

A job should not enter `CI_GATE_REQUIRED` before it has been observed green. #5836's
own PR predated the shards it added, so nothing forced that observation.