### PR TITLE
fix(ci): pin the Dolt CLI — 2.3.0 broke DOLT_RESET on fresh databases (ga-m0dlk)

### DIFF
--- a/.github/workflows/ci-measurements.yml
+++ b/.github/workflows/ci-measurements.yml
@@ -66,7 +66,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |
@@ -113,7 +113,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |
@@ -144,7 +144,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |
@@ -177,7 +177,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |
@@ -222,7 +222,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |
@@ -287,7 +287,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |
@@ -355,7 +355,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |
@@ -423,7 +423,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |
@@ -528,7 +528,7 @@ jobs:
           path: prebuilt-bd
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |
@@ -594,7 +594,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -401,7 +401,7 @@ jobs:
           restore-keys: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-race-
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |
@@ -505,7 +505,7 @@ jobs:
           restore-keys: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-race-
 
       - name: Install Dolt (Linux/macOS)
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Verify dolt on PATH
         run: dolt version
@@ -625,7 +625,7 @@ jobs:
           cache: false
 
       - name: Install Dolt CLI
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Verify dolt on PATH
         run: dolt version
@@ -703,7 +703,7 @@ jobs:
           chmod +x bd-linux-gms-pure
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |
@@ -787,7 +787,7 @@ jobs:
           chmod +x bd-linux-gms-pure
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |
@@ -878,7 +878,7 @@ jobs:
       - name: Install Dolt CLI
         # TestProxiedServerExternalCreate needs the dolt binary on PATH; the
         # shared harness itself uses the dolt sql-server container image.
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Install Dolt
         run: |
-          curl -L https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+          ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |

--- a/.github/workflows/pr-risk.yml
+++ b/.github/workflows/pr-risk.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Install Dolt CLI
         # TestProxiedServerExternalCreate needs the dolt binary on PATH; the
         # shared harness itself uses the dolt sql-server container image.
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |
@@ -303,7 +303,7 @@ jobs:
           git config --global user.email "ci@beads.test"
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Dolt
         run: |
@@ -352,7 +352,7 @@ jobs:
           git config --global user.email "ci@beads.test"
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Dolt
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -663,7 +663,7 @@ jobs:
           restore-keys: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-race-
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |
@@ -741,7 +741,7 @@ jobs:
           cache: false
 
       - name: Install Dolt CLI
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Verify dolt on PATH
         run: dolt version
@@ -842,7 +842,7 @@ jobs:
           restore-keys: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-race-
 
       - name: Install Dolt (Linux/macOS)
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Verify dolt on PATH
         run: dolt version
@@ -895,7 +895,7 @@ jobs:
           cache: false
 
       - name: Install Dolt CLI
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Git and Dolt identity
         run: |

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -95,7 +95,7 @@ jobs:
           git config --global user.email "ci@beads.test"
 
       - name: Install Dolt
-        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+        run: ./scripts/ci/install-dolt.sh
 
       - name: Configure Dolt
         run: |

