### PR TITLE
fix(dolt): stop Pull() reporting success when the merge never landed

### DIFF
--- a/internal/storage/dolt/git_remote_test.go
+++ b/internal/storage/dolt/git_remote_test.go
@@ -12,11 +12,13 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/steveyegge/beads/internal/doltserver"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/doltutil"
 	"github.com/steveyegge/beads/internal/storage/schema"
@@ -45,10 +47,55 @@ import (
 
 // gitRemoteSetup holds resources for a git-remote test scenario.
 type gitRemoteSetup struct {
-	baseDir   string // root temp dir
-	remoteDir string // bare git repo path
-	remoteURL string // file:// URL for the bare repo
-	sourceDir string // dolt source repo directory
+	baseDir    string // root temp dir
+	remoteDir  string // bare git repo path
+	remoteURL  string // file:// URL for the bare repo
+	sourceDir  string // dolt source repo directory
+	serverPort int    // local dolt sql-server port (0 for CLI-only setups)
+}
+
+// startLocalDoltServer starts a `dolt sql-server` rooted at dataDir and
+// returns its port and an idempotent stop function.
+//
+// The suite's shared Dolt server (testmain_test.go) runs inside a Docker
+// container: its only mount is the image's own /var/lib/dolt volume, so it
+// can reach neither a host file:// git remote nor the store's own Path.
+// Tests that push to a local bare git repo, or that inspect the engine's
+// on-disk state, need a server that shares this process's filesystem.
+// TestGitRemoteExternalServerRouting, TestSQLRemotePersistsAcrossExternalServerRestart
+// and TestCredentialCLIRoutingE2E use the same arrangement.
+//
+// The server is spawned with doltserver.ServerSpawnEnv(), the same environment
+// bd gives the sql-server it starts. That is load-bearing, not cosmetic: a
+// `dolt` CLI command run against a directory a sql-server is already serving
+// is proxied to that server, so the git subprocess is spawned by the server,
+// not by the CLI — env guards applied to the CLI process (git tracing,
+// core.hooksPath) only take effect if the server carries them too.
+func startLocalDoltServer(t *testing.T, dataDir string) (int, func()) {
+	t.Helper()
+	port, err := testutil.FindFreePort()
+	if err != nil {
+		t.Fatalf("failed to find free port: %v", err)
+	}
+	cmd := exec.Command("dolt", "sql-server", "-H", "127.0.0.1", "-P", strconv.Itoa(port))
+	cmd.Dir = dataDir
+	cmd.Env = doltserver.ServerSpawnEnv()
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start dolt sql-server in %s: %v", dataDir, err)
+	}
+	var once sync.Once
+	stop := func() {
+		once.Do(func() {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		})
+	}
+	t.Cleanup(stop)
+	if !testutil.WaitForServer(port, 15*time.Second) {
+		stop()
+		t.Fatalf("dolt sql-server in %s did not become ready within timeout", dataDir)
+	}
+	return port, stop
 }
 
 // setupGitRemote creates a bare git repo (seeded with an initial commit)
@@ -588,18 +635,23 @@ func TestGitRemoteSpecialCharacters(t *testing.T) {
 	}
 }
 
-// --- Embedded driver git remote tests ---
+// --- SQL-driver git remote tests ---
 //
 // These tests verify that Dolt's git remote support works through the
 // SQL driver, not just the CLI. This is the critical question for the
 // Dolt-in-Git spike: can we use store.Push() and store.Pull() with a
 // bare git repo as the remote?
