### PR TITLE
fix(dolt): stop full-suite shard 3 asserting on a schema-init path bd never takes

### DIFF
--- a/internal/storage/dolt/dolt_test.go
+++ b/internal/storage/dolt/dolt_test.go
@@ -134,6 +134,12 @@ func requireCleanTables(ctx context.Context, t *testing.T, store *DoltStore, tab
 //
 // Automatically marks the test as safe for parallel execution since each test
 // gets its own Dolt connection checked out to a unique branch.
+//
+// This call blocks twice — once in t.Parallel() until the sequential phase
+// ends, then again on testSem, which admits two tests at a time. In a shard of
+// 60+ tests that wait is minutes, so build the test's context AFTER this
+// returns. A context created before it spends its whole budget in the queue
+// and is already expired by the time the test body runs.
 func setupTestStore(t *testing.T) (*DoltStore, func()) {
 	t.Helper()
 	skipIfNoDolt(t)

--- a/internal/storage/dolt/federation_test.go
+++ b/internal/storage/dolt/federation_test.go
@@ -141,11 +141,11 @@ func TestFederationDatabaseIsolation(t *testing.T) {
 func TestFederationVersionControlAPIs(t *testing.T) {
 	skipIfNoDolt(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
 
 	// setupTestStore already checked this store out to its own isolated
 	// branch (testutil.StartTestBranch), not the shared database's literal
@@ -255,11 +255,11 @@ func TestFederationVersionControlAPIs(t *testing.T) {
 func TestFederationRemoteConfiguration(t *testing.T) {
 	skipIfNoDolt(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
 
 	// Add a remote (configuration only - won't actually connect)
 	// Production would use: dolthub://org/repo, s3://bucket/path, etc.
@@ -284,11 +284,11 @@ func TestFederationRemoteConfiguration(t *testing.T) {
 func TestFederationHistoryQueries(t *testing.T) {
 	skipIfNoDolt(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
 
 	// Create issue
 	issue := &types.Issue{
@@ -352,11 +352,11 @@ func TestFederationHistoryQueries(t *testing.T) {
 func TestFederationListRemotes(t *testing.T) {
 	skipIfNoDolt(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
 
 	// Initially no remotes (except possibly origin if Dolt adds one by default)
 	remotes, err := store.ListRemotes(ctx)
@@ -388,11 +388,11 @@ func TestFederationListRemotes(t *testing.T) {
 func TestFederationSyncStatus(t *testing.T) {
 	skipIfNoDolt(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
 
 	// Get status for a nonexistent peer (should not error, just return partial data)
 	status, err := store.SyncStatus(ctx, "nonexistent-peer")
@@ -415,11 +415,11 @@ func TestFederationSyncStatus(t *testing.T) {
 func TestFederationSyncCommitsPendingPeerMetadataBeforeFetch(t *testing.T) {
 	skipIfNoDolt(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
 
 	peer := &storage.FederationPeer{
 		Name:        "peer-metadata-sync",
@@ -480,11 +480,11 @@ func federationStatusHasTable(t *testing.T, ctx context.Context, store *DoltStor
 func TestFederationPushPullMethods(t *testing.T) {
 	skipIfNoDolt(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
 
 	// These should fail gracefully since no remote exists
 	err := store.PushTo(ctx, "nonexistent")

--- a/internal/storage/dolt/git_remote_test.go
+++ b/internal/storage/dolt/git_remote_test.go
@@ -12,11 +12,13 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/steveyegge/beads/internal/doltserver"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/doltutil"
 	"github.com/steveyegge/beads/internal/storage/schema"
@@ -45,10 +47,55 @@ import (
 
 // gitRemoteSetup holds resources for a git-remote test scenario.
 type gitRemoteSetup struct {
-	baseDir   string // root temp dir
-	remoteDir string // bare git repo path
-	remoteURL string // file:// URL for the bare repo
-	sourceDir string // dolt source repo directory
+	baseDir    string // root temp dir
+	remoteDir  string // bare git repo path
+	remoteURL  string // file:// URL for the bare repo
+	sourceDir  string // dolt source repo directory
+	serverPort int    // local dolt sql-server port (0 for CLI-only setups)
+}
+
+// startLocalDoltServer starts a `dolt sql-server` rooted at dataDir and
+// returns its port and an idempotent stop function.
+//
+// The suite's shared Dolt server (testmain_test.go) runs inside a Docker
+// container: its only mount is the image's own /var/lib/dolt volume, so it
+// can reach neither a host file:// git remote nor the store's own Path.
+// Tests that push to a local bare git repo, or that inspect the engine's
+// on-disk state, need a server that shares this process's filesystem.
+// TestGitRemoteExternalServerRouting, TestSQLRemotePersistsAcrossExternalServerRestart
+// and TestCredentialCLIRoutingE2E use the same arrangement.
+//
+// The server is spawned with doltserver.ServerSpawnEnv(), the same environment
+// bd gives the sql-server it starts. That is load-bearing, not cosmetic: a
+// `dolt` CLI command run against a directory a sql-server is already serving
+// is proxied to that server, so the git subprocess is spawned by the server,
+// not by the CLI — env guards applied to the CLI process (git tracing,
+// core.hooksPath) only take effect if the server carries them too.
+func startLocalDoltServer(t *testing.T, dataDir string) (int, func()) {
+	t.Helper()
+	port, err := testutil.FindFreePort()
+	if err != nil {
+		t.Fatalf("failed to find free port: %v", err)
+	}
+	cmd := exec.Command("dolt", "sql-server", "-H", "127.0.0.1", "-P", strconv.Itoa(port))
+	cmd.Dir = dataDir
+	cmd.Env = doltserver.ServerSpawnEnv()
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start dolt sql-server in %s: %v", dataDir, err)
+	}
+	var once sync.Once
+	stop := func() {
+		once.Do(func() {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		})
+	}
+	t.Cleanup(stop)
+	if !testutil.WaitForServer(port, 15*time.Second) {
+		stop()
+		t.Fatalf("dolt sql-server in %s did not become ready within timeout", dataDir)
+	}
+	return port, stop
 }
 
 // setupGitRemote creates a bare git repo (seeded with an initial commit)
@@ -588,18 +635,23 @@ func TestGitRemoteSpecialCharacters(t *testing.T) {
 	}
 }
 
-// --- Embedded driver git remote tests ---
+// --- SQL-driver git remote tests ---
 //
 // These tests verify that Dolt's git remote support works through the
 // SQL driver, not just the CLI. This is the critical question for the
 // Dolt-in-Git spike: can we use store.Push() and store.Pull() with a
 // bare git repo as the remote?
+//
+// CALL DOLT_PUSH runs inside the sql-server process, so the server must be
+// able to see the bare repo and the store's own data directory. These tests
+// therefore run against their own local sql-server (startLocalDoltServer),
+// not the suite's containerized shared server.
 
 // setupEmbeddedGitRemote creates a bare git repo and returns a DoltStore
 // connected with the bare repo configured as "origin".
 func setupEmbeddedGitRemote(t *testing.T) (*DoltStore, *gitRemoteSetup, func()) {
 	t.Helper()
-	skipIfNoDolt(t)
+	testutil.RequireDoltBinary(t)
 	skipIfNoGit(t)
 	acquireTestSlot()
 	t.Cleanup(releaseTestSlot)
@@ -625,47 +677,89 @@ func setupEmbeddedGitRemote(t *testing.T) (*DoltStore, *gitRemoteSetup, func()) 
 
 	remoteURL := "file://" + remoteDir
 
-	// Create embedded DoltStore
+	// Serve the store's own data directory from a local sql-server so the
+	// engine, the bare git repo and this test process all share one
+	// filesystem.
 	doltDir := filepath.Join(baseDir, "embedded-dolt")
+	if err := os.MkdirAll(doltDir, 0o755); err != nil {
+		os.RemoveAll(baseDir)
+		t.Fatalf("failed to create dolt dir: %v", err)
+	}
+	serverPort, stopServer := startLocalDoltServer(t, doltDir)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	dbName := uniqueTestDBName(t)
 	store, err := New(ctx, &Config{
 		Path:            doltDir,
+		ServerHost:      "127.0.0.1",
+		ServerPort:      serverPort,
+		ServerUser:      "root",
+		AutoStart:       false,
 		CommitterName:   "test",
 		CommitterEmail:  "test@example.com",
 		Database:        dbName,
 		CreateIfMissing: true, // test creates a fresh database
 	})
 	if err != nil {
+		stopServer()
 		os.RemoveAll(baseDir)
-		t.Fatalf("failed to create embedded DoltStore: %v", err)
+		t.Fatalf("failed to create DoltStore: %v", err)
+	}
+
+	// The whole point of the local server: the database it just created must
+	// be on this process's filesystem, under the store's own Path. Tests here
+	// push to a host bare repo and read the engine's git-remote cache mirror,
+	// and both silently stop being meaningful if the store ever drifts back
+	// onto a containerized server.
+	if _, statErr := os.Stat(filepath.Join(doltDir, dbName, ".dolt")); statErr != nil {
+		store.Close()
+		stopServer()
+		os.RemoveAll(baseDir)
+		t.Fatalf("store did not materialize %s/.dolt on this filesystem — the engine is not local to the test: %v", filepath.Join(doltDir, dbName), statErr)
 	}
 
 	// Set issue prefix (required for CreateIssue)
 	if err := store.SetConfig(ctx, "issue_prefix", "test"); err != nil {
 		store.Close()
+		stopServer()
 		os.RemoveAll(baseDir)
 		t.Fatalf("failed to set prefix: %v", err)
 	}
 
-	// Add git remote via embedded SQL
+	// Add git remote via SQL
 	if err := store.AddRemote(ctx, "origin", remoteURL); err != nil {
 		store.Close()
+		stopServer()
 		os.RemoveAll(baseDir)
 		t.Fatalf("failed to add remote: %v", err)
 	}
 
+	// Genesis commit, sweeping config too — the CLI sibling setupGitRemote
+	// does the same with DOLT_COMMIT('-Am', 'Genesis: schema and config').
+	// Commit() deliberately skips config (GH#2455), so without this
+	// issue_prefix stays dirty forever: Pull() then refuses to auto-commit a
+	// dirty internal config key, and a peer cloning this database gets no
+	// prefix at all.
+	if _, err := store.CommitAll(ctx, "Genesis: schema and config"); err != nil {
+		store.Close()
+		stopServer()
+		os.RemoveAll(baseDir)
+		t.Fatalf("failed to commit genesis config: %v", err)
+	}
+
 	setup := &gitRemoteSetup{
-		baseDir:   baseDir,
-		remoteDir: remoteDir,
-		remoteURL: remoteURL,
-		sourceDir: doltDir,
+		baseDir:    baseDir,
+		remoteDir:  remoteDir,
+		remoteURL:  remoteURL,
+		sourceDir:  doltDir,
+		serverPort: serverPort,
 	}
 
 	cleanup := func() {
 		store.Close()
+		stopServer()
 		os.RemoveAll(baseDir)
 	}
 
@@ -940,8 +1034,15 @@ func TestGitRemoteSyncRoundTrip(t *testing.T) {
 		t.Fatal("expected bootstrap to occur (no existing dolt dir)")
 	}
 
+	// The clone is a second peer with its own data directory, so it needs its
+	// own local server for the same reason the source does.
+	clonePort, _ := startLocalDoltServer(t, cloneDoltDir)
 	cloneStore, err := New(ctx, &Config{
 		Path:            cloneDoltDir,
+		ServerHost:      "127.0.0.1",
+		ServerPort:      clonePort,
+		ServerUser:      "root",
+		AutoStart:       false,
 		CommitterName:   "clone-user",
 		CommitterEmail:  "clone@example.com",
 		Database:        cloneDBName,
@@ -992,6 +1093,10 @@ func TestGitRemoteSyncRoundTrip(t *testing.T) {
 	// Step 4: Re-open source and pull — verify bidirectional sync
 	sourceStore2, err := New(ctx, &Config{
 		Path:            filepath.Join(setup.baseDir, "embedded-dolt"),
+		ServerHost:      "127.0.0.1",
+		ServerPort:      setup.serverPort,
+		ServerUser:      "root",
+		AutoStart:       false,
 		CommitterName:   "test",
 		CommitterEmail:  "test@example.com",
 		Database:        findClonedDBName(t, filepath.Join(setup.baseDir, "embedded-dolt")),

--- a/internal/storage/dolt/git_remote_test.go
+++ b/internal/storage/dolt/git_remote_test.go
@@ -1183,6 +1183,14 @@ func TestCreateIssueAfterPull(t *testing.T) {
 		t.Fatalf("Pull failed: %v", err)
 	}
 
+	// Pin what the pull itself delivered, before any further write. Pull()
+	// reporting success while the peer's row never arrived, and Pull()
+	// delivering the row only for a later write to drop it, are different
+	// bugs; asserting only at the end of the test cannot tell them apart.
+	if pulled, pulledErr := store.GetIssue(ctx, "ai-clone-001"); pulledErr != nil || pulled == nil {
+		t.Fatalf("Pull reported success but the peer's ai-clone-001 is not in the source store (err=%v)", pulledErr)
+	}
+
 	postPullIssue := &types.Issue{
 		ID:        "ai-src-002",
 		Title:     "Source issue after pull",

--- a/internal/storage/dolt/git_remote_test.go
+++ b/internal/storage/dolt/git_remote_test.go
@@ -228,6 +228,40 @@ func sourceCommitAndPush(t *testing.T, dir, msg string) {
 	doltPush(t, dir)
 }
 
+// doltGitRemoteReadCacheTTL mirrors dolt's own defaultSyncForReadTTL
+// (store/blobstore/git_blobstore.go). Dolt resolves a file:// URL that points
+// at a git repo to a git+file:// remote served by GitBlobstore, and
+// GitBlobstore.syncForRead skips the underlying `git fetch` entirely when it
+// last synced less than this long ago:
+//
+//	if ttl := gbs.syncForReadTTL; ttl > 0 { if sinceLast < ttl { return nil } }
+//
+// The blobstore is cached for the life of the sql-server process
+// (dbfactory.gitRemoteCache), so the window is per-server, not per-connection.
+const doltGitRemoteReadCacheTTL = 1 * time.Second
+
+// waitOutGitRemoteReadCache blocks until a push made by a *different* process
+// is guaranteed visible to the next remote read performed by a sql-server this
+// test already used to touch the same remote.
+//
+// Without it these tests race a silent upstream staleness window: a pull
+// issued inside doltGitRemoteReadCacheTTL of the server's previous remote sync
+// reads the cached view, finds the peer's commit absent, and reports
+// "Everything up-to-date" with fast_forward=0 — so store.Pull() returns nil
+// having merged nothing and the peer's rows never arrive. Verified against
+// dolt 2.3.1: with the peer's push and the pull 0.74s apart the pull reports
+// success and delivers nothing; at 1.18s apart the same sequence reports
+// "merge successful" and the row arrives. That is why these tests failed only
+// on CI, whose runners complete the intervening clone/insert/push faster than
+// a loaded developer machine.
+//
+// This sleep removes an unintended dependency on an upstream cache; it does
+// not weaken any assertion below it. If bd's push/pull were actually broken,
+// every assertion still fails exactly as before.
+func waitOutGitRemoteReadCache() {
+	time.Sleep(doltGitRemoteReadCacheTTL + 500*time.Millisecond)
+}
+
 // --- Clone verification helpers (all CLI-based) ---
 
 // queryCSV runs a SQL query via dolt CLI and returns parsed rows as maps.
@@ -811,6 +845,10 @@ func TestGitRemoteEmbeddedPushPull(t *testing.T) {
 	sourceInsertIssue(t, cloneDir, "emb-git-002", "Added in clone")
 	sourceCommitAndPush(t, cloneDir, "Add emb-git-002 from clone")
 
+	// The clone pushed from its own process; this store's sql-server last read
+	// the remote during store.Push() above and caches that view briefly.
+	waitOutGitRemoteReadCache()
+
 	// Pull via embedded driver
 	if err := store.Pull(ctx); err != nil {
 		t.Fatalf("Pull failed: %v", err)
@@ -1090,6 +1128,10 @@ func TestGitRemoteSyncRoundTrip(t *testing.T) {
 	// Close clone store before re-opening source
 	cloneStore.Close()
 
+	// The clone pushed from its own sql-server; the source's server last read
+	// the remote during step 1's push and caches that view briefly.
+	waitOutGitRemoteReadCache()
+
 	// Step 4: Re-open source and pull — verify bidirectional sync
 	sourceStore2, err := New(ctx, &Config{
 		Path:            filepath.Join(setup.baseDir, "embedded-dolt"),
@@ -1174,6 +1216,10 @@ func TestCreateIssueAfterPull(t *testing.T) {
 	}
 	sourceInsertIssue(t, cloneDir, "ai-clone-001", "Clone issue generating events")
 	sourceCommitAndPush(t, cloneDir, "Add ai-clone-001")
+
+	// The peer pushed from its own process; this store's sql-server last read
+	// the remote during store.Push() above and caches that view briefly.
+	waitOutGitRemoteReadCache()
 
 	// Pull into the source store — this is the code path under test.
 	// With UUID primary keys, there are no counter collisions after pull.

--- a/internal/storage/dolt/initschema_multiprocess_test.go
+++ b/internal/storage/dolt/initschema_multiprocess_test.go
@@ -55,7 +55,10 @@ func TestHelperSchemaInit(t *testing.T) {
 	db.SetMaxOpenConns(2)
 	db.SetMaxIdleConns(1)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	// Must leave room for the retry wrapper's full serverRetryMaxElapsed (30s)
+	// budget on top of connect time, or the context cuts the retry short and
+	// re-creates the failure it exists to absorb.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
 	if err := db.PingContext(ctx); err != nil {
@@ -63,9 +66,18 @@ func TestHelperSchemaInit(t *testing.T) {
 		os.Exit(1)
 	}
 
-	_, err = initSchemaOnDB(ctx, db)
+	// initSchemaOnDBWithRetry, not the raw initSchemaOnDB: every production
+	// caller (DoltStore.initSchema, DoltStore.ApplySchemaMigrations) goes
+	// through this wrapper, and the 5s GET_LOCK wait in
+	// schema.MigrateUpWithLock is deliberately sized to fit inside its retry
+	// budget — see migrationLockAcquireTimeoutSeconds. Racing the raw call and
+	// demanding a first-try win asserts on a path no bd process ever takes:
+	// with N processes on one fresh database, N-1 of them are supposed to lose
+	// the lock and come back. #5880 made the same change in this file's
+	// TestMultiProcessSchemaInit_DoltVerify and missed this subprocess helper.
+	_, err = initSchemaOnDBWithRetry(ctx, db)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "ERROR: initSchemaOnDB: %v\n", err)
+		fmt.Fprintf(os.Stderr, "ERROR: initSchemaOnDBWithRetry: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -124,7 +136,10 @@ func TestMultiProcessSchemaInit(t *testing.T) {
 	for i := 0; i < numProcs; i++ {
 		procID := strconv.Itoa(i)
 		eg.Go(func() error {
-			subCtx, subCancel := context.WithTimeout(egCtx, 30*time.Second)
+			// Same reasoning as the subprocess's own context: this bound has to
+			// cover process start, connect, and the retry wrapper's whole 30s
+			// budget, so it cannot itself be 30s.
+			subCtx, subCancel := context.WithTimeout(egCtx, 2*time.Minute)
 			defer subCancel()
 
 			cmd := exec.CommandContext(subCtx, testBin,

--- a/internal/storage/dolt/testmain_helper_sentinel_test.go
+++ b/internal/storage/dolt/testmain_helper_sentinel_test.go
@@ -1,0 +1,49 @@
+package dolt
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"testing"
+)
+
+// helperSentinelRead matches how a TestHelper* entry point reads its own
+// sentinel, e.g. os.Getenv("BEADS_SCHEMA_INIT_HELPER").
+var helperSentinelRead = regexp.MustCompile(`os\.Getenv\("(BEADS_[A-Z0-9_]*_HELPER)"\)`)
+
+// TestHelperSubprocessSentinelsAreComplete keeps helperSubprocessSentinels in
+// sync with the helper entry points that actually exist. A missing entry is
+// silent and expensive: TestMain would start a Dolt container the subprocess
+// never uses, then leak it when the helper exits via os.Exit.
+func TestHelperSubprocessSentinelsAreComplete(t *testing.T) {
+	sources, err := filepath.Glob("*_test.go")
+	if err != nil {
+		t.Fatalf("glob test sources: %v", err)
+	}
+	if len(sources) == 0 {
+		t.Fatal("no *_test.go sources found — the scan below would vacuously pass")
+	}
+
+	var found []string
+	for _, source := range sources {
+		data, err := os.ReadFile(source)
+		if err != nil {
+			t.Fatalf("read %s: %v", source, err)
+		}
+		for _, match := range helperSentinelRead.FindAllStringSubmatch(string(data), -1) {
+			found = append(found, match[1])
+			if !slices.Contains(helperSubprocessSentinels, match[1]) {
+				t.Errorf("%s reads helper sentinel %s, which is missing from helperSubprocessSentinels in testmain_test.go", source, match[1])
+			}
+		}
+	}
+
+	// The reverse direction is the control: if the pattern above ever stops
+	// matching, this fails instead of letting the scan pass on zero hits.
+	for _, sentinel := range helperSubprocessSentinels {
+		if !slices.Contains(found, sentinel) {
+			t.Errorf("helperSubprocessSentinels lists %s, but no test source reads it — stale entry, or helperSentinelRead no longer matches", sentinel)
+		}
+	}
+}

--- a/internal/storage/dolt/testmain_test.go
+++ b/internal/storage/dolt/testmain_test.go
@@ -23,6 +23,26 @@ var testSharedDB string
 // testSharedConn is a raw *sql.DB for branch operations in the shared database.
 var testSharedConn *sql.DB
 
+// helperSubprocessSentinels are the env vars a parent test sets when it
+// re-execs this test binary as a helper subprocess. Keep in sync with the
+// TestHelper* entry points — TestHelperSubprocessSentinelsAreComplete fails the
+// build if a new one is added without listing it here.
+var helperSubprocessSentinels = []string{
+	"BEADS_SCHEMA_INIT_HELPER",
+	"BEADS_MULTISTORE_HELPER",
+}
+
+// isHelperSubprocess reports whether this process was re-exec'd as a helper
+// subprocess rather than run as the suite itself.
+func isHelperSubprocess() bool {
+	for _, sentinel := range helperSubprocessSentinels {
+		if os.Getenv(sentinel) == "1" {
+			return true
+		}
+	}
+	return false
+}
+
 func TestMain(m *testing.M) {
 	os.Exit(testMainInner(m))
 }
@@ -57,6 +77,18 @@ func testMainInner(m *testing.M) int {
 	// sql-server (testcontainer or external port). The new database-name
 	// firewall in dolt.New refuses test-named DBs unless this opt-in is set.
 	os.Setenv("BEADS_TEST_SERVER", "1")
+	if isHelperSubprocess() {
+		// A helper subprocess is handed its server's port by the parent test
+		// and never looks at this suite's own server. Starting one anyway
+		// costs a Dolt container plus a full migration chain per subprocess:
+		// TestMultiProcessSchemaInit spawns 8 at once, so the machine ran 9
+		// Dolt servers to measure a lock race between 8 clients of the
+		// parent's single server. Worse, every helper exits through os.Exit,
+		// which skips the deferred TerminateDoltContainer below and leaks the
+		// container. That load is what pushed the contended GET_LOCK past its
+		// 5s wait in CI shard 3.
+		return m.Run()
+	}
 	if err := testutil.EnsureDoltContainerForTestMain(); err != nil {
 		fmt.Fprintf(os.Stderr, "WARN: %v, skipping Dolt tests\n", err)
 	} else {


### PR DESCRIPTION
> **Status: all 16 `test-server-storage-full` shards green, `Test (Server Dolt Conformance)` green, and both `CI Gate / Required` checks green** (PR Risk run `32419035372`). 119/119 checks pass. `Test Nix Flake` failed once on a `proxy.golang.org` transport error (`stream error: stream ID 3683; INTERNAL_ERROR`) and passed on a re-run of the identical commit — infra flake, unrelated to this diff.

This PR now carries **three** fixes and supersedes #5888:

1. `fix(dolt): git-remote tests need a sql-server that shares their filesystem` — #5888's topology fix (shards 10, 15).
2. `fix(dolt): stop shard 3 asserting on a schema-init path bd never takes` — shard 3.
3. `test(dolt): stop racing dolt's 1s git-remote read cache` — shards 1, 9, and latently 15.

## Third fix: `TestCreateIssueAfterPull` / `TestGitRemoteEmbeddedPushPull`

#5888's topology fix was necessary but not sufficient. Putting the engine, the bare repo and the test process on one filesystem *exposed* a race the containerized shared server had hidden:

Dolt resolves a `file://` URL pointing at a git repo into a `git+file://` remote served by `GitBlobstore`. `GitBlobstore.syncForRead` **skips the underlying `git fetch` entirely** when it last synced less than `defaultSyncForReadTTL` = 1s ago (`store/blobstore/git_blobstore.go:399` and `:739`), and the blobstore is cached for the life of the sql-server process (`dbfactory.gitRemoteCache`), so the window is per-server, not per-connection. A pull landing inside it reads the cached view, misses the peer's commit, and reports `"Everything up-to-date"` with `fast_forward=0` — so `store.Pull()` returns nil having merged nothing.

Measured against dolt 2.3.1, with the row independently confirmed present on the remote by a third clone every time:

| push→pull gap | pull reported | rows delivered |
|---|---|---|
| 0.856 / 0.777 / 0.764 / 0.765s | "Everything up-to-date" | **0** |
| 2.816 / 2.822s | "merge successful" | 1 |

6/6, clean split at the 1s boundary. The Push→Pull window is 1.75s for `TestCreateIssueAfterPull` and 2.04s for `TestGitRemoteEmbeddedPushPull` on a loaded dev box; CI runners do the intervening clone/insert/push faster and push both under 1s — the shorter one crosses first, which is exactly why `TestCreateIssueAfterPull` failed on 3 of 3 CI runs and `TestGitRemoteEmbeddedPushPull` on 2 of 3.

The tests now wait the documented TTL out before a pull that follows a push made by a *different* process. No assertion is skipped, loosened, or made vacuous — if push/pull were genuinely broken every assertion still fails identically. Routing through the CLI does not help: in a served directory `dolt pull` is proxied to the same sql-server and reads the same cached view (verified), and `gitBlobstoreSyncForReadTTLOverride` is only ever set by dolt's own tests, so there is no client-side lever.

**Worth flagging beyond CI:** `Pull()` can return success while delivering none of a peer's rows. It is bounded (~1s) and self-heals on the next pull, so it is not an emergency — but a caller must not treat one successful pull as proof it has everything. If bd ever grows a "sync complete, safe to act" guarantee, this is the hole it has to close.

---

**Base retargeted to `main`.** `pr-risk.yml` only triggers on `pull_request: branches: [main]`, so a PR stacked onto #5888's branch would have run **zero** full-suite shards — the exact vacuous-green trap this lane exists to close. Targeting `main` means this PR carries #5888's two commits as well, so one CI run measures the whole remaining set. Merge #5888 first and this rebases to just the shard-3 commit, or merge this and #5888 becomes redundant.

---

Stacked on #5888 (`fix/be-server-lane-git-remote-tests`), because that branch is what the remaining full-suite failures are measured against. Retarget to `main` if #5888 lands first.

`test-server-storage-full` shard 3 has failed **every** run since #5836 added the 16-way matrix and wired it into `CI_GATE_REQUIRED`. Two tests, two test bugs. Both reproduce locally with the real `.github/scripts/server-storage-test-shard.sh` against a live Dolt server, with the same failure name set and the same error strings as CI.

## `TestMultiProcessSchemaInit`

```
ERROR: initSchemaOnDB: schema migration: schema: acquire migration lock: schema migration lock unavailable: timeout
```

**Not a product defect.** The subprocess helper called the raw `initSchemaOnDB`. `grep` finds no non-test caller of it: every bd process reaches schema init through `initSchemaOnDBWithRetry` (`DoltStore.initSchema`, `DoltStore.ApplySchemaMigrations`), and `isRetryableError` classifies `ErrMigrationLockUnavailable` as retryable on purpose. `migrationLockAcquireTimeoutSeconds = 5` carries the comment "Keep this below the server-mode callers' retry budgets so a contended lock wait can time out and still leave room for a real retry." Losing the `GET_LOCK` race and coming back **is** the designed behaviour. Racing eight processes on one fresh database and demanding all eight win on the first try asserts on a path production does not have.

#5880 made exactly this change to this same file's `TestMultiProcessSchemaInit_DoltVerify` — with a comment saying why — and missed the subprocess helper.

The helpers also each started a Dolt container they never used. `TestMain` calls `EnsureDoltContainerForTestMain` unconditionally, so eight helpers spawned eight idle servers on top of the parent's: the nine `dolt sql-server --host=0.0.0.0 --port=3306` processes in the CI diagnostics dump, verified locally by diffing `docker ps` across one helper invocation. Each leaked, too — the helpers exit via `os.Exit`, which skips the deferred `TerminateDoltContainer`. That load is what pushed the contended lock past its 5s wait. `TestMain` now skips the suite server for helper subprocesses, which are handed the parent's port anyway; a guard test keeps the sentinel list in sync with the `TestHelper*` entry points so the next helper cannot regress it silently.

The subprocess timeouts were also 30s — exactly the retry budget they had to contain, leaving the retry no room. Now 2 minutes.

## `TestFederationListRemotes` (+ 6 siblings)

```
federation_test.go:364: failed to list remotes: list remotes: context deadline exceeded
```

Seven `federation_test.go` tests built a one-minute context **before** calling `setupTestStore`, which parks the test at `t.Parallel()` and then queues it on a two-slot semaphore. In a 60-test shard that wait exceeds a minute, so the test resumed with an already-expired context and failed 0.5s into its own body. The context now starts after the store exists, and `setupTestStore`'s doc says why.

## Verification

Real shard script, live Dolt server, `BEADS_TEST_ENV_RUN_DOLT=1`, prebuilt binary as in CI:

| | PASS | FAIL | SKIP |
|---|---|---|---|
| before (this branch's base) | 60 | 2 | 0 |
| after | **62** | **0** | **0** |

Zero skips both times — nothing went vacuously green. `TestMultiProcessSchemaInit` still does its real work: "All 8 subprocesses completed successfully", `schema_migrations max version: 65`.

The new guard test was falsified in both directions: dropping a listed sentinel fails the forward check, adding a bogus one fails the reverse check. The helper path was confirmed to start zero containers (down from two).

No test was skipped, disabled, or loosened.

Refs #5836, #5880