--- a/internal/storage/dolt/fresh_bootstrap_heal_integration_test.go
+++ b/internal/storage/dolt/fresh_bootstrap_heal_integration_test.go
@@ -120,6 +120,7 @@ func TestFreshBootstrapHealIncarnation(t *testing.T) {
 		if facts.bootstrapHeal == nil {
 			t.Fatal("exact bare CREATE did not return a capability")
 		}
+		requireWorkingHardReset(t, ctx, db)
 
 		prepareFreshBootstrapV51Dirty(t, ctx, db, "creator_debris")
 		if _, err := initSchemaOnDBWithBootstrapHeal(
@@ -226,6 +227,32 @@ func freshBootstrapIntegrationConfig(beadsDir string, port int, database, pathSu
 		Database:        database,
 		CreateIfMissing: true,
 		MaxOpenConns:    1,
+	}
+}
+
+// requireWorkingHardReset fails before the heal under test runs when this
+// database's CALL DOLT_RESET('--hard') is already broken, so a broken Dolt is
+// named as such instead of masquerading as a beads defect.
+//
+// Dolt 2.3.0 regressed the procedure: roughly one freshly created database in
+// twenty comes up with it permanently unusable, answering
+// "Error 1105 (HY000): context canceled" to every session for the life of the
+// server process (measured 2026-08-20: 2.1.8 0/40, 2.2.0 0/60, 2.3.0 3/60,
+// 2.3.1 3/100 fresh databases broken). Without this probe the defect surfaces
+// only as the heal's generic #4566 dirty-table refusal, which reads like a
+// beads bug and points the reader at "run 'bd dolt commit'" — advice that
+// cannot work, because the reset the heal needs is the thing that is broken.
+//
+// The probe is safe on the database under test: on a pristine, just-created
+// database the hard reset is a no-op, and over 60 fresh databases a successful
+// first reset never broke a later one.
+func requireWorkingHardReset(t *testing.T, ctx context.Context, db *sql.DB) {
+	t.Helper()
+	if err := schema.DrainCall(ctx, db, "CALL DOLT_RESET('--hard')"); err != nil {
+		t.Fatalf("this Dolt server cannot CALL DOLT_RESET('--hard') on a database it just created: %v\n"+
+			"That is the Dolt 2.3.0 regression, not a beads failure — the bootstrap heal this test "+
+			"exercises is unimplementable on such a server. Check the pinned CLI version in "+
+			"scripts/ci/install-dolt.sh and `dolt version`.", err)
 	}
 }
 

--- a/internal/storage/dolt/git_remote_test.go
+++ b/internal/storage/dolt/git_remote_test.go
@@ -12,11 +12,13 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/steveyegge/beads/internal/doltserver"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/doltutil"
 	"github.com/steveyegge/beads/internal/storage/schema"
@@ -45,10 +47,55 @@ import (
 
 // gitRemoteSetup holds resources for a git-remote test scenario.
 type gitRemoteSetup struct {
-	baseDir   string // root temp dir
-	remoteDir string // bare git repo path
-	remoteURL string // file:// URL for the bare repo
-	sourceDir string // dolt source repo directory
+	baseDir    string // root temp dir
+	remoteDir  string // bare git repo path
+	remoteURL  string // file:// URL for the bare repo
+	sourceDir  string // dolt source repo directory
+	serverPort int    // local dolt sql-server port (0 for CLI-only setups)
+}
+
+// startLocalDoltServer starts a `dolt sql-server` rooted at dataDir and
+// returns its port and an idempotent stop function.
+//
+// The suite's shared Dolt server (testmain_test.go) runs inside a Docker
+// container: its only mount is the image's own /var/lib/dolt volume, so it
+// can reach neither a host file:// git remote nor the store's own Path.
+// Tests that push to a local bare git repo, or that inspect the engine's
+// on-disk state, need a server that shares this process's filesystem.
+// TestGitRemoteExternalServerRouting, TestSQLRemotePersistsAcrossExternalServerRestart
+// and TestCredentialCLIRoutingE2E use the same arrangement.
+//
+// The server is spawned with doltserver.ServerSpawnEnv(), the same environment
+// bd gives the sql-server it starts. That is load-bearing, not cosmetic: a
+// `dolt` CLI command run against a directory a sql-server is already serving
+// is proxied to that server, so the git subprocess is spawned by the server,
+// not by the CLI — env guards applied to the CLI process (git tracing,
+// core.hooksPath) only take effect if the server carries them too.
+func startLocalDoltServer(t *testing.T, dataDir string) (int, func()) {
+	t.Helper()
+	port, err := testutil.FindFreePort()
+	if err != nil {
+		t.Fatalf("failed to find free port: %v", err)
+	}
+	cmd := exec.Command("dolt", "sql-server", "-H", "127.0.0.1", "-P", strconv.Itoa(port))
+	cmd.Dir = dataDir
+	cmd.Env = doltserver.ServerSpawnEnv()
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start dolt sql-server in %s: %v", dataDir, err)
+	}
+	var once sync.Once
+	stop := func() {
+		once.Do(func() {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		})
+	}
+	t.Cleanup(stop)
+	if !testutil.WaitForServer(port, 15*time.Second) {
+		stop()
+		t.Fatalf("dolt sql-server in %s did not become ready within timeout", dataDir)
+	}
+	return port, stop
 }
 
 // setupGitRemote creates a bare git repo (seeded with an initial commit)
@@ -588,18 +635,23 @@ func TestGitRemoteSpecialCharacters(t *testing.T) {
 	}
 }
 
