### PR TITLE
fix(ci): pin the Dolt CLI — 2.3.0 regressed DOLT_RESET on fresh databases (shard 12)

### DIFF
--- a/.github/workflows/ci-measurements.yml
+++ b/.github/workflows/ci-measurements.yml
@@ -66,7 +66,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |
@@ -113,7 +113,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |
@@ -144,7 +144,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |
@@ -177,7 +177,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |
@@ -222,7 +222,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |
@@ -287,7 +287,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |
@@ -355,7 +355,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |
@@ -423,7 +423,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |
@@ -528,7 +528,7 @@ jobs:
           path: prebuilt-bd
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |
@@ -594,7 +594,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -401,7 +401,7 @@ jobs:
           restore-keys: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-race-
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |
@@ -505,7 +505,7 @@ jobs:
           restore-keys: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-race-
 
       - name: Install Dolt (Linux/macOS)
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Verify dolt on PATH
         run: dolt version
@@ -625,7 +625,7 @@ jobs:
           cache: false
 
       - name: Install Dolt CLI
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Verify dolt on PATH
         run: dolt version
@@ -703,7 +703,7 @@ jobs:
           chmod +x bd-linux-gms-pure
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |
@@ -787,7 +787,7 @@ jobs:
           chmod +x bd-linux-gms-pure
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |
@@ -878,7 +878,7 @@ jobs:
       - name: Install Dolt CLI
         # TestProxiedServerExternalCreate needs the dolt binary on PATH; the
         # shared harness itself uses the dolt sql-server container image.
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Install Dolt
         run: |
-          curl -L https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+          ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |

--- a/.github/workflows/pr-risk.yml
+++ b/.github/workflows/pr-risk.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Install Dolt CLI
         # TestProxiedServerExternalCreate needs the dolt binary on PATH; the
         # shared harness itself uses the dolt sql-server container image.
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |
@@ -303,7 +303,7 @@ jobs:
           git config --global user.email "ci@beads.test"
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Dolt
         run: |
@@ -352,7 +352,7 @@ jobs:
           git config --global user.email "ci@beads.test"
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Dolt
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -663,7 +663,7 @@ jobs:
           restore-keys: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-race-
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |
@@ -741,7 +741,7 @@ jobs:
           cache: false
 
       - name: Install Dolt CLI
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Verify dolt on PATH
         run: dolt version
@@ -842,7 +842,7 @@ jobs:
           restore-keys: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-race-
 
       - name: Install Dolt (Linux/macOS)
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Verify dolt on PATH
         run: dolt version
@@ -895,7 +895,7 @@ jobs:
           cache: false
 
       - name: Install Dolt CLI
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -95,7 +95,7 @@ jobs:
           git config --global user.email "ci@beads.test"
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Dolt
         run: |

