### PR TITLE
fix(schema): CLI bundle never got migration 0060's storage_class

### DIFF
--- a/internal/storage/schema/cli_migrations.go
+++ b/internal/storage/schema/cli_migrations.go
@@ -17,6 +17,26 @@ package schema
 // databases, where PREPARE/EXECUTE runs over a real driver connection and
 // this limitation does not apply.
 //
+// Dolt 2.3.0 fixed #11345, and that fix MASKS a missing override here rather
+// than removing the need for one: on 2.3.x the CLI executes the prepared
+// ALTER, so a bundle that forgot the direct statement still lands the right
+// schema and TestCLIBundleMatchesRuntimeCommittedSchema goes green against a
+// 2.2.0 sql-server. Measured 2026-08-21 by running AllMigrationsSQL() through
+// each CLI and diffing information_schema: 2.1.8 and 2.2.0 produce
+// byte-identical snapshots; 2.3.1 lands three extra columns (0060's
+// storage_class on issues and wisps) and one extra widening (0065's
+// wisp_comments.text). So every override below must be justified against the
+// pre-2.3 behavior, and the string assertions in
+// TestAllMigrationsSQLUsesDirectDDLForKnownCLIIncompatibilities — which need
+// no Dolt binary at all — are the guard that survives a CLI version bump.
+//
+// 0065 deliberately has no override yet. It is invisible to the parity
+// oracle, which excludes wisp_ tables, and a direct MODIFY breaks
+// TestFullChainFromPreWispsAndMissingDependenciesIDConvergesThroughDoltCLI,
+// which replays this substitution over a database whose wisp_comments was
+// dropped and which 0047's repair does not recreate. That needs the test's
+// contract settled first, so it is tracked separately.
+//
 // For a migration whose PREPARE'd DML matters on this path (not just DDL),
 // the fix is not a direct-SQL override here — it is to not depend on
 // PREPARE'd writes to real tables in the source migration at all. Migration
@@ -79,6 +99,11 @@ func cliCompatibleMigrationSQL(name, sqlText string) string {
 		// schema delta: create the ephemeral leases table, drop the issues/
 		// wisps lease columns 0054 added. row_lock stays (see the migration).
 		return cliMigration0055MoveLeasesToTable
+	case "0060_add_storage_class.up.sql":
+		// Direct DDL for the same reason as 0054: the source migration's
+		// PREPARE guards make it idempotent on upgraded databases, and a
+		// fresh bundle always needs the column on both planes.
+		return cliMigration0060AddStorageClass
 	default:
 		return sqlText
 	}
@@ -119,6 +144,9 @@ ALTER TABLE issues DROP COLUMN lease_expires_at;
 ALTER TABLE issues DROP COLUMN heartbeat_at;
 ALTER TABLE wisps DROP COLUMN lease_expires_at;
 ALTER TABLE wisps DROP COLUMN heartbeat_at;`
+
+const cliMigration0060AddStorageClass = `ALTER TABLE issues ADD COLUMN storage_class VARCHAR(16);
+ALTER TABLE wisps ADD COLUMN storage_class VARCHAR(16);`
 
 const cliMigration0041SplitDependenciesTarget = `DELETE FROM dolt_nonlocal_tables;
 CALL DOLT_COMMIT('-Am', 'disable nonlocal tables for fk migrations');

--- a/internal/storage/schema/schema_test.go
+++ b/internal/storage/schema/schema_test.go
@@ -1874,6 +1874,12 @@ func TestAllMigrationsSQLUsesDirectDDLForKnownCLIIncompatibilities(t *testing.T)
 		"ALTER TABLE schema_migrations DROP COLUMN applied_at",
 		"ALTER TABLE issues MODIFY COLUMN close_reason LONGTEXT DEFAULT ''",
 		"ALTER TABLE comments MODIFY COLUMN text LONGTEXT NOT NULL",
+		// Trailing semicolons matter: without them these substrings also
+		// match the quoted DDL inside the source migrations' SET @sql
+		// guards, and the assertion would pass whether or not the direct
+		// statement is in the bundle.
+		"ALTER TABLE issues ADD COLUMN storage_class VARCHAR(16);",
+		"ALTER TABLE wisps ADD COLUMN storage_class VARCHAR(16);",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("AllMigrationsSQL missing direct CLI DDL %q", want)
@@ -1884,6 +1890,10 @@ func TestAllMigrationsSQLUsesDirectDDLForKnownCLIIncompatibilities(t *testing.T)
 		"ALTER TABLE child_counters DROP FOREIGN KEY fk_counter_parent",
 		"@issues_cr_needs_fix",
 		"@comments_needs_fix",