-// --- Embedded driver git remote tests ---
+// --- SQL-driver git remote tests ---
 //
 // These tests verify that Dolt's git remote support works through the
 // SQL driver, not just the CLI. This is the critical question for the
 // Dolt-in-Git spike: can we use store.Push() and store.Pull() with a
 // bare git repo as the remote?
+//
+// CALL DOLT_PUSH runs inside the sql-server process, so the server must be
+// able to see the bare repo and the store's own data directory. These tests
+// therefore run against their own local sql-server (startLocalDoltServer),
+// not the suite's containerized shared server.
 
 // setupEmbeddedGitRemote creates a bare git repo and returns a DoltStore
 // connected with the bare repo configured as "origin".
 func setupEmbeddedGitRemote(t *testing.T) (*DoltStore, *gitRemoteSetup, func()) {
 	t.Helper()
-	skipIfNoDolt(t)
+	testutil.RequireDoltBinary(t)
 	skipIfNoGit(t)
 	acquireTestSlot()
 	t.Cleanup(releaseTestSlot)
@@ -625,47 +677,89 @@ func setupEmbeddedGitRemote(t *testing.T) (*DoltStore, *gitRemoteSetup, func()) 
 
 	remoteURL := "file://" + remoteDir
 
-	// Create embedded DoltStore
+	// Serve the store's own data directory from a local sql-server so the
+	// engine, the bare git repo and this test process all share one
+	// filesystem.
 	doltDir := filepath.Join(baseDir, "embedded-dolt")
+	if err := os.MkdirAll(doltDir, 0o755); err != nil {
+		os.RemoveAll(baseDir)
+		t.Fatalf("failed to create dolt dir: %v", err)
+	}
+	serverPort, stopServer := startLocalDoltServer(t, doltDir)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	dbName := uniqueTestDBName(t)
 	store, err := New(ctx, &Config{
 		Path:            doltDir,
+		ServerHost:      "127.0.0.1",
+		ServerPort:      serverPort,
+		ServerUser:      "root",
+		AutoStart:       false,
 		CommitterName:   "test",
 		CommitterEmail:  "test@example.com",
 		Database:        dbName,
 		CreateIfMissing: true, // test creates a fresh database
 	})
 	if err != nil {
+		stopServer()
 		os.RemoveAll(baseDir)
-		t.Fatalf("failed to create embedded DoltStore: %v", err)
+		t.Fatalf("failed to create DoltStore: %v", err)
+	}
+
+	// The whole point of the local server: the database it just created must
+	// be on this process's filesystem, under the store's own Path. Tests here
+	// push to a host bare repo and read the engine's git-remote cache mirror,
+	// and both silently stop being meaningful if the store ever drifts back
+	// onto a containerized server.
+	if _, statErr := os.Stat(filepath.Join(doltDir, dbName, ".dolt")); statErr != nil {
+		store.Close()
+		stopServer()
+		os.RemoveAll(baseDir)
+		t.Fatalf("store did not materialize %s/.dolt on this filesystem — the engine is not local to the test: %v", filepath.Join(doltDir, dbName), statErr)
 	}
 
 	// Set issue prefix (required for CreateIssue)
 	if err := store.SetConfig(ctx, "issue_prefix", "test"); err != nil {
 		store.Close()
+		stopServer()
 		os.RemoveAll(baseDir)
 		t.Fatalf("failed to set prefix: %v", err)
 	}
 
-	// Add git remote via embedded SQL
+	// Add git remote via SQL
 	if err := store.AddRemote(ctx, "origin", remoteURL); err != nil {
 		store.Close()
+		stopServer()
 		os.RemoveAll(baseDir)
 		t.Fatalf("failed to add remote: %v", err)
 	}
 
+	// Genesis commit, sweeping config too — the CLI sibling setupGitRemote
+	// does the same with DOLT_COMMIT('-Am', 'Genesis: schema and config').
+	// Commit() deliberately skips config (GH#2455), so without this
+	// issue_prefix stays dirty forever: Pull() then refuses to auto-commit a
+	// dirty internal config key, and a peer cloning this database gets no
+	// prefix at all.
+	if _, err := store.CommitAll(ctx, "Genesis: schema and config"); err != nil {
+		store.Close()
+		stopServer()
+		os.RemoveAll(baseDir)
+		t.Fatalf("failed to commit genesis config: %v", err)
+	}
+
 	setup := &gitRemoteSetup{
-		baseDir:   baseDir,
-		remoteDir: remoteDir,
-		remoteURL: remoteURL,
-		sourceDir: doltDir,
+		baseDir:    baseDir,
+		remoteDir:  remoteDir,
+		remoteURL:  remoteURL,
+		sourceDir:  doltDir,
+		serverPort: serverPort,
 	}
 
 	cleanup := func() {
 		store.Close()
+		stopServer()
 		os.RemoveAll(baseDir)
 	}
 
@@ -940,8 +1034,15 @@ func TestGitRemoteSyncRoundTrip(t *testing.T) {
 		t.Fatal("expected bootstrap to occur (no existing dolt dir)")
 	}
 
+	// The clone is a second peer with its own data directory, so it needs its
+	// own local server for the same reason the source does.
+	clonePort, _ := startLocalDoltServer(t, cloneDoltDir)
 	cloneStore, err := New(ctx, &Config{
 		Path:            cloneDoltDir,
+		ServerHost:      "127.0.0.1",
+		ServerPort:      clonePort,
+		ServerUser:      "root",
+		AutoStart:       false,
 		CommitterName:   "clone-user",
 		CommitterEmail:  "clone@example.com",
 		Database:        cloneDBName,
@@ -992,6 +1093,10 @@ func TestGitRemoteSyncRoundTrip(t *testing.T) {
 	// Step 4: Re-open source and pull — verify bidirectional sync
 	sourceStore2, err := New(ctx, &Config{
 		Path:            filepath.Join(setup.baseDir, "embedded-dolt"),
+		ServerHost:      "127.0.0.1",
+		ServerPort:      setup.serverPort,
+		ServerUser:      "root",
+		AutoStart:       false,
 		CommitterName:   "test",
 		CommitterEmail:  "test@example.com",
 		Database:        findClonedDBName(t, filepath.Join(setup.baseDir, "embedded-dolt")),

--- a/internal/storage/dolt/git_remote_test.go
+++ b/internal/storage/dolt/git_remote_test.go
@@ -1183,6 +1183,14 @@ func TestCreateIssueAfterPull(t *testing.T) {
 		t.Fatalf("Pull failed: %v", err)
 	}
 
+	// Pin what the pull itself delivered, before any further write. Pull()
+	// reporting success while the peer's row never arrived, and Pull()
+	// delivering the row only for a later write to drop it, are different
+	// bugs; asserting only at the end of the test cannot tell them apart.
+	if pulled, pulledErr := store.GetIssue(ctx, "ai-clone-001"); pulledErr != nil || pulled == nil {
+		t.Fatalf("Pull reported success but the peer's ai-clone-001 is not in the source store (err=%v)", pulledErr)
+	}
+
 	postPullIssue := &types.Issue{
 		ID:        "ai-src-002",
 		Title:     "Source issue after pull",

--- a/scripts/ci/install-dolt.sh
+++ b/scripts/ci/install-dolt.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install a pinned Dolt CLI. Every CI job that needs `dolt` on PATH must go
+# through this script instead of piping the upstream install.sh from
+# releases/latest, because "latest" silently changes the binary under test.
+#
+# Keep this version in sync with internal/testutil/testdoltcommon.go:
+# DoltDockerImage and scripts/ci/pull-dolt-image.sh. Tests run the CLI (the
+# per-test sql-server that doltserver.Start launches) and the container
+# side by side against the same databases; letting the two drift means the
+# suite is exercising a Dolt pair no release ever shipped.
+#
+# Why pinned rather than latest: Dolt 2.3.0 (released 2026-08-13) regressed
+# CALL DOLT_RESET('--hard') so that roughly one freshly created database in
+# twenty comes up with the procedure permanently broken --
+# "Error 1105 (HY000): context canceled" on every connection, from any
+# session, for the life of the server process. Measured 2026-08-20 by
+# creating fresh databases and immediately calling the procedure: 2.1.8 0/40
+# broken, 2.2.0 0/60, 2.3.0 3/60, 2.3.1 3/100. That is what made
+# TestFreshBootstrapHealIncarnation fail on a coin flip the day
+# releases/latest moved to 2.3.x, and it also puts bd dolt compact/flatten
+# and the #4566 fresh-bootstrap heal at risk on 2.3.x. Raise this pin only
+# once a Dolt release is confirmed clean by that same measurement.
+readonly version="2.2.0"
+readonly max_attempts=3
+readonly retry_delay_seconds=5
+
+arch="$(uname -m)"
+case "$arch" in
+  x86_64 | amd64) arch="amd64" ;;
+  aarch64 | arm64) arch="arm64" ;;
+  *)
+    printf 'Unsupported architecture for pinned dolt install: %s\n' "$arch" >&2
+    exit 1
+    ;;
+esac
+
+os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+readonly asset="dolt-${os}-${arch}.tar.gz"
+readonly url="https://github.com/dolthub/dolt/releases/download/v${version}/${asset}"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+  if curl -fsSL -o "$workdir/$asset" "$url"; then
+    break
+  fi
+  status=$?
+  if ((attempt == max_attempts)); then
+    printf 'Failed to download %s after %d attempts.\n' "$url" "$max_attempts" >&2
+    exit "$status"
+  fi
+  printf 'Failed to download %s (attempt %d/%d); retrying in %d seconds.\n' \
+    "$url" "$attempt" "$max_attempts" "$retry_delay_seconds" >&2
+  sleep "$retry_delay_seconds"
+done
+
+tar -xzf "$workdir/$asset" -C "$workdir"
+sudo install -m 0755 "$workdir/dolt-${os}-${arch}/bin/dolt" /usr/local/bin/dolt
+
+# Fail loudly if PATH resolves to some other dolt: a stale runner-image copy
+# earlier on PATH would silently put the suite back on an unpinned binary.
+# No `| head` here: pipefail turns dolt's SIGPIPE into a failed install.
+installed="$(dolt version)"
+installed="${installed%%$'\n'*}"
+if [[ "$installed" != *"$version"* ]]; then
+  printf 'dolt on PATH reports "%s", want version %s (which dolt: %s)\n' \
+    "$installed" "$version" "$(command -v dolt)" >&2
+  exit 1
+fi
+printf 'Installed pinned %s\n' "$installed"

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -1217,3 +1217,85 @@ func contains(items []string, want string) bool {
 	}
 	return false
 }
+
+// TestWorkflowsInstallPinnedDolt keeps the Dolt CLI under test pinned. Every
+// workflow used to install it by piping dolthub/dolt's releases/latest
+// install.sh, so the binary under test changed whenever upstream published —
+// including backports, which can move "latest" backwards. When Dolt 2.3.0
+// landed it regressed CALL DOLT_RESET('--hard'): roughly one freshly created
+// database in twenty comes up with the procedure permanently broken
+// ("Error 1105 (HY000): context canceled"), which made
+// TestFreshBootstrapHealIncarnation fail on a coin flip. See
+// scripts/ci/install-dolt.sh for the per-version measurements. The CLI is now
+// pinned to the same release as the container image, so the two halves of
+// every server-mode test (the per-test sql-server doltserver.Start launches,
+// and the shared container) can never drift apart.
+func TestWorkflowsInstallPinnedDolt(t *testing.T) {
+	workflowDir := filepath.Join(sourceRepoRoot(t), ".github", "workflows")
+	entries, err := os.ReadDir(workflowDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	installers := 0
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".yml" {
+			continue
+		}
+		path := filepath.Join(workflowDir, entry.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		body := string(data)
+		if strings.Contains(body, "dolt/releases/latest") {
+			t.Errorf("%s installs dolt from releases/latest; use ./scripts/ci/install-dolt.sh so the "+
+				"binary under test is pinned", entry.Name())
+		}
+		installers += strings.Count(body, "scripts/ci/install-dolt.sh")
+	}
+	if installers == 0 {
+		t.Fatal("no workflow installs dolt via scripts/ci/install-dolt.sh — the pin is not wired up")
+	}
+}
+
+// TestPinnedDoltCLIMatchesContainerImage keeps the CLI pin and the sql-server
+// container pin on the same Dolt release. Server-mode tests run both at once
+// against the same databases; a drifting pair tests a combination no release
+// ever shipped.
+func TestPinnedDoltCLIMatchesContainerImage(t *testing.T) {
+	root := sourceRepoRoot(t)
+
+	installer, err := os.ReadFile(filepath.Join(root, "scripts", "ci", "install-dolt.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cliVersion := captureOne(t, `(?m)^readonly version="([0-9]+\.[0-9]+\.[0-9]+)"$`, string(installer), "scripts/ci/install-dolt.sh")
+
+	common, err := os.ReadFile(filepath.Join(root, "internal", "testutil", "testdoltcommon.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	imageVersion := captureOne(t, `dolthub/dolt-sql-server:([0-9]+\.[0-9]+\.[0-9]+)`, string(common), "testdoltcommon.go:DoltDockerImage")
+
+	pullScript, err := os.ReadFile(filepath.Join(root, "scripts", "ci", "pull-dolt-image.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pullVersion := captureOne(t, `dolthub/dolt-sql-server:([0-9]+\.[0-9]+\.[0-9]+)`, string(pullScript), "scripts/ci/pull-dolt-image.sh")
+
+	if cliVersion != imageVersion || cliVersion != pullVersion {
+		t.Errorf("dolt pins disagree: CLI %s, DoltDockerImage %s, pull-dolt-image.sh %s",
+			cliVersion, imageVersion, pullVersion)
+	}
+}
+
+func captureOne(t *testing.T, pattern, body, source string) string {
+	t.Helper()
+
+	matches := regexp.MustCompile(pattern).FindStringSubmatch(body)
+	if matches == nil {
+		t.Fatalf("%s does not match %s", source, pattern)
+	}
+	return matches[1]
+}


### PR DESCRIPTION
Stacked on #5888. The diff here is the third commit only; retarget to `main` once #5888 merges.

## This is an upstream Dolt defect, not a beads bug and not a test bug

`Test (Server Dolt Full Suite 12/16)` has been failing on a coin flip. The CI excerpt everyone quotes is truncated — the second line is the whole story:

```
schema: fresh-bootstrap reset: Error 1105 (HY000): context canceled
```

So the heal was authorized and its capability consumed; what failed is the `CALL DOLT_RESET('--hard')` in `schema.MigrateUpWithLock`. All three failing shard-12 jobs carry that second line; the passing job does not.

**Dolt 2.3.0 (2026-08-13) regressed `DOLT_RESET('--hard')`.** Roughly one freshly created database in twenty comes up with the procedure permanently unusable, answering `Error 1105 (HY000): context canceled` to every session, from any connection, for the life of the server process. Not transient: retried on the same pinned conn, a fresh `*sql.Conn`, and a brand-new `*sql.DB`/TCP connection — all fail. `SELECT 1`, `CALL DOLT_CLEAN()` and `CALL DOLT_CHECKOUT('.')` still work on that database; only the hard reset is dead.

Beads-free reproduction — start a sql-server, loop `CREATE DATABASE x_i` → connect → `CALL DOLT_RESET('--hard')`:

| version | broken |
|---|---|
| 2.1.8 | 0/40 |
| 2.2.0 | 0/60 |
| 2.3.0 | **3/60** |
| 2.3.1 | **3/100** |

Mechanism (PLAUSIBLE-by-reading dolt source): `DOLT_RESET --hard` is the only caller of `dsess.ResetGlobals` → `AutoIncrementTracker.InitWithRoots`, which caches a terminal `initErr` and returns it before it can ever re-init.

## Why it looked intermittent

Every workflow installed the CLI by piping dolthub/dolt `releases/latest`, while `internal/testutil/testdoltcommon.go` pinned the sql-server **container** at 2.2.0 — so the suite has been running a CLI/server pair no release ever shipped. 2.3.0 landed Aug 13, 2.3.1 on Aug 19, the day before the failures. `latest` can also move backwards: v1.88.2 was published after v2.2.4.

**At a ~5% per-run coin flip, three consecutive green shard-12 runs is p≈0.86.** Green runs on this shard were never evidence.

## What was ruled out, each with a control

- **Load is not the variable:** 0 failures in 48 isolated runs and 0 in 3 full shard-12 runs on 2.1.8 at 6-way parallelism on a load-140 box; 6 failures in 36 runs with *only* the dolt binary swapped to 2.3.1.
- **Not the heal predicate:** every branch of `consumeIfCurrentIncarnation` was instrumented to print its denial reason. Failing runs printed none and reached the reset.
- **Not cross-session working-set visibility:** `MaxOpenConns` is 1, and a probe issuing the reset immediately after `CREATE DATABASE` — before any migration, before anything is dirtied — already fails. The database is born broken.
- Also ruled out with controls: container/parallel-test leakage (reproduced with `DOCKER_HOST` pointed at a dead socket), `acquireTestSlot`, a pre-parked deadline, and Dolt auto-GC.

## The change

- **`scripts/ci/install-dolt.sh`** (new) installs a pinned Dolt and verifies `dolt version` on PATH actually resolves to it, recording the per-version measurements and the criterion for raising the pin.
- All **25 install sites across six workflows** route through it.
- **`scripts/ci_workflow_test.go`**: `TestWorkflowsInstallPinnedDolt` rejects any return to `releases/latest`; `TestPinnedDoltCLIMatchesContainerImage` fails when the CLI pin, `DoltDockerImage` and `pull-dolt-image.sh` disagree. Both verified to fail when they should.
- **One preflight probe** in `fresh_bootstrap_heal_integration_test.go`. Assertions unchanged, nothing skipped, no `t.Skip`. On a broken Dolt the test still **FAILS** — it just names the Dolt regression instead of the #4566 "run `bd dolt commit`" advice, which cannot work when the reset the heal needs is the broken thing. Measured safe: over 60 fresh databases, a successful first reset never broke a later one.

## Verification

48 runs (6 workers × 8) plus two full shard-12 runs on the pinned version: **zero failures**, target subtest 4.38s. Same binary on 2.3.1: **3 of 24 still fail**, now in 0.04s with the explicit diagnosis. `go vet ./...` clean, shellcheck clean, `make test` exit 0.

## Carry forward — pinning CI does not fix these

1. **Blast radius beyond tests.** `internal/storage/versioncontrolops/{compact,flatten,mergesettle}.go` all issue `DOLT_RESET('--hard')`. On any Dolt 2.3.x server, ~5% of databases have `bd dolt compact` / `flatten` / `merge-settle` rollback permanently broken.
2. **The docs still send users to 2.3.x.** `docs/getting-started/sync-setup.md` and `docs/architecture/dolt.md` recommend installing `releases/latest`.
3. **Needs an upstream report** — no open dolthub/dolt issue was found for this.

Filed as `ga-m0dlk`.