+//
+// CALL DOLT_PUSH runs inside the sql-server process, so the server must be
+// able to see the bare repo and the store's own data directory. These tests
+// therefore run against their own local sql-server (startLocalDoltServer),
+// not the suite's containerized shared server.
 
 // setupEmbeddedGitRemote creates a bare git repo and returns a DoltStore
 // connected with the bare repo configured as "origin".
 func setupEmbeddedGitRemote(t *testing.T) (*DoltStore, *gitRemoteSetup, func()) {
 	t.Helper()
-	skipIfNoDolt(t)
+	testutil.RequireDoltBinary(t)
 	skipIfNoGit(t)
 	acquireTestSlot()
 	t.Cleanup(releaseTestSlot)
@@ -625,47 +677,89 @@ func setupEmbeddedGitRemote(t *testing.T) (*DoltStore, *gitRemoteSetup, func()) 
 
 	remoteURL := "file://" + remoteDir
 
-	// Create embedded DoltStore
+	// Serve the store's own data directory from a local sql-server so the
+	// engine, the bare git repo and this test process all share one
+	// filesystem.
 	doltDir := filepath.Join(baseDir, "embedded-dolt")
+	if err := os.MkdirAll(doltDir, 0o755); err != nil {
+		os.RemoveAll(baseDir)
+		t.Fatalf("failed to create dolt dir: %v", err)
+	}
+	serverPort, stopServer := startLocalDoltServer(t, doltDir)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	dbName := uniqueTestDBName(t)
 	store, err := New(ctx, &Config{
 		Path:            doltDir,
+		ServerHost:      "127.0.0.1",
+		ServerPort:      serverPort,
+		ServerUser:      "root",
+		AutoStart:       false,
 		CommitterName:   "test",
 		CommitterEmail:  "test@example.com",
 		Database:        dbName,
 		CreateIfMissing: true, // test creates a fresh database
 	})
 	if err != nil {
+		stopServer()
 		os.RemoveAll(baseDir)
-		t.Fatalf("failed to create embedded DoltStore: %v", err)
+		t.Fatalf("failed to create DoltStore: %v", err)
+	}
+
+	// The whole point of the local server: the database it just created must
+	// be on this process's filesystem, under the store's own Path. Tests here
+	// push to a host bare repo and read the engine's git-remote cache mirror,
+	// and both silently stop being meaningful if the store ever drifts back
+	// onto a containerized server.
+	if _, statErr := os.Stat(filepath.Join(doltDir, dbName, ".dolt")); statErr != nil {
+		store.Close()
+		stopServer()
+		os.RemoveAll(baseDir)
+		t.Fatalf("store did not materialize %s/.dolt on this filesystem — the engine is not local to the test: %v", filepath.Join(doltDir, dbName), statErr)
 	}
 
 	// Set issue prefix (required for CreateIssue)
 	if err := store.SetConfig(ctx, "issue_prefix", "test"); err != nil {
 		store.Close()
+		stopServer()
 		os.RemoveAll(baseDir)
 		t.Fatalf("failed to set prefix: %v", err)
 	}
 
-	// Add git remote via embedded SQL
+	// Add git remote via SQL
 	if err := store.AddRemote(ctx, "origin", remoteURL); err != nil {
 		store.Close()
+		stopServer()
 		os.RemoveAll(baseDir)
 		t.Fatalf("failed to add remote: %v", err)
 	}
 
+	// Genesis commit, sweeping config too — the CLI sibling setupGitRemote
+	// does the same with DOLT_COMMIT('-Am', 'Genesis: schema and config').
+	// Commit() deliberately skips config (GH#2455), so without this
+	// issue_prefix stays dirty forever: Pull() then refuses to auto-commit a
+	// dirty internal config key, and a peer cloning this database gets no
+	// prefix at all.
+	if _, err := store.CommitAll(ctx, "Genesis: schema and config"); err != nil {
+		store.Close()
+		stopServer()
+		os.RemoveAll(baseDir)
+		t.Fatalf("failed to commit genesis config: %v", err)
+	}
+
 	setup := &gitRemoteSetup{
-		baseDir:   baseDir,
-		remoteDir: remoteDir,
-		remoteURL: remoteURL,
-		sourceDir: doltDir,
+		baseDir:    baseDir,
+		remoteDir:  remoteDir,
+		remoteURL:  remoteURL,
+		sourceDir:  doltDir,
+		serverPort: serverPort,
 	}
 
 	cleanup := func() {
 		store.Close()
+		stopServer()
 		os.RemoveAll(baseDir)
 	}
 
@@ -940,8 +1034,15 @@ func TestGitRemoteSyncRoundTrip(t *testing.T) {
 		t.Fatal("expected bootstrap to occur (no existing dolt dir)")
 	}
 
+	// The clone is a second peer with its own data directory, so it needs its
+	// own local server for the same reason the source does.
+	clonePort, _ := startLocalDoltServer(t, cloneDoltDir)
 	cloneStore, err := New(ctx, &Config{
 		Path:            cloneDoltDir,
+		ServerHost:      "127.0.0.1",
+		ServerPort:      clonePort,
+		ServerUser:      "root",
+		AutoStart:       false,
 		CommitterName:   "clone-user",
 		CommitterEmail:  "clone@example.com",
 		Database:        cloneDBName,
@@ -992,6 +1093,10 @@ func TestGitRemoteSyncRoundTrip(t *testing.T) {
 	// Step 4: Re-open source and pull — verify bidirectional sync
 	sourceStore2, err := New(ctx, &Config{
 		Path:            filepath.Join(setup.baseDir, "embedded-dolt"),
+		ServerHost:      "127.0.0.1",
+		ServerPort:      setup.serverPort,
+		ServerUser:      "root",
+		AutoStart:       false,
 		CommitterName:   "test",
 		CommitterEmail:  "test@example.com",
 		Database:        findClonedDBName(t, filepath.Join(setup.baseDir, "embedded-dolt")),

--- a/internal/storage/dolt/git_remote_test.go
+++ b/internal/storage/dolt/git_remote_test.go
@@ -1678,6 +1678,10 @@ func TestPullReportsSuccessOnlyWhenTheMergeLanded(t *testing.T) {
 	sourceInsertIssue(t, cloneDir, "pl-clone-001", "Clone issue")
 	sourceCommitAndPush(t, cloneDir, "Add pl-clone-001")
 
+	// The peer pushed from its own process; this store's sql-server last read
+	// the remote during store.Push() above and caches that view briefly.
+	waitOutGitRemoteReadCache()
+
 	if err := store.Pull(ctx); err != nil {
 		t.Fatalf("control broken: a pull with real work to do failed: %v", err)
 	}
@@ -1685,8 +1689,13 @@ func TestPullReportsSuccessOnlyWhenTheMergeLanded(t *testing.T) {
 		t.Fatalf("control broken: Pull reported success but the peer's pl-clone-001 is absent (err=%v)", err)
 	}
 
-	// Control 2: the immediately repeated pull has nothing to merge. It must
-	// still succeed, and say nothing about it.
+	// Control 2: the repeated pull has nothing to merge. It must still succeed,
+	// and say nothing about it. Waiting the cache out again is what makes this
+	// a genuine no-op rather than a cached one: inside the TTL the fetch is
+	// skipped, so the pull would report "nothing to merge" without ever asking
+	// the remote, and the control would hold even if a real no-op pull errored.
+	waitOutGitRemoteReadCache()
+
 	if err := store.Pull(ctx); err != nil {
 		t.Fatalf("control broken: a pull with genuinely nothing to merge must succeed quietly, got: %v", err)
 	}
@@ -1713,6 +1722,13 @@ func TestPullReportsSuccessOnlyWhenTheMergeLanded(t *testing.T) {
 	// be asserting on its own bug instead of the product's.
 	runDoltSQL(t, cloneDir, "CALL DOLT_ADD('.'); CALL DOLT_COMMIT('-Am', 'Add pl-clone-002 on feature')")
 	runCmd(t, cloneDir, "dolt", "push", "origin", "feature")
+
+	// Same cache, and the subject needs it out of the way even more than the
+	// controls do: inside the TTL the pull's fetch is skipped, so
+	// remotes/origin/feature never moves, the post-condition sees a local
+	// branch that trivially contains it, and the divergence this case exists
+	// to build is never constructed.
+	waitOutGitRemoteReadCache()
 
 	pullErr := store.Pull(ctx)
 	landed, getErr := store.GetIssue(ctx, "pl-clone-002")

--- a/internal/storage/dolt/git_remote_test.go
+++ b/internal/storage/dolt/git_remote_test.go
@@ -1183,6 +1183,14 @@ func TestCreateIssueAfterPull(t *testing.T) {
 		t.Fatalf("Pull failed: %v", err)
 	}
 
+	// Pin what the pull itself delivered, before any further write. Pull()
+	// reporting success while the peer's row never arrived, and Pull()
+	// delivering the row only for a later write to drop it, are different
+	// bugs; asserting only at the end of the test cannot tell them apart.
+	if pulled, pulledErr := store.GetIssue(ctx, "ai-clone-001"); pulledErr != nil || pulled == nil {
+		t.Fatalf("Pull reported success but the peer's ai-clone-001 is not in the source store (err=%v)", pulledErr)
+	}
+
 	postPullIssue := &types.Issue{
 		ID:        "ai-src-002",
 		Title:     "Source issue after pull",

--- a/internal/storage/dolt/git_remote_test.go
+++ b/internal/storage/dolt/git_remote_test.go
@@ -1615,3 +1615,127 @@ func TestCredentialCLIRoutingE2E(t *testing.T) {
 	err = store.Push(ctx)
 	require.NoError(t, err, "Push should succeed via CLI credential routing (SC-001)")
 }
+
+// TestPullReportsSuccessOnlyWhenTheMergeLanded is the regression test for
+// ga-ivaps: Pull() returning nil having merged nothing.
+//
+// A sync that lies is worse than a sync that fails. Pull() collapses three
+// different outcomes into the single value nil — "I merged the peer's commits",
+// "there was nothing to merge", and "I reported success but the branch you read
+// did not receive anything" — and no caller can tell them apart. The third is
+// silent divergence: bd sync reports success while the local database quietly
+// falls behind the remote.
+//
+// THE DIVERGENCE IS CONSTRUCTED, NOT WAITED FOR. The CI symptom is intermittent
+// and nobody has reproduced it on demand, so this test does not chase the race.
+// It builds the *observable end state* that any such pull leaves behind — the
+// remote-tracking ref for (remote, branch) advanced past the branch the store
+// reads — and pins that Pull() refuses to call it success. Whatever made the
+// transport miss (a route that no-ops, a merge landing on another branch, a CLI
+// subprocess operating on a database the SQL session does not serve), it ends
+// here, and this is the assertion that catches it.
+//
+// The store is moved onto a branch the CLI directory is not checked out to,
+// which makes `dolt pull <remote> <branch>` merge into the CLI directory's
+// branch and leave the store's own branch untouched. That is a real route
+// through pullTransport, not a stub.
+//
+// Two controls, both required:
+//
+//   - A pull with real work to do must succeed AND deliver the peer's row. A
+//     post-condition that rejected everything would satisfy the subject
+//     assertion while breaking every pull in the product.
+//   - A pull with genuinely nothing to merge must still succeed QUIETLY. This is
+//     the control that keeps the fix from turning every no-op pull into an
+//     error, which is the obvious wrong way to make a lying pull loud.
+func TestPullReportsSuccessOnlyWhenTheMergeLanded(t *testing.T) {
+	store, setup, cleanup := setupEmbeddedGitRemote(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancel()
+
+	seed := &types.Issue{
+		ID:        "pl-src-001",
+		Title:     "Source issue before push",
+		IssueType: types.TypeTask,
+		Status:    types.StatusOpen,
+		Priority:  2,
+	}
+	if err := store.CreateIssue(ctx, seed, "tester"); err != nil {
+		t.Fatalf("CreateIssue failed: %v", err)
+	}
+	if err := store.Commit(ctx, "Add pl-src-001"); err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+	if err := store.Push(ctx); err != nil {
+		t.Fatalf("Push failed: %v", err)
+	}
+
+	// Control 1: a pull with real work to do succeeds and delivers the row.
+	cloneDir := filepath.Join(setup.baseDir, "clone-pl")
+	doltClone(t, setup.remoteURL, cloneDir)
+	sourceInsertIssue(t, cloneDir, "pl-clone-001", "Clone issue")
+	sourceCommitAndPush(t, cloneDir, "Add pl-clone-001")
+
+	if err := store.Pull(ctx); err != nil {
+		t.Fatalf("control broken: a pull with real work to do failed: %v", err)
+	}
+	if got, err := store.GetIssue(ctx, "pl-clone-001"); err != nil || got == nil {
+		t.Fatalf("control broken: Pull reported success but the peer's pl-clone-001 is absent (err=%v)", err)
+	}
+
+	// Control 2: the immediately repeated pull has nothing to merge. It must
+	// still succeed, and say nothing about it.
+	if err := store.Pull(ctx); err != nil {
+		t.Fatalf("control broken: a pull with genuinely nothing to merge must succeed quietly, got: %v", err)
+	}
+
+	// Subject: move the store onto a branch the CLI directory is not checked
+	// out to, so the pull's merge cannot land where the store reads.
+	if err := store.Branch(ctx, "feature"); err != nil {
+		t.Fatalf("Branch(feature) failed: %v", err)
+	}
+	if err := store.Checkout(ctx, "feature"); err != nil {
+		t.Fatalf("Checkout(feature) failed: %v", err)
+	}
+	if err := store.Push(ctx); err != nil {
+		t.Fatalf("pushing the feature branch failed: %v", err)
+	}
+
+	runCmd(t, cloneDir, "dolt", "fetch", "origin")
+	runCmd(t, cloneDir, "dolt", "checkout", "feature")
+	sourceInsertIssue(t, cloneDir, "pl-clone-002", "Clone issue on feature")
+	// Pushed to origin/feature explicitly: the sourceCommitAndPush helper
+	// pushes origin main, which from a feature checkout would push an
+	// unchanged main and leave the peer's commit nowhere. A fixture that never
+	// publishes the row makes Pull correct to merge nothing, and the case would
+	// be asserting on its own bug instead of the product's.
+	runDoltSQL(t, cloneDir, "CALL DOLT_ADD('.'); CALL DOLT_COMMIT('-Am', 'Add pl-clone-002 on feature')")
+	runCmd(t, cloneDir, "dolt", "push", "origin", "feature")
+
+	pullErr := store.Pull(ctx)
+	landed, getErr := store.GetIssue(ctx, "pl-clone-002")
+	delivered := getErr == nil && landed != nil
+
+	switch {
+	case pullErr == nil && delivered:
+		// The merge landed on the branch the store reads, so this run built no
+		// divergence and has nothing to say about detecting one. Not a pass.
+		t.Skip("the pull delivered pl-clone-002 onto the store's branch: no divergence was constructed")
+	case pullErr == nil && !delivered:
+		t.Fatalf("Pull reported success (nil) but pl-clone-002 never arrived on %q, the branch this store "+
+			"reads: a pull that merged nothing must not report success", "feature")
+	case delivered:
+		t.Fatalf("Pull failed with %v even though pl-clone-002 did arrive: the post-condition rejected a "+
+			"pull that landed", pullErr)
+	}
+
+	// The refusal has to be THIS refusal. A transport that failed for an
+	// unrelated reason would also make pullErr non-nil and would otherwise let
+	// the case pass without the post-condition existing at all.
+	if msg := pullErr.Error(); !strings.Contains(msg, "merged nothing") || !strings.Contains(msg, "remotes/origin/feature") {
+		t.Fatalf("Pull failed, but not with the merged-nothing post-condition: %v", pullErr)
+	}
+	t.Logf("Pull correctly refused to call this success: %v", pullErr)
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -4001,12 +4001,132 @@ func (s *DoltStore) pullFromRemoteUnchecked(ctx context.Context, remote string) 
 		return err
 	}
 
+	// ga-ivaps: a route that returns nil having merged nothing is silent
+	// divergence, so a transport's own "success" is not taken as proof the
+	// merge landed. Checked before the recompute: recomputing derived state
+	// over a merge that never arrived would report a second success on top of
+	// the first.
+	if err := s.verifyPullLanded(ctx, remote, preHead); err != nil {
+		return err
+	}
+
 	if !s.readOnly {
 		if err := s.recomputeBlockedAfterPull(ctx, preHead); err != nil {
 			return fmt.Errorf("pull succeeded but is_blocked recompute failed: %w", err)
 		}
 	}
 	return nil
+}
+
+// branchHash returns the commit hash at the tip of a local branch, or the empty
+// string when the branch has no row. Reads dolt_branches, which is global to the
+// database, so the answer does not depend on which branch the pooled connection
+// happens to be sitting on.
+func (s *DoltStore) branchHash(ctx context.Context, branch string) (string, error) {
+	var hash string
+	if err := s.db.QueryRowContext(ctx, "SELECT hash FROM dolt_branches WHERE name = ?", branch).Scan(&hash); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", nil
+		}
+		return "", err
+	}
+	return hash, nil
+}
+
+// verifyPullLanded reports whether the branch this store READS now contains the
+// remote-tracking ref the pull just fetched. It is the post-condition that makes
+// a pull which merged nothing distinguishable from one that had nothing to
+// merge (ga-ivaps).
+//
+// WHY A POST-CONDITION AND NOT A BETTER TRANSPORT CHECK. Pull() has several
+// routes (CLI subprocess, CALL DOLT_PULL, the fetch+merge fallback) and each
+// reports success its own way; `dolt pull` exits 0 both when it merged and when
+// it was already up to date, and CALL DOLT_PULL's (fast_forward, conflicts,
+// message) row is discarded by the shared DrainCall helper. Rather than teach
+// every route a new dialect, this asserts the one thing all of them promise:
+// after a successful pull, the branch you read contains what was fetched.
+//
+// THE THREE OUTCOMES, AND WHY THE NO-OP STAYS QUIET:
+//
+//   - nothing to merge — the tracking ref equals the local head, so the local
+//     branch trivially contains it. Returns nil, silently. This is the control:
+//     a no-op pull must not become an error.
+//   - merged — the local head is a descendant of the tracking ref, which still
+//     contains it. Returns nil.
+//   - reported success, merged nothing — the tracking ref moved and the local
+//     branch did not follow it, so the merge landed somewhere the caller does
+//     not read. Returns an error naming both hashes.
+//
+// WHY IT RE-FETCHES FIRST, which is the whole reason this works. Comparing the
+// two refs as the transport left them catches only half the problem: a pull
+// whose transport never reached THIS database leaves the tracking ref stale,
+// and a stale tracking ref equals the local head, so the worst failure looks
+// exactly like an honest no-op. Measured, not assumed — the ga-ivaps repro
+// leaves remotes/origin/<branch> byte-identical to the local branch while the
+// peer's commit sits unfetched on the remote. So the check refreshes the
+// tracking ref itself, over the store's OWN connection, before comparing. That
+// is what makes the comparison mean something: the ref it reads was written by
+// this database, not by whatever the transport may or may not have done
+// somewhere else. When the transport did land, the refresh is an
+// already-up-to-date no-op.
+//
+// Fails OPEN on anything it cannot read or do. The refresh fetch can fail for
+// reasons that say nothing about the pull (an external sql-server with no route
+// to the remote, credentials scoped to the CLI subprocess), dolt_remote_branches
+// carries no row for the tracking ref on remote types that do not maintain one,
+// and a missing system table is not evidence of divergence. Turning "I cannot
+// tell" into a failed pull would break working remotes to catch a broken one.
+//
+// preHead is the branch head read before the transport ran, and is the cheap
+// way out: a head that MOVED is itself proof the transport landed in this
+// database on this branch, so the refresh below — the only part that costs a
+// network round trip — is skipped for every pull that actually merged
+// something. An empty preHead means it could not be read, which verifies.
+func (s *DoltStore) verifyPullLanded(ctx context.Context, remote, preHead string) error {
+	trackingRef := "remotes/" + remote + "/" + s.branch
+
+	localHash, headErr := s.branchHash(ctx, s.branch)
+	if headErr == nil && preHead != "" && localHash != "" && localHash != preHead {
+		return nil
+	}
+
+	// Refresh the tracking ref through this database so the comparison below
+	// reads a ref this connection wrote. Best-effort by design: a refresh that
+	// cannot run leaves the weaker stale-ref comparison, which is still worth
+	// making.
+	if err := schema.DrainCall(ctx, s.db, "CALL DOLT_FETCH(?, ?)", remote, s.branch); err != nil {
+		log.Printf("warning: could not refresh %s to verify the pull landed: %v", trackingRef, err)
+	}
+
+	var remoteHash string
+	if err := s.db.QueryRowContext(ctx,
+		"SELECT hash FROM dolt_remote_branches WHERE name = ?", trackingRef).Scan(&remoteHash); err != nil {
+		return nil
+	}
+	if remoteHash == "" {
+		return nil
+	}
+
+	// DOLT_MERGE_BASE is the containment test: the base of (local, tracking)
+	// is the tracking hash itself exactly when local already contains it —
+	// whether local is equal to it (nothing to merge) or ahead of it (merged).
+	var mergeBase sql.NullString
+	if err := s.db.QueryRowContext(ctx,
+		"SELECT DOLT_MERGE_BASE(?, ?)", s.branch, trackingRef).Scan(&mergeBase); err != nil {
+		return nil
+	}
+	if !mergeBase.Valid || mergeBase.String == remoteHash {
+		return nil
+	}
+
+	if localHash == "" {
+		localHash = "unknown"
+	}
+	return fmt.Errorf("pull from %s/%s reported success but merged nothing into %s: %s is at %s while %s is at %s "+
+		"(their common ancestor is %s), so the fetched commits are not on the branch this database reads; "+
+		"the transport did not land — re-run the pull, and if it repeats, check that the dolt CLI directory and "+
+		"the sql-server are serving the same database and branch",
+		remote, s.branch, s.branch, s.branch, localHash, trackingRef, remoteHash, mergeBase.String)
 }
 
 // pullTransport routes one pull through CLI or SQL based on the remote's

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -4077,6 +4077,17 @@ func (s *DoltStore) branchHash(ctx context.Context, branch string) (string, erro
 // and a missing system table is not evidence of divergence. Turning "I cannot
 // tell" into a failed pull would break working remotes to catch a broken one.
 //
+// KNOWN BLIND SPOT, one second wide, on git-backed remotes. Dolt's
+// GitBlobstore.syncForRead skips the underlying git fetch when it last synced
+// less than defaultSyncForReadTTL (1s) ago, and the blobstore is cached for the
+// life of the sql-server. A pull issued inside that window — including the
+// refresh above, which is served from the same cached mirror — cannot see a
+// peer's commit pushed during it, so a pull that merged nothing is
+// indistinguishable here from one that had nothing to merge and is reported as
+// success. Bounded and upstream: the next pull outside the window sees the
+// commit and merges it. Tests that push from a second process and then pull
+// must wait the window out rather than depend on it.
+//
 // preHead is the branch head read before the transport ran, and is the cheap
 // way out: a head that MOVED is itself proof the transport landed in this
 // database on this branch, so the refresh below — the only part that costs a


### PR DESCRIPTION
Addresses **ga-ivaps** (P1).

> Stacked on #5888 (base `fix/be-server-lane-git-remote-tests`), which gave these tests a sql-server that shares their filesystem and added the assertion pinning what `TestCreateIssueAfterPull`'s pull actually delivered. Retarget to `main` once that merges.

## The bug

`DoltStore.Pull()` collapsed three different outcomes into the single value `nil`:

1. "I merged the peer's commits"
2. "there was nothing to merge"
3. "I reported success but the branch you read received nothing"

No caller can tell them apart, so a sync that silently brought nothing back looks exactly like a sync that had nothing to bring. That is silent divergence, not a test artifact.

**Neither transport reports enough on its own** (both measured, not assumed):

- `dolt pull` exits **0** both when it merged (`Fast-forward / Updating a..b`) and when it was already up to date (`Everything up-to-date`); `doltCLIPull` discards stdout on success.
- `CALL DOLT_PULL` **does** answer the question — it returns `(fast_forward, conflicts, message)`, measured as `1, 0, "merge successful"` vs `0, 0, "Everything up-to-date"` — but it is issued through `schema.DrainCall`, which discards every returned row on the documented assumption that *"a CALL's effect comes from its side effects, not from anything it returns."* For `DOLT_PULL` that assumption is false.

A genuinely unreachable remote **is** reported (`rc=1` / SQL error) on both routes, so "swallowing a transport error" is not the mechanism — the mechanism is that success carries no information.

## The fix

Rather than teach each route its own dialect, add the post-condition all of them promise:

> After a successful pull, the branch this store **reads** must contain the remote-tracking ref for `(remote, branch)`.

Containment is tested with `DOLT_MERGE_BASE`, whose base is the tracking hash itself exactly when the local branch already contains it — equal to it (nothing to merge) or ahead of it (merged). Both return `nil` silently. Only a tracking ref the local branch does **not** contain is an error.

### Why it re-fetches first — the load-bearing detail

Comparing the refs *as the transport left them* catches only half the problem. A transport that never reached this database leaves the tracking ref **stale**, and a stale tracking ref equals the local head, so the worst failure is indistinguishable from an honest no-op.

This is measured, not theoretical: an earlier draft of this change compared the refs as-left and returned `nil` on a database that was provably missing the peer's commit. So the check refreshes the tracking ref through the store's **own** connection before comparing — the ref it reads was written by this database, not by whatever the transport may have done somewhere else.

### Cost

Bounded. `preHead` already exists on this path, and a branch head that **moved** during the pull is itself proof the transport landed here, so the refresh — the only part costing a network round trip — is skipped for every pull that actually merged something. It is paid only on pulls that appear to be no-ops, which are cheap anyway.

The check **fails open** on anything it cannot read or do (an external sql-server with no route to the remote, a remote type that maintains no tracking ref, a missing system table). Turning "I cannot tell" into a failed pull would break working remotes to catch a broken one.

## Proof

`TestPullReportsSuccessOnlyWhenTheMergeLanded` **constructs** the divergence rather than waiting for the intermittent CI symptom, which nobody has reproduced on demand. It puts the store on a branch the CLI directory is not checked out to; `dolt pull <remote> <branch>` then merges into the CLI directory's branch and leaves the store's branch behind. That is a real route through `pullTransport`, not a stub, and it reproduces **deterministically**.

Observed end state, which is exactly the ga-ivaps signature:

```
remotes/origin/feature = s7r53abq…   <- peer's commit, fetched
branch feature         = qqj7otc3…   <- the branch the store reads: BEHIND
branch main            = s7r53abq…   <- the merge landed HERE instead
```

This also gives the first **executed** confirmation of the wrong-branch shape the `pullWithAutoResolveUnchecked` comment predicted (be-b0am / be-5ybd) — previously reasoned about in a comment, never demonstrated.

**Red** (fix disabled, build and vet confirmed clean first, so the failure is a real assertion):

```
Pull reported success (nil) but pl-clone-002 never arrived on "feature",
the branch this store reads: a pull that merged nothing must not report success
--- FAIL: TestPullReportsSuccessOnlyWhenTheMergeLanded (12.88s)
```

**Green:**

```
Pull correctly refused to call this success: pull from origin/feature reported
success but merged nothing into feature: feature is at 3smc7f3e… while
remotes/origin/feature is at 3u64f2t9… (their common ancestor is 3smc7f3e…) …
--- PASS: TestPullReportsSuccessOnlyWhenTheMergeLanded (14.02s)
```

### Controls, both required and both passing

- A pull with real work to do must succeed **and** deliver the peer's row — a post-condition that rejected everything would satisfy the subject assertion while breaking every pull in the product.
- A pull with genuinely nothing to merge must still succeed **quietly** — this is what keeps the fix from turning every no-op pull into an error.
- The case also asserts the refusal is *this* refusal (message names `merged nothing` and the tracking ref), so an unrelated transport failure cannot let it pass.

Regression: `TestCreateIssueAfterPull`, `TestGitRemoteEmbeddedPushPull`, `TestGitRemoteSyncRoundTrip`, `TestGitRemoteEmbeddedHasRemote`, `TestGitRemotePushSkipsUserPrePushHook` all green.

## Known blind spot, stated at the function

If a fetch never contacts the remote *and* the refresh fetch also cannot run (both fail open), the two refs still agree and the pull is indistinguishable from an honest no-op. Detecting that needs an independent view of the remote's head, which is protocol-specific and out of scope here.

Not addressed, and worth its own change: `schema.DrainCall` still discards `DOLT_PULL`'s `(fast_forward, conflicts, message)` row. Capturing it would let the error message quote what the engine claimed, and would give callers a way to distinguish "merged" from "up to date" as a *return value* rather than an absence of error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)