### PR TITLE
fix(storage/dolt): stop Transaction.SearchIssues dropping the keyset cursor and eight other filter fields

### DIFF
--- a/backend/conformance/conformance.go
+++ b/backend/conformance/conformance.go
@@ -267,6 +267,8 @@ func RunAll(t *testing.T, factory Factory) {
 	t.Run("TransactionReadYourWrites", func(t *testing.T) { testTransactionReadYourWrites(t, factory) })
 	t.Run("TransactionUpdateRecordsHistory", func(t *testing.T) { testTransactionUpdateRecordsHistory(t, factory) })
 	t.Run("TransactionSearchIncludeDependencies", func(t *testing.T) { testTransactionSearchIncludeDependencies(t, factory) })
+	t.Run("TransactionSearchKeysetWalk", func(t *testing.T) { testTransactionSearchKeysetWalk(t, factory) })
+	t.Run("TransactionSearchFilterParity", func(t *testing.T) { testTransactionSearchFilterParity(t, factory) })
 }
 
 // RunDeferredReads runs a curated three-case subset — statistics, external-ref

--- a/backend/conformance/transaction_parity.go
+++ b/backend/conformance/transaction_parity.go
@@ -1,10 +1,15 @@
 package conformance
 
 import (
+	"errors"
+	"fmt"
+	"reflect"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/steveyegge/beads/internal/storage"
+	storageops "github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -135,6 +140,424 @@ func testTransactionSearchIncludeDependencies(t *testing.T, f Factory) {
 				id, len(off[id]))
 		}
 	}
