### PR TITLE
fix(dolt): stop discarding what CALL DOLT_PULL says the pull did (ga-bq9zd)

### DIFF
--- a/internal/storage/dolt/pull_report.go
+++ b/internal/storage/dolt/pull_report.go
@@ -1,0 +1,77 @@
+package dolt
+
+import (
+	"github.com/steveyegge/beads/internal/storage/schema"
+)
+
+// doltMergeSucceededMessage is the message DOLT_PULL and DOLT_MERGE put in
+// their `message` column when they actually merged something. Every other
+// message either names a reason nothing merged or is absent.
+//
+// Measured on Dolt 2.1.8, all four outcomes of CALL DOLT_PULL('origin','main'):
+//
+//	fast_forward  conflicts  message
+//	1             0          merge successful                    (fast-forward)
+//	0             0          merge successful                    (three-way)
+//	0             0          Everything up-to-date               (no-op, level)
+//	0             0          cannot fast forward from a to b. a is ahead of b already
+//
+// Two things follow, and both are why this constant exists rather than a
+// fast_forward check. fast_forward is 0 for a genuine three-way merge AND for
+// both no-ops, so it does not answer "did anything merge"; it distinguishes the
+// KIND of merge, which is what its name says and what dolt uses it for. And the
+// no-op has more than one spelling — doltdb.ErrUpToDate and doltdb.ErrIsAhead
+// are both surfaced as the message with a nil error — so enumerating the
+// negatives is a losing game. The single positive is the stable thing to match:
+// upstream returns this exact literal from all three of its merged paths
+// (dprocedures/dolt_merge.go, dolt_pull.go) and pins it in hundreds of its own
+// enginetest expectations, so it cannot drift without breaking dolt's suite.
+const doltMergeSucceededMessage = "merge successful"
+
+// pullReport is what the engine itself said a pull did. It is the in-band
+// answer to "did anything actually arrive", which an error alone cannot give:
+// a pull that merged 400 commits and a pull that found the remote unchanged
+// both return nil.
+//
+// This is the TRANSPORT's own report and nothing more. It is not proof the
+// merge landed where the caller reads — a merge that succeeded on the wrong
+// branch reports "merge successful" quite truthfully — and it exists only on
+// the SQL routes, because `dolt pull` as a subprocess exits 0 either way and
+// says nothing structured. Reported is false in both of those cases and in
+// every other case where no row came back; a caller that treats !Reported as
+// "nothing merged" has misread it.
+type pullReport struct {
+	// Reported is true when a transport handed back an engine row at all.
+	// When it is false every other field is meaningless, not merely zero.
+	Reported bool
+
+	// Merged is true when the engine says commits were merged.
+	Merged bool
+
+	// Conflicted is dolt's conflicts column, which despite the plural name is
+	// a 0/1 FLAG (dprocedures: noConflictsOrViolations=0,
+	// hasConflictsOrViolations=1), not a count. It covers constraint
+	// violations as well as conflicts. Use GetConflicts for the actual set.
+	Conflicted bool
+
+	// Message is the engine's own words, for error text and logs. Not a
+	// control-flow input beyond Merged above.
+	Message string
+}
+
+// parseMergeReport reads the row CALL DOLT_PULL or CALL DOLT_MERGE returned.
+// Both carry `conflicts` and `message`; DOLT_MERGE additionally carries `hash`,
+// which this ignores. A nil row (no rows returned) reports nothing.
+func parseMergeReport(row schema.CallRow) pullReport {
+	if row == nil {
+		return pullReport{}
+	}
+	message, _ := row.Str("message")
+	conflicts, _ := row.Int("conflicts")
+	return pullReport{
+		Reported:   true,
+		Merged:     message == doltMergeSucceededMessage,
+		Conflicted: conflicts != 0,
+		Message:    message,
+	}
+}