+		// 0060 guards its ALTERs with PREPARE/EXECUTE for idempotent re-runs
+		// on upgraded databases. Only the main series is bundled, so this
+		// token can only come from that file's source text.
+		"COLUMN_NAME = 'storage_class'",
 	} {
 		if strings.Contains(got, forbidden) {
 			t.Fatalf("AllMigrationsSQL contains source prepared-DDL guard %q", forbidden)
@@ -1928,6 +1938,8 @@ WHERE table_schema = DATABASE()
 	requireDoltColumnShape(t, dir, "wisps", "no_history", "tinyint(1)", "YES")
 	requireDoltColumnShape(t, dir, "wisps", "started_at", "datetime", "YES")
 	requireDoltColumnShape(t, dir, "wisps", "wisp_type", "varchar(32)", "YES")
+	requireDoltColumnShape(t, dir, "issues", "storage_class", "varchar(16)", "YES")
+	requireDoltColumnShape(t, dir, "wisps", "storage_class", "varchar(16)", "YES")
 }
 
 func runDoltCommand(t *testing.T, dir string, args ...string) {


### PR DESCRIPTION
Unblocks #5894. Shard 11 (`Test (Server Dolt Full Suite 11/16)`,
`TestCLIBundleMatchesRuntimeCommittedSchema`) fails there deterministically —
twice on the identical commit, and a third time on a re-run I triggered while
investigating. It is not caused by the pin. The pin exposes it.

## What the oracle compares

`TestCLIBundleMatchesRuntimeCommittedSchema` builds two databases and diffs
`information_schema`:

- **"CLI bundle"** — `dolt init` + `AllMigrationsSQL()` piped through the local
  `dolt` **CLI** binary. Not a checked-in artifact; generated at test time by
  whatever `dolt` is on PATH. **This is the side #5894 re-pins.**
- **"runtime"** — a `bd`-initialised database against the
  `dolthub/dolt-sql-server:2.2.0` **container**, which #5894 does not touch.

## Root cause

Migration 0060 adds `issues.storage_class` and `wisps.storage_class` via
`PREPARE stmt FROM @sql; EXECUTE stmt` so it is idempotent on upgraded
databases. The Dolt CLI batch path silently no-ops prepared DDL
(dolthub/dolt#11345) while `EXECUTE` reports success — which is exactly why
`cliCompatibleMigrationSQL` already carries direct-DDL overrides for 0051,
0053, 0054 and 0055. 0060 landed on 2026-07-29 without one, so the bundle has
been missing the column ever since. The runtime side goes over a real driver
connection, where `PREPARE`/`EXECUTE` works, so it has the column — hence the
three `only in runtime` lines and the ordinal shift of `blocked_by_count` from
056 to 057.

## Why nobody noticed

Both guards were down at the same time.

1. The oracle lives in `internal/storage/dolt` behind the `integration` tag —
   part of the ~1125 tests no PR lane ran until #5836.
2. By the time #5836 un-stranded it, CI's unpinned
   `curl …/releases/latest | bash` install had moved to Dolt 2.3.x, which
   **fixed** #11345. On 2.3.x the CLI executes 0060's prepared `ALTER`, so the
   bundle matched anyway and the test went green.

That is why matching versions looked worse than mismatched ones: CLI 2.3.1 +
server 2.2.0 passed, CLI 2.2.0 + server 2.2.0 failed.

## Measured, same code, same 2.2.0 sql-server container

| dolt CLI | before | after |
| --- | --- | --- |
| 2.1.8 | FAIL | PASS |
| 2.2.0 | FAIL | PASS |
| 2.3.1 | PASS | PASS |

Both failures reproduce #5894's CI output line for line — 405 vs 408 entries,
`storage_class` only in runtime. Running `AllMigrationsSQL()` through each CLI
and diffing `information_schema` directly gives the same answer: 2.1.8 and
2.2.0 produce byte-identical snapshots; 2.3.1 produces three extra columns.

**2.1.8 is not an escape hatch.** It is the other candidate pin (clean on the
`DOLT_RESET` bug at 0/40, and what the production fleet runs), but it has the
same prepared-DDL behaviour as 2.2.0, so re-pinning would have left shard 11
red. The bundle had to be fixed either way.

## The guard

`TestAllMigrationsSQLUsesDirectDDLForKnownCLIIncompatibilities` gets the
matching assertions. They are string checks over the generated bundle with no
Dolt binary involved, so unlike the parity oracle they cannot be masked by a
CLI upgrade. The trailing semicolons are load-bearing: without one, the
substring also matches the quoted DDL inside 0060's own `SET @sql` guard and
the assertion proves nothing. Verified by running the tests red before the fix.

## Known drift left unfixed

0065's `wisp_comments.text` widening no-ops the same way. It is invisible to the
oracle (which excludes `wisp_` tables) and a direct `MODIFY` breaks
`TestFullChainFromPreWispsAndMissingDependenciesIDConvergesThroughDoltCLI`,
which replays this substitution over a database whose `wisp_comments` was
dropped and which 0047's repair does not recreate. Documented in the source;
needs that test's contract settled first.

## Also

`gh run rerun --failed` on #5894 was previously refused with *"its workflow file
may be broken"*. The workflow files are fine — `POST .../rerun-failed-jobs` on
the same run is accepted now that the run has fully completed. The refusal
tracked run state, not a parse failure.