### PR TITLE
fix(storage/dolt): SearchIssues review follow-ups (maintainer follow-up to #5891)

### DIFF
--- a/backend/conformance/transaction_parity.go
+++ b/backend/conformance/transaction_parity.go
@@ -348,11 +348,33 @@ func testTransactionSearchFilterParity(t *testing.T, f Factory) {
 		for _, leg := range []struct {
 			sortBy   string
 			sortDesc bool
-		}{{"created", false}, {"created", true}, {"title", false}} {
-			filter := types.IssueFilter{IDPrefix: parityPrefix, SkipWisps: true, Limit: 100, SortBy: leg.sortBy, SortDesc: leg.sortDesc}
+			limit    int
+		}{
+			{"created", false, 100},
+			{"created", true, 100},
+			{"title", false, 100},
+			// "id" is the only Go-side sort key (sqlbuild.IsGoSideSort): it
+			// renders no ORDER BY and is sorted — and, when bounded, trimmed —
+			// in Go, so it exercises a branch none of the SQL-side keys above
+			// reach. The bounded leg drives the Go-side eff-trim (len(ids) >
+			// eff), the one place this path withholds the SQL LIMIT and cuts
+			// the page in Go.
+			{"id", false, 100},
+			{"id", true, 100},
+			{"id", false, 2},
+		} {
+			filter := types.IssueFilter{IDPrefix: parityPrefix, SkipWisps: true, Limit: leg.limit, SortBy: leg.sortBy, SortDesc: leg.sortDesc}
 			oracle, err := s.SearchIssues(c, "", filter)
 			must(t, err)
 			want := orderedIDs(oracle)
+
+			// Control: a bound below the fixture size must actually cut the
+			// oracle's page, or the parity check below cannot tell a Go-side
+			// trim from a path that ignored the bound.
+			if leg.limit < parityFixtureSize && len(want) != leg.limit {
+				t.Fatalf("control broken: SortBy=%q oracle under Limit=%d answered %d rows %v, want %d",
+					leg.sortBy, leg.limit, len(want), want, leg.limit)
+			}
 
 			var got []string
 			must(t, s.RunInTransaction(c, "bd: parity sort", func(tx storage.Transaction) error {
@@ -364,18 +386,18 @@ func testTransactionSearchFilterParity(t *testing.T, f Factory) {
 				return nil
 			}))
 			if !reflect.DeepEqual(got, want) {
-				t.Errorf("in-tx SearchIssues(SortBy=%q, SortDesc=%v) = %v, want %v — the sort was accepted and ignored",
-					leg.sortBy, leg.sortDesc, got, want)
+				t.Errorf("in-tx SearchIssues(SortBy=%q, SortDesc=%v, Limit=%d) = %v, want %v — the sort was accepted and ignored",
+					leg.sortBy, leg.sortDesc, leg.limit, got, want)
 			}
 			// Control: the two directions must not be the same sequence, or
 			// the comparison above proves nothing about SortDesc.
-			if leg.sortBy == "created" && leg.sortDesc {
+			if leg.sortDesc {
 				ascFilter := filter
 				ascFilter.SortDesc = false
 				asc, ascErr := s.SearchIssues(c, "", ascFilter)
 				must(t, ascErr)
 				if reflect.DeepEqual(orderedIDs(asc), want) {
-					t.Fatalf("control broken: created ASC and DESC answer the same sequence %v", want)
+					t.Fatalf("control broken: %s ASC and DESC answer the same sequence %v", leg.sortBy, want)
 				}
 			}
 		}

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -520,6 +520,14 @@ func (t *doltTransaction) GetIssue(ctx context.Context, id string) (*types.Issue
 // regularTx/ignoredTx (see txFor). Not worth re-implementing: partial-ID
 // resolution calls the (fast) store path, never a transaction, so this is cold.
 func (t *doltTransaction) SearchIssueIDs(ctx context.Context, query string, filter types.IssueFilter) ([]string, error) {
+	// The caller wants ids only, so opt out of the bulk label read SearchIssues
+	// would otherwise run and then project away. filter is a value copy, so this
+	// does not touch the caller's filter. SkipLabels gates only hydration: the
+	// label-driven WHERE predicates (LabelPattern, ExcludeLabels, LabelRegex,
+	// Labels/LabelsAny) are built from their own filter fields in
+	// BuildIssueFilterClauses and still select the same rows. Dependency
+	// hydration is already gated on IncludeDependencies, so it costs nothing here.
+	filter.SkipLabels = true
 	issues, err := t.SearchIssues(ctx, query, filter)
 	if err != nil {
 		return nil, err
@@ -611,7 +619,12 @@ func (t *doltTransaction) SearchIssues(ctx context.Context, query string, filter
 			_ = rows.Close()
 			return nil, wrapScanError("search issues in tx", err)
 		}
-		// GH#3567: a label/dependency subquery can repeat a row.
+		// Structural parity with issueops.searchTableInTxT, which dedups because
+		// it can drive from a joined label table where a row repeats (GH#3567).
+		// This tx query is JOIN-free — only id IN (<correlated subquery>)
+		// predicates from sqlbuild.BuildIssueFilterClauses — so a row cannot
+		// actually repeat on this path; the dedup mirrors the reference rather
+		// than guarding a live duplicate source here.
 		if _, dup := seen[id]; dup {
 			continue
 		}


### PR DESCRIPTION
Maintainer follow-up carrying the adoption-review follow-up fixes for #5891. Those fixes were prepared as a single maintainer fixup during the `/adopt-pr` review loop, but #5891 merged from its original contributor head before the fixup could land, so they never reached `main`.

## Original PR
- PR: https://github.com/gastownhall/beads/pull/5891
- Title: `fix(storage/dolt): stop Transaction.SearchIssues dropping the keyset cursor and eight other filter fields`
- State: **MERGED** (2026-08-21; merge commit `66048d4`)
- Configured adoption base: `fix/ga-1huib-tx-backend-parity`
- Original GitHub base at merge: `main`

Base note: the configured adoption base `fix/ga-1huib-tx-backend-parity` is no longer the live base — #5891 merged into `main` (GitHub retargeted it once the integration base branch was gone). This follow-up therefore targets `main`, where #5891's change now lives, and the fixup cherry-picks onto `main` cleanly.

## What this carries
Contributor commits are already in `main` via #5891, so this PR carries **only** the maintainer fixup (2 files, +42/-7):

- **`internal/storage/dolt` `SearchIssueIDs`**: set `filter.SkipLabels` before delegating to `SearchIssues`, so the ids-only projection no longer runs a bulk label read it immediately discards. `SkipLabels` gates only label hydration, so the selected row set is unchanged; the label-driven `WHERE` predicates are still built from their own filter fields.
- **`backend/conformance/transaction_parity.go`**: add `SortBy:"id"` parity legs (asc, desc, and a bounded leg) so the Go-side sort-and-trim branch — the only sort key applied in Go — is exercised against the store oracle, including the eff-trim under a bound. A control assertion proves the bound actually cuts the oracle page, and the ASC/DESC direction control is generalized to cover every descending leg.
- Clarify the seen-map `GH#3567` comment: the dedup is structural parity with `issueops.searchTableInTxT`, not a live guard on this JOIN-free tx path.

---
_Maintainer follow-up via `/adopt-pr`. Original contributor commits preserved in #5891._