+}
+
+// testTransactionSearchKeysetWalk pins Transaction.SearchIssues to honoring the
+// IssueFilter.AfterCreatedAt/AfterID keyset position (ga-v1nuj).
+//
+// This is the LIVENESS case of the family. Every other dropped filter field
+// costs the caller a wrong row set; a dropped keyset position costs it the loop:
+// each page re-answers the first one, so a caller paging to exhaustion never
+// advances. Depending on how the caller bounds itself that is an infinite loop
+// or a silently truncated read, and neither reports an error.
+//
+// The oracle is RunSearchPaging's store-level walk over the same fixture — the
+// same verb, on the same store, with the transaction taken away. Both backends
+// already answer it, so the sequence below is not a backend opinion.
+//
+// Two controls keep the walk assertion honest:
+//
+//   - The bounded page loop plus the seen-set is itself the detector: a backend
+//     that drops the cursor re-answers page 0 forever, which trips "repeated"
+//     on the second page rather than hanging the suite. Reintroducing the drop
+//     must turn this case red, or it is not testing what it exists for.
+//   - A result set that fits in one page must still work, and the page after it
+//     must be empty. Without that leg a backend could pass by answering nothing
+//     at all after the first page — dropping rows rather than repeating them —
+//     and the walk's no-repeat assertion alone would not notice.
+//
+// NOTHING IN THIS CASE FAILS THE TEST FROM INSIDE A TRANSACTION CALLBACK.
+// t.Fatalf unwinds with runtime.Goexit, which abandons the open transaction
+// instead of returning through RunInTransaction's commit/rollback — the suite
+// then blocks on the stranded transaction until the whole binary's timeout
+// fires, and a ten-minute goroutine dump replaces the assertion that was
+// supposed to be the output. Every callback here only collects; the assertions
+// run after it has returned.
+func testTransactionSearchKeysetWalk(t *testing.T, f Factory) {
+	s := f(t)
+	c := ctx()
+	seedKeysetOverflow(t, s)
+
+	// Oracle: the store-level one-shot read fixes the sequence the paged walk
+	// has to reproduce. A backend that pages correctly but orders differently
+	// fails here rather than on the walk, and the two read differently.
+	full, err := s.SearchIssues(c, "", keysetOverflowFilter())
+	must(t, err)
+	if got := orderedIDs(full); !reflect.DeepEqual(got, keysetOverflowOrder) {
+		t.Fatalf("oracle broken: store-level one-shot read = %v, want %v (created_at DESC, id ASC)", got, keysetOverflowOrder)
+	}
+
+	const pageSize = 2
+	var walked []string
+	var repeated string
+	repeatedPage := -1
+	must(t, s.RunInTransaction(c, "bd: keyset walk", func(tx storage.Transaction) error {
+		seen := make(map[string]bool, len(keysetOverflowOrder))
+		var afterCreatedAt *time.Time
+		afterID := ""
+		// Bounded on purpose: one more iteration than there are rows. A
+		// backend that ignores the position would otherwise spin forever, and
+		// a hung suite reports nothing. The bound converts that into the
+		// "repeated" report below.
+		for page := 0; page <= len(keysetOverflowOrder); page++ {
+			filter := keysetOverflowFilter()
+			filter.Limit = pageSize
+			filter.AfterCreatedAt = afterCreatedAt
+			filter.AfterID = afterID
+			rows, rowsErr := tx.SearchIssues(c, "", filter)
+			if rowsErr != nil {
+				return fmt.Errorf("page %d: %w", page, rowsErr)
+			}
+			if len(rows) == 0 {
+				return nil
+			}
+			if len(rows) > pageSize {
+				return fmt.Errorf("page %d answered %d rows over a Limit of %d", page, len(rows), pageSize)
+			}
+			for _, issue := range rows {
+				if seen[issue.ID] {
+					repeated, repeatedPage = issue.ID, page
+					return nil
+				}
+				seen[issue.ID] = true
+				walked = append(walked, issue.ID)
+			}
+			last := rows[len(rows)-1]
+			at := last.CreatedAt.UTC()
+			afterCreatedAt = &at
+			afterID = last.ID
+		}
+		return nil
+	}))
+
+	if repeated != "" {
+		t.Fatalf("in-tx page %d repeated %q after walking %v: the keyset position was accepted and "+
+			"ignored, so the walk never advanced past its first page", repeatedPage, repeated, walked)
+	}
+	if !reflect.DeepEqual(walked, keysetOverflowOrder) {
+		t.Fatalf("in-tx keyset walk = %v, want the one-shot sequence %v with nothing dropped and nothing repeated",
+			walked, keysetOverflowOrder)
+	}
+
+	// Control: a result set that fits in one page is not a special case. The
+	// whole set comes back at once, and the page positioned after its last row
+	// is empty — which is what terminates the walk above.
+	var single, tail []string
+	must(t, s.RunInTransaction(c, "bd: keyset single page", func(tx storage.Transaction) error {
+		filter := keysetOverflowFilter()
+		filter.Limit = len(keysetOverflowOrder)
+		rows, rowsErr := tx.SearchIssues(c, "", filter)
+		if rowsErr != nil {
+			return fmt.Errorf("single page: %w", rowsErr)
+		}
+		single = orderedIDs(rows)
+		if len(rows) == 0 {
+			return nil
+		}
+		last := rows[len(rows)-1]
+		at := last.CreatedAt.UTC()
+		filter.AfterCreatedAt = &at
+		filter.AfterID = last.ID
+		past, pastErr := tx.SearchIssues(c, "", filter)
+		if pastErr != nil {
+			return fmt.Errorf("page past the end: %w", pastErr)
+		}
+		tail = orderedIDs(past)
+		return nil
+	}))
+	if !reflect.DeepEqual(single, keysetOverflowOrder) {
+		t.Fatalf("control broken: a single page sized to the whole set = %v, want %v", single, keysetOverflowOrder)
+	}
+	if len(tail) != 0 {
+		t.Fatalf("control broken: the page positioned after the last row answered %v, want nothing — "+
+			"a walk positioned past the end must terminate", tail)
+	}
+}
+
+// testTransactionSearchFilterParity pins the rest of the filter surface
+// Transaction.SearchIssues accepted and dropped (ga-v1nuj).
+//
+// Same shape as the keyset case and the same oracle rule: each leg's expected
+// row set is what the STORE-LEVEL SearchIssues answers for the identical filter
+// on the identical store, never what the other backend answers. Every filter
+// carries SkipWisps so the oracle queries the issues table alone — the
+// transaction's single-table search is not a wisp-merge, and letting that
+// unrelated divergence into these legs would make them assert two things at
+// once.
+//
+// The load-bearing control is per leg: the filter must exclude at least one row
+// the unfiltered read returns. A predicate that happens to match everything
+// makes "ignored" and "honored" the same answer, and the leg would pass on a
+// backend that never read the field.
+func testTransactionSearchFilterParity(t *testing.T, f Factory) {
+	s := f(t)
+	c := ctx()
+	seedFilterParityFixture(t, s)
+
+	started := parityStarted(1)
+	blocked := true
+	for _, leg := range []struct {
+		name   string
+		filter types.IssueFilter
+	}{
+		{"Statuses", types.IssueFilter{Statuses: []types.Status{types.StatusOpen, types.StatusInProgress}}},
+		{"ExcludeLabels", types.IssueFilter{ExcludeLabels: []string{"area-api"}}},
+		{"LabelPattern", types.IssueFilter{LabelPattern: "area-*"}},
+		{"LabelRegex", types.IssueFilter{LabelRegex: "^area-api$"}},
+		{"IsBlocked", types.IssueFilter{IsBlocked: &blocked}},
+		{"StartedAfter", types.IssueFilter{StartedAfter: &started}},
+		{"StartedBefore", types.IssueFilter{StartedBefore: &started}},
+	} {
+		t.Run(leg.name, func(t *testing.T) {
+			filter := leg.filter
+			filter.IDPrefix = parityPrefix
+			filter.SkipWisps = true
+			filter.Limit = 100
+
+			oracle, err := s.SearchIssues(c, "", filter)
+			must(t, err)
+			want := issueIDs(oracle)
+
+			// Control: the predicate has to exclude something, or the leg
+			// cannot tell an honored field from an ignored one.
+			if len(want) == 0 {
+				t.Fatalf("oracle broken: %s matched nothing on the fixture", leg.name)
+			}
+			if len(want) == parityFixtureSize {
+				t.Fatalf("control broken: %s matched all %d fixture rows, so ignoring it and honoring it "+
+					"give the same answer", leg.name, parityFixtureSize)
+			}
+
+			var got []string
+			must(t, s.RunInTransaction(c, "bd: parity "+leg.name, func(tx storage.Transaction) error {
+				rows, rowsErr := tx.SearchIssues(c, "", filter)
+				if rowsErr != nil {
+					return rowsErr
+				}
+				got = issueIDs(rows)
+				return nil
+			}))
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("in-tx SearchIssues(%s) = %v, want %v (what the store-level search answers for the "+
+					"same filter) — the field was accepted and ignored", leg.name, got, want)
+			}
+		})
+	}
+
+	t.Run("SortBy", func(t *testing.T) {
+		for _, leg := range []struct {
+			sortBy   string
+			sortDesc bool
+		}{{"created", false}, {"created", true}, {"title", false}} {
+			filter := types.IssueFilter{IDPrefix: parityPrefix, SkipWisps: true, Limit: 100, SortBy: leg.sortBy, SortDesc: leg.sortDesc}
+			oracle, err := s.SearchIssues(c, "", filter)
+			must(t, err)
+			want := orderedIDs(oracle)
+
+			var got []string
+			must(t, s.RunInTransaction(c, "bd: parity sort", func(tx storage.Transaction) error {
+				rows, rowsErr := tx.SearchIssues(c, "", filter)
+				if rowsErr != nil {
+					return rowsErr
+				}
+				got = orderedIDs(rows)
+				return nil
+			}))
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("in-tx SearchIssues(SortBy=%q, SortDesc=%v) = %v, want %v — the sort was accepted and ignored",
+					leg.sortBy, leg.sortDesc, got, want)
+			}
+			// Control: the two directions must not be the same sequence, or
+			// the comparison above proves nothing about SortDesc.
+			if leg.sortBy == "created" && leg.sortDesc {
+				ascFilter := filter
+				ascFilter.SortDesc = false
+				asc, ascErr := s.SearchIssues(c, "", ascFilter)
+				must(t, ascErr)
+				if reflect.DeepEqual(orderedIDs(asc), want) {
+					t.Fatalf("control broken: created ASC and DESC answer the same sequence %v", want)
+				}
+			}
+		}
+	})
+
+	t.Run("MaxRows", func(t *testing.T) {
+		filter := types.IssueFilter{IDPrefix: parityPrefix, SkipWisps: true, MaxRows: 2, MaxRowsSource: "--max-rows"}
+
+		// Oracle: the store-level search refuses this cap with the typed error
+		// cmd/bd classifies into exit code 2.
+		_, oracleErr := s.SearchIssues(c, "", filter)
+		var oracleTooMany *storageops.ErrTooManyRows
+		if !errors.As(oracleErr, &oracleTooMany) {
+			t.Fatalf("oracle broken: store-level MaxRows=2 over %d rows failed with %T (%v), want *issueops.ErrTooManyRows",
+				parityFixtureSize, oracleErr, oracleErr)
+		}
+
+		var txErr error
+		var rows []*types.Issue
+		must(t, s.RunInTransaction(c, "bd: parity maxrows", func(tx storage.Transaction) error {
+			rows, txErr = tx.SearchIssues(c, "", filter)
+			return nil
+		}))
+		var txTooMany *storageops.ErrTooManyRows
+		if !errors.As(txErr, &txTooMany) {
+			t.Fatalf("in-tx SearchIssues(MaxRows=2) returned %d rows %v and %v; want *issueops.ErrTooManyRows — "+
+				"the defensive row cap was accepted and ignored", len(rows), orderedIDs(rows), txErr)
+		}
+		if txTooMany.Cap != oracleTooMany.Cap {
+			t.Errorf("in-tx cap error reports Cap = %d, want %d", txTooMany.Cap, oracleTooMany.Cap)
+		}
+		if txTooMany.Source != oracleTooMany.Source {
+			t.Errorf("in-tx cap error reports Source = %q, want the caller's %q", txTooMany.Source, oracleTooMany.Source)
+		}
+
+		// Control: the same search under a cap it cannot exceed is an ordinary
+		// result, so the leg above is detecting the cap and not a broken search.
+		under := filter
+		under.MaxRows = parityFixtureSize
+		var underRows []string
+		must(t, s.RunInTransaction(c, "bd: parity maxrows under", func(tx storage.Transaction) error {
+			ok, okErr := tx.SearchIssues(c, "", under)
+			if okErr != nil {
+				return fmt.Errorf("MaxRows=%d over %d rows: %w", parityFixtureSize, parityFixtureSize, okErr)
+			}
+			underRows = issueIDs(ok)
+			return nil
+		}))
+		if len(underRows) != parityFixtureSize {
+			t.Fatalf("control broken: MaxRows=%d answered %v, want the whole %d-row fixture",
+				parityFixtureSize, underRows, parityFixtureSize)
+		}
+	})
+
+	t.Run("LabelHydration", func(t *testing.T) {
+		filter := types.IssueFilter{IDPrefix: parityPrefix, SkipWisps: true, Limit: 100}
+
+		oracle, err := s.SearchIssues(c, "", filter)
+		must(t, err)
+		want := labelsByIssue(oracle)
+		if len(want[parityLabeled]) == 0 {
+			t.Fatalf("oracle broken: store-level search hydrated no labels for %s", parityLabeled)
+		}
+		if len(want[parityUnlabeled]) != 0 {
+			t.Fatalf("control broken: %s carries labels, so a backend hydrating nothing would still match it",
+				parityUnlabeled)
+		}
+
+		var got map[string][]string
+		must(t, s.RunInTransaction(c, "bd: parity labels", func(tx storage.Transaction) error {
+			rows, rowsErr := tx.SearchIssues(c, "", filter)
+			if rowsErr != nil {
+				return rowsErr
+			}
+			got = labelsByIssue(rows)
+			return nil
+		}))
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("in-tx SearchIssues hydrated labels %v, want %v (what the store-level search hydrates) — "+
+				"a caller reading Issue.Labels from a transaction got an empty slice for a labeled issue",
+				got, want)
+		}
+
+		// Control: SkipLabels is read, not ignored in the other direction.
+		skipped := filter
+		skipped.SkipLabels = true
+		var skippedLabels map[string][]string
+		must(t, s.RunInTransaction(c, "bd: parity labels skipped", func(tx storage.Transaction) error {
+			rows, rowsErr := tx.SearchIssues(c, "", skipped)
+			if rowsErr != nil {
+				return rowsErr
+			}
+			skippedLabels = labelsByIssue(rows)
+			return nil
+		}))
+		for _, id := range sortedLabelKeys(skippedLabels) {
+			if len(skippedLabels[id]) != 0 {
+				t.Errorf("control broken: %s hydrated %v under SkipLabels", id, skippedLabels[id])
+			}
+		}
+	})
+}
+
+// --- filter-parity fixture ---
+
+const (
+	parityPrefix      = "txf-"
+	parityFixtureSize = 5
+	parityLabeled     = "txf-api"
+	parityUnlabeled   = "txf-plain"
+)
+
+// parityStarted is the fixture clock for started_at. DATETIME stores whole
+// seconds, so every value is one.
+func parityStarted(offset int) time.Time {
+	return time.Date(2024, 3, 4, 5, 6, 7, 0, time.UTC).Add(time.Duration(offset) * time.Minute)
+}
+
+// seedFilterParityFixture builds one fixture that makes every leg of
+// testTransactionSearchFilterParity discriminating: two labels on distinct
+// issues, three distinct statuses, one issue blocked by an open dependency, and
+// started_at values on either side of the cursor the started legs use.
+func seedFilterParityFixture(t *testing.T, s storage.DoltStorage) {
+	t.Helper()
+	c := ctx()
+	early, late := parityStarted(0), parityStarted(2)
+
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{
+		ID: parityLabeled, Title: "Aardvark", Priority: 1, Status: types.StatusOpen,
+		CreatedAt: pagingSecond(4), UpdatedAt: pagingSecond(4), StartedAt: &early,
+	}), "actor"))
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{
+		ID: parityUnlabeled, Title: "Buffalo", Priority: 2, Status: types.StatusInProgress,
+		CreatedAt: pagingSecond(3), UpdatedAt: pagingSecond(3), StartedAt: &late,
+	}), "actor"))
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{
+		ID: "txf-ui", Title: "Cheetah", Priority: 0, Status: types.StatusClosed,
+		CreatedAt: pagingSecond(2), UpdatedAt: pagingSecond(2),
+	}), "actor"))
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{
+		ID: "txf-blocked", Title: "Dingo", Priority: 3, Status: types.StatusOpen,
+		CreatedAt: pagingSecond(1), UpdatedAt: pagingSecond(1),
+	}), "actor"))
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{
+		ID: "txf-blocker", Title: "Emu", Priority: 1, Status: types.StatusOpen,
+		CreatedAt: pagingSecond(0), UpdatedAt: pagingSecond(0),
+	}), "actor"))
+
+	must(t, s.AddLabel(c, parityLabeled, "area-api", "actor"))
+	must(t, s.AddLabel(c, "txf-ui", "area-ui", "actor"))
+	must(t, s.AddDependency(c, &types.Dependency{
+		IssueID:     "txf-blocked",
+		DependsOnID: "txf-blocker",
+		Type:        types.DepBlocks,
+	}, "actor"))
+}
+
+// labelsByIssue keys hydrated labels by issue ID, normalizing the empty slice
+// and nil to the same value so a comparison asserts on content rather than on
+// which zero value a backend happened to leave behind.
+func labelsByIssue(issues []*types.Issue) map[string][]string {
+	byID := make(map[string][]string, len(issues))
+	for _, issue := range issues {
+		labels := append([]string(nil), issue.Labels...)
+		sort.Strings(labels)
+		if labels == nil {
+			labels = []string{}
+		}
+		byID[issue.ID] = labels
+	}
+	return byID
+}
+
+// sortedKeys returns a map's keys in a stable order so failure messages name
+// the same issues in the same order on every run.
+func sortedLabelKeys(byID map[string][]string) []string {
+	keys := make([]string, 0, len(byID))
+	for k := range byID {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // countIssueEvents counts an issue's history events of one type.

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -15,6 +15,7 @@ import (
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/storage/sqlbuild"
 	"github.com/steveyegge/beads/internal/storage/versioncontrolops"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -532,346 +533,89 @@ func (t *doltTransaction) SearchIssueIDs(ctx context.Context, query string, filt
 
 // SearchIssues searches for issues within the transaction.
 //
-// It is a SECOND filter builder, hand-rolled here because issueops' shared one
-// merges issues and wisps over a single *sql.Tx while this transaction splits
-// those tiers across regularTx/ignoredTx (see txFor). Being a second builder is
-// the hazard: a field it does not implement is not refused, it is IGNORED, and
-// the caller gets plausible wrong rows with no error.
+// The WHERE clause, the ORDER BY, the row bound and the label/dependency
+// hydration all come from the SHARED implementation the store-level searches
+// use (sqlbuild.BuildIssueFilterClauses, sqlbuild.OrderBy,
+// issueops.EffectiveSearchLimit/EnforceMaxRowsCap,
+// issueops.GetLabelsForIssuesFromTableInTx). This used to be a second,
+// hand-rolled filter builder, and that was the whole defect: a field the second
+// builder did not implement was not refused, it was IGNORED, and the caller got
+// plausible wrong rows with no error (ga-v1nuj — Statuses, ExcludeLabels,
+// LabelPattern, LabelRegex, IsBlocked, StartedAfter/StartedBefore,
+// SortBy/SortDesc, MaxRows and the AfterID/AfterCreatedAt keyset cursor were all
+// accepted and dropped; labels were never hydrated at all). A new filter field
+// now reaches this path for free, which is the point of not having a second
+// builder.
 //
-// This builder does NOT honor the following IssueFilter fields, all of which
-// the store-level DoltStore.SearchIssues does (measured against it on one
-// fixture, 2026-08-20): Statuses, ExcludeLabels, LabelPattern, LabelRegex,
-// IsBlocked, StartedAfter/StartedBefore, the AfterID/AfterCreatedAt keyset
-// cursor, SortBy/SortDesc (results are always priority ASC, created_at DESC),
-// and MaxRows/MaxRowsSource (the defensive row cap is not enforced). It also
-// never hydrates Issue.Labels, so SkipLabels=false does not get labels. Callers
-// needing any of those must use the store-level search. Tracked as siblings of
-// ga-1huib.8; the fix that removes the divergence for good is deleting this
-// builder in favor of the shared one, not adding fields to it one at a time.
+// What still differs from the store-level search, deliberately and visibly:
 //
-// IncludeDependencies IS honored (ga-1huib.8), through the same bulk read
-// issueops uses.
+//   - NO WISP MERGE. This runs ONE table — issues, or wisps when the filter
+//     routes there — because doltTransaction splits the two tiers across
+//     regularTx/ignoredTx (see txFor) and the shared searchInTx merges them over
+//     a single *sql.Tx. So a default (SkipWisps=false) search here answers what
+//     a SkipWisps=true search answers at the store level. That is a structural
+//     difference in the transaction, not a dropped filter field, and merging the
+//     tiers is its own change with its own blast radius.
+//   - filter.Lite and filter.NoIDShrink are not read. Both describe HOW to
+//     fetch, not WHICH rows: ignoring Lite returns fully populated rows with
+//     IsLitePartial left false, which is exactly what that flag promises a
+//     caller may receive, and this path is always id-shrunk anyway. Neither can
+//     produce a wrong answer, so neither is worth a refusal.
+//   - filter.Offset is not read — nor is it read by issueops, so the store-level
+//     search ignores it too. Refusing it HERE would invent a divergence rather
+//     than remove one.
 func (t *doltTransaction) SearchIssues(ctx context.Context, query string, filter types.IssueFilter) ([]*types.Issue, error) {
-	table := "issues"
+	tables := issueops.IssuesFilterTables
 	if filter.Ephemeral != nil && *filter.Ephemeral {
-		table = "wisps"
+		tables = issueops.WispsFilterTables
 	}
 	// If searching by IDs that are all ephemeral, use wisps table (bd-w2w)
 	if len(filter.IDs) > 0 && allEphemeral(filter.IDs) {
-		table = "wisps"
+		tables = issueops.WispsFilterTables
 	}
 
-	// Derive related table names from the main table
-	depTable := "dependencies"
-	labelTable := "labels"
-	if table == "wisps" {
-		depTable = "wisp_dependencies"
-		labelTable = "wisp_labels"
+	whereClauses, args, err := issueops.BuildIssueFilterClauses(query, filter, tables)
+	if err != nil {
+		return nil, err
 	}
-
-	whereClauses := []string{}
-	args := []interface{}{}
-
-	// Text search — optimized to avoid full-table scans (hq-319).
-	if query != "" {
-		lowerQuery := strings.ToLower(query)
-		if looksLikeIssueID(query) {
-			whereClauses = append(whereClauses, "(id = ? OR id LIKE ? OR LOWER(title) LIKE ?)")
-			args = append(args, lowerQuery, lowerQuery+"%", "%"+lowerQuery+"%")
-		} else {
-			whereClauses = append(whereClauses, "(LOWER(title) LIKE ? OR id LIKE ?)")
-			pattern := "%" + lowerQuery + "%"
-			args = append(args, pattern, pattern)
-		}
-	}
-
-	if filter.TitleSearch != "" {
-		whereClauses = append(whereClauses, "LOWER(title) LIKE ?")
-		args = append(args, "%"+strings.ToLower(filter.TitleSearch)+"%")
-	}
-	if filter.TitleContains != "" {
-		whereClauses = append(whereClauses, "LOWER(title) LIKE ?")
-		args = append(args, "%"+strings.ToLower(filter.TitleContains)+"%")
-	}
-	if filter.DescriptionContains != "" {
-		whereClauses = append(whereClauses, "LOWER(description) LIKE ?")
-		args = append(args, "%"+strings.ToLower(filter.DescriptionContains)+"%")
-	}
-	if filter.NotesContains != "" {
-		whereClauses = append(whereClauses, "LOWER(notes) LIKE ?")
-		args = append(args, "%"+strings.ToLower(filter.NotesContains)+"%")
-	}
-	if filter.ExternalRefContains != "" {
-		whereClauses = append(whereClauses, "LOWER(external_ref) LIKE ?")
-		args = append(args, "%"+strings.ToLower(filter.ExternalRefContains)+"%")
-	}
-	if filter.ExternalRef != nil {
-		whereClauses = append(whereClauses, "external_ref = ?")
-		args = append(args, *filter.ExternalRef)
-	}
-
-	// Status
-	if filter.Status != nil {
-		whereClauses = append(whereClauses, "status = ?")
-		args = append(args, *filter.Status)
-	}
-	if len(filter.ExcludeStatus) > 0 {
-		placeholders := make([]string, len(filter.ExcludeStatus))
-		for i, s := range filter.ExcludeStatus {
-			placeholders[i] = "?"
-			args = append(args, string(s))
-		}
-		whereClauses = append(whereClauses, fmt.Sprintf("status NOT IN (%s)", strings.Join(placeholders, ",")))
-	}
-
-	if len(filter.ExcludeTypes) > 0 {
-		placeholders := make([]string, len(filter.ExcludeTypes))
-		for i, tp := range filter.ExcludeTypes {
-			placeholders[i] = "?"
-			args = append(args, string(tp))
-		}
-		//nolint:gosec // G201: table is hardcoded to "issues" or "wisps"
-		whereClauses = append(whereClauses, fmt.Sprintf("id IN (SELECT id FROM %s WHERE issue_type NOT IN (%s))", table, strings.Join(placeholders, ",")))
-	}
-
-	// Priority
-	if filter.Priority != nil {
-		whereClauses = append(whereClauses, "priority = ?")
-		args = append(args, *filter.Priority)
-	}
-	if filter.PriorityMin != nil {
-		whereClauses = append(whereClauses, "priority >= ?")
-		args = append(args, *filter.PriorityMin)
-	}
-	if filter.PriorityMax != nil {
-		whereClauses = append(whereClauses, "priority <= ?")
-		args = append(args, *filter.PriorityMax)
-	}
-
-	if filter.IssueType != nil {
-		//nolint:gosec // G201: table is hardcoded to "issues" or "wisps"
-		whereClauses = append(whereClauses, fmt.Sprintf("id IN (SELECT id FROM %s WHERE issue_type = ?)", table))
-		args = append(args, *filter.IssueType)
-	}
-
-	// Assignee
-	if filter.Assignee != nil {
-		whereClauses = append(whereClauses, "assignee = ?")
-		args = append(args, *filter.Assignee)
-	}
-
-	// Date ranges
-	if filter.CreatedAfter != nil {
-		whereClauses = append(whereClauses, "created_at > ?")
-		args = append(args, filter.CreatedAfter.Format(time.RFC3339))
-	}
-	if filter.CreatedBefore != nil {
-		whereClauses = append(whereClauses, "created_at < ?")
-		args = append(args, filter.CreatedBefore.Format(time.RFC3339))
-	}
-	if filter.UpdatedAfter != nil {
-		whereClauses = append(whereClauses, "updated_at > ?")
-		args = append(args, filter.UpdatedAfter.Format(time.RFC3339))
-	}
-	if filter.UpdatedBefore != nil {
-		whereClauses = append(whereClauses, "updated_at < ?")
-		args = append(args, filter.UpdatedBefore.Format(time.RFC3339))
-	}
-	if filter.ClosedAfter != nil {
-		whereClauses = append(whereClauses, "closed_at > ?")
-		args = append(args, filter.ClosedAfter.Format(time.RFC3339))
-	}
-	if filter.ClosedBefore != nil {
-		whereClauses = append(whereClauses, "closed_at < ?")
-		args = append(args, filter.ClosedBefore.Format(time.RFC3339))
-	}
-	if filter.DeferAfter != nil {
-		whereClauses = append(whereClauses, "defer_until > ?")
-		args = append(args, filter.DeferAfter.Format(time.RFC3339))
-	}
-	if filter.DeferBefore != nil {
-		whereClauses = append(whereClauses, "defer_until < ?")
-		args = append(args, filter.DeferBefore.Format(time.RFC3339))
-	}
-	if filter.DueAfter != nil {
-		whereClauses = append(whereClauses, "due_at > ?")
-		args = append(args, filter.DueAfter.Format(time.RFC3339))
-	}
-	if filter.DueBefore != nil {
-		whereClauses = append(whereClauses, "due_at < ?")
-		args = append(args, filter.DueBefore.Format(time.RFC3339))
-	}
-
-	// Empty/null checks
-	if filter.EmptyDescription {
-		whereClauses = append(whereClauses, "(description IS NULL OR description = '')")
-	}
-	if filter.NoAssignee {
-		whereClauses = append(whereClauses, "(assignee IS NULL OR assignee = '')")
-	}
-	if filter.NoLabels {
-		//nolint:gosec // G201: labelTable is hardcoded to "labels" or "wisp_labels"
-		whereClauses = append(whereClauses, fmt.Sprintf("id NOT IN (SELECT DISTINCT issue_id FROM %s)", labelTable))
-	}
-
-	// Label filtering (AND)
-	if len(filter.Labels) > 0 {
-		for _, label := range filter.Labels {
-			//nolint:gosec // G201: labelTable is hardcoded to "labels" or "wisp_labels"
-			whereClauses = append(whereClauses, fmt.Sprintf("id IN (SELECT issue_id FROM %s WHERE label = ?)", labelTable))
-			args = append(args, label)
-		}
-	}
-
-	// Label filtering (OR)
-	if len(filter.LabelsAny) > 0 {
-		placeholders := make([]string, len(filter.LabelsAny))
-		for i, label := range filter.LabelsAny {
-			placeholders[i] = "?"
-			args = append(args, label)
-		}
-		//nolint:gosec // G201: labelTable is hardcoded to "labels" or "wisp_labels"
-		whereClauses = append(whereClauses, fmt.Sprintf("id IN (SELECT issue_id FROM %s WHERE label IN (%s))", labelTable, strings.Join(placeholders, ", ")))
-	}
-
-	// ID filtering
-	if len(filter.IDs) > 0 {
-		placeholders := make([]string, len(filter.IDs))
-		for i, id := range filter.IDs {
-			placeholders[i] = "?"
-			args = append(args, id)
-		}
-		whereClauses = append(whereClauses, fmt.Sprintf("id IN (%s)", strings.Join(placeholders, ", ")))
-	}
-
-	if filter.IDPrefix != "" {
-		whereClauses = append(whereClauses, "id LIKE ?")
-		args = append(args, filter.IDPrefix+"%")
-	}
-	if filter.SpecIDPrefix != "" {
-		whereClauses = append(whereClauses, "spec_id LIKE ?")
-		args = append(args, filter.SpecIDPrefix+"%")
-	}
-
-	// Source repo
-	if filter.SourceRepo != nil {
-		whereClauses = append(whereClauses, "source_repo = ?")
-		args = append(args, *filter.SourceRepo)
-	}
-
-	// Ephemeral filtering (when querying issues table with explicit ephemeral filter)
-	if filter.Ephemeral != nil {
-		if *filter.Ephemeral {
-			whereClauses = append(whereClauses, "ephemeral = 1")
-		} else {
-			whereClauses = append(whereClauses, "(ephemeral = 0 OR ephemeral IS NULL)")
-		}
-	}
-
-	// Pinned filtering
-	if filter.Pinned != nil {
-		if *filter.Pinned {
-			whereClauses = append(whereClauses, "pinned = 1")
-		} else {
-			whereClauses = append(whereClauses, "(pinned = 0 OR pinned IS NULL)")
-		}
-	}
-
-	// Template filtering
-	if filter.IsTemplate != nil {
-		if *filter.IsTemplate {
-			whereClauses = append(whereClauses, "is_template = 1")
-		} else {
-			whereClauses = append(whereClauses, "(is_template = 0 OR is_template IS NULL)")
-		}
-	}
-
-	// Parent filtering
-	if filter.ParentID != nil {
-		parentID := *filter.ParentID
-		//nolint:gosec // G201: depTable is hardcoded to "dependencies" or "wisp_dependencies"
-		whereClauses = append(whereClauses, fmt.Sprintf("(id IN (SELECT issue_id FROM %s WHERE type = 'parent-child' AND %s = ?) OR (id LIKE CONCAT(?, '.%%') AND id NOT IN (SELECT issue_id FROM %s WHERE type = 'parent-child')))", depTable, issueops.DepTargetExpr, depTable))
-		args = append(args, parentID, parentID)
-	}
-
-	// No-parent filtering
-	if filter.NoParent {
-		//nolint:gosec // G201: depTable is hardcoded to "dependencies" or "wisp_dependencies"
-		whereClauses = append(whereClauses, fmt.Sprintf("id NOT IN (SELECT issue_id FROM %s WHERE type = 'parent-child')", depTable))
-	}
-
-	// Molecule type filtering
-	if filter.MolType != nil {
-		whereClauses = append(whereClauses, "mol_type = ?")
-		args = append(args, string(*filter.MolType))
-	}
-
-	// Wisp type filtering
-	if filter.WispType != nil {
-		whereClauses = append(whereClauses, "wisp_type = ?")
-		args = append(args, string(*filter.WispType))
-	}
-
-	// Time-based scheduling filters
-	if filter.Deferred {
-		whereClauses = append(whereClauses, "(defer_until IS NOT NULL OR status = ?)")
-		args = append(args, types.StatusDeferred)
-	}
-	if filter.Overdue {
-		whereClauses = append(whereClauses, "due_at IS NOT NULL AND due_at < ? AND status != ?")
-		args = append(args, time.Now().UTC().Format(time.RFC3339), types.StatusClosed)
-	}
-
-	// Metadata existence check
-	if filter.HasMetadataKey != "" {
-		if err := storage.ValidateMetadataKey(filter.HasMetadataKey); err != nil {
-			return nil, err
-		}
-		whereClauses = append(whereClauses, "JSON_EXTRACT(metadata, ?) IS NOT NULL")
-		args = append(args, storage.JSONMetadataPath(filter.HasMetadataKey))
-	}
-
-	// Metadata field equality filters
-	if len(filter.MetadataFields) > 0 {
-		metaKeys := make([]string, 0, len(filter.MetadataFields))
-		for k := range filter.MetadataFields {
-			metaKeys = append(metaKeys, k)
-		}
-		sort.Strings(metaKeys)
-		for _, k := range metaKeys {
-			if err := storage.ValidateMetadataKey(k); err != nil {
-				return nil, err
-			}
-			whereClauses = append(whereClauses, "JSON_UNQUOTE(JSON_EXTRACT(metadata, ?)) = ?")
-			args = append(args, storage.JSONMetadataPath(k), filter.MetadataFields[k])
-		}
-	}
-
 	whereSQL := ""
 	if len(whereClauses) > 0 {
 		whereSQL = "WHERE " + strings.Join(whereClauses, " AND ")
 	}
 
+	// A page bound is only pushed under an order the query can express (the rule
+	// issueops.searchTableInTxT states): a Go-side sort key renders no ORDER BY,
+	// and a LIMIT with no ORDER BY does not return the first n rows, it returns n
+	// rows. Under such a key the query scans the whole matching set and the bound
+	// is applied below, after the order exists.
+	goSideSort := sqlbuild.IsGoSideSort(filter.SortBy)
+	eff := issueops.EffectiveSearchLimit(filter.Limit, filter.MaxRows)
 	limitSQL := ""
-	if filter.Limit > 0 {
-		limitSQL = fmt.Sprintf(" LIMIT %d", filter.Limit)
+	if eff > 0 && !goSideSort {
+		limitSQL = fmt.Sprintf(" LIMIT %d", eff)
 	}
 
-	//nolint:gosec // G201: table is hardcoded, whereSQL is parameterized
-	rows, err := t.txFor(table).QueryContext(ctx, fmt.Sprintf(`
-		SELECT id FROM %s %s ORDER BY priority ASC, created_at DESC %s
-	`, table, whereSQL, limitSQL), args...)
+	//nolint:gosec // G201: table name is a fixed constant, whereSQL is parameterized
+	rows, err := t.txFor(tables.Main).QueryContext(ctx, fmt.Sprintf(
+		`SELECT id FROM %s %s %s %s`,
+		tables.Main, whereSQL, sqlbuild.OrderBy(filter.SortBy, filter.SortDesc, ""), limitSQL), args...)
 	if err != nil {
 		return nil, wrapQueryError("search issues in tx", err)
 	}
 
 	var ids []string
+	seen := make(map[string]struct{})
 	for rows.Next() {
 		var id string
 		if err := rows.Scan(&id); err != nil {
 			_ = rows.Close()
 			return nil, wrapScanError("search issues in tx", err)
 		}
+		// GH#3567: a label/dependency subquery can repeat a row.
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
 		ids = append(ids, id)
 	}
 	if err := rows.Err(); err != nil {
@@ -879,6 +623,13 @@ func (t *doltTransaction) SearchIssues(ctx context.Context, query string, filter
 		return nil, wrapQueryError("search issues in tx: rows iteration", err)
 	}
 	_ = rows.Close()
+
+	if goSideSort {
+		sort.SliceStable(ids, func(i, j int) bool { return sqlbuild.LessID(ids[i], ids[j], filter.SortDesc) })
+		if eff > 0 && len(ids) > eff {
+			ids = ids[:eff]
+		}
+	}
 
 	var issues []*types.Issue
 	for _, id := range ids {
@@ -888,10 +639,47 @@ func (t *doltTransaction) SearchIssues(ctx context.Context, query string, filter
 		}
 		issues = append(issues, issue)
 	}
-	if err := t.hydrateSearchDependencies(ctx, depTable, filter, issues); err != nil {
+	if err := t.hydrateSearchLabels(ctx, tables, filter, issues); err != nil {
+		return nil, err
+	}
+	if err := t.hydrateSearchDependencies(ctx, tables.Dependencies, filter, issues); err != nil {
+		return nil, err
+	}
+
+	// Trim to the caller's page before the cap check, exactly as
+	// issueops.searchInTx does: the cap is a statement about the rows actually
+	// handed back, and eff can exceed filter.Limit when MaxRows sized the bound.
+	if filter.Limit > 0 && len(issues) > filter.Limit {
+		issues = issues[:filter.Limit]
+	}
+	if err := issueops.EnforceMaxRowsCap(len(issues), filter.MaxRows, filter.MaxRowsSource); err != nil {
 		return nil, err
 	}
 	return issues, nil
+}
+
+// hydrateSearchLabels populates Issue.Labels from the tier the search ran
+// against, using the same bulk read issueops.searchInTx uses. SkipLabels is the
+// caller's opt-out; without this the transaction answered every search with
+// unlabeled issues while the store-level search labeled them (ga-v1nuj).
+func (t *doltTransaction) hydrateSearchLabels(ctx context.Context, tables issueops.FilterTables, filter types.IssueFilter, issues []*types.Issue) error {
+	if filter.SkipLabels || len(issues) == 0 {
+		return nil
+	}
+	ids := make([]string, len(issues))
+	for i, issue := range issues {
+		ids[i] = issue.ID
+	}
+	labelsByID, err := issueops.GetLabelsForIssuesFromTableInTx(ctx, t.txFor(tables.Labels), tables.Labels, ids)
+	if err != nil {
+		return fmt.Errorf("search issues in tx: hydrate labels: %w", err)
+	}
+	for _, issue := range issues {
+		if labels, ok := labelsByID[issue.ID]; ok {
+			issue.Labels = labels
+		}
+	}
+	return nil
 }
 
 // hydrateSearchDependencies populates Issue.Dependencies when the filter asked


### PR DESCRIPTION
Fixes **ga-v1nuj** (P0).

> Stacked on #5886 (base `fix/ga-1huib-tx-backend-parity`), which fixed `IncludeDependencies` on this same function and replaced the false "supports the same filter fields" comment with a measured list. Retarget to `main` once that merges.

## The bug

`doltTransaction.SearchIssues` hand-rolled a **second** filter builder. A field that second builder did not implement was not refused — it was **ignored** — so the caller got plausible wrong rows with no error.

The dangerous one is the `AfterID`/`AfterCreatedAt` keyset cursor. Dropping it is a **liveness** bug, not merely a wrong-answer bug: every page re-answers the first one, so a caller paging to exhaustion never advances. Depending on how that caller bounds itself, that is an infinite loop or a silently truncated read.

Measured by execution against the store-level search on one fixture, the builder also dropped `Statuses`, `ExcludeLabels`, `LabelPattern`, `LabelRegex`, `IsBlocked`, `StartedAfter`/`StartedBefore`, `SortBy`/`SortDesc`, `MaxRows`/`MaxRowsSource`, and never hydrated `Issue.Labels` at all. (`LabelRegex` and `StartedAfter`/`Before` had previously only been verified by inspection; the new conformance cases confirm them by execution.)

## The fix

Delete the second builder rather than add fields to it one at a time. The WHERE clause, ORDER BY, row bound, cap, and label/dependency hydration now come from the same shared implementation the store-level searches use — `sqlbuild.BuildIssueFilterClauses`, `sqlbuild.OrderBy`, `issueops.EffectiveSearchLimit`/`EnforceMaxRowsCap`, `issueops.GetLabelsForIssuesFromTableInTx`. A new filter field now reaches this path for free.

`sqlbuild.BuildIssueFilterClauses` is a strict superset of what the hand-rolled builder emitted — no field it handled is lost.

## Decided per field, by meaning

**Honoured:** everything on the measured list above.

**Deliberately still not read, now documented at the function:**

| Field | Why not a refusal |
|---|---|
| `Lite` | Describes HOW to fetch, not WHICH rows. Ignoring it returns fully populated rows with `IsLitePartial` left false — exactly what the flag promises a caller may receive. `domain/db` also ignores it on the uncounted search. |
| `NoIDShrink` | Same class; this path is always id-shrunk anyway. Cannot produce a wrong answer. |
| `Offset` | `issueops` ignores it too, so the store-level search ignores it. Refusing it **here** would invent a divergence rather than remove one. |

**Remaining structural difference,** documented at the function: this path runs a single table and does not merge wisps, because `doltTransaction` splits the tiers across `regularTx`/`ignoredTx` while the shared `searchInTx` merges them over one `*sql.Tx`. So a default search here answers what a `SkipWisps: true` search answers at the store level. That is a property of the transaction, not a dropped filter field, and merging the tiers is its own change with its own blast radius.

## Proof

Two conformance cases, so both Dolt backends are held to the same contract. Each takes its expectation from an **oracle** — the store-level form of the same operation on the same store — never from the other backend.

- `TransactionSearchKeysetWalk` — pages a set whose same-second group overflows the page; the walk must terminate and return each row exactly once.
  - *Control:* a single-page result set still works, and the page past the end is empty.
  - *Mutation-verified:* reintroducing **only** the cursor drop reddens this case and nothing else.
- `TransactionSearchFilterParity` — one leg per dropped field, asserting the transaction answers what the store-level search answers for the identical filter.
  - *Control per leg:* the predicate must exclude at least one row, so a leg cannot pass on a backend that never reads the field.

Red state confirmed to build and vet clean before running, so the failures are real assertions.

<details><summary>Red (before)</summary>

```
--- FAIL: TestConformance/TransactionSearchKeysetWalk
    in-tx page 1 repeated "ks-newer" after walking [ks-newer ks-a1]: the keyset
    position was accepted and ignored, so the walk never advanced past its first page
--- FAIL: TestConformance/TransactionSearchFilterParity/Statuses
--- FAIL: .../ExcludeLabels   --- FAIL: .../LabelPattern   --- FAIL: .../LabelRegex
--- FAIL: .../IsBlocked       --- FAIL: .../StartedAfter   --- FAIL: .../StartedBefore
--- FAIL: .../SortBy          --- FAIL: .../MaxRows        --- FAIL: .../LabelHydration
```
</details>

<details><summary>Green (after)</summary>

```
--- PASS: TestConformance/TransactionSearchKeysetWalk (0.88s)
--- PASS: TestConformance/TransactionSearchFilterParity (0.88s)
        --- PASS: .../Statuses .../ExcludeLabels .../LabelPattern .../LabelRegex
        --- PASS: .../IsBlocked .../StartedAfter .../StartedBefore
        --- PASS: .../SortBy .../MaxRows .../LabelHydration
ok  github.com/steveyegge/beads/internal/storage/dolt  26.022s
```

Full suite: `TestConformance` green end-to-end against the server-mode Dolt backend (`BEADS_TEST_ENV_RUN_DOLT=1`, `-tags=integration,gms_pure_go`).
</details>

## Test-hygiene note

No assertion in either case runs inside a `RunInTransaction` callback. `t.Fatalf` unwinds with `runtime.Goexit`, which abandons the open transaction rather than returning through the commit/rollback path — the suite then blocks on the stranded transaction until the binary timeout and a goroutine dump replaces the assertion. The first draft of this test did exactly that; the callbacks now only collect and the assertions run after they return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)