--- a/internal/storage/dolt/dolt_test.go
+++ b/internal/storage/dolt/dolt_test.go
@@ -134,6 +134,12 @@ func requireCleanTables(ctx context.Context, t *testing.T, store *DoltStore, tab
 //
 // Automatically marks the test as safe for parallel execution since each test
 // gets its own Dolt connection checked out to a unique branch.
+//
+// This call blocks twice — once in t.Parallel() until the sequential phase
+// ends, then again on testSem, which admits two tests at a time. In a shard of
+// 60+ tests that wait is minutes, so build the test's context AFTER this
+// returns. A context created before it spends its whole budget in the queue
+// and is already expired by the time the test body runs.
 func setupTestStore(t *testing.T) (*DoltStore, func()) {
 	t.Helper()
 	skipIfNoDolt(t)

--- a/internal/storage/dolt/federation_test.go
+++ b/internal/storage/dolt/federation_test.go
@@ -141,11 +141,11 @@ func TestFederationDatabaseIsolation(t *testing.T) {
 func TestFederationVersionControlAPIs(t *testing.T) {
 	skipIfNoDolt(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
 
 	// setupTestStore already checked this store out to its own isolated
 	// branch (testutil.StartTestBranch), not the shared database's literal
@@ -255,11 +255,11 @@ func TestFederationVersionControlAPIs(t *testing.T) {
 func TestFederationRemoteConfiguration(t *testing.T) {
 	skipIfNoDolt(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
 
 	// Add a remote (configuration only - won't actually connect)
 	// Production would use: dolthub://org/repo, s3://bucket/path, etc.
@@ -284,11 +284,11 @@ func TestFederationRemoteConfiguration(t *testing.T) {
 func TestFederationHistoryQueries(t *testing.T) {
 	skipIfNoDolt(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
 
 	// Create issue
 	issue := &types.Issue{
@@ -352,11 +352,11 @@ func TestFederationHistoryQueries(t *testing.T) {
 func TestFederationListRemotes(t *testing.T) {
 	skipIfNoDolt(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
 
 	// Initially no remotes (except possibly origin if Dolt adds one by default)
 	remotes, err := store.ListRemotes(ctx)
@@ -388,11 +388,11 @@ func TestFederationListRemotes(t *testing.T) {
 func TestFederationSyncStatus(t *testing.T) {
 	skipIfNoDolt(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
 
 	// Get status for a nonexistent peer (should not error, just return partial data)
 	status, err := store.SyncStatus(ctx, "nonexistent-peer")
@@ -415,11 +415,11 @@ func TestFederationSyncStatus(t *testing.T) {
 func TestFederationSyncCommitsPendingPeerMetadataBeforeFetch(t *testing.T) {
 	skipIfNoDolt(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
 
 	peer := &storage.FederationPeer{
 		Name:        "peer-metadata-sync",
@@ -480,11 +480,11 @@ func federationStatusHasTable(t *testing.T, ctx context.Context, store *DoltStor
 func TestFederationPushPullMethods(t *testing.T) {
 	skipIfNoDolt(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
 
 	// These should fail gracefully since no remote exists
 	err := store.PushTo(ctx, "nonexistent")

--- a/internal/storage/dolt/fresh_bootstrap_heal_integration_test.go
+++ b/internal/storage/dolt/fresh_bootstrap_heal_integration_test.go
@@ -120,6 +120,7 @@ func TestFreshBootstrapHealIncarnation(t *testing.T) {
 		if facts.bootstrapHeal == nil {
 			t.Fatal("exact bare CREATE did not return a capability")
 		}
+		requireWorkingHardReset(t, ctx, db)
 
 		prepareFreshBootstrapV51Dirty(t, ctx, db, "creator_debris")
 		if _, err := initSchemaOnDBWithBootstrapHeal(
@@ -226,6 +227,32 @@ func freshBootstrapIntegrationConfig(beadsDir string, port int, database, pathSu
 		Database:        database,
 		CreateIfMissing: true,
 		MaxOpenConns:    1,
+	}
+}
+
+// requireWorkingHardReset fails before the heal under test runs when this
+// database's CALL DOLT_RESET('--hard') is already broken, so a broken Dolt is
+// named as such instead of masquerading as a beads defect.
+//
+// Dolt 2.3.0 regressed the procedure: roughly one freshly created database in
+// twenty comes up with it permanently unusable, answering
+// "Error 1105 (HY000): context canceled" to every session for the life of the
+// server process (measured 2026-08-20: 2.1.8 0/40, 2.2.0 0/60, 2.3.0 3/60,
+// 2.3.1 3/100 fresh databases broken). Without this probe the defect surfaces
+// only as the heal's generic #4566 dirty-table refusal, which reads like a
+// beads bug and points the reader at "run 'bd dolt commit'" — advice that
+// cannot work, because the reset the heal needs is the thing that is broken.
+//
+// The probe is safe on the database under test: on a pristine, just-created
+// database the hard reset is a no-op, and over 60 fresh databases a successful
+// first reset never broke a later one.
+func requireWorkingHardReset(t *testing.T, ctx context.Context, db *sql.DB) {
+	t.Helper()
+	if err := schema.DrainCall(ctx, db, "CALL DOLT_RESET('--hard')"); err != nil {
+		t.Fatalf("this Dolt server cannot CALL DOLT_RESET('--hard') on a database it just created: %v\n"+
+			"That is the Dolt 2.3.0 regression, not a beads failure — the bootstrap heal this test "+
+			"exercises is unimplementable on such a server. Check the pinned CLI version in "+
+			"scripts/ci/install-dolt.sh and `dolt version`.", err)
 	}
 }
 

--- a/internal/storage/dolt/git_remote_test.go
+++ b/internal/storage/dolt/git_remote_test.go
@@ -12,11 +12,13 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/steveyegge/beads/internal/doltserver"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/doltutil"
 	"github.com/steveyegge/beads/internal/storage/schema"
@@ -45,10 +47,55 @@ import (
 
 // gitRemoteSetup holds resources for a git-remote test scenario.
 type gitRemoteSetup struct {
-	baseDir   string // root temp dir
-	remoteDir string // bare git repo path
-	remoteURL string // file:// URL for the bare repo
-	sourceDir string // dolt source repo directory
+	baseDir    string // root temp dir
+	remoteDir  string // bare git repo path
+	remoteURL  string // file:// URL for the bare repo
+	sourceDir  string // dolt source repo directory
+	serverPort int    // local dolt sql-server port (0 for CLI-only setups)
+}
+
+// startLocalDoltServer starts a `dolt sql-server` rooted at dataDir and
+// returns its port and an idempotent stop function.
+//
+// The suite's shared Dolt server (testmain_test.go) runs inside a Docker
+// container: its only mount is the image's own /var/lib/dolt volume, so it
+// can reach neither a host file:// git remote nor the store's own Path.
+// Tests that push to a local bare git repo, or that inspect the engine's
+// on-disk state, need a server that shares this process's filesystem.
+// TestGitRemoteExternalServerRouting, TestSQLRemotePersistsAcrossExternalServerRestart
+// and TestCredentialCLIRoutingE2E use the same arrangement.
+//
+// The server is spawned with doltserver.ServerSpawnEnv(), the same environment
+// bd gives the sql-server it starts. That is load-bearing, not cosmetic: a
+// `dolt` CLI command run against a directory a sql-server is already serving
+// is proxied to that server, so the git subprocess is spawned by the server,
+// not by the CLI — env guards applied to the CLI process (git tracing,
+// core.hooksPath) only take effect if the server carries them too.
+func startLocalDoltServer(t *testing.T, dataDir string) (int, func()) {
+	t.Helper()
+	port, err := testutil.FindFreePort()
+	if err != nil {
+		t.Fatalf("failed to find free port: %v", err)
+	}
+	cmd := exec.Command("dolt", "sql-server", "-H", "127.0.0.1", "-P", strconv.Itoa(port))
+	cmd.Dir = dataDir
+	cmd.Env = doltserver.ServerSpawnEnv()
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start dolt sql-server in %s: %v", dataDir, err)
+	}
+	var once sync.Once
+	stop := func() {
+		once.Do(func() {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		})
+	}
+	t.Cleanup(stop)
+	if !testutil.WaitForServer(port, 15*time.Second) {
+		stop()
+		t.Fatalf("dolt sql-server in %s did not become ready within timeout", dataDir)
+	}
+	return port, stop
 }
 
 // setupGitRemote creates a bare git repo (seeded with an initial commit)
@@ -588,18 +635,23 @@ func TestGitRemoteSpecialCharacters(t *testing.T) {
 	}
 }
 
-// --- Embedded driver git remote tests ---
+// --- SQL-driver git remote tests ---
 //
 // These tests verify that Dolt's git remote support works through the
 // SQL driver, not just the CLI. This is the critical question for the
 // Dolt-in-Git spike: can we use store.Push() and store.Pull() with a
 // bare git repo as the remote?
+//
+// CALL DOLT_PUSH runs inside the sql-server process, so the server must be
+// able to see the bare repo and the store's own data directory. These tests
+// therefore run against their own local sql-server (startLocalDoltServer),
+// not the suite's containerized shared server.
 
 // setupEmbeddedGitRemote creates a bare git repo and returns a DoltStore
 // connected with the bare repo configured as "origin".
 func setupEmbeddedGitRemote(t *testing.T) (*DoltStore, *gitRemoteSetup, func()) {
 	t.Helper()
-	skipIfNoDolt(t)
+	testutil.RequireDoltBinary(t)
 	skipIfNoGit(t)
 	acquireTestSlot()
 	t.Cleanup(releaseTestSlot)
@@ -625,47 +677,89 @@ func setupEmbeddedGitRemote(t *testing.T) (*DoltStore, *gitRemoteSetup, func()) 
 
 	remoteURL := "file://" + remoteDir
 
-	// Create embedded DoltStore
+	// Serve the store's own data directory from a local sql-server so the
+	// engine, the bare git repo and this test process all share one
+	// filesystem.
 	doltDir := filepath.Join(baseDir, "embedded-dolt")
+	if err := os.MkdirAll(doltDir, 0o755); err != nil {
+		os.RemoveAll(baseDir)
+		t.Fatalf("failed to create dolt dir: %v", err)
+	}
+	serverPort, stopServer := startLocalDoltServer(t, doltDir)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	dbName := uniqueTestDBName(t)
 	store, err := New(ctx, &Config{
 		Path:            doltDir,
+		ServerHost:      "127.0.0.1",
+		ServerPort:      serverPort,
+		ServerUser:      "root",
+		AutoStart:       false,
 		CommitterName:   "test",
 		CommitterEmail:  "test@example.com",
 		Database:        dbName,
 		CreateIfMissing: true, // test creates a fresh database
 	})
 	if err != nil {
+		stopServer()
 		os.RemoveAll(baseDir)
-		t.Fatalf("failed to create embedded DoltStore: %v", err)
+		t.Fatalf("failed to create DoltStore: %v", err)
+	}
+
+	// The whole point of the local server: the database it just created must
+	// be on this process's filesystem, under the store's own Path. Tests here
+	// push to a host bare repo and read the engine's git-remote cache mirror,
+	// and both silently stop being meaningful if the store ever drifts back
+	// onto a containerized server.
+	if _, statErr := os.Stat(filepath.Join(doltDir, dbName, ".dolt")); statErr != nil {
+		store.Close()
+		stopServer()
+		os.RemoveAll(baseDir)
+		t.Fatalf("store did not materialize %s/.dolt on this filesystem — the engine is not local to the test: %v", filepath.Join(doltDir, dbName), statErr)
 	}
 
 	// Set issue prefix (required for CreateIssue)
 	if err := store.SetConfig(ctx, "issue_prefix", "test"); err != nil {
 		store.Close()
+		stopServer()
 		os.RemoveAll(baseDir)
 		t.Fatalf("failed to set prefix: %v", err)
 	}
 
-	// Add git remote via embedded SQL
+	// Add git remote via SQL
 	if err := store.AddRemote(ctx, "origin", remoteURL); err != nil {
 		store.Close()
+		stopServer()
 		os.RemoveAll(baseDir)
 		t.Fatalf("failed to add remote: %v", err)
 	}
 
+	// Genesis commit, sweeping config too — the CLI sibling setupGitRemote
+	// does the same with DOLT_COMMIT('-Am', 'Genesis: schema and config').
+	// Commit() deliberately skips config (GH#2455), so without this
+	// issue_prefix stays dirty forever: Pull() then refuses to auto-commit a
+	// dirty internal config key, and a peer cloning this database gets no
+	// prefix at all.
+	if _, err := store.CommitAll(ctx, "Genesis: schema and config"); err != nil {
+		store.Close()
+		stopServer()
+		os.RemoveAll(baseDir)
+		t.Fatalf("failed to commit genesis config: %v", err)
+	}
+
 	setup := &gitRemoteSetup{
-		baseDir:   baseDir,
-		remoteDir: remoteDir,
-		remoteURL: remoteURL,
-		sourceDir: doltDir,
+		baseDir:    baseDir,
+		remoteDir:  remoteDir,
+		remoteURL:  remoteURL,
+		sourceDir:  doltDir,
+		serverPort: serverPort,
 	}
 
 	cleanup := func() {
 		store.Close()
+		stopServer()
 		os.RemoveAll(baseDir)
 	}
 
@@ -940,8 +1034,15 @@ func TestGitRemoteSyncRoundTrip(t *testing.T) {
 		t.Fatal("expected bootstrap to occur (no existing dolt dir)")
 	}
 
+	// The clone is a second peer with its own data directory, so it needs its
+	// own local server for the same reason the source does.
+	clonePort, _ := startLocalDoltServer(t, cloneDoltDir)
 	cloneStore, err := New(ctx, &Config{
 		Path:            cloneDoltDir,
+		ServerHost:      "127.0.0.1",
+		ServerPort:      clonePort,
+		ServerUser:      "root",
+		AutoStart:       false,
 		CommitterName:   "clone-user",
 		CommitterEmail:  "clone@example.com",
 		Database:        cloneDBName,
@@ -992,6 +1093,10 @@ func TestGitRemoteSyncRoundTrip(t *testing.T) {
 	// Step 4: Re-open source and pull — verify bidirectional sync
 	sourceStore2, err := New(ctx, &Config{
 		Path:            filepath.Join(setup.baseDir, "embedded-dolt"),
+		ServerHost:      "127.0.0.1",
+		ServerPort:      setup.serverPort,
+		ServerUser:      "root",
+		AutoStart:       false,
 		CommitterName:   "test",
 		CommitterEmail:  "test@example.com",
 		Database:        findClonedDBName(t, filepath.Join(setup.baseDir, "embedded-dolt")),

--- a/internal/storage/dolt/git_remote_test.go
+++ b/internal/storage/dolt/git_remote_test.go
@@ -1183,6 +1183,14 @@ func TestCreateIssueAfterPull(t *testing.T) {
 		t.Fatalf("Pull failed: %v", err)
 	}
 
+	// Pin what the pull itself delivered, before any further write. Pull()
+	// reporting success while the peer's row never arrived, and Pull()
+	// delivering the row only for a later write to drop it, are different
+	// bugs; asserting only at the end of the test cannot tell them apart.
+	if pulled, pulledErr := store.GetIssue(ctx, "ai-clone-001"); pulledErr != nil || pulled == nil {
+		t.Fatalf("Pull reported success but the peer's ai-clone-001 is not in the source store (err=%v)", pulledErr)
+	}
+
 	postPullIssue := &types.Issue{
 		ID:        "ai-src-002",
 		Title:     "Source issue after pull",

--- a/internal/storage/dolt/git_remote_test.go
+++ b/internal/storage/dolt/git_remote_test.go
@@ -228,6 +228,40 @@ func sourceCommitAndPush(t *testing.T, dir, msg string) {
 	doltPush(t, dir)
 }
 
+// doltGitRemoteReadCacheTTL mirrors dolt's own defaultSyncForReadTTL
+// (store/blobstore/git_blobstore.go). Dolt resolves a file:// URL that points
+// at a git repo to a git+file:// remote served by GitBlobstore, and
+// GitBlobstore.syncForRead skips the underlying `git fetch` entirely when it
+// last synced less than this long ago:
+//
+//	if ttl := gbs.syncForReadTTL; ttl > 0 { if sinceLast < ttl { return nil } }
+//
+// The blobstore is cached for the life of the sql-server process
+// (dbfactory.gitRemoteCache), so the window is per-server, not per-connection.
+const doltGitRemoteReadCacheTTL = 1 * time.Second
+
+// waitOutGitRemoteReadCache blocks until a push made by a *different* process
+// is guaranteed visible to the next remote read performed by a sql-server this
+// test already used to touch the same remote.
+//
+// Without it these tests race a silent upstream staleness window: a pull
+// issued inside doltGitRemoteReadCacheTTL of the server's previous remote sync
+// reads the cached view, finds the peer's commit absent, and reports
+// "Everything up-to-date" with fast_forward=0 — so store.Pull() returns nil
+// having merged nothing and the peer's rows never arrive. Verified against
+// dolt 2.3.1: with the peer's push and the pull 0.74s apart the pull reports
+// success and delivers nothing; at 1.18s apart the same sequence reports
+// "merge successful" and the row arrives. That is why these tests failed only
+// on CI, whose runners complete the intervening clone/insert/push faster than
+// a loaded developer machine.
+//
+// This sleep removes an unintended dependency on an upstream cache; it does
+// not weaken any assertion below it. If bd's push/pull were actually broken,
+// every assertion still fails exactly as before.
+func waitOutGitRemoteReadCache() {
+	time.Sleep(doltGitRemoteReadCacheTTL + 500*time.Millisecond)
+}
+
 // --- Clone verification helpers (all CLI-based) ---
 
 // queryCSV runs a SQL query via dolt CLI and returns parsed rows as maps.
@@ -811,6 +845,10 @@ func TestGitRemoteEmbeddedPushPull(t *testing.T) {
 	sourceInsertIssue(t, cloneDir, "emb-git-002", "Added in clone")
 	sourceCommitAndPush(t, cloneDir, "Add emb-git-002 from clone")
 
+	// The clone pushed from its own process; this store's sql-server last read
+	// the remote during store.Push() above and caches that view briefly.
+	waitOutGitRemoteReadCache()
+
 	// Pull via embedded driver
 	if err := store.Pull(ctx); err != nil {
 		t.Fatalf("Pull failed: %v", err)
@@ -1090,6 +1128,10 @@ func TestGitRemoteSyncRoundTrip(t *testing.T) {
 	// Close clone store before re-opening source
 	cloneStore.Close()
 
+	// The clone pushed from its own sql-server; the source's server last read
+	// the remote during step 1's push and caches that view briefly.
+	waitOutGitRemoteReadCache()
+
 	// Step 4: Re-open source and pull — verify bidirectional sync
 	sourceStore2, err := New(ctx, &Config{
 		Path:            filepath.Join(setup.baseDir, "embedded-dolt"),
@@ -1174,6 +1216,10 @@ func TestCreateIssueAfterPull(t *testing.T) {
 	}
 	sourceInsertIssue(t, cloneDir, "ai-clone-001", "Clone issue generating events")
 	sourceCommitAndPush(t, cloneDir, "Add ai-clone-001")
+
+	// The peer pushed from its own process; this store's sql-server last read
+	// the remote during store.Push() above and caches that view briefly.
+	waitOutGitRemoteReadCache()
 
 	// Pull into the source store — this is the code path under test.
 	// With UUID primary keys, there are no counter collisions after pull.

--- a/internal/storage/dolt/initschema_multiprocess_test.go
+++ b/internal/storage/dolt/initschema_multiprocess_test.go
@@ -55,7 +55,10 @@ func TestHelperSchemaInit(t *testing.T) {
 	db.SetMaxOpenConns(2)
 	db.SetMaxIdleConns(1)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	// Must leave room for the retry wrapper's full serverRetryMaxElapsed (30s)
+	// budget on top of connect time, or the context cuts the retry short and
+	// re-creates the failure it exists to absorb.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
 	if err := db.PingContext(ctx); err != nil {
@@ -63,9 +66,18 @@ func TestHelperSchemaInit(t *testing.T) {
 		os.Exit(1)
 	}
 
-	_, err = initSchemaOnDB(ctx, db)
+	// initSchemaOnDBWithRetry, not the raw initSchemaOnDB: every production
+	// caller (DoltStore.initSchema, DoltStore.ApplySchemaMigrations) goes
+	// through this wrapper, and the 5s GET_LOCK wait in
+	// schema.MigrateUpWithLock is deliberately sized to fit inside its retry
+	// budget — see migrationLockAcquireTimeoutSeconds. Racing the raw call and
+	// demanding a first-try win asserts on a path no bd process ever takes:
+	// with N processes on one fresh database, N-1 of them are supposed to lose
+	// the lock and come back. #5880 made the same change in this file's
+	// TestMultiProcessSchemaInit_DoltVerify and missed this subprocess helper.
+	_, err = initSchemaOnDBWithRetry(ctx, db)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "ERROR: initSchemaOnDB: %v\n", err)
+		fmt.Fprintf(os.Stderr, "ERROR: initSchemaOnDBWithRetry: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -124,7 +136,10 @@ func TestMultiProcessSchemaInit(t *testing.T) {
 	for i := 0; i < numProcs; i++ {
 		procID := strconv.Itoa(i)
 		eg.Go(func() error {
-			subCtx, subCancel := context.WithTimeout(egCtx, 30*time.Second)
+			// Same reasoning as the subprocess's own context: this bound has to
+			// cover process start, connect, and the retry wrapper's whole 30s
+			// budget, so it cannot itself be 30s.
+			subCtx, subCancel := context.WithTimeout(egCtx, 2*time.Minute)
 			defer subCancel()
 
 			cmd := exec.CommandContext(subCtx, testBin,

--- a/internal/storage/dolt/testmain_helper_sentinel_test.go
+++ b/internal/storage/dolt/testmain_helper_sentinel_test.go
@@ -1,0 +1,49 @@
+package dolt
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"testing"
+)
+
+// helperSentinelRead matches how a TestHelper* entry point reads its own
+// sentinel, e.g. os.Getenv("BEADS_SCHEMA_INIT_HELPER").
+var helperSentinelRead = regexp.MustCompile(`os\.Getenv\("(BEADS_[A-Z0-9_]*_HELPER)"\)`)
+
+// TestHelperSubprocessSentinelsAreComplete keeps helperSubprocessSentinels in
+// sync with the helper entry points that actually exist. A missing entry is
+// silent and expensive: TestMain would start a Dolt container the subprocess
+// never uses, then leak it when the helper exits via os.Exit.
+func TestHelperSubprocessSentinelsAreComplete(t *testing.T) {
+	sources, err := filepath.Glob("*_test.go")
+	if err != nil {
+		t.Fatalf("glob test sources: %v", err)
+	}
+	if len(sources) == 0 {
+		t.Fatal("no *_test.go sources found — the scan below would vacuously pass")
+	}
+
+	var found []string
+	for _, source := range sources {
+		data, err := os.ReadFile(source)
+		if err != nil {
+			t.Fatalf("read %s: %v", source, err)
+		}
+		for _, match := range helperSentinelRead.FindAllStringSubmatch(string(data), -1) {
+			found = append(found, match[1])
+			if !slices.Contains(helperSubprocessSentinels, match[1]) {
+				t.Errorf("%s reads helper sentinel %s, which is missing from helperSubprocessSentinels in testmain_test.go", source, match[1])
+			}
+		}
+	}
+
+	// The reverse direction is the control: if the pattern above ever stops
+	// matching, this fails instead of letting the scan pass on zero hits.
+	for _, sentinel := range helperSubprocessSentinels {
+		if !slices.Contains(found, sentinel) {
+			t.Errorf("helperSubprocessSentinels lists %s, but no test source reads it — stale entry, or helperSentinelRead no longer matches", sentinel)
+		}
+	}
+}

--- a/internal/storage/dolt/testmain_test.go
+++ b/internal/storage/dolt/testmain_test.go
@@ -23,6 +23,26 @@ var testSharedDB string
 // testSharedConn is a raw *sql.DB for branch operations in the shared database.
 var testSharedConn *sql.DB
 
+// helperSubprocessSentinels are the env vars a parent test sets when it
+// re-execs this test binary as a helper subprocess. Keep in sync with the
+// TestHelper* entry points — TestHelperSubprocessSentinelsAreComplete fails the
+// build if a new one is added without listing it here.
+var helperSubprocessSentinels = []string{
+	"BEADS_SCHEMA_INIT_HELPER",
+	"BEADS_MULTISTORE_HELPER",
+}
+
+// isHelperSubprocess reports whether this process was re-exec'd as a helper
+// subprocess rather than run as the suite itself.
+func isHelperSubprocess() bool {
+	for _, sentinel := range helperSubprocessSentinels {
+		if os.Getenv(sentinel) == "1" {
+			return true
+		}
+	}
+	return false
+}
+
 func TestMain(m *testing.M) {
 	os.Exit(testMainInner(m))
 }
@@ -57,6 +77,18 @@ func testMainInner(m *testing.M) int {
 	// sql-server (testcontainer or external port). The new database-name
 	// firewall in dolt.New refuses test-named DBs unless this opt-in is set.
 	os.Setenv("BEADS_TEST_SERVER", "1")
+	if isHelperSubprocess() {
+		// A helper subprocess is handed its server's port by the parent test
+		// and never looks at this suite's own server. Starting one anyway
+		// costs a Dolt container plus a full migration chain per subprocess:
+		// TestMultiProcessSchemaInit spawns 8 at once, so the machine ran 9
+		// Dolt servers to measure a lock race between 8 clients of the
+		// parent's single server. Worse, every helper exits through os.Exit,
+		// which skips the deferred TerminateDoltContainer below and leaks the
+		// container. That load is what pushed the contended GET_LOCK past its
+		// 5s wait in CI shard 3.
+		return m.Run()
+	}
 	if err := testutil.EnsureDoltContainerForTestMain(); err != nil {
 		fmt.Fprintf(os.Stderr, "WARN: %v, skipping Dolt tests\n", err)
 	} else {

--- a/scripts/ci/install-dolt.sh
+++ b/scripts/ci/install-dolt.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install a pinned Dolt CLI. Every CI job that needs `dolt` on PATH must go
+# through this script instead of piping the upstream install.sh from
+# releases/latest, because "latest" silently changes the binary under test.
+#
+# Keep this version in sync with internal/testutil/testdoltcommon.go:
+# DoltDockerImage and scripts/ci/pull-dolt-image.sh. Tests run the CLI (the
+# per-test sql-server that doltserver.Start launches) and the container
+# side by side against the same databases; letting the two drift means the
+# suite is exercising a Dolt pair no release ever shipped.
+#
+# Why pinned rather than latest: Dolt 2.3.0 (released 2026-08-13) regressed
+# CALL DOLT_RESET('--hard') so that roughly one freshly created database in
+# twenty comes up with the procedure permanently broken --
+# "Error 1105 (HY000): context canceled" on every connection, from any
+# session, for the life of the server process. Measured 2026-08-20 by
+# creating fresh databases and immediately calling the procedure: 2.1.8 0/40
+# broken, 2.2.0 0/60, 2.3.0 3/60, 2.3.1 3/100. That is what made
+# TestFreshBootstrapHealIncarnation fail on a coin flip the day
+# releases/latest moved to 2.3.x, and it also puts bd dolt compact/flatten
+# and the #4566 fresh-bootstrap heal at risk on 2.3.x. Raise this pin only
+# once a Dolt release is confirmed clean by that same measurement.
+readonly version="2.2.0"
+readonly max_attempts=3
+readonly retry_delay_seconds=5
+
+arch="$(uname -m)"
+case "$arch" in
+  x86_64 | amd64) arch="amd64" ;;
+  aarch64 | arm64) arch="arm64" ;;
+  *)
+    printf 'Unsupported architecture for pinned dolt install: %s\n' "$arch" >&2
+    exit 1
+    ;;
+esac
+
+os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+readonly asset="dolt-${os}-${arch}.tar.gz"
+readonly url="https://github.com/dolthub/dolt/releases/download/v${version}/${asset}"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+  if curl -fsSL -o "$workdir/$asset" "$url"; then
+    break
+  fi
+  status=$?
+  if ((attempt == max_attempts)); then
+    printf 'Failed to download %s after %d attempts.\n' "$url" "$max_attempts" >&2
+    exit "$status"
+  fi
+  printf 'Failed to download %s (attempt %d/%d); retrying in %d seconds.\n' \
+    "$url" "$attempt" "$max_attempts" "$retry_delay_seconds" >&2
+  sleep "$retry_delay_seconds"
+done
+
+tar -xzf "$workdir/$asset" -C "$workdir"
+sudo install -m 0755 "$workdir/dolt-${os}-${arch}/bin/dolt" /usr/local/bin/dolt
+
+# Fail loudly if PATH resolves to some other dolt: a stale runner-image copy
+# earlier on PATH would silently put the suite back on an unpinned binary.
+# No `| head` here: pipefail turns dolt's SIGPIPE into a failed install.
+installed="$(dolt version)"
+installed="${installed%%$'\n'*}"
+if [[ "$installed" != *"$version"* ]]; then
+  printf 'dolt on PATH reports "%s", want version %s (which dolt: %s)\n' \
+    "$installed" "$version" "$(command -v dolt)" >&2
+  exit 1
+fi
+printf 'Installed pinned %s\n' "$installed"

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -1217,3 +1217,85 @@ func contains(items []string, want string) bool {
 	}
 	return false
 }
+
+// TestWorkflowsInstallPinnedDolt keeps the Dolt CLI under test pinned. Every
+// workflow used to install it by piping dolthub/dolt's releases/latest
+// install.sh, so the binary under test changed whenever upstream published —
+// including backports, which can move "latest" backwards. When Dolt 2.3.0
+// landed it regressed CALL DOLT_RESET('--hard'): roughly one freshly created
+// database in twenty comes up with the procedure permanently broken
+// ("Error 1105 (HY000): context canceled"), which made
+// TestFreshBootstrapHealIncarnation fail on a coin flip. See
+// scripts/ci/install-dolt.sh for the per-version measurements. The CLI is now
+// pinned to the same release as the container image, so the two halves of
+// every server-mode test (the per-test sql-server doltserver.Start launches,
+// and the shared container) can never drift apart.
+func TestWorkflowsInstallPinnedDolt(t *testing.T) {
+	workflowDir := filepath.Join(sourceRepoRoot(t), ".github", "workflows")
+	entries, err := os.ReadDir(workflowDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	installers := 0
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".yml" {
+			continue
+		}
+		path := filepath.Join(workflowDir, entry.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		body := string(data)
+		if strings.Contains(body, "dolt/releases/latest") {
+			t.Errorf("%s installs dolt from releases/latest; use ./scripts/ci/install-dolt.sh so the "+
+				"binary under test is pinned", entry.Name())
+		}
+		installers += strings.Count(body, "scripts/ci/install-dolt.sh")
+	}
+	if installers == 0 {
+		t.Fatal("no workflow installs dolt via scripts/ci/install-dolt.sh — the pin is not wired up")
+	}
+}
+
+// TestPinnedDoltCLIMatchesContainerImage keeps the CLI pin and the sql-server
+// container pin on the same Dolt release. Server-mode tests run both at once
+// against the same databases; a drifting pair tests a combination no release
+// ever shipped.
+func TestPinnedDoltCLIMatchesContainerImage(t *testing.T) {
+	root := sourceRepoRoot(t)
+
+	installer, err := os.ReadFile(filepath.Join(root, "scripts", "ci", "install-dolt.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cliVersion := captureOne(t, `(?m)^readonly version="([0-9]+\.[0-9]+\.[0-9]+)"$`, string(installer), "scripts/ci/install-dolt.sh")
+
+	common, err := os.ReadFile(filepath.Join(root, "internal", "testutil", "testdoltcommon.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	imageVersion := captureOne(t, `dolthub/dolt-sql-server:([0-9]+\.[0-9]+\.[0-9]+)`, string(common), "testdoltcommon.go:DoltDockerImage")
+
+	pullScript, err := os.ReadFile(filepath.Join(root, "scripts", "ci", "pull-dolt-image.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pullVersion := captureOne(t, `dolthub/dolt-sql-server:([0-9]+\.[0-9]+\.[0-9]+)`, string(pullScript), "scripts/ci/pull-dolt-image.sh")
+
+	if cliVersion != imageVersion || cliVersion != pullVersion {
+		t.Errorf("dolt pins disagree: CLI %s, DoltDockerImage %s, pull-dolt-image.sh %s",
+			cliVersion, imageVersion, pullVersion)
+	}
+}
+
+func captureOne(t *testing.T, pattern, body, source string) string {
+	t.Helper()
+
+	matches := regexp.MustCompile(pattern).FindStringSubmatch(body)
+	if matches == nil {
+		t.Fatalf("%s does not match %s", source, pattern)
+	}
+	return matches[1]
+}


### PR DESCRIPTION
**Superset of #5889** (which is itself a superset of #5888). Those fix the five deterministic full-suite shard failures; this one fixes the sixth, intermittent one. `pr-risk.yml` is `on: pull_request: branches: [main]`, so a PR stacked on another PR's branch runs **zero** full-suite shards — hence base `main` and the commit stack. Merge #5889 first and this rebases to just the last commit.

## Shard 12 was never a beads race, and never runner load

`Test (Server Dolt Full Suite 12/16)` failed on a coin flip with `TestFreshBootstrapHealIncarnation/exact_creator_heals_its_interrupted_bootstrap`. **The error everyone was reading is truncated.** The CI log has a second line:

```
fresh_bootstrap_heal_integration_test.go:128: creator-authorized migration: schema migration:
    pending schema migrations alter pre-existing dirty tables: issues; run 'bd dolt commit' ... (#4566)
    schema: fresh-bootstrap reset: Error 1105 (HY000): context canceled
```

So the heal **was** authorized and its capability **was** consumed. What failed is the `CALL DOLT_RESET('--hard')` at `internal/storage/schema/lock.go:233`. All three failing shard-12 jobs carry that second line (96568108600, 96546109612, 96540595048); the passing job 96571321686 does not.

## Dolt 2.3.0 regressed `DOLT_RESET --hard`

A beads-free probe — `CREATE DATABASE x_i`, connect, `CALL DOLT_RESET('--hard')`:

| dolt | fresh databases with a permanently broken hard reset |
|---|---|
| 2.1.8 | 0/40 |
| 2.2.0 | 0/60 |
| 2.3.0 | **3/60** |
| 2.3.1 | **3/100** |

Not transient: retried on the same pinned conn, a new `*sql.Conn`, and a brand-new `*sql.DB`/TCP connection — all fail. `SELECT 1`, `CALL DOLT_CLEAN()` and `CALL DOLT_CHECKOUT('.')` still work; only `DOLT_RESET --hard` is dead, and it stays dead for the life of the server process. Mechanism (PLAUSIBLE-by-reading dolt source): `DOLT_RESET --hard` is the only caller of `dsess.ResetGlobals` → `AutoIncrementTracker.InitWithRoots`, which caches a terminal `initErr` and returns it before it can re-init. A probe that calls the procedure **immediately after `CREATE DATABASE`, before any migration**, already fails — the database is born broken, so the dirty-tables precondition is irrelevant.

## Why it started the day it did

Every workflow installed the CLI by piping `dolthub/dolt/releases/latest/download/install.sh`, so the binary under test changed the moment 2.3.x shipped — v2.3.0 on 2026-08-13, v2.3.1 on 2026-08-19, the day before the failures. Meanwhile `internal/testutil/testdoltcommon.go` had the **container** pinned at `2.2.0` the whole time. Confirmed directly from CI logs: the failing shard-12 job prints `dolt version 2.3.1` while `DoltDockerImage = "dolthub/dolt-sql-server:2.2.0"`. The suite was exercising a CLI/server pair no release ever shipped. `latest` can even move backwards — v1.88.2 was published after v2.2.4.

## Ruled out, each with a control

Parallel-test contention (reproduced with no container at all, single test); runner load (0/48 failures on 2.1.8 under 6-way parallelism on a load-140 box vs 6/36 on 2.3.1, same conditions); `acquireTestSlot` (this test uses neither it nor `t.Parallel`); a deadline created before a parallel park (fails 1.03s in; later subtests share the same live ctx); Dolt auto-GC (disabled — still failed).

## The change

- `scripts/ci/install-dolt.sh` (new) — installs a pinned Dolt, then **verifies `dolt version` on PATH actually resolves to it**, with the measurements and the criterion for raising the pin recorded inline.
- All 25 install sites across 6 workflows route through it. No `releases/latest` remains.
- `scripts/ci_workflow_test.go` — `TestWorkflowsInstallPinnedDolt` rejects any return to `releases/latest`; `TestPinnedDoltCLIMatchesContainerImage` fails when the CLI pin, `DoltDockerImage` and `pull-dolt-image.sh` disagree. Both verified to fail when they should.
- `fresh_bootstrap_heal_integration_test.go` — one preflight probe. **Assertions unchanged, nothing skipped.** On a broken Dolt the test still **fails**; it just names the Dolt regression instead of emitting the #4566 "run `bd dolt commit`" advice, which cannot work when the reset the heal needs is the broken thing. Measured safe: across 60 fresh databases a successful first reset never broke a later one.

**Verification:** 48 runs of the test (6 workers × 8) and 2 full shard-12 runs on pinned 2.2.0 — zero failures, target subtest 4.38s. The same binary on 2.3.1 still fails 3/24, now in 0.04s with the explicit diagnosis. `go vet ./...`, `gofmt`, `shellcheck` and `make test` all clean.

## Two things that outlive this PR

1. **Production blast radius.** `internal/storage/versioncontrolops/compact.go`, `flatten.go` and `mergesettle.go` all issue `DOLT_RESET('--hard')`. On any Dolt 2.3.x server roughly one database in twenty will have `bd dolt compact` / `bd dolt flatten` / merge-settle rollback permanently broken. **Pinning CI does not fix that**, and `docs/getting-started/sync-setup.md` and `docs/architecture/dolt.md` still tell users to install `releases/latest`. This needs an upstream report to dolthub/dolt; no open issue found.
2. **A design property, left unchanged:** `lock.go` consumes the one-shot heal capability *before* the reset, so **any** reset failure permanently burns it and the outer retry can never converge. The comment says that is intentional; flagging it, not weakening it.

Refs #5836, #5880, #5888, #5889