--- a/internal/storage/dolt/pull_report_sql_route_test.go
+++ b/internal/storage/dolt/pull_report_sql_route_test.go
@@ -1,0 +1,155 @@
+package dolt
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+)
+
+// TestPullTransportReportsWhetherAnythingMerged is the end-to-end proof for
+// ga-bq9zd: on the SQL pull route, "I merged the peer's commits" and "there was
+// nothing to merge" are now different RETURN VALUES, not two spellings of nil.
+//
+// Both are still successes. That is the point and it is the control: the fix
+// adds information, it does not turn no-op pulls into errors. A change that
+// made the second pull fail would look like it caught something and would
+// break every idle `bd sync` in the product.
+//
+// The fixture keeps everything inside the sql-server's own filesystem — a
+// file:// remote the server creates on push, and a peer database it clones from
+// that remote — so it does not care whether that server is a container or a
+// host process. The peer is a real second database advancing the remote, not a
+// stub: without it the first pull would have nothing to merge and the subject
+// assertion would be indistinguishable from the control.
+func TestPullTransportReportsWhetherAnythingMerged(t *testing.T) {
+	skipIfNoDolt(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	tmpDir := t.TempDir()
+	dbName := uniqueTestDBName(t)
+	peerDB := dbName + "_peer"
+
+	store, err := New(ctx, &Config{
+		Path:            tmpDir,
+		CommitterName:   "test",
+		CommitterEmail:  "test@example.com",
+		Database:        dbName,
+		CreateIfMissing: true,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() {
+		dropCtx, dropCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer dropCancel()
+		_, _ = store.db.ExecContext(dropCtx, fmt.Sprintf("DROP DATABASE IF EXISTS `%s`", peerDB))
+		_, _ = store.db.ExecContext(dropCtx, fmt.Sprintf("DROP DATABASE IF EXISTS `%s`", dbName))
+		store.Close()
+	}()
+
+	mustExec := func(stage, query string, args ...any) {
+		t.Helper()
+		if _, err := store.db.ExecContext(ctx, query, args...); err != nil {
+			t.Fatalf("%s: %v", stage, err)
+		}
+	}
+
+	// A table of our own, so the assertion "the peer's row arrived" does not
+	// depend on any beads-schema sweeping/ignore behaviour.
+	mustExec("create marker", "CREATE TABLE pull_report_marker (id INT PRIMARY KEY, v VARCHAR(64))")
+	mustExec("stage", "CALL DOLT_ADD('-A')")
+	mustExec("commit", "CALL DOLT_COMMIT('-m', 'test: pull report marker')")
+
+	// file:// inside the server's filesystem; Dolt creates it on push.
+	remoteURL := "file://" + filepath.Join(tmpDir, "pull-report-remote")
+	mustExec("add remote", "CALL DOLT_REMOTE('add', 'origin', ?)", remoteURL)
+	mustExec("push", "CALL DOLT_PUSH('origin', 'main')")
+
+	store.remote = "origin"
+	store.branch = "main"
+
+	// The peer: a real clone of the remote, on the same server.
+	mustExec("clone peer", "CALL DOLT_CLONE(?, ?)", remoteURL, peerDB)
+	peer := openPeerDB(t, store.connStr, peerDB)
+	defer peer.Close()
+
+	mustPeerExec := func(stage, query string, args ...any) {
+		t.Helper()
+		if _, err := peer.ExecContext(ctx, query, args...); err != nil {
+			t.Fatalf("peer %s: %v", stage, err)
+		}
+	}
+	mustPeerExec("insert", "INSERT INTO pull_report_marker VALUES (1, 'from peer')")
+	mustPeerExec("stage", "CALL DOLT_ADD('-A')")
+	mustPeerExec("commit", "CALL DOLT_COMMIT('-m', 'peer: add marker row')")
+	mustPeerExec("push", "CALL DOLT_PUSH('origin', 'main')")
+
+	// SUBJECT: a pull with real work to do reports that it merged.
+	merged, err := store.pullTransportReporting(ctx, "origin")
+	if err != nil {
+		t.Fatalf("pull with work to do failed: %v", err)
+	}
+	t.Logf("merged pull reported: %+v", merged)
+
+	// Control for the subject: the pull must actually have delivered the row.
+	// Without this, a report saying "merged" could be reporting a merge that
+	// never happened, and the case would pass on a lie.
+	var got string
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT v FROM pull_report_marker WHERE id = 1").Scan(&got); err != nil {
+		t.Fatalf("control broken: the pull did not deliver the peer's row: %v", err)
+	}
+	if got != "from peer" {
+		t.Fatalf("control broken: marker = %q, want %q", got, "from peer")
+	}
+	if !merged.Reported {
+		t.Fatalf("the SQL pull route returned no engine report at all (%+v); the DOLT_PULL/DOLT_MERGE row is still being discarded", merged)
+	}
+	if !merged.Merged {
+		t.Errorf("a pull that demonstrably merged the peer's commit reported Merged=false (message %q)", merged.Message)
+	}
+
+	// CONTROL: the immediately repeated pull has genuinely nothing to merge.
+	// It must still SUCCEED — and now say so.
+	noop, err := store.pullTransportReporting(ctx, "origin")
+	if err != nil {
+		t.Fatalf("control broken: a pull with nothing to merge must still succeed, got: %v", err)
+	}
+	t.Logf("no-op pull reported: %+v", noop)
+	if !noop.Reported {
+		t.Fatalf("no-op pull returned no engine report (%+v)", noop)
+	}
+	if noop.Merged {
+		t.Errorf("a pull with nothing to merge reported Merged=true (message %q)", noop.Message)
+	}
+
+	// The whole point, stated as one assertion: the two outcomes are now
+	// distinguishable at the call site. Before this change both were nil.
+	if merged.Merged == noop.Merged {
+		t.Fatalf("a merged pull and a no-op pull are still indistinguishable: both reported Merged=%v", merged.Merged)
+	}
+}
+
+// openPeerDB opens a single-connection *sql.DB against another database on the
+// same server as the store, by reusing the store's DSN with the name swapped.
+func openPeerDB(t *testing.T, connStr, dbName string) *sql.DB {
+	t.Helper()
+	cfg, err := mysql.ParseDSN(connStr)
+	if err != nil {
+		t.Fatalf("parse store DSN: %v", err)
+	}
+	cfg.DBName = dbName
+	db, err := sql.Open("mysql", cfg.FormatDSN())
+	if err != nil {
+		t.Fatalf("open peer database %q: %v", dbName, err)
+	}
+	db.SetMaxOpenConns(1)
+	return db
+}

--- a/internal/storage/dolt/pull_report_test.go
+++ b/internal/storage/dolt/pull_report_test.go
@@ -1,0 +1,131 @@
+package dolt
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/schema"
+)
+
+// row builds a CallRow the way the driver hands one back: every column as a
+// NullString, NULL columns present but invalid.
+func row(pairs ...any) schema.CallRow {
+	r := make(schema.CallRow, len(pairs)/2)
+	for i := 0; i < len(pairs); i += 2 {
+		name := pairs[i].(string)
+		switch v := pairs[i+1].(type) {
+		case nil:
+			r[name] = sql.NullString{}
+		case string:
+			r[name] = sql.NullString{String: v, Valid: true}
+		default:
+			panic("row: value must be string or nil")
+		}
+	}
+	return r
+}
+
+// TestParseMergeReportDistinguishesMergedFromNoOp pins the mapping from a Dolt
+// merge/pull row to the answer callers actually want: did anything arrive?
+//
+// Every row below was MEASURED against dolt 2.1.8, not invented. The two that
+// matter most are the pair that a fast_forward check gets wrong: a genuine
+// three-way merge and a level no-op BOTH report fast_forward=0, so anything
+// keying off that column calls a real merge "nothing happened".
+func TestParseMergeReportDistinguishesMergedFromNoOp(t *testing.T) {
+	cases := []struct {
+		name       string
+		row        schema.CallRow
+		wantReport bool
+		wantMerged bool
+		wantConfl  bool
+	}{
+		{
+			name:       "DOLT_PULL fast-forward merged",
+			row:        row("fast_forward", "1", "conflicts", "0", "message", "merge successful"),
+			wantReport: true, wantMerged: true,
+		},
+		{
+			// The case fast_forward gets wrong: merged, but not a fast-forward.
+			name:       "DOLT_PULL three-way merged",
+			row:        row("fast_forward", "0", "conflicts", "0", "message", "merge successful"),
+			wantReport: true, wantMerged: true,
+		},
+		{
+			name:       "DOLT_PULL nothing to merge",
+			row:        row("fast_forward", "0", "conflicts", "0", "message", "Everything up-to-date"),
+			wantReport: true, wantMerged: false,
+		},
+		{
+			// The second spelling of "nothing merged" — local is ahead. Proves
+			// the parse matches the single positive rather than enumerating
+			// negatives it cannot know the full set of.
+			name:       "DOLT_PULL local already ahead",
+			row:        row("fast_forward", "0", "conflicts", "0", "message", "cannot fast forward from a to b. a is ahead of b already"),
+			wantReport: true, wantMerged: false,
+		},
+		{
+			name:       "DOLT_MERGE merged, extra hash column ignored",
+			row:        row("hash", "j8mark005d49cbhf0pnfb84dh8v7i79k", "fast_forward", "0", "conflicts", "0", "message", "merge successful"),
+			wantReport: true, wantMerged: true,
+		},
+		{
+			name:       "DOLT_MERGE nothing to merge",
+			row:        row("hash", "", "fast_forward", "0", "conflicts", "0", "message", "cannot fast forward from a to b. a is ahead of b already"),
+			wantReport: true, wantMerged: false,
+		},
+		{
+			// dolt returns a NULL message whenever its internal message is
+			// empty. NULL is not "merge successful".
+			name:       "NULL message is not a merge",
+			row:        row("fast_forward", "0", "conflicts", "0", "message", nil),
+			wantReport: true, wantMerged: false,
+		},
+		{
+			name:       "conflicts flag set",
+			row:        row("fast_forward", "0", "conflicts", "1", "message", "merge successful"),
+			wantReport: true, wantMerged: true, wantConfl: true,
+		},
+		{
+			// A transport that returned no row at all — every CLI route. This
+			// is NOT "nothing merged"; it is "no report", and Merged must not
+			// be read when Reported is false.
+			name: "no row means no report",
+			row:  nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseMergeReport(tc.row)
+			if got.Reported != tc.wantReport {
+				t.Errorf("Reported = %v, want %v", got.Reported, tc.wantReport)
+			}
+			if got.Merged != tc.wantMerged {
+				t.Errorf("Merged = %v, want %v (message %q)", got.Merged, tc.wantMerged, got.Message)
+			}
+			if got.Conflicted != tc.wantConfl {
+				t.Errorf("Conflicted = %v, want %v", got.Conflicted, tc.wantConfl)
+			}
+		})
+	}
+}
+
+// TestParseMergeReportControlRejectsNearMisses is the control for the test
+// above: if parseMergeReport reported Merged for anything that merely looks
+// like success, the cases above would pass for the wrong reason.
+func TestParseMergeReportControlRejectsNearMisses(t *testing.T) {
+	nearMisses := []string{
+		"Merge successful",  // dolt's literal is lower-case
+		"merge successful.", // no trailing period upstream
+		"merge succeeded",
+		"fast forward",
+		"",
+	}
+	for _, msg := range nearMisses {
+		got := parseMergeReport(row("fast_forward", "1", "conflicts", "0", "message", msg))
+		if got.Merged {
+			t.Errorf("parseMergeReport(message=%q).Merged = true; a near-miss message must not count as a merge", msg)
+		}
+	}
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -4014,49 +4014,66 @@ func (s *DoltStore) pullFromRemoteUnchecked(ctx context.Context, remote string) 
 // each route carries. Split from pullFromRemote so every successful route
 // funnels back through the is_blocked recompute.
 func (s *DoltStore) pullTransport(ctx context.Context, remote string) error {
+	_, err := s.pullTransportReporting(ctx, remote)
+	return err
+}
+
+// pullTransportReporting is pullTransport plus the transport's own account of
+// what it did. The CLI routes have none to give — `dolt pull` exits 0 whether
+// it merged or was already up to date, and its stdout is discarded — so they
+// report nothing; the SQL routes return what CALL DOLT_PULL (or the fallback's
+// CALL DOLT_MERGE) said. See pullReport for what that does and does not prove.
+func (s *DoltStore) pullTransportReporting(ctx context.Context, remote string) (pullReport, error) {
 	creds := s.credentialsForRemote(remote)
 	// Git-protocol remotes: use CLI to avoid MySQL connection timeout during transfer.
 	// Must check before remoteUser — Hosted Dolt SSH remotes have remoteUser set
 	// but still need CLI to avoid SQL connection timeout.
 	// Credentials are passed directly to the subprocess via cmd.Env.
 	if useCLI, err := s.prepareCLIRouteForGitProtocol(ctx, remote); err != nil {
-		return err
+		return pullReport{}, err
 	} else if useCLI {
 		// CLI pull leaves any conflicts in the working set; run the auto-resolver so
 		// git-protocol remotes get the same audit-only dependency / metadata repair
 		// as the SQL DOLT_PULL path (#4259).
-		return s.finishCLIPull(ctx, s.doltCLIPull(ctx, remote, creds))
+		return pullReport{}, s.finishCLIPull(ctx, s.doltCLIPull(ctx, remote, creds))
 	}
 	// Credential CLI routing: mirrors git-protocol path, including post-pull
 	// auto-resolution.
 	if useCLI, err := s.prepareCLIRouteForCredentials(ctx, remote, creds); err != nil {
-		return err
+		return pullReport{}, err
 	} else if useCLI {
-		return s.finishCLIPull(ctx, s.doltCLIPull(ctx, remote, creds))
+		return pullReport{}, s.finishCLIPull(ctx, s.doltCLIPull(ctx, remote, creds))
 	}
 	// Cloud auth CLI routing (GH#6), including post-pull auto-resolution.
 	if useCLI, err := s.prepareCLIRouteForCloudAuth(ctx, remote); err != nil {
-		return err
+		return pullReport{}, err
 	} else if useCLI {
-		return s.finishCLIPull(ctx, s.doltCLIPull(ctx, remote, creds))
+		return pullReport{}, s.finishCLIPull(ctx, s.doltCLIPull(ctx, remote, creds))
 	}
 	// Local file:// pulls intentionally stay on the SQL path. The matching CLI
 	// guard is a push-only optimization; SQL pull keeps pullWithAutoResolve in
 	// charge of metadata-only conflict repair.
+	var report pullReport
 	if s.remoteUser != "" && remote == s.remote {
-		return withRemoteOperationEnv(creds, s.isS3Remote(ctx, remote), func() error {
-			if err := s.pullWithAutoResolve(ctx, remote, "CALL DOLT_PULL('--user', ?, ?, ?)", s.remoteUser, remote, s.branch); err != nil {
+		err := withRemoteOperationEnv(creds, s.isS3Remote(ctx, remote), func() error {
+			var err error
+			report, err = s.pullWithAutoResolveReporting(ctx, remote, "CALL DOLT_PULL('--user', ?, ?, ?)", s.remoteUser, remote, s.branch)
+			if err != nil {
 				return fmt.Errorf("failed to pull from %s/%s: %w", remote, s.branch, err)
 			}
 			return nil
 		})
+		return report, err
 	}
-	return withRemoteOperationEnv(nil, s.isS3Remote(ctx, remote), func() error {
-		if err := s.pullWithAutoResolve(ctx, remote, "CALL DOLT_PULL(?, ?)", remote, s.branch); err != nil {
+	err := withRemoteOperationEnv(nil, s.isS3Remote(ctx, remote), func() error {
+		var err error
+		report, err = s.pullWithAutoResolveReporting(ctx, remote, "CALL DOLT_PULL(?, ?)", remote, s.branch)
+		if err != nil {
 			return fmt.Errorf("failed to pull from %s/%s: %w", remote, s.branch, err)
 		}
 		return nil
 	})
+	return report, err
 }
 
 // pullWithAutoResolve executes a DOLT_PULL query with long timeout and auto-resolves
@@ -4091,12 +4108,24 @@ func (s *DoltStore) openLongTimeoutConn() (*sql.DB, error) {
 // fallback targets it directly, so pulls from non-default remotes (PullRemote,
 // federation peers) no longer fall back to s.remote.
 func (s *DoltStore) pullWithAutoResolve(ctx context.Context, remote string, query string, args ...any) error {
-	return s.withCircuitWrite(ctx, func(ctx context.Context) error {
-		return s.pullWithAutoResolveUnchecked(ctx, remote, query, args...)
-	})
+	_, err := s.pullWithAutoResolveReporting(ctx, remote, query, args...)
+	return err
 }
 
-func (s *DoltStore) pullWithAutoResolveUnchecked(ctx context.Context, remote string, query string, args ...any) error {
+// pullWithAutoResolveReporting is pullWithAutoResolve plus the row the pull (or
+// the fetch+merge fallback) returned — the engine's own account of whether
+// anything merged. See pullReport.
+func (s *DoltStore) pullWithAutoResolveReporting(ctx context.Context, remote string, query string, args ...any) (pullReport, error) {
+	var report pullReport
+	err := s.withCircuitWrite(ctx, func(ctx context.Context) error {
+		var err error
+		report, err = s.pullWithAutoResolveUnchecked(ctx, remote, query, args...)
+		return err
+	})
+	return report, err
+}
+
+func (s *DoltStore) pullWithAutoResolveUnchecked(ctx context.Context, remote string, query string, args ...any) (pullReport, error) {
 	// Audited for be-b0am's fresh-connection branch hazard: NOT safe, and all
 	// three callers share it. Passing a branch argument does not avoid it.
 	//
@@ -4120,18 +4149,18 @@ func (s *DoltStore) pullWithAutoResolveUnchecked(ctx context.Context, remote str
 	// sites. The fix is s.pinStoreBranch(ctx, db) before BeginTx below.
 	db, err := s.openLongTimeoutConn()
 	if err != nil {
-		return err
+		return pullReport{}, err
 	}
 	defer db.Close()
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
+		return pullReport{}, fmt.Errorf("failed to begin transaction: %w", err)
 	}
 
 	// Allow commits with conflicts so we can inspect and resolve them.
 	if _, err := tx.ExecContext(ctx, "SET @@dolt_allow_commit_conflicts = 1"); err != nil {
 		_ = tx.Rollback()
-		return fmt.Errorf("failed to set dolt_allow_commit_conflicts: %w", err)
+		return pullReport{}, fmt.Errorf("failed to set dolt_allow_commit_conflicts: %w", err)
 	}
 	// bd-6dnrw.4: a merge that violates a foreign key (e.g. one clone deleted
 	// an issue while another inserted a child row referencing it) rolls the
@@ -4141,10 +4170,16 @@ func (s *DoltStore) pullWithAutoResolveUnchecked(ctx context.Context, remote str
 	// to commit anything the repair did not fully clear.
 	if _, err := tx.ExecContext(ctx, "SET @@dolt_force_transaction_commit = 1"); err != nil {
 		_ = tx.Rollback()
-		return fmt.Errorf("failed to set dolt_force_transaction_commit: %w", err)
+		return pullReport{}, fmt.Errorf("failed to set dolt_force_transaction_commit: %w", err)
 	}
 
-	pullErr := schema.DrainCall(ctx, tx, query, args...)
+	// DOLT_PULL's row is the engine's only in-band account of what the pull
+	// did: `dolt pull` on the CLI exits 0 whether it merged or was already up
+	// to date, and so does this CALL. Capturing it costs nothing — the drain
+	// is identical — and it is the difference between a caller that knows
+	// nothing arrived and one that only knows no error occurred (ga-bq9zd).
+	pullRow, pullErr := schema.CallReturningRow(ctx, tx, query, args...)
+	report := parseMergeReport(pullRow)
 
 	// GH#3144: When DOLT_PULL fails because upstream branch tracking is not
 	// configured in repo_state.json (common when remote was added via
@@ -4153,17 +4188,25 @@ func (s *DoltStore) pullWithAutoResolveUnchecked(ctx context.Context, remote str
 	if pullErr != nil && isBranchTrackingError(pullErr) {
 		if err := schema.DrainCall(ctx, tx, "CALL DOLT_FETCH(?, ?)", remote, s.branch); err != nil {
 			_ = tx.Rollback()
-			return fmt.Errorf("fetch from %s/%s: %w", remote, s.branch, err)
+			return pullReport{}, fmt.Errorf("fetch from %s/%s: %w", remote, s.branch, err)
 		}
 		trackingRef := remote + "/" + s.branch
-		mergeErr := schema.DrainCall(ctx, tx, "CALL DOLT_MERGE(?)", trackingRef)
+		// The merge, not the pull, is now what happened — so its row replaces
+		// the failed pull's report rather than adding to it.
+		mergeRow, mergeErr := schema.CallReturningRow(ctx, tx, "CALL DOLT_MERGE(?)", trackingRef)
+		report = parseMergeReport(mergeRow)
+		// Retained deliberately even though DOLT_MERGE reports the ordinary
+		// no-op as a MESSAGE with a nil error (measured: "Everything
+		// up-to-date" and "cannot fast forward from a to b. a is ahead of b
+		// already" both arrive that way). Dolt's squash path still returns
+		// "Already up to date." as a real error, and that is what this catches.
 		if mergeErr != nil && strings.Contains(mergeErr.Error(), "up to date") {
 			mergeErr = nil
 		}
 		pullErr = mergeErr
 	}
 
-	return s.settleMergeInTx(ctx, tx, pullErr)
+	return report, s.settleMergeInTx(ctx, tx, pullErr)
 }
 
 // settleMergeInTx finishes a pull/merge that ran in tx: it auto-resolves the

--- a/internal/storage/schema/call_returning_row_test.go
+++ b/internal/storage/schema/call_returning_row_test.go
@@ -1,0 +1,167 @@
+package schema
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+)
+
+// TestCallReturningRowCapturesFirstRowAndStillDrains is the contract for the
+// helper that lets a caller read what a Dolt procedure reported without giving
+// up the drain that keeps a pinned connection usable.
+//
+// The drain half is the load-bearing half — see DrainCall's comment for the
+// go-sql-driver error-path asymmetry it exists to survive — so the case feeds
+// back TWO result sets with several rows each. Capturing must not shorten the
+// walk: if it did, the surplus rows and the whole second result set would be
+// left queued on the wire, which is exactly the "busy buffer" ->
+// "driver: bad connection" bug DrainCall was written to prevent.
+func TestCallReturningRowCapturesFirstRowAndStillDrains(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	first := sqlmock.NewRows([]string{"fast_forward", "conflicts", "message"}).
+		AddRow(int64(0), int64(0), "merge successful").
+		AddRow(int64(1), int64(1), "a later row that must be drained, not captured")
+	second := sqlmock.NewRows([]string{"other"}).
+		AddRow("a whole second result set that must be drained")
+
+	mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_PULL(?, ?)")).
+		WithArgs("origin", "main").
+		WillReturnRows(first, second)
+
+	row, err := CallReturningRow(context.Background(), db, "CALL DOLT_PULL(?, ?)", "origin", "main")
+	if err != nil {
+		t.Fatalf("CallReturningRow: %v", err)
+	}
+
+	if msg, ok := row.Str("message"); !ok || msg != "merge successful" {
+		t.Errorf(`row.Str("message") = %q, %v; want "merge successful", true`, msg, ok)
+	}
+	if ff, ok := row.Int("fast_forward"); !ok || ff != 0 {
+		t.Errorf(`row.Int("fast_forward") = %d, %v; want 0, true`, ff, ok)
+	}
+	if c, ok := row.Int("conflicts"); !ok || c != 0 {
+		t.Errorf(`row.Int("conflicts") = %d, %v; want 0, true`, c, ok)
+	}
+
+	// The capture is the FIRST row, not the last one seen while draining.
+	if msg, _ := row.Str("message"); msg != "merge successful" {
+		t.Errorf("captured row was overwritten while draining: message = %q", msg)
+	}
+	// Nothing from the second result set leaked into the captured row.
+	if _, ok := row.Str("other"); ok {
+		t.Error(`captured row contains "other" from the second result set`)
+	}
+
+	// sqlmock reports an unconsumed result set as an unmet expectation, so
+	// this is the assertion that the drain really walked to the end.
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("statement was not fully drained: %v", err)
+	}
+}
+
+// TestCallReturningRowEdgeCases covers the shapes a Dolt procedure row actually
+// takes: a NULL message (DOLT_PULL returns NULL whenever its internal message
+// is empty), a procedure that returns no rows at all, and a failing query.
+func TestCallReturningRowEdgeCases(t *testing.T) {
+	t.Run("null column reports absent, not empty", func(t *testing.T) {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+		if err != nil {
+			t.Fatalf("sqlmock: %v", err)
+		}
+		t.Cleanup(func() { _ = db.Close() })
+		mock.ExpectQuery("CALL DOLT_PULL").WillReturnRows(
+			sqlmock.NewRows([]string{"fast_forward", "conflicts", "message"}).
+				AddRow(int64(0), int64(0), nil))
+
+		row, err := CallReturningRow(context.Background(), db, "CALL DOLT_PULL()")
+		if err != nil {
+			t.Fatalf("CallReturningRow: %v", err)
+		}
+		if v, ok := row.Str("message"); ok {
+			t.Errorf(`NULL message reported present with value %q`, v)
+		}
+		if _, ok := row.Str("no_such_column"); ok {
+			t.Error("absent column reported present")
+		}
+		if _, ok := row.Int("message"); ok {
+			t.Error("NULL message parsed as an integer")
+		}
+	})
+
+	t.Run("no rows yields a nil row and no error", func(t *testing.T) {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+		if err != nil {
+			t.Fatalf("sqlmock: %v", err)
+		}
+		t.Cleanup(func() { _ = db.Close() })
+		mock.ExpectQuery("CALL DOLT_ADD").WillReturnRows(sqlmock.NewRows([]string{"status"}))
+
+		row, err := CallReturningRow(context.Background(), db, "CALL DOLT_ADD('.')")
+		if err != nil {
+			t.Fatalf("CallReturningRow: %v", err)
+		}
+		if row != nil {
+			t.Errorf("row = %v, want nil", row)
+		}
+		// Reading from a nil row must report absent, not panic.
+		if _, ok := row.Str("status"); ok {
+			t.Error("nil row reported a value")
+		}
+		if _, ok := row.Int("status"); ok {
+			t.Error("nil row reported an integer")
+		}
+	})
+
+	t.Run("query error propagates", func(t *testing.T) {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+		if err != nil {
+			t.Fatalf("sqlmock: %v", err)
+		}
+		t.Cleanup(func() { _ = db.Close() })
+		boom := errors.New("branch not found")
+		mock.ExpectQuery("CALL DOLT_PULL").WillReturnError(boom)
+
+		row, err := CallReturningRow(context.Background(), db, "CALL DOLT_PULL()")
+		if !errors.Is(err, boom) {
+			t.Fatalf("err = %v, want %v", err, boom)
+		}
+		if row != nil {
+			t.Errorf("row = %v, want nil on error", row)
+		}
+	})
+}
+
+// TestDrainCallStillDiscardsEverything is the control for the refactor that put
+// DrainCall and CallReturningRow on one shared drain loop: DrainCall's own
+// behaviour must be unchanged. It walks every result set and reports only the
+// statement's error — a row it cannot decode is not DrainCall's problem, and
+// must not become a new way for a migration to fail.
+func TestDrainCallStillDiscardsEverything(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	mock.ExpectQuery(regexp.QuoteMeta("CALL DOLT_COMMIT('-m', ?)")).
+		WithArgs("m").
+		WillReturnRows(
+			sqlmock.NewRows([]string{"hash"}).AddRow("abc").AddRow("def"),
+			sqlmock.NewRows([]string{"extra"}).AddRow(nil),
+		)
+
+	if err := DrainCall(context.Background(), db, "CALL DOLT_COMMIT('-m', ?)", "m"); err != nil {
+		t.Fatalf("DrainCall: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("DrainCall stopped draining early: %v", err)
+	}
+}

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -1305,24 +1305,133 @@ var procedureCallRe = regexp.MustCompile(`(?i)(?:^|;|\n)\s*CALL\s`)
 // dolt_nonlocal_tables rows, 0041 DELETEs then commits them) are made
 // replay-safe by pre-migration repairs keyed to their version, not by editing
 // their shipped SQL — see preMigrationRepair and migration_repairs.go.
+// Most Dolt procedures are called for their side effects alone, and DrainCall
+// discards what they return. That is a statement about these CALL SITES, not
+// about stored procedures in general: DOLT_PULL and DOLT_MERGE report what they
+// did — whether anything merged, and whether it conflicted — only in the row
+// they return. A caller that needs that report uses CallReturningRow, which
+// drains identically.
 func DrainCall(ctx context.Context, db DBConn, query string, args ...any) error {
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = rows.Close() }()
+	return drainResultSets(rows, nil)
+}
+
+// CallRow is the first row of a CALL's first result set, keyed by column name.
+// Dolt's procedure rows mix integers with a nullable message, and their column
+// ORDER is a documented-but-unversioned detail (dolt_pull.go pins the
+// fast_forward index in a const with a comment warning it must be updated if
+// the schema changes), so values are read by name and scanned as NullString.
+type CallRow map[string]sql.NullString
+
+// Str returns the named column's text. ok is false when the column is absent
+// from the row or is SQL NULL — DOLT_PULL returns a NULL message whenever its
+// internal message is empty, which is a distinct outcome from any message it
+// might actually spell out.
+func (r CallRow) Str(name string) (value string, ok bool) {
+	v, present := r[name]
+	if !present || !v.Valid {
+		return "", false
+	}
+	return v.String, true
+}
+
+// Int returns the named column parsed as an integer. ok is false when the
+// column is absent, NULL, or not a number.
+func (r CallRow) Int(name string) (value int, ok bool) {
+	s, present := r.Str(name)
+	if !present {
+		return 0, false
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(s))
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// CallReturningRow runs a CALL exactly as DrainCall does — consuming every row
+// of every result set, so the pinned connection is left clean for the next
+// command — and additionally returns the FIRST row of the FIRST result set.
+//
+// The drain is the load-bearing part and is shared with DrainCall verbatim; see
+// DrainCall's comment for the go-sql-driver error-path asymmetry that makes it
+// necessary. Scanning a row does not shorten the drain: the loop keeps running
+// to the end of every result set whether or not the scan succeeded. Reaching
+// for QueryRowContext instead would drain only the first result set and
+// reintroduce the busy-buffer bug on the pinned *sql.Tx that the pull path uses.
+//
+// A CALL that returns no rows at all yields a nil CallRow and a nil error;
+// reading a column from a nil CallRow reports absent rather than panicking.
+func CallReturningRow(ctx context.Context, db DBConn, query string, args ...any) (CallRow, error) {
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var first CallRow
+	if err := drainResultSets(rows, &first); err != nil {
+		return nil, err
+	}
+	return first, nil
+}
+
+// drainResultSets consumes every row of every result set the statement
+// produced. When capture is non-nil the first row of the first result set is
+// also scanned into it; every other row is read and discarded, which is what
+// frees the connection buffer for the next command.
+//
+// A scan failure is recorded and the drain continues, so a row this package
+// cannot decode still leaves a usable connection behind. The drain's own error
+// wins over the scan's: a broken result set explains a failed scan, not the
+// other way round.
+func drainResultSets(rows *sql.Rows, capture *CallRow) error {
+	var scanErr error
+	firstSet := true
 	for {
-		// Consume every row of the current result set. The values are
-		// irrelevant — a CALL's effect comes from its side effects, not from
-		// anything it returns — but reading them is what frees the connection
-		// buffer for the next command.
-		for rows.Next() { //nolint:revive // intentional drain, no body needed
+		for rows.Next() {
+			if capture != nil && firstSet && *capture == nil && scanErr == nil {
+				row, err := scanRowByColumn(rows)
+				if err != nil {
+					scanErr = err
+					continue
+				}
+				*capture = row
+			}
 		}
+		firstSet = false
 		if !rows.NextResultSet() {
 			break
 		}
 	}
-	return rows.Err()
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	return scanErr
+}
+
+// scanRowByColumn reads the row the cursor is on into a column-name-keyed map.
+func scanRowByColumn(rows *sql.Rows) (CallRow, error) {
+	cols, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
+	values := make([]sql.NullString, len(cols))
+	targets := make([]any, len(cols))
+	for i := range values {
+		targets[i] = &values[i]
+	}
+	if err := rows.Scan(targets...); err != nil {
+		return nil, err
+	}
+	row := make(CallRow, len(cols))
+	for i, name := range cols {
+		row[name] = values[i]
+	}
+	return row, nil
 }
 
 // execMigrationBody applies one migration file's SQL on the pinned migration


### PR DESCRIPTION
Follow-up from ga-ivaps / #5892. Base is `main`; **verified to merge cleanly with #5892** (`git merge-tree` clean, and the merged tree builds and vets).

## The problem

`CALL DOLT_PULL` returns `(fast_forward, conflicts, message)` — the engine's only in-band account of whether anything merged. `schema.DrainCall` threw the row away, on an explicit comment asserting that *"a CALL's effect comes from its side effects, not from anything it returns"*. For `DOLT_PULL` and `DOLT_MERGE` that assertion is false, and the cost is that a pull which merged 400 commits and a pull which found the remote unchanged both return the same value: `nil`.

## What the engine actually returns

Measured against dolt 2.1.8 (`CALL DOLT_PULL('origin','main')`, real bare-git remote, four states constructed):

| fast_forward | conflicts | message | reality |
|---|---|---|---|
| 1 | 0 | `merge successful` | merged (fast-forward) |
| 0 | 0 | `merge successful` | **merged (three-way)** |
| 0 | 0 | `Everything up-to-date` | nothing to merge |
| 0 | 0 | `cannot fast forward from a to b. a is ahead of b already` | nothing to merge |

Two things follow, and both shape the parse:

- **`fast_forward` is not the signal.** It is `0` for a genuine three-way merge *and* for both no-ops. Anything keying off it calls a real merge "nothing happened". It names the *kind* of merge, which is what dolt uses it for.
- **"Nothing merged" has more than one spelling.** `doltdb.ErrUpToDate` and `doltdb.ErrIsAhead` are both surfaced as the *message* with a **nil error**, so enumerating the negatives is a losing game. The single positive is the stable thing to match: upstream returns the literal `"merge successful"` from all three of its merged paths (`dprocedures/dolt_merge.go`, `dolt_pull.go`) and pins it in hundreds of its own enginetest expectations, so it cannot drift without breaking dolt's suite.

## What changed

- **`schema.CallReturningRow`** — a sibling of `DrainCall` that walks the result sets *identically* and additionally scans the first row, keyed by column name. Both now share one drain loop.
- **`DrainCall`'s contract is unchanged.** Same signature, same semantics, same error behaviour — a row it cannot decode is still not its problem and cannot become a new way for a migration to fail. Its comment is corrected to say the discard is a statement about *those call sites*, not about stored procedures in general.
- **`pullReport`** — typed transport outcome; `pullTransportReporting` / `pullWithAutoResolveReporting` alongside the existing error-only wrappers, so all six existing call sites are untouched.
- The GH#3144 fetch+merge fallback now reads `DOLT_MERGE`'s row too. Its `strings.Contains(err, "up to date")` tolerance is **kept** and now carries a comment explaining what it really catches: the ordinary no-op arrives as a *message with a nil error*, but dolt's squash path still returns `"Already up to date."` as a real error.

Row-by-name rather than by position is deliberate: dolt pins the `fast_forward` index in a const whose own comment warns it must be updated if the schema changes.

## What this is NOT — and why #5892 still needs its post-condition

The row is the transport's own account and nothing more.

- It **does not prove the merge landed where the caller reads.** A merge that succeeded on the wrong branch reports `merge successful` quite truthfully — which is exactly the shape ga-ivaps reproduced.
- It **only exists on the SQL routes.** A git-protocol remote routes to the `dolt pull` subprocess, which exits 0 either way and says nothing structured. Confirmed by execution: dolt normalizes `file://<bare git repo>` to `git+file://…`, which `doltutil.IsGitProtocolURL` matches — so **the route ga-ivaps was found on would not have been covered by this at all.**

`pullReport.Reported` is false in both of those cases; a caller reading `!Reported` as "nothing merged" has misread it. **#5892's post-condition should be kept as-is.** This is the complementary in-band signal, not a replacement.

## Scope

The report deliberately stops at the transport seam. It is **not** wired into `pullFromRemoteUnchecked`, because #5892 is open on that exact function. The user-visible payoff — `bd dolt pull` saying "Already up to date." instead of an unconditional "Pull complete." — belongs on top of #5892, not in a conflict with it.

## Correction to the bead

ga-bq9zd predicted this would "surface the conflicts count without a second query". It is not a count: it is a **0/1 flag** (`noConflictsOrViolations=0`, `hasConflictsOrViolations=1`) that also covers constraint violations. Typed as `Conflicted bool`, with `GetConflicts` named as the way to get the actual set.

## Tests — red-then-green, build and vet clean in the red state

- `TestPullTransportReportsWhetherAnythingMerged` — real SQL route, real peer database cloned from the remote. **RED:** `the SQL pull route returned no engine report at all ({Reported:false …})` — and note the fixture's own control had already passed at that point, i.e. the pull genuinely *had* merged the peer's row. **GREEN:** `{Reported:true Merged:true Message:merge successful}` then `{Reported:true Merged:false Message:Everything up-to-date}`.
  - **Control:** both pulls must still *succeed*. This adds information; it does not turn no-op pulls into errors. A change that made the second pull fail would look like it caught something and would break every idle `bd sync`.
  - **Control:** the merged pull must actually have delivered the peer's row, so a report saying "merged" cannot pass on a lie.
- `TestParseMergeReport…` — the four measured rows plus `DOLT_MERGE`'s extra `hash` column, a NULL message, and the no-row case. **Control:** `TestParseMergeReportControlRejectsNearMisses` rejects `"Merge successful"`, `"merge successful."`, `"merge succeeded"`, `""` — so the suite is not passing because everything matches.
- `TestCallReturningRowCapturesFirstRowAndStillDrains` — two result sets, several rows each; capturing must not shorten the walk. **RED** via disabling the capture in the shared loop. **Control:** `TestDrainCallStillDiscardsEverything` pins that `DrainCall` itself is unchanged by the refactor.

Full `internal/storage/schema` package green with `BEADS_TEST_ENV_RUN_DOLT=1`; `go build ./...`, `go vet`, `gofmt` and